### PR TITLE
docs(governance): NENE2 継承のガバナンスと開発規約を初期化する (#1)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -1,0 +1,16 @@
+---
+description: NeNe Invoice 全作業共通の正本と安全方針
+alwaysApply: true
+---
+
+# Project Rules
+
+- 正本は `README.md`、`AGENTS.md`、`docs/CONTRIBUTING.md`、`docs/inheritance-from-nene2.md`、`docs/development/`、`docs/workflow.md`。
+- AI/エージェントは作業前に `AGENTS.md` と関連 docs を確認する。
+- フレームワーク挙動は NENE2 upstream（`vendor/hideyukimori/nene2/docs/`）を参照する。製品ルールはこのリポジトリの docs を優先する。
+- **sibling 製品に統合しない。** 依存方向は `NeNe Invoice → upstream API` のみ（ADR 0002）。
+- 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
+- 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
+- NeNe Invoice はセルフホスト OSS の見積・請求・入金管理 — 適格請求書対応、Admin UI、PDF。
+- 金額は **integer cents**（float 禁止）。実装は疎結合、型安全、OpenAPI/MCP 境界を優先（NENE2 継承）。
+- Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -1,0 +1,14 @@
+---
+description: Issue ベース開発と branch / PR / merge 運用
+alwaysApply: true
+---
+
+# Issue Driven Workflow
+
+- コード、ドキュメント、設定変更は **必ず GitHub Issue ベース**。Issue 作成前に編集しない。
+- 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
+- **`main` へ直接 commit / push しない。** ブランチ名は `type/issue-number-summary`。
+- 標準完了フロー: commit → push → PR 作成（`Closes #番号` + セルフレビューチェックリスト名）→ CI 確認 → **merge** → ローカル `main` 同期。
+- コミットは Conventional Commits（`docs/development/commit-conventions.md`）。description/body は日本語、type/scope は英語。**subject に `(#issue)` を含める。**
+- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合はその指示を優先する。
+- 正本: `docs/workflow.md`、`docs/development/commit-conventions.md`（NENE2 継承）。

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+/vendor/
+/node_modules/
+/.env
+/.env.local
+/.env.*.local
+/.phpunit.result.cache
+/.phpstan.cache/
+/.php-cs-fixer.cache
+/var/
+/public_html/assets/
+/public_html/admin/*
+!/public_html/admin/.htaccess
+/storage/
+/build/
+/frontend/node_modules/
+/frontend/apps/*/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent / AI Guide
+
+This file is the entry point for AI agents working on NeNe Invoice.
+
+## Read First
+
+- **Current work & status:** `docs/todo/current.md`
+- **Product vision:** `docs/explanation/product-vision.md`
+- **Glossary:** `docs/explanation/glossary.md`
+- **Naming conventions:** `docs/development/naming-conventions.md`
+- Inheritance map: `docs/inheritance-from-nene2.md`
+- Human and AI collaboration: `docs/CONTRIBUTING.md`
+- Workflow: `docs/workflow.md`
+- Coding standards: `docs/development/coding-standards.md`
+- Backend standards: `docs/development/backend-standards.md`
+- Commit messages: `docs/development/commit-conventions.md`
+- AI tool policy: `docs/integrations/ai-tools.md`
+- Roadmap: `docs/roadmap.md`
+- Milestones: `docs/milestones/2026-05-governance-and-foundation.md`
+
+## Operating Rules
+
+- **Issue-driven**: no substantive code, doc, or config change without a GitHub Issue. Create one first.
+- **No direct commits to `main`**. Branch `type/issue-number-summary` → PR → merge after checks.
+- **Commits**: Conventional Commits; type/scope English, description/body Japanese, `(#issue)` in subject.
+- **Full lifecycle** (unless user limits scope): Issue → branch → implement → verify → commit → push → PR → merge → sync `main`.
+- Read NENE2 upstream docs for framework behavior; read local docs for product rules.
+- **Never integrate billing into NeNe Records or other sibling repos.** Dependency direction is `NeNe Invoice → upstream APIs`, never the reverse. See ADR 0002.
+- Keep `docs/todo/current.md` and milestones aligned with Issues and PRs.
+- Keep changes focused. Do not mix governance, feature work, and unrelated cleanup in one PR.
+- Do not commit secrets, credentials, local `.env` files, or generated build outputs.
+- Prefer explicit, typed, testable code over hidden framework behavior.
+- When docs and Cursor rules conflict, update the docs first and keep `.cursor/rules/` concise.
+
+## Project Direction
+
+NeNe Invoice is a self-hosted quote and invoice OSS on NENE2:
+
+- **Primary operators:** Japan SMB on PHP shared hosting (Tier A); **also** Docker/VPS (Tier B). Same codebase — ADR 0003 (planned).
+- Create quotes and invoices with Japan invoice system fields (適格請求書).
+- Track payment status and overdue reminders.
+- Admin UI for clients, line items, documents, and company settings.
+- OpenAPI as the contract; MCP for ops/read-write agent tooling on documented HTTP boundaries.
+- **Not** full accounting software — sibling to [NeNe Records](https://github.com/hideyukiMORI/nene-records), not a module inside it.
+
+## Framework Reference
+
+Install `hideyukimori/nene2` via Composer. For HTTP runtime, middleware, Problem Details, and MCP patterns, NENE2 upstream documentation is authoritative unless a local ADR says otherwise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md — NeNe Invoice
+
+Claude Code / AI エージェント向け実行ガイド。詳細ポリシーの正本は `docs/` 以下。
+
+---
+
+## プロダクト一言要約
+
+自己ホスト型 **見積・請求・入金管理** OSS（MIT）。日本 SMB 向け **適格請求書** 対応。NENE2 上の sibling product — Records / Corpus / Concierge と HTTP 連携のみ。
+
+```
+Admin UI (React)  ──→  NeNe Invoice API (NENE2/PHP 8.4)  ──→  MySQL
+Ops / MCP         ──→         │
+                               ↓ HTTP read-only / webhook（任意）
+                    NeNe Records / NeNe Concierge / 外部 API
+```
+
+---
+
+## 現在の開発状況
+
+> **最終更新: 2026-05-29**（`docs/todo/current.md` が正本）
+
+| フェーズ | 状態 |
+| --- | --- |
+| Phase 0 ガバナンス | 🔄 進行中（Issue #1） |
+| Phase 0+ プロダクト設計 | 🔲 Issue #2 以降 |
+| Phase 1 ランタイム scaffold | 🔲 未着手 |
+
+---
+
+## ワークフロー
+
+1. **GitHub Issue を作成**（または番号を確認）する。Issue なしに編集しない。
+2. `docs/roadmap.md`, `docs/todo/current.md`, 関連 Issue/PR を確認する。
+3. `main` から `type/issue-number-summary` ブランチを切る。
+4. 実装 → 品質チェック → commit。
+5. PR 作成：`Closes #N` + セルフレビューチェックリスト名を本文に記載。
+6. CI green → merge → ローカル `main` sync。
+
+**コミット形式:**
+```
+<type>(<scope>): <日本語の説明> (#<issue>)
+```
+
+**絶対禁止:**
+- `main` への直接 commit/push
+- Issue なしの変更
+- `.env` / トークン / パスワードのコミット
+- sibling 製品への請求ロジック統合（ADR 0002）
+
+---
+
+## アーキテクチャ規約（概要）
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+- Namespace: `NeneInvoice\`
+- ドメイン別フォルダ（`Client/`, `Quote/`, `Invoice/`, `Payment/` 等）
+- レイヤー別フォルダ禁止（`src/Handlers/` 等）
+- JSON: **snake_case** 固定
+- 金額: **integer cents**（float 禁止）
+- SQL: `Pdo*Repository` 内のみ
+
+詳細: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`
+
+---
+
+## Source of Truth
+
+| 目的 | ドキュメント |
+| --- | --- |
+| 現在のタスク | `docs/todo/current.md` |
+| ロードマップ | `docs/roadmap.md` |
+| プロダクトビジョン | `docs/explanation/product-vision.md` |
+| ワークフロー | `docs/workflow.md` |
+| NENE2 継承 | `docs/inheritance-from-nene2.md` |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hideyukiMORI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# NeNe Invoice
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+
+**Self-hosted quote and invoice management for Japan SMB — built on [NENE2](https://github.com/hideyukiMORI/NENE2).**
+
+NeNe Invoice is an open-source billing platform: create quotes, issue invoice-compliant PDFs, track payments, and operate everything on infrastructure you control — without a monthly SaaS subscription.
+
+> **Status:** Phase 0 — governance and product design. Runtime scaffold follows in Phase 0+ Issues.
+
+## Goals (summary)
+
+- **Japan invoice compliance** — qualified invoice (適格請求書) fields, tax rates, registration number
+- **Self-hosted OSS** — MIT licensed; shared hosting (Tier A) or Docker/VPS (Tier B)
+- **Quote-to-cash flow** — estimate → invoice → payment tracking
+- **Sibling to NeNe ecosystem** — HTTP integration with Records, Concierge, Corpus; never merged into CMS
+- **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
+
+## Documentation
+
+| Topic | Document |
+| --- | --- |
+| **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
+| **Glossary** | [`docs/explanation/glossary.md`](./docs/explanation/glossary.md) |
+| **Product vision** | Issue #2 (in progress) |
+| **Naming conventions** | [`docs/development/naming-conventions.md`](./docs/development/naming-conventions.md) |
+| **NENE2 inheritance** | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
+| **Workflow** | [`docs/workflow.md`](./docs/workflow.md) |
+| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) |
+| **Current work** | [`docs/todo/current.md`](./docs/todo/current.md) |
+
+## Ecosystem
+
+```
+NENE2 (framework)
+  ├── NeNe Records   (CMS · optional product catalog upstream)
+  ├── NeNe Corpus    (knowledge chat — optional)
+  ├── NeNe Concierge (scenario chat · lead capture upstream)
+  └── NeNe Invoice   (quote · invoice · payment — this repo)
+```
+
+Integration is **HTTP-only**. NeNe Invoice never shares databases with sibling products.
+
+## Contributing
+
+See [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md). All work is Issue-driven; do not commit directly to `main`.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+NeNe Invoice is built through small, Issue-driven changes. This document is the shared entry point for humans and AI agents.
+
+## Required Reading
+
+| Topic | Document |
+| --- | --- |
+| NENE2 inheritance map | `docs/inheritance-from-nene2.md` |
+| Sibling product boundaries | `docs/integrations/sibling-products.md` |
+| Workflow | `docs/workflow.md` |
+| Coding standards | `docs/development/coding-standards.md` |
+| Naming conventions | `docs/development/naming-conventions.md` |
+| Glossary | `docs/explanation/glossary.md` |
+| Backend standards (PHP/API) | `docs/development/backend-standards.md` |
+| Commit messages | `docs/development/commit-conventions.md` |
+| AI tools | `docs/integrations/ai-tools.md` |
+| Agent entry point | `AGENTS.md` |
+| Roadmap | `docs/roadmap.md` |
+| Current work | `docs/todo/current.md` |
+
+## Collaboration Policy
+
+Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md):
+
+1. Create or reuse a GitHub Issue **before** editing.
+2. Branch from `main` as `type/issue-number-summary`.
+3. Implement, verify (`composer check` when applicable), commit with `(#issue)`.
+4. Push, open PR with `Closes #number`, merge after checks — **do not push directly to `main`**.
+
+- Use one branch and one PR per focused work unit.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Explain intent, impact, verification, and remaining risk in PRs.
+- Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
+
+## Secrets
+
+Do not commit passwords, tokens, private URLs, production credentials, or local `.env` files. Commit only non-secret examples such as `.env.example` when needed.
+
+Sensitive keys for this product include:
+
+- Admin JWT secrets
+- Upstream API bearer tokens (NeNe Records, NeNe Concierge)
+- SMTP credentials for invoice email delivery
+
+## Engineering Theme
+
+NeNe Invoice should stay readable, secure, and self-hostable:
+
+- strict, typed, explicit boundaries (inherited from NENE2)
+- decoupled use cases and infrastructure
+- OpenAPI contracts before client assumptions
+- Japan invoice compliance fields validated at API layer
+- MCP access only through documented HTTP boundaries
+- **never** merge into or embed inside NeNe Records (ADR 0002)
+
+## Upstream Framework
+
+Runtime HTTP, middleware, and DI patterns come from [NENE2](https://github.com/hideyukiMORI/NENE2). When framework behavior is unclear, read NENE2 docs under `vendor/hideyukimori/nene2/docs/` after `composer install`.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR 0000: Title
+
+## Status
+
+proposed
+
+## Context
+
+Describe the problem, constraints, and trade-offs that make this decision necessary.
+
+## Decision
+
+Describe the decision in clear, direct language.
+
+## Consequences
+
+Describe the expected benefits, costs, and follow-up work.
+
+## Related
+
+- Issue: `#000`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0001-inherit-nene2-governance.md
+++ b/docs/adr/0001-inherit-nene2-governance.md
@@ -1,0 +1,51 @@
+# ADR 0001: Inherit NENE2 Governance and Workflow
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Invoice is a consumer application built on [NENE2](https://github.com/hideyukiMORI/NENE2). The maintainer wants the same strict engineering discipline as NENE2 and sibling NeNe products (Records, Corpus, Concierge) — Issue-driven workflow, Conventional Commits, self-review checklists, and AI-readable documentation — without copying the entire NENE2 documentation tree.
+
+Alternatives considered:
+
+1. **Link-only** — rejected; product-specific rules (billing, invoice compliance, sibling boundaries) would be unclear.
+2. **Full copy** — rejected; upstream drift would be hard to track.
+3. **Hybrid inheritance** (chosen): local source-of-truth for workflow and product rules; reference NENE2 upstream for framework runtime behavior.
+
+## Decision
+
+Adopt NENE2 governance patterns locally:
+
+- Issue-driven development with `type/issue-number-summary` branches
+- Conventional Commits (English type/scope, Japanese description/body, Issue number in subject)
+- Self-review checklists under `docs/review/`
+- ADR policy under `docs/development/adr.md`
+- AI agent entry via `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/`
+- Inheritance map in `docs/inheritance-from-nene2.md`
+
+Framework HTTP, middleware, validation, and MCP behavior remain defined by NENE2 unless this repository records an explicit deviation in a later ADR.
+
+## Consequences
+
+**Benefits**
+
+- Contributors and AI agents have a single local entry point.
+- Product rules (billing model, invoice fields, upstream boundaries) stay separate from framework rules.
+- NENE2 upstream improvements remain consumable via Composer.
+
+**Costs**
+
+- Two documentation layers must stay mentally in sync when NENE2 workflow policy changes materially.
+
+**Follow-up**
+
+- Scaffold runtime and CI (Phase 0+).
+- Add billing and compliance ADRs as domains stabilize.
+
+## Related
+
+- NENE2 workflow: https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md
+- NeNe Records ADR 0001 (precedent): https://github.com/hideyukiMORI/nene-records/blob/main/docs/adr/0001-inherit-nene2-governance.md
+- Inheritance map: `docs/inheritance-from-nene2.md`

--- a/docs/adr/0002-separate-from-sibling-products.md
+++ b/docs/adr/0002-separate-from-sibling-products.md
@@ -1,0 +1,67 @@
+# ADR 0002: Separate Product from Sibling NeNe Applications
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Invoice is a quote and invoice platform. Sibling products in the NeNe ecosystem each own a distinct domain:
+
+- **NeNe Records** — CMS and typed entity platform
+- **NeNe Corpus** — knowledge chat with citations
+- **NeNe Concierge** — scenario-driven conversion chat
+
+NeNe Invoice may consume sibling HTTP APIs (product catalog from Records, leads from Concierge) but must not embed billing logic into those repositories or share their databases.
+
+Alternatives considered:
+
+1. **Billing module inside NeNe Records** — rejected; mixes CMS and financial failure domains; Concierge already plans HTTP integration to separate Shop/Booking products.
+2. **Shared database** — rejected; couples schemas and bypasses API contracts.
+3. **Independent product with HTTP clients** (chosen): NeNe Invoice calls sibling APIs only.
+
+## Decision
+
+NeNe Invoice is a **separate repository and deployable unit**:
+
+- Dependency direction: `NeNe Invoice → sibling API`. Never `Sibling → NeNe Invoice` code inclusion.
+- No shared PHP codebase beyond Composer dependency on NENE2.
+- No invoice routes, PDF generation, or payment logic in sibling repos.
+- Siblings expose documented HTTP APIs; NeNe Invoice implements `Upstream/` HTTP clients when integration is needed.
+- MCP tools map to NeNe Invoice OpenAPI operations only — not direct access to sibling databases.
+
+```
+Admin UI / MCP
+    ↓
+NeNe Invoice API (clients, quotes, invoices, payments)
+    ↓
+NeNe Invoice database (owned here)
+    ↓ optional HTTP
+NeNe Records / NeNe Concierge / external APIs
+```
+
+Billing-owned data (clients, quotes, invoices, payments, PDF artifacts metadata) lives in **NeNe Invoice database only**.
+
+## Consequences
+
+**Benefits**
+
+- Sibling products remain stable when billing services change.
+- Clear OSS story: four products, one framework, HTTP integration.
+- Security boundaries: CMS admin JWT ≠ billing admin JWT.
+
+**Costs**
+
+- Multiple repos to maintain; cross-repo API contracts must stay documented.
+- Some duplication of admin UI patterns (acceptable; different domains).
+
+**Follow-up**
+
+- Document upstream client env vars in `docs/integrations/sibling-products.md`.
+- Add contract tests when Records product catalog API is consumed.
+
+## Related
+
+- Product vision: `docs/explanation/product-vision.md`
+- Sibling integration policy: `docs/integrations/sibling-products.md`
+- NeNe Concierge glossary (Shop/Booking precedent): https://github.com/hideyukiMORI/nene-concierge/blob/main/docs/explanation/glossary.md

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -1,0 +1,48 @@
+# ADR Policy
+
+NeNe Invoice uses lightweight Architecture Decision Records, inherited from [NENE2 ADR policy](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/adr.md).
+
+## When to write an ADR
+
+Write an ADR when a decision affects:
+
+- quote, invoice, payment architecture, or public API contracts
+- Japan invoice compliance strategy or PDF generation approach
+- dependency or framework integration choices
+- authentication, authorization, or MCP safety boundaries
+- dual deployment (Tier A shared hosting vs Tier B Docker)
+- release, versioning, or compatibility policy
+- long-term maintenance cost
+
+Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/current.md`.
+
+## Directory and naming
+
+```text
+docs/adr/
+├── 0000-template.md
+├── 0001-inherit-nene2-governance.md
+├── 0002-separate-from-sibling-products.md
+└── NNNN-short-title.md
+```
+
+Use a stable four-digit sequence. Do not renumber after publication.
+
+## Status values
+
+- `proposed`
+- `accepted`
+- `deprecated`
+- `superseded`
+
+Supersede old ADRs instead of silently rewriting history.
+
+## Template
+
+Use `docs/adr/0000-template.md`.
+
+## Relationship to NENE2 ADRs
+
+- NENE2 ADRs describe **framework** decisions.
+- NeNe Invoice ADRs describe **product** decisions.
+- When consuming NENE2, prefer upstream ADRs for framework behavior; record local deviations here.

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -1,0 +1,111 @@
+# Backend Standards
+
+NeNe Invoice backend policy for PHP API code. Adapted from [NeNe Records](https://github.com/hideyukiMORI/nene-records) and [NeNe Corpus](https://github.com/hideyukiMORI/nene-corpus) backend standards for a **billing OSS** on NENE2.
+
+**Framework baseline:** NENE2 `docs/development/` — deviate only via local ADR.
+
+**Naming and terms:** [`naming-conventions.md`](./naming-conventions.md), [`glossary.md`](../explanation/glossary.md).
+
+---
+
+## 1. Project shape
+
+NeNe Invoice is a **NENE2 consumer project**:
+
+```
+vendor/hideyukimori/nene2/   ← framework (do not edit)
+src/                         ← product code (NeneInvoice\)
+tests/                       ← mirrors src/
+docs/openapi/openapi.yaml    ← public contract
+public_html/index.php        ← front controller
+```
+
+Namespace: `NeneInvoice\`
+
+---
+
+## 2. Module layout (domain-grouped)
+
+Organize by **domain**, not technical layer:
+
+```
+src/
+  ApplicationServiceProvider.php
+  Http/
+  AdminAuth/
+  Company/          # issuer profile, tax registration, bank info
+  Client/           # customer master
+  Quote/            # estimates
+  Invoice/          # issued invoices, qualified invoice fields
+  LineItem/         # shared line item logic (quote + invoice)
+  Payment/          # payment records, status
+  Pdf/              # server-side PDF generation
+  Upstream/         # optional HTTP clients (Records, Concierge)
+```
+
+**Zero-tolerance placement:** handlers live in their domain folder (`Invoice/CreateInvoiceHandler.php`), not `src/Handlers/`.
+
+---
+
+## 3. Layering rules
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+| Layer | May | Must not |
+| --- | --- | --- |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response | SQL, business rules, direct PDF library calls |
+| **UseCase** | Business rules, tax calculation, orchestration | `$_SERVER`, PDO, raw HTTP |
+| **Repository** | SQL / persistence | HTTP, PDF generation |
+| **Pdf adapter** | Render PDF from DTO | Domain invariants, SQL |
+
+Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
+
+---
+
+## 4. HTTP & OpenAPI
+
+- Every public route appears in `docs/openapi/openapi.yaml` with `operationId`.
+- Success and Problem Details error shapes documented.
+- RFC 9457 Problem Details for errors; base URL `https://nene-invoice.dev/problems/`.
+- Admin routes require JWT Bearer auth (Phase 1+).
+
+---
+
+## 5. Money and tax
+
+- Store all amounts as **integer cents** (`subtotal_cents`, `tax_cents`, `total_cents`).
+- Tax rates: store as basis points or documented enum — never float percentages in persisted data.
+- Japan qualified invoice fields validated in UseCase layer before PDF generation.
+- PDF totals must match API-calculated cents — single source of truth in UseCase.
+
+---
+
+## 6. Database
+
+- Phinx migrations under `database/migrations/`.
+- Schema snapshots under `database/schema/`.
+- Soft delete: `is_deleted`, `deleted_at` unless ADR says otherwise.
+- Multi-tenant: `organization_id` on tenant-scoped tables when tenancy lands (ADR TBD).
+
+---
+
+## 7. Testing
+
+- UseCase tests: no DB — inject repository fakes or in-memory implementations.
+- Repository tests: SQLite in-memory PDO.
+- HTTP tests: contract tests against OpenAPI shapes.
+- PDF tests: assert byte output or snapshot hash — do not visually review in CI.
+
+---
+
+## 8. Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Self-review: [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md).

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,57 @@
+# Coding Standards
+
+NeNe Invoice coding standards split by surface. **Full policies live in the dedicated documents below** — this file is the index.
+
+| Surface | Source of truth |
+| --- | --- |
+| **PHP / API / database** | [`backend-standards.md`](./backend-standards.md) |
+| **Naming (code, API, DB, tests)** | [`naming-conventions.md`](./naming-conventions.md) |
+| **Product terms (glossary)** | [`../explanation/glossary.md`](../explanation/glossary.md) |
+| **React / TypeScript admin** | [`frontend-standards.md`](./frontend-standards.md) (Phase 2+) |
+| **NENE2 inheritance map** | [`../inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
+
+**Framework baseline:** [NENE2 coding standards](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md) — NeNe Invoice deviates only where local docs or ADRs say so.
+
+---
+
+## Shared rules (all surfaces)
+
+- GitHub Issue-driven work; focused PRs; no direct commits to `main`
+- **Strict typing** at boundaries — PHP readonly DTOs; TypeScript strict mode (when frontend exists)
+- **OpenAPI** is the public API contract; MCP maps to the same HTTP operations
+- Application Problem Details `type`: `https://nene-invoice.dev/problems/{problem-name}`
+- **Monetary values:** integer cents everywhere — no floats in DB or JSON
+- **Placement violations block merge** — see backend standards
+- Public docs, OpenAPI text, and API error metadata: **English**
+- Issues, PRs, commits, `.cursor/rules/`: **Japanese allowed**
+- **Never integrate billing into sibling products** — ADR 0002
+
+---
+
+## Backend (summary)
+
+Full policy: **`docs/development/backend-standards.md`**. Naming: **`docs/development/naming-conventions.md`**.
+
+- NENE2 consumer — framework in `vendor/`, product in `src/`
+- Domain-grouped modules — not layer folders
+- Handler → UseCase → RepositoryInterface → PdoRepository
+- No PDO/SQL outside `Pdo*Repository`; no business logic in handlers
+- Phinx migrations + `database/schema/` snapshots
+- PHPUnit: in-memory use cases, SQLite repositories, OpenAPI contract tests
+- `composer check` before merge
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+When `frontend/` exists:
+
+```bash
+npm run check --prefix frontend
+```

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,61 @@
+# Commit Message Conventions
+
+NeNe Invoice uses Conventional Commits, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md) and sibling NeNe products.
+
+## Format
+
+```text
+<type>(<optional scope>): <description> (#<issue>)
+
+[optional body]
+
+[optional footer]
+```
+
+## Language
+
+- Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in **English**.
+- Write the **description and body in Japanese**.
+- Include the related GitHub Issue number in the **subject** for all work.
+
+Example:
+
+```text
+docs(governance): Issue 駆動ワークフローを NENE2 正本に整合する (#1)
+```
+
+```text
+feat(invoice): 適格請求書 PDF 生成 UseCase を追加する (#12)
+```
+
+## Issue number
+
+| Situation | Rule |
+| --- | --- |
+| Normal work | Subject **must** include `(#issue)` |
+| Docs-only follow-up on same Issue | Reuse the same Issue number |
+
+If you start editing without an Issue, **stop and create one first** — see `docs/workflow.md`.
+
+## Common Types
+
+| Type | Use |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change without feature or bug fix |
+| `test` | Test additions or changes |
+| `build` | Dependency or build setup |
+| `ci` | CI configuration |
+| `chore` | Maintenance |
+
+## Body
+
+Use the body when the reason is not obvious from the subject. Explain why the change exists, what trade-off was chosen, and whether follow-up work remains.
+
+## Breaking Changes
+
+Use `!` or a `BREAKING CHANGE:` footer when public API, configuration, CLI, or documented behavior changes incompatibly.
+
+Public API changes must also update OpenAPI and, when applicable, `docs/mcp/tools.json`.

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -1,0 +1,15 @@
+# Frontend Standards
+
+**Status:** Phase 2 — not implemented yet.
+
+NeNe Invoice admin UI will follow sibling product conventions:
+
+- React + TypeScript + Vite
+- Strict mode enabled
+- API client maps **snake_case** JSON without renaming fields
+- UI strings in locale catalogs (Japanese primary for operators)
+- No admin JWT in public document download pages
+
+When `frontend/` lands, expand this document with component layout, test strategy, and build output paths (`public_html/admin/`).
+
+Until then, mark frontend checklist items as `N/A` in PRs.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -1,0 +1,224 @@
+# Naming Conventions
+
+Authoritative naming rules for NeNe Invoice code, API contracts, database objects, tests, and English documentation.
+
+**Glossary (product terms):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
+
+**Framework baseline:** NENE2 [`domain-layer.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/domain-layer.md) and [`database-migrations.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/database-migrations.md). This document is the NeNe Invoice override and extension list.
+
+---
+
+## 1. PHP
+
+### Files and namespaces
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Namespace root | `NeneInvoice\` | `NeneInvoice\Invoice\CreateInvoiceHandler` |
+| Domain folder | PascalCase singular domain name | `src/Client/`, `src/Invoice/` |
+| File name | Match the primary class | `CreateInvoiceHandler.php` |
+| One public class per file | Required | — |
+
+### Classes and interfaces
+
+| Role | Pattern | Example |
+| --- | --- | --- |
+| HTTP handler | `{Verb}{Noun}Handler` | `CreateInvoiceHandler`, `ListClientsHandler` |
+| Use case interface | `{Verb}{Noun}UseCaseInterface` | `CreateInvoiceUseCaseInterface` |
+| Use case impl | `{Verb}{Noun}UseCase` | `CreateInvoiceUseCase` |
+| Use case method | Always `execute` | `execute(CreateInvoiceInput $input): CreateInvoiceOutput` |
+| Input DTO | `{Verb}{Noun}Input` | `CreateInvoiceInput` |
+| Output DTO | `{Verb}{Noun}Output` | `CreateInvoiceOutput` |
+| Domain entity | Singular noun, no suffix | `Client`, `Quote`, `Invoice`, `Payment` |
+| Repository interface | `{Entity}RepositoryInterface` | `InvoiceRepositoryInterface` |
+| PDO repository | `Pdo{Entity}Repository` | `PdoInvoiceRepository` |
+| PDF adapter | `{Purpose}PdfGenerator` in `Pdf/` | `InvoicePdfGenerator` |
+| Domain exception | `{Entity}{Reason}Exception` | `InvoiceNotFoundException` |
+| Service provider | `{Purpose}ServiceProvider` | `RuntimeServiceProvider` |
+
+All application classes: `final` and `readonly` where applicable. Every PHP file: `declare(strict_types=1);`.
+
+### Modules (`src/`)
+
+Use only domain-grouped top-level folders. Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
+
+Planned domains (Phase 1+): `Client/`, `Quote/`, `Invoice/`, `Payment/`, `Company/`, `LineItem/`, `Pdf/`, `AdminAuth/`, `Http/`.
+
+### Methods and properties
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Methods | camelCase | `findById`, `markAsPaid` |
+| Properties | camelCase | `$clientId`, `$invoiceRepository` |
+| Constants | UPPER_SNAKE_CASE | `MAX_LINE_ITEMS` |
+
+Repository methods use **domain verbs**: `findById`, `save`, `delete` — not `selectById`, `insertRow`.
+
+---
+
+## 2. HTTP routes and OpenAPI
+
+### URL paths
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Path segments | lowercase **kebab-case** | `/admin/clients`, `/admin/invoices` |
+| Collection paths | plural noun | `/admin/quotes`, `/admin/payments` |
+| Single resource | `{id}` path param | `/admin/invoices/{id}` |
+| Public download | noun path | `/documents/invoices/{token}/pdf` |
+| Path param name | lowercase singular | `id`, `clientId` |
+
+Admin mutating routes live under `/admin/…`.
+
+### operationId
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Case | camelCase | `getHealth`, `createInvoice` |
+| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listClients`, `getInvoiceById` |
+| Stability | Never rename after release; deprecate instead | — |
+
+Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mcp/tools.json` `operationId`.
+
+### OpenAPI schema names
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Response schema | `{Resource}Response` | `InvoiceResponse` |
+| List response | `{Resource}ListResponse` | `ClientListResponse` |
+| Create request | `Create{Resource}Request` | `CreateQuoteRequest` |
+| Tag names | PascalCase singular group | `System`, `Admin`, `Client`, `Invoice` |
+
+Public OpenAPI summaries, descriptions, and examples: **English only**.
+
+---
+
+## 3. JSON (request and response bodies)
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Property names | **snake_case** | `client_id`, `issued_at`, `tax_rate` |
+| Money amounts | integer **cents** | `subtotal_cents`, `tax_cents`, `total_cents` |
+| Booleans | `is_` / `has_` prefix | `is_paid`, `is_qualified_invoice` |
+| Timestamps | `_at` suffix, ISO 8601 string | `issued_at`, `due_at`, `paid_at` |
+| Foreign keys | `{entity}_id` | `client_id`, `quote_id` |
+| List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
+
+Do not mix camelCase in public JSON. Do not use floats for money.
+
+---
+
+## 4. Problem Details and validation errors
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Base URL | `https://nene-invoice.dev/problems/` | — |
+| Type slug | kebab-case | `validation-failed`, `invoice-not-found` |
+| Validation `errors[].field` | snake_case path | `body.tax_registration_number` |
+| Validation `errors[].code` | snake_case | `required`, `invalid_invoice_number` |
+
+Problem Details `title` and `detail`: English.
+
+---
+
+## 5. Database
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Table names | snake_case, **plural** | `clients`, `quotes`, `invoices`, `line_items`, `payments` |
+| Column names | snake_case | `client_id`, `total_cents`, `issued_at` |
+| Money columns | `*_cents` suffix, integer | `subtotal_cents`, `tax_cents` |
+| Primary key | `id` | BIGINT auto-increment |
+| Foreign key column | `{singular_entity}_id` | `quote_id`, `invoice_id` |
+| Index names | `idx_{table}_{columns}` | `idx_invoices_client_id` |
+| Unique constraints | `uniq_{table}_{columns}` | `uniq_invoices_number` |
+
+SQL lives only in `Pdo*Repository` classes.
+
+### Migrations
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260529120000_create_invoices_table.php` |
+| Snapshot file | `database/schema/{table}.sql` | `database/schema/invoices.sql` |
+
+---
+
+## 6. Environment variables
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Names | UPPER_SNAKE_CASE | `DB_HOST`, `NENE_INVOICE_PORT` |
+| Prefix | Product-specific compose overrides | `NENE_INVOICE_` |
+| Secrets | Never commit; document in `.env.example` only | — |
+
+---
+
+## 7. Tests
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Test class | `{ClassUnderTest}Test` | `CreateInvoiceUseCaseTest` |
+| Test method | `test_{behavior}_when_{condition}` | `test_rejects_missing_registration_number_when_qualified_invoice` |
+| Test namespace | Mirror `src/` under `tests/` | `tests/Invoice/CreateInvoiceUseCaseTest.php` |
+
+---
+
+## 8. MCP tools
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Tool `name` | Same as OpenAPI `operationId` | `listInvoices` |
+| Tool `title` | Short English Title Case | `List Invoices` |
+| `safety` | `read` or `write` | Prefer `read` until auth review passes |
+
+Catalog: `docs/mcp/tools.json`. Validate with `composer mcp`.
+
+---
+
+## 9. Frontend (Phase 2+)
+
+| Item | Rule |
+| --- | --- |
+| Components | PascalCase file and export |
+| Hooks | camelCase with `use` prefix |
+| API client | Maps snake_case JSON; do not rename API fields in transit |
+| Admin SPA | React + TypeScript strict mode |
+
+Full frontend standards: **`docs/development/frontend-standards.md`** (Phase 2).
+
+---
+
+## 10. Documentation and commits
+
+| Surface | Language | Naming |
+| --- | --- | --- |
+| Public docs, OpenAPI, API errors | English | Use glossary canonical terms |
+| Issues, PRs, commit bodies | Japanese allowed | Prefer glossary English term on first mention |
+| Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
+| ADR file | `NNNN-kebab-title.md` | `0002-separate-from-sibling-products.md` |
+
+When adding a new public term, update [`glossary.md`](../explanation/glossary.md) in the same PR.
+
+---
+
+## 11. Prohibited patterns
+
+- Layer-first folders (`src/Handlers/`, `src/Repositories/`)
+- SQL outside `Pdo*Repository`
+- camelCase in public JSON property names
+- Float or DECIMAL for money in SQLite tests or API JSON
+- Renaming shipped `operationId` values
+- Embedding billing logic in NeNe Records or other sibling repos
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Review checklists: [`docs/review/`](../review/).

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -1,0 +1,38 @@
+# Self-Review Checklist Policy
+
+NeNe Invoice uses self-review checklists before push or PR, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/self-review.md).
+
+## How to use
+
+1. Identify the work type.
+2. Open the matching checklist in `docs/review/`.
+3. Review every applicable item.
+4. Run the narrowest useful verification.
+5. Mention the checklist in the PR body.
+
+Example:
+
+```text
+Self-review: backend-api, openapi-contract
+```
+
+If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist items to pass review.
+
+## Checklist files
+
+| File | Use for |
+| --- | --- |
+| `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
+| `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
+| `database.md` | Migrations, repositories, soft delete |
+| `middleware-security.md` | Auth, CORS, logging, rate limits |
+| `docs-policy.md` | Workflow, ADRs, roadmap, Cursor rules |
+| `frontend.md` | **Phase 2 — not in repo yet.** Admin React/TypeScript |
+
+Do **not** use `frontend.md` until Phase 2 creates `frontend/`. Until then, skip that checklist or mark `N/A`.
+
+## AI agents
+
+Pick relevant checklists before finalizing changes. Do not claim an item passed if it was not checked.
+
+If no checklist matches, use `docs/workflow.md`, `docs/development/coding-standards.md`, and `docs/inheritance-from-nene2.md` directly.

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -1,0 +1,20 @@
+# Glossary
+
+Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments. Use these spellings consistently.
+
+| Term | Definition | Avoid |
+| --- | --- | --- |
+| **quote** | An estimate sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers (OK in UI copy) |
+| **invoice** | A billing document issued to a client; may be a qualified invoice (適格請求書) | "bill" |
+| **qualified invoice** | Japan invoice system compliant document with required fields and registration number | "適格請求書" in English API fields |
+| **client** | Customer / buyer organization or individual in the billing system | "customer" in code (OK in UI) |
+| **line item** | A single row on a quote or invoice (description, quantity, unit price) | "row", "detail line" |
+| **payment** | A recorded receipt against an invoice | "receipt" (reserved for PDF noun) |
+| **issuer** | The company that issues quotes and invoices (operator's company profile) | "seller" |
+| **registration number** | Japan invoice registration number (インボイス登録番号) | "T-number" alone without context |
+| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server tier" |
+| **Tier B** | Docker / VPS deployment | "cloud-only" |
+| **handler** | HTTP entry point class | "controller" |
+| **use case** | Business logic class with `execute()` | "service" (in UseCase sense) |
+
+Expanded definitions will follow in Issue #2 product documentation.

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -1,0 +1,90 @@
+# Inheritance from NENE2
+
+NeNe Invoice inherits engineering governance from [NENE2](https://github.com/hideyukiMORI/NENE2). This document is the source of truth for what is inherited, what is adapted, and what is NeNe Invoice–specific.
+
+## Relationship
+
+| Layer | Repository | Role |
+| --- | --- | --- |
+| Framework runtime | [NENE2](https://github.com/hideyukiMORI/NENE2) | HTTP runtime, DI, middleware, Problem Details, OpenAPI/MCP patterns |
+| Application platform | **NeNe Invoice** (this repo) | Quote, invoice, payment, client, PDF, admin UI |
+| Sibling products | [nene-records](https://github.com/hideyukiMORI/nene-records), [nene-corpus](https://github.com/hideyukiMORI/nene-corpus), [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Optional upstream HTTP integrations |
+| Reference trials | [NENE2-FT](https://github.com/hideyukiMORI/NENE2-FT) | Patterns and friction notes from field trials |
+
+NeNe Invoice is a **consumer project**, not a fork of NENE2. Framework code stays in NENE2; product code stays here.
+
+## Inherited by policy (same rules)
+
+These policies are adopted with the same intent as NENE2 and sibling NeNe products. Local copies live in this repository.
+
+| Topic | Local document |
+| --- | --- |
+| Issue-driven workflow | `docs/workflow.md` |
+| Conventional Commits | `docs/development/commit-conventions.md` |
+| Self-review before PR | `docs/development/self-review.md` |
+| ADR operation | `docs/development/adr.md` |
+| AI agent workflow | `docs/integrations/ai-tools.md`, `AGENTS.md` |
+| Cursor summaries | `.cursor/rules/` |
+
+## Inherited by reference (framework behavior)
+
+When implementing HTTP, middleware, validation, or error responses, follow NENE2 upstream docs unless NeNe Invoice records an explicit deviation in an ADR.
+
+| Topic | NENE2 upstream |
+| --- | --- |
+| HTTP runtime (PSR-7/15/17) | `docs/development/http-runtime.md` |
+| Middleware order and security | `docs/development/middleware-security.md` |
+| Request validation layers | `docs/development/request-validation.md` |
+| Problem Details errors | `docs/development/api-error-responses.md` |
+| Authentication boundaries | `docs/development/authentication-boundary.md` |
+| OpenAPI conventions | `docs/integrations/openapi.md` |
+| MCP tool policy | `docs/integrations/mcp-tools.md`, `docs/explanation/why-mcp.md` |
+| Database adapter boundaries | `docs/development/database-migrations.md` |
+| Domain / use case layering | `docs/development/domain-layer.md` |
+
+Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs/` as the framework reference during development.
+
+## Adapted for NeNe Invoice
+
+| Topic | NeNe Invoice choice |
+| --- | --- |
+| Product goal | API-first quote and invoice platform (not general accounting) |
+| Public Problem Details base URL | `https://nene-invoice.dev/problems/` |
+| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + billing additions |
+| Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
+| Monetary values | Integer **cents** in DB and JSON; no floats |
+| Language policy | English for public docs, OpenAPI, API error metadata; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
+| Review checklists | `docs/review/` — task-specific lists for this product |
+
+## NeNe Invoice–specific (not inherited)
+
+Record these in ADRs or product docs when they stabilize:
+
+- Client / quote / invoice / payment domain model
+- Japan qualified invoice (適格請求書) field validation rules
+- PDF generation strategy (server-side, no client-side tax calculation)
+- Admin frontend vs public document download boundaries
+- MCP tool catalog for billing operations
+- Release versioning of the NeNe Invoice product (`v0.x` until first stable API)
+
+## When upstream and local docs conflict
+
+1. Update the **local source-of-truth doc** in this repository first.
+2. If the conflict is about **framework behavior**, prefer NENE2 upstream unless an ADR documents a deliberate deviation.
+3. Keep `.cursor/rules/` as a short summary; do not duplicate full policy text there.
+
+## Verification commands (once runtime is scaffolded)
+
+NeNe Invoice should expose the same quality gates as NENE2 consumer projects:
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+When `frontend/` exists:
+
+```bash
+npm run check --prefix frontend
+```

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -1,0 +1,39 @@
+# AI Tools Policy
+
+NeNe Invoice inherits NENE2 AI integration principles with billing-specific boundaries.
+
+## Agent entry
+
+- `AGENTS.md` — read first
+- `CLAUDE.md` — quick rules
+- `.cursor/rules/` — Cursor summaries
+
+## MCP boundary
+
+- MCP tools map to **OpenAPI HTTP operations** only.
+- MCP is for **operators and development agents**, not public document download clients.
+- Do not add tools that read the database directly or execute shell commands without Issue + security review.
+- Write tools (create invoice, mark paid) require auth review before catalog publication.
+
+Validate catalog:
+
+```bash
+composer mcp
+```
+
+## Secrets in agent sessions
+
+Agents must not commit:
+
+- `.env` files
+- Admin JWT secrets
+- Production upstream URLs with embedded credentials
+- SMTP passwords
+
+## Cross-repo work
+
+- CMS or catalog API gaps → Issue in **nene-records**, not workarounds here.
+- Lead capture API gaps → Issue in **nene-concierge**.
+- Framework bugs → Issue in **NENE2**.
+
+See also: `docs/integrations/sibling-products.md`, ADR 0002.

--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -1,0 +1,44 @@
+# Sibling Product Integration
+
+NeNe Invoice integrates with other NeNe ecosystem products **via HTTP only**. See ADR 0002.
+
+## Dependency direction
+
+```
+NeNe Invoice  →  HTTP  →  NeNe Records / NeNe Concierge / NeNe Corpus (optional)
+```
+
+Never embed NeNe Invoice code in sibling repositories. Never share databases.
+
+## Planned integrations
+
+| Sibling | Direction | Use case | Phase |
+| --- | --- | --- | --- |
+| **NeNe Records** | Invoice → Records (read) | Import product names and prices for line items | Phase 4+ |
+| **NeNe Concierge** | Concierge → Invoice (write via webhook/API) | Create draft client or quote from scenario lead capture | Phase 4+ |
+| **NeNe Corpus** | None required | No default integration | — |
+
+## Environment variables (planned)
+
+Document in `.env.example` when clients land:
+
+| Variable | Purpose |
+| --- | --- |
+| `NENE_RECORDS_API_BASE_URL` | Optional product catalog upstream |
+| `NENE_RECORDS_BEARER_TOKEN` | Read-only token for Records API |
+| `NENE_CONCIERGE_WEBHOOK_SECRET` | Verify inbound lead webhooks |
+
+## Implementation rules
+
+- HTTP clients live in `src/Upstream/`.
+- UseCases depend on interfaces, not concrete HTTP clients.
+- Upstream failures must degrade gracefully (local manual entry always available).
+- Contract tests when upstream OpenAPI is stable.
+
+## Reporting bugs
+
+| Symptom | Open Issue in |
+| --- | --- |
+| Missing Records catalog API | nene-records |
+| Concierge action node needs Invoice endpoint | nene-concierge (or here if Invoice API is the deliverable) |
+| NENE2 middleware / Problem Details | NENE2 |

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -1,0 +1,26 @@
+# Milestone: Governance and Foundation (2026-05)
+
+Goal: establish NeNe Invoice engineering discipline inherited from NENE2 and sibling NeNe products before billing features grow.
+
+**Status: in progress**
+
+> **Workflow note:** Phase 0 governance lands via Issue #1 → branch → PR → merge. All subsequent work uses the same pattern.
+
+## Acceptance Criteria
+
+- [x] GitHub repository created (`hideyukiMORI/nene-invoice`)
+- [ ] `docs/inheritance-from-nene2.md` documents local vs upstream rules
+- [ ] `docs/workflow.md` and commit conventions in place
+- [ ] `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` exist
+- [ ] `.cursor/rules/` summaries for always-on agent guidance
+- [ ] `docs/review/` initial self-review checklists
+- [ ] ADR 0001 and ADR 0002 accepted
+- [ ] `docs/roadmap.md`, `docs/todo/current.md` initialized
+- [ ] Product vision documented (Issue #2)
+- [ ] `composer check` green on `main` (runtime scaffold — follow-up Issue)
+
+## Follow-up Milestone
+
+Phase 0+ — NENE2 runtime scaffold, health endpoint, OpenAPI stub, CI.
+
+Then Phase 1 — Core billing API (clients, quotes, invoices, payments).

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,0 +1,18 @@
+# Backend API Self-Review
+
+Use for handlers, use cases, validation, routes, and HTTP behavior.
+
+Source policies: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`, `docs/inheritance-from-nene2.md`.
+
+## Checklist
+
+- [ ] Change has a linked GitHub Issue; commit subject includes `(#issue)`.
+- [ ] Handler stays thin: parse → DTO → UseCase → response.
+- [ ] Business rules live in UseCase, not Handler or Repository.
+- [ ] Money fields use integer cents — no floats.
+- [ ] Japan invoice validation rules enforced in UseCase before persistence/PDF.
+- [ ] New routes documented in OpenAPI with `operationId`.
+- [ ] Problem Details used for errors; no stack traces in responses.
+- [ ] Admin mutating routes require auth when applicable.
+- [ ] Tests cover happy path and at least one failure case.
+- [ ] `composer check` or narrowest equivalent run and noted in PR.

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,0 +1,16 @@
+# Database Self-Review
+
+Use for migrations, repositories, and schema changes.
+
+Source policies: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`.
+
+## Checklist
+
+- [ ] Migration file name follows `YYYYMMDDHHMMSS_snake_description.php`.
+- [ ] Table names plural snake_case; money columns use `*_cents` integer.
+- [ ] Foreign keys named `{entity}_id`.
+- [ ] SQL only in `Pdo*Repository` classes.
+- [ ] Schema snapshot updated under `database/schema/` when applicable.
+- [ ] Soft delete columns consistent (`is_deleted`, `deleted_at`) unless ADR says otherwise.
+- [ ] Repository tests use SQLite in-memory PDO.
+- [ ] Rollback considered for destructive migrations.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -1,0 +1,27 @@
+# Documentation and Policy Self-Review
+
+Use for policy docs, workflow docs, ADRs, roadmap updates, TODO updates, and Cursor rules.
+
+Source policies:
+
+- `docs/workflow.md`
+- `docs/development/adr.md`
+- `docs/inheritance-from-nene2.md`
+- `docs/explanation/glossary.md`
+- `docs/development/naming-conventions.md`
+- `docs/todo/current.md`
+- `docs/roadmap.md`
+
+## Checklist
+
+- [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
+- [ ] `docs/roadmap.md` or `docs/todo/current.md` updated when project state changed.
+- [ ] Major architecture decisions considered whether an ADR is needed.
+- [ ] NENE2 inheritance changes reflected in `docs/inheritance-from-nene2.md`.
+- [ ] Public source-of-truth docs and OpenAPI text remain English unless policy allows otherwise.
+- [ ] Cursor rules stay concise; full policy not duplicated in `.cursor/rules/`.
+- [ ] Issue and PR references included where useful.
+- [ ] Wording is concrete enough for humans and AI agents to follow.
+- [ ] English docs use canonical terms from `docs/explanation/glossary.md`.
+- [ ] New public terms added to glossary and/or `naming-conventions.md` when introduced.
+- [ ] `git diff --check` reviewed for whitespace errors.

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -1,0 +1,15 @@
+# Frontend Self-Review
+
+**Status:** Phase 2 — not implemented yet.
+
+When `frontend/` exists, use this checklist for React/TypeScript admin UI changes.
+
+## Checklist (placeholder)
+
+- [ ] TypeScript strict mode passes.
+- [ ] API client uses snake_case fields without renaming.
+- [ ] UI strings in locale catalogs.
+- [ ] Admin JWT not stored in localStorage without documented threat model.
+- [ ] `npm run check --prefix frontend` passes.
+
+Until Phase 2, mark `N/A` in PRs.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -1,0 +1,15 @@
+# Middleware and Security Self-Review
+
+Use for auth, CORS, logging, rate limits, and security-sensitive changes.
+
+Source policies: NENE2 middleware docs, `docs/integrations/ai-tools.md`.
+
+## Checklist
+
+- [ ] Secrets not logged (JWT, SMTP password, upstream bearer tokens).
+- [ ] Admin JWT not exposed to public document download routes.
+- [ ] CORS config explicit — no `*` in production paths.
+- [ ] Auth middleware on admin mutating routes.
+- [ ] PDF download tokens time-limited or scoped when public.
+- [ ] No sensitive data in Problem Details `detail` for production.
+- [ ] MCP write tools reviewed for auth and audit requirements.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,0 +1,16 @@
+# OpenAPI Contract Self-Review
+
+Use for OpenAPI schema changes, examples, and contract tests.
+
+Source policies: `docs/development/naming-conventions.md`, NENE2 OpenAPI conventions.
+
+## Checklist
+
+- [ ] Every new route has `operationId` in camelCase — stable after release.
+- [ ] Request/response schemas use snake_case property names.
+- [ ] Money fields documented as integer cents with description.
+- [ ] Success and Problem Details responses documented.
+- [ ] Examples included for non-trivial endpoints.
+- [ ] `composer openapi` passes.
+- [ ] MCP catalog updated when ops-facing endpoints change (`composer mcp`).
+- [ ] Public text (summary, description) is English.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,71 @@
+# Roadmap
+
+NeNe Invoice is a self-hosted quote and invoice OSS on NENE2 — Japan SMB billing without SaaS lock-in.
+
+## North Star
+
+Operators can self-host a billing platform that:
+
+- manages clients and company issuer profile
+- creates quotes and converts them to invoices
+- issues Japan qualified invoice (適格請求書) compliant PDFs
+- tracks payment status and overdue items
+- runs on **Tier A** shared hosting or **Tier B** Docker/VPS
+- optionally integrates with NeNe Records and NeNe Concierge via HTTP
+
+Detailed product scope: [`docs/explanation/product-vision.md`](./explanation/product-vision.md) (Issue #2).
+
+## Phase 0: Governance and Foundation
+
+Goal: engineering discipline before product features grow.
+
+- Governance docs, ADR 0001/0002, inheritance map
+- Product vision and requirements documentation
+- NENE2 consumer scaffold, `GET /health`, OpenAPI, CI
+- Cursor rules and self-review checklists
+
+Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
+
+**Status: in progress (2026-05-29).**
+
+## Phase 1: Core Billing API
+
+Goal: client master, quotes, invoices, payments — API and DB only.
+
+- `clients`, `quotes`, `invoices`, `line_items`, `payments`, `company_settings` schema
+- Japan invoice field validation in UseCases
+- Admin JWT auth
+- OpenAPI + PHPUnit
+
+## Phase 2: Admin UI + PDF
+
+Goal: operators manage billing without CLI.
+
+- React admin SPA
+- Server-side qualified invoice PDF generation
+- Email invoice delivery (SMTP)
+
+## Phase 3: Tier A Shared Hosting
+
+Goal: Japan SMB install path.
+
+- Web installer + release ZIP
+- Operator documentation
+- Same-origin admin on shared hosting
+
+## Phase 4: Ecosystem Integration
+
+Goal: connect to sibling products.
+
+- NeNe Records product catalog import
+- NeNe Concierge lead → draft quote webhook
+- MCP tool catalog for billing operations
+
+## Non-goals (summary)
+
+See product vision for full list. Short version:
+
+- Not full double-entry accounting
+- Not payroll or expense reimbursement
+- Not a WordPress plugin
+- Not embedded inside NeNe Records

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,0 +1,36 @@
+# Current Work
+
+Last updated: 2026-05-29
+
+## Active
+
+| Issue | Branch | Topic | Status |
+| --- | --- | --- | --- |
+| #1 | `docs/1-governance-foundation` | Governance and foundation docs | 🔄 PR pending |
+| #2 | — | Product vision and requirements | 🔲 next |
+
+## Phase 0 Backlog (Issues to create after #1 merges)
+
+| Priority | Topic | Notes |
+| --- | --- | --- |
+| P0 | NENE2 runtime scaffold + health endpoint | composer.json, docker compose, GET /health |
+| P0 | OpenAPI stub + MCP catalog | docs/openapi/openapi.yaml, docs/mcp/tools.json |
+| P0 | Backend CI workflow | GitHub Actions — PHPUnit, PHPStan, OpenAPI |
+| P1 | ADR 0003 dual deployment strategy | Tier A / Tier B — follow Corpus/Concierge pattern |
+
+## State Summary
+
+**Phase 0 — Governance: in progress**
+
+- GitHub repository created: `hideyukiMORI/nene-invoice`
+- Issue #1: governance initialization
+- Issue #2: product vision (queued)
+
+No runtime code yet. `composer check` lands with scaffold Issue.
+
+## Handoff Notes
+
+- Namespace: `NeneInvoice\`
+- Problem Details base: `https://nene-invoice.dev/problems/`
+- Money: integer cents everywhere
+- Sibling boundary: ADR 0002 — HTTP only, no shared DB

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,74 @@
+# Workflow
+
+NeNe Invoice uses GitHub Issues for work tracking and local Markdown for project memory. This workflow inherits [NENE2 `docs/workflow.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md) with the substitutions below.
+
+See also: `docs/inheritance-from-nene2.md`.
+
+## Standard Flow
+
+1. Create or reuse a focused GitHub Issue.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+3. Create a branch from `main` named like `type/issue-number-summary`.
+4. Implement the smallest useful change.
+5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
+6. Review the relevant self-review checklist in `docs/review/`.
+7. Run the narrowest meaningful verification available.
+8. Commit with Conventional Commits and include the Issue number.
+9. Push the branch and create a PR linked to the Issue.
+10. Merge after review and checks.
+11. Return local `main` to the merged, clean state.
+
+## Branch Names
+
+Use Conventional Commit style as the prefix:
+
+- `docs/1-governance-foundation`
+- `feat/5-client-crud`
+- `fix/12-tax-rate-validation`
+- `test/8-invoice-pdf-generation`
+
+## PR Requirements
+
+Every PR should include:
+
+- purpose
+- change summary
+- verification results
+- self-review checklist used, when applicable
+- related Issue, preferably `Closes #number`
+- remaining risks or follow-up work
+
+Do not commit directly to `main`.
+
+## Local Project Memory
+
+- `docs/roadmap.md`: long-lived direction and phases
+- `docs/milestones/`: medium-sized goals and acceptance criteria
+- `docs/todo/current.md`: current task board and handoff notes
+- `docs/adr/`: major architecture decisions
+- `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
+
+Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.
+
+Use ADRs for decisions that affect architecture, public contracts, dependency choices, or long-term maintenance. See `docs/development/adr.md`.
+
+Use self-review checklists before push or PR. See `docs/development/self-review.md`.
+
+## AI Agent Responsibilities
+
+AI agents should manage the normal lifecycle when asked to complete work:
+
+- create or reuse the Issue
+- create the Issue branch
+- read `AGENTS.md` and relevant docs before editing
+- edit only relevant files
+- review relevant self-review checklists
+- verify the change
+- commit, push, open PR, merge, and sync `main`
+- update local docs that describe project state
+
+If a user explicitly says investigation only, no commit, no PR, or another narrower scope, follow that instruction.
+
+## Initial Issues Backlog
+
+Phase 0 bootstrap Issues are tracked in `docs/todo/current.md`. After governance lands, use GitHub Issues for all work — no direct `main` commits.


### PR DESCRIPTION
## Summary

- Initialize NeNe Invoice repository with governance inherited from NENE2 and sibling NeNe products (Records, Corpus, Concierge)
- Add workflow, commit conventions, naming conventions, backend standards, self-review checklists, ADRs 0001/0002
- Add AGENTS.md, CLAUDE.md, Cursor rules, roadmap/todo/milestone placeholders

## Test plan

- [x] All governance docs present and internally consistent
- [x] ADR 0001 and 0002 accepted

Self-review: docs-policy

Closes #1

Made with [Cursor](https://cursor.com)