### PR TITLE
docs(product): プロダクトビジョン・要件・ドメインモデルを文書化する (#3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This file is the entry point for AI agents working on NeNe Invoice.
 
 - **Current work & status:** `docs/todo/current.md`
 - **Product vision:** `docs/explanation/product-vision.md`
+- **Requirements:** `docs/explanation/requirements.md`
+- **Domain model:** `docs/explanation/domain-model.md`
 - **Glossary:** `docs/explanation/glossary.md`
 - **Naming conventions:** `docs/development/naming-conventions.md`
 - Inheritance map: `docs/inheritance-from-nene2.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@ Ops / MCP         ──→         │
 
 | フェーズ | 状態 |
 | --- | --- |
-| Phase 0 ガバナンス | 🔄 進行中（Issue #1） |
-| Phase 0+ プロダクト設計 | 🔲 Issue #2 以降 |
-| Phase 1 ランタイム scaffold | 🔲 未着手 |
+| Phase 0 ガバナンス | ✅ 完了（Issue #1） |
+| Phase 0 プロダクト設計 | 🔄 Issue #3 PR 待ち |
+| Phase 0+ ランタイム scaffold | 🔲 Issue #4 以降 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,94 @@
 # NeNe Invoice
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
 
-**Self-hosted quote and invoice management for Japan SMB — built on [NENE2](https://github.com/hideyukiMORI/NENE2).**
+**Quote, invoice, and payment tracking for Japan SMB — self-hosted on your stack.**
 
-NeNe Invoice is an open-source billing platform: create quotes, issue invoice-compliant PDFs, track payments, and operate everything on infrastructure you control — without a monthly SaaS subscription.
+NeNe Invoice is an open-source billing platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). Create quotes, issue **qualified invoice** (適格請求書) PDFs, track payments, and run everything on shared hosting or Docker — without a monthly SaaS fee.
 
-> **Status:** Phase 0 — governance and product design. Runtime scaffold follows in Phase 0+ Issues.
+> **Example operator:** an office manager on shared hosting issues invoice-compliant PDFs from admin UI instead of Excel + manual PDF — see [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md#primary-persona).
 
-## Goals (summary)
+## Goals
 
-- **Japan invoice compliance** — qualified invoice (適格請求書) fields, tax rates, registration number
-- **Self-hosted OSS** — MIT licensed; shared hosting (Tier A) or Docker/VPS (Tier B)
-- **Quote-to-cash flow** — estimate → invoice → payment tracking
-- **Sibling to NeNe ecosystem** — HTTP integration with Records, Concierge, Corpus; never merged into CMS
+- **Japan invoice compliance** — registration number, tax rates, qualified invoice PDF fields
+- **Self-hosted OSS** — MIT licensed; Tier A shared hosting or Tier B Docker/VPS
+- **Quote-to-cash** — estimate → invoice → payment in one product
+- **Sibling to NeNe ecosystem** — optional HTTP link to Records / Concierge; never merged into CMS
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
+
+## Quick Start
+
+**Status:** Phase 0 — product design complete; runtime scaffold in progress (Issue #4).
+
+```bash
+git clone https://github.com/hideyukiMORI/nene-invoice.git
+cd nene-invoice
+# docker compose up — lands with Issue #4
+```
+
+## Architecture (planned)
+
+```
+Admin UI (React)  ──→  NeNe Invoice API (NENE2)  ──→  MySQL
+Ops / MCP           ──→         │
+                                ↓ HTTP (optional)
+                    NeNe Records / NeNe Concierge
+```
+
+- **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository
+- **Money**: integer cents everywhere — no floats
+- **PDF**: server-side qualified invoice generation
+- **Deploy**: Tier A (shared hosting) + Tier B (Docker) — ADR 0003 planned
+
+## Current Status
+
+| Phase | Scope | Status |
+| --- | --- | --- |
+| 0 | Governance + product docs | ✅ |
+| 0+ | Runtime scaffold, OpenAPI, CI | 🔲 Issues #4–#7 |
+| 1 | Core billing API | 🔲 Planned |
+| 2 | Admin UI + PDF | 🔲 Planned |
+| 3 | Tier A shared hosting | 🔲 Planned |
+
+See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
+
+## Non-goals
+
+- Not full accounting / general ledger
+- Not payroll or expense reimbursement
+- Not inventory or POS
+- Not a WordPress plugin
+- Not embedded inside NeNe Records
+
+Full list: [`docs/explanation/product-vision.md#non-goals`](./docs/explanation/product-vision.md#non-goals)
 
 ## Documentation
 
 | Topic | Document |
 | --- | --- |
-| **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
+| **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
+| **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
+| **Domain model** | [`docs/explanation/domain-model.md`](./docs/explanation/domain-model.md) |
 | **Glossary** | [`docs/explanation/glossary.md`](./docs/explanation/glossary.md) |
-| **Product vision** | Issue #2 (in progress) |
-| **Naming conventions** | [`docs/development/naming-conventions.md`](./docs/development/naming-conventions.md) |
-| **NENE2 inheritance** | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
+| **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | **Workflow** | [`docs/workflow.md`](./docs/workflow.md) |
-| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) |
-| **Current work** | [`docs/todo/current.md`](./docs/todo/current.md) |
 
 ## Ecosystem
 
-```
-NENE2 (framework)
-  ├── NeNe Records   (CMS · optional product catalog upstream)
-  ├── NeNe Corpus    (knowledge chat — optional)
-  ├── NeNe Concierge (scenario chat · lead capture upstream)
-  └── NeNe Invoice   (quote · invoice · payment — this repo)
-```
+Part of the [hideyukiMORI NeNe portfolio](https://github.com/hideyukiMORI):
 
-Integration is **HTTP-only**. NeNe Invoice never shares databases with sibling products.
+| Product | Role |
+| --- | --- |
+| [NENE2](https://github.com/hideyukiMORI/NENE2) | Framework runtime |
+| [nene-records](https://github.com/hideyukiMORI/nene-records) | CMS · optional product catalog |
+| [nene-corpus](https://github.com/hideyukiMORI/nene-corpus) | Knowledge chat |
+| [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Scenario chat · optional leads |
+| **nene-invoice** | Quote · invoice · payment (this repo) |
 
 ## Contributing
 
-See [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md). All work is Issue-driven; do not commit directly to `main`.
+Issue-driven development — see [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -1,0 +1,167 @@
+# Domain Model
+
+NeNe Invoice domain overview — entities, relationships, and state machines. Implementation follows Handler → UseCase → Repository layering.
+
+See also: [`requirements.md`](./requirements.md), [`glossary.md`](./glossary.md).
+
+---
+
+## Entity relationship (MVP)
+
+```mermaid
+erDiagram
+    company_settings ||--o{ quote : "issuer"
+    company_settings ||--o{ invoice : "issuer"
+    client ||--o{ quote : "buyer"
+    client ||--o{ invoice : "buyer"
+    quote ||--o| invoice : "converts_to"
+    quote ||--|{ line_item : "has"
+    invoice ||--|{ line_item : "has"
+    invoice ||--o{ payment : "receives"
+```
+
+- **company_settings**: singleton per organization (Phase 1 single-tenant; multi-tenant adds `organization_id`).
+- **line_item**: polymorphic parent — `parent_type` + `parent_id` (`quote` or `invoice`).
+- **payment**: always linked to one invoice; partial payments sum to `amount_cents` on invoice.
+
+---
+
+## Quote state machine
+
+```
+                    ┌──────────┐
+                    │  draft   │
+                    └────┬─────┘
+                         │ finalize / send
+                         ▼
+                    ┌──────────┐
+         ┌──────────│   sent   │──────────┐
+         │          └────┬─────┘          │
+         │ reject        │ accept         │ valid_until passed
+         ▼               ▼                ▼
+    ┌──────────┐   ┌──────────┐     ┌──────────┐
+    │ rejected │   │ accepted │     │ expired  │
+    └──────────┘   └────┬─────┘     └──────────┘
+                        │ convert_to_invoice
+                        ▼
+                   (creates invoice)
+```
+
+**Rules:**
+
+- Only `draft` quotes are freely editable.
+- `sent` quotes: line items locked; status transitions only.
+- Only `accepted` quotes may convert to invoice (UseCase validates).
+
+---
+
+## Invoice state machine
+
+```
+                    ┌──────────┐
+                    │  draft   │
+                    └────┬─────┘
+                         │ issue (generates number, locks fields)
+                         ▼
+                    ┌──────────┐
+         ┌──────────│  issued  │────────────────┐
+         │          └────┬─────┘                │
+         │               │ record payment       │ due_at < today
+         │               ▼                      ▼
+         │     ┌──────────────────┐        ┌──────────┐
+         │     │ partially_paid   │        │ overdue  │ (computed flag)
+         │     └────────┬─────────┘        └──────────┘
+         │              │ full payment
+         │              ▼
+         │         ┌──────────┐
+         └────────►│   paid   │
+                   └──────────┘
+```
+
+**Rules:**
+
+- `issued` invoices: line items and tax totals immutable (credit notes = Phase 4+).
+- `paid` when sum(payments.amount_cents) >= invoice.total_cents.
+- `overdue`: computed when status is `issued` or `partially_paid` and `due_at < now`.
+
+---
+
+## Tax calculation (UseCase)
+
+Single source of truth for API and PDF:
+
+```
+For each line_item:
+  line_subtotal_cents = quantity * unit_price_cents
+  line_tax_cents = round(line_subtotal_cents * tax_rate_bps / 10000)
+
+Group by tax_rate_bps:
+  taxable_amount_cents[rate] += line_subtotal_cents
+  tax_cents[rate] += line_tax_cents
+
+subtotal_cents = sum(line_subtotal_cents)
+tax_cents = sum(line_tax_cents)
+total_cents = subtotal_cents + tax_cents
+```
+
+Rounding: half-up to integer cents per line (document choice — record in ADR when implementing).
+
+---
+
+## Document numbering
+
+| Document | Pattern | Example |
+| --- | --- | --- |
+| Quote | `{prefix}{year}-{seq:03d}` | `EST-2026-001` |
+| Invoice | `{prefix}{year}-{seq:03d}` | `INV-2026-001` |
+
+Sequences scoped per organization and year. Stored in `document_sequences` table (Phase 1).
+
+---
+
+## PDF generation boundary
+
+```
+UseCase (calculates totals, validates qualified fields)
+    ↓ InvoicePdfInput DTO
+Pdf/InvoicePdfGenerator (infrastructure — TCPDF or similar)
+    ↓ bytes
+Handler (Content-Type: application/pdf)
+```
+
+UseCase never calls PDF library directly. Handler never recalculates tax.
+
+---
+
+## Planned modules (`src/`)
+
+| Module | Responsibility |
+| --- | --- |
+| `Company/` | Issuer profile settings |
+| `Client/` | Buyer master |
+| `Quote/` | Quote CRUD, status transitions |
+| `Invoice/` | Invoice CRUD, issue, convert from quote |
+| `LineItem/` | Shared line item attach/detach |
+| `Payment/` | Payment recording |
+| `Pdf/` | PDF rendering adapters |
+| `DocumentSequence/` | Auto-number generation |
+| `AdminAuth/` | JWT login |
+| `Upstream/` | Optional Records / Concierge HTTP clients |
+
+---
+
+## Integration touchpoints (Phase 4+)
+
+| Event | Direction | Action |
+| --- | --- | --- |
+| Concierge lead captured | Concierge → Invoice | POST webhook creates `client` draft + optional `quote` draft |
+| Records product selected | Invoice → Records | GET catalog item → prefill line_item description and unit_price_cents |
+| Invoice issued | Invoice → external | Webhook or email (SMTP) — no sibling required |
+
+---
+
+## Related
+
+- Requirements: [`requirements.md`](./requirements.md)
+- Backend standards: [`../development/backend-standards.md`](../development/backend-standards.md)
+- ADR 0002: [`../adr/0002-separate-from-sibling-products.md`](../adr/0002-separate-from-sibling-products.md)

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -1,20 +1,24 @@
 # Glossary
 
-Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments. Use these spellings consistently.
+Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments.
 
 | Term | Definition | Avoid |
 | --- | --- | --- |
-| **quote** | An estimate sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers (OK in UI copy) |
-| **invoice** | A billing document issued to a client; may be a qualified invoice (適格請求書) | "bill" |
-| **qualified invoice** | Japan invoice system compliant document with required fields and registration number | "適格請求書" in English API fields |
-| **client** | Customer / buyer organization or individual in the billing system | "customer" in code (OK in UI) |
-| **line item** | A single row on a quote or invoice (description, quantity, unit price) | "row", "detail line" |
-| **payment** | A recorded receipt against an invoice | "receipt" (reserved for PDF noun) |
-| **issuer** | The company that issues quotes and invoices (operator's company profile) | "seller" |
-| **registration number** | Japan invoice registration number (インボイス登録番号) | "T-number" alone without context |
-| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server tier" |
-| **Tier B** | Docker / VPS deployment | "cloud-only" |
+| **quote** | An estimate (見積書) sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers |
+| **invoice** | A billing document (請求書) issued to a client | "bill" |
+| **qualified invoice** | Japan invoice system compliant document (適格請求書) with required issuer, tax, and registration fields | mixing Japanese in API field names |
+| **issuer** | The operator's company that issues quotes and invoices (自社) | "seller", "supplier" in code |
+| **client** | Customer / buyer (取引先) in the billing system | "customer" in code identifiers |
+| **line item** | A single row on a quote or invoice (品名, quantity, unit price, tax rate) | "row", "detail" |
+| **payment** | A recorded receipt against an invoice (入金) | "receipt" (PDF noun) |
+| **registration number** | Japan invoice registration number (インボイス登録番号), format `T` + 13 digits | "T-number" without context |
+| **tax rate bps** | Tax rate in basis points (1000 = 10.00%, 800 = 8.00%) | float percentages in DB |
+| **quote-to-cash** | Flow from estimate through invoice to payment | "order-to-cash" (ERP term) |
+| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server" in code |
+| **Tier B** | Docker / VPS deployment | "cloud tier" |
 | **handler** | HTTP entry point class | "controller" |
-| **use case** | Business logic class with `execute()` | "service" (in UseCase sense) |
+| **use case** | Business logic class with `execute()` | "service" (UseCase sense) |
+| **sync PDF download** | Single HTTP response returning PDF bytes | "streaming PDF" |
+| **overdue** | Invoice past `due_at` with unpaid balance — computed status | stored status in Phase 1 (optional) |
 
-Expanded definitions will follow in Issue #2 product documentation.
+When adding terms, update this table in the same PR.

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -1,0 +1,144 @@
+# Product Vision
+
+NeNe Invoice is a self-hosted quote and invoice platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). This document records why the product exists, what it optimizes for, and how it relates to the NeNe ecosystem.
+
+## Origin
+
+Every Japan SMB must issue **qualified invoices** (適格請求書) under the invoice system (インボイス制度). SaaS accounting tools (freee, Money Forward, Yayoi) solve this well but charge recurring fees and hold financial data on vendor infrastructure. Many micro-businesses on **shared hosting** already run their website on the same server — they want billing documents without another monthly subscription.
+
+NeNe Invoice offers an alternative: **run quote and invoice management on infrastructure you control**, with source code you can audit, and optional integration with sibling NeNe products for catalog and lead capture.
+
+The product showcases NENE2's strengths — OpenAPI-first APIs, Clean Architecture, MCP-ready ops boundaries, and field-trial-grade security — in a **back-office application** every SMB needs, not a demo endpoint.
+
+## North Star
+
+Operators and AI agents can:
+
+- register company issuer profile (name, address, invoice registration number, bank details)
+- manage **clients** (buyers) with billing addresses
+- create **quotes** (見積書) with line items and tax breakdown
+- convert accepted quotes to **invoices** (請求書) with one action
+- issue **qualified invoice** PDFs that meet Japan invoice system requirements
+- record **payments** and see overdue / unpaid status at a glance
+- optionally import product names from [NeNe Records](https://github.com/hideyukiMORI/nene-records) or create draft clients from [NeNe Concierge](https://github.com/hideyukiMORI/nene-concierge) leads
+- operate all of the above via admin UI, REST API, or MCP tools
+
+Operators keep financial document data on their stack. End clients receive PDF or email — they never need an account.
+
+NeNe Invoice is **not** a PHP framework. It is a **product** that consumes NENE2.
+
+## Target Operators and Markets
+
+**Primary — Japan SMB on Tier A shared hosting**
+
+Companies with 1–20 staff who already pay for shared hosting (Xserver, Sakura, Lolipop, etc.) and find SaaS accounting monthly fees heavy. A general-affairs or accounting staff member — often not an engineer — manages invoices today in Excel or paper. After Phase 3, they should install via **web installer**, enter company registration number, create clients and invoices from admin UI — without Docker or CLI.
+
+**Secondary — Tier B developers and VPS operators**
+
+Docker Compose for local development and production. Same API and admin UI as Tier A.
+
+**Multi-tenant hosting operators (later)**
+
+Agencies running one NeNe Invoice instance for multiple client organizations — same pattern as NeNe Records / Concierge multi-tenancy.
+
+## Primary Persona
+
+A fictional but representative operator:
+
+> A **regional food ingredient wholesaler** with 8 employees runs its website on shared hosting. The **office manager** creates quotes in Excel, converts to PDF manually, and tracks payments in a spreadsheet. Since the invoice system started, they must include registration numbers and correct tax rates on every document. freee is ¥1,980/month — leadership prefers a **one-time setup on existing hosting** plus no recurring SaaS. After Phase 3, they install NeNe Invoice beside their WordPress site, enter clients once, issue qualified invoice PDFs from admin UI, and email them — paying only for hosting they already have.
+
+The same pattern applies to **small manufacturers**, **creative agencies**, **equipment dealers**, and any B2B SMB that quotes before invoicing.
+
+## Primary Use Case
+
+NeNe Invoice optimizes for **quote-to-cash for B2B SMB**:
+
+1. Operator registers **issuer profile** (自社情報 + インボイス登録番号).
+2. Operator adds **clients** (取引先).
+3. Operator creates a **quote** with line items (品名, 数量, 単価, 税率).
+4. Client accepts → operator converts quote to **invoice** (請求書).
+5. System generates **qualified invoice PDF** with required fields.
+6. Operator sends PDF by email or download link.
+7. Client pays → operator records **payment** → invoice marked paid.
+
+**Not the primary story:** full double-entry bookkeeping, payroll, expense reimbursement, inventory, or POS. Those belong to other products or Phase 4+ integrations.
+
+## Dual Deployment (planned — ADR 0003)
+
+Same codebase, two installation paths:
+
+| Tier | Path | Admin access |
+| --- | --- | --- |
+| **Tier A — shared hosting** | Release ZIP + web installer + MySQL | Browser admin SPA |
+| **Tier B — Docker / VPS** | `docker compose up` | Browser admin SPA |
+
+## Philosophy
+
+### 1. Quote-to-cash, not full accounting
+
+NeNe Invoice owns the document flow from estimate to payment tracking. It does not replace a tax accountant or ERP. Export to CSV for accounting software is a Phase 2+ feature, not day-one scope.
+
+### 2. Japan invoice compliance as first-class data
+
+Qualified invoice fields are validated at the API layer — not optional PDF templates. Registration number format, tax rate (10% / 8%), reduced-rate flags, and issuer/buyer identification are domain rules in UseCases.
+
+### 3. Integer cents everywhere
+
+All amounts stored and transmitted as integer cents. No floats in database or JSON. PDF rendering uses the same cents values the API calculated.
+
+### 4. Self-hosted OSS first
+
+MIT license. Operators control data. SMTP for email delivery uses operator-provided credentials — no vendor mail relay required.
+
+### 5. MCP for operators, not for clients
+
+MCP tools map to admin API operations ("list overdue invoices", "create quote for client X"). Client-facing PDF download uses tokenized URLs — not MCP.
+
+### 6. Separation from sibling products
+
+NeNe Records owns CMS content. NeNe Corpus owns knowledge chat. NeNe Concierge owns scenario chat. NeNe Invoice owns billing documents. Integration is HTTP-only — ADR 0002.
+
+```
+NENE2 (framework)
+  ├── NeNe Records   (CMS · optional product catalog upstream)
+  ├── NeNe Corpus    (knowledge chat — no default link)
+  ├── NeNe Concierge (scenario chat · optional lead upstream)
+  └── NeNe Invoice   (quote · invoice · payment — this repo)
+```
+
+## Comparison
+
+| Aspect | SaaS accounting (freee/MF) | Excel + manual PDF | NeNe Invoice |
+| --- | --- | --- | --- |
+| License / cost | Monthly subscription | Free but error-prone | OSS + hosting you already pay |
+| Data location | Vendor cloud | Local files | Your server |
+| Qualified invoice | Built-in | Manual | Built-in, API-validated |
+| AI / MCP ops | Vendor lock-in | None | OpenAPI + MCP catalog |
+| Ecosystem link | None | None | Records / Concierge HTTP |
+
+## Non-goals
+
+See also [`requirements.md`](./requirements.md#explicit-non-goals).
+
+- **Not** full double-entry accounting or general ledger
+- **Not** payroll, expense reimbursement, or fixed-asset management
+- **Not** inventory management or POS (NeNe Shop is a separate future product)
+- **Not** a WordPress plugin (coexist on same domain is fine)
+- **Not** embedded inside NeNe Records or other sibling repos
+- **Not** e-invoice (電子インボイス) PEPPOL network transmission in Phase 1–3 — PDF + email first
+- **Not** payment gateway integration in Phase 1 — manual payment recording first; Stripe/PayPay in Phase 4+
+
+## Success Criteria (Phase 3 complete)
+
+- Operator on Tier A shared hosting installs without SSH
+- Creates qualified invoice PDF with registration number in under 10 minutes after install
+- `composer check` and admin smoke tests green
+- OpenAPI documents all admin operations; MCP catalog validates
+
+## Related
+
+- Requirements: [`requirements.md`](./requirements.md)
+- Domain model: [`domain-model.md`](./domain-model.md)
+- Glossary: [`glossary.md`](./glossary.md)
+- Roadmap: [`../roadmap.md`](../roadmap.md)
+- Sibling boundaries: [`../integrations/sibling-products.md`](../integrations/sibling-products.md)

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -1,0 +1,176 @@
+# Requirements
+
+Functional and compliance requirements for NeNe Invoice. MVP scope maps to **Phase 1–3** unless noted.
+
+See also: [`product-vision.md`](./product-vision.md), [`domain-model.md`](./domain-model.md).
+
+---
+
+## 1. User roles
+
+| Role | Capabilities | Phase |
+| --- | --- | --- |
+| **admin** | Full CRUD on clients, quotes, invoices, payments, company settings | 1 |
+| **viewer** (optional) | Read-only access to documents and reports | 3+ |
+| **public client** | Download invoice PDF via time-limited token URL — no login | 2 |
+
+Phase 1: single admin user (JWT). Multi-user RBAC is Phase 3+.
+
+---
+
+## 2. Core entities (MVP)
+
+| Entity | Purpose | Key fields |
+| --- | --- | --- |
+| **company_settings** | Issuer (自社) profile | legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
+| **client** | Buyer (取引先) | name, contact_name, email, billing_address, **registration_number** (optional for B2B qualified invoice) |
+| **quote** | Estimate (見積書) | client_id, quote_number, issued_at, valid_until, status, subtotal_cents, tax_cents, total_cents, notes |
+| **invoice** | Bill (請求書) | client_id, quote_id (optional), invoice_number, issued_at, due_at, status, subtotal_cents, tax_cents, total_cents, **is_qualified_invoice** |
+| **line_item** | Row on quote or invoice | parent_type (quote/invoice), parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order |
+| **payment** | Payment record | invoice_id, paid_at, amount_cents, method (bank_transfer/cash/other), notes |
+
+All money: **integer cents**. Tax rate: **basis points** (1000 = 10.00%).
+
+---
+
+## 3. Japan qualified invoice (適格請求書) — required fields
+
+When `is_qualified_invoice = true`, the system must enforce and render:
+
+### Issuer (supplier)
+
+- [ ] Legal name (氏名又は名称)
+- [ ] Address (住所又は所在地)
+- [ ] **Registration number** (登録番号) — format `T` + 13 digits
+- [ ] Issue date (請求書の交付年月日)
+
+### Buyer (optional on simplified invoices, required for full B2B)
+
+- [ ] Name (氏名又は名称)
+- [ ] Address (住所又は所在地) — when provided
+
+### Transaction details
+
+- [ ] Line items: description (取引内容), tax rate per line or document
+- [ ] Taxable amount per rate category (税率ごとの対価の額)
+- [ ] Consumption tax per rate category (税率ごとの消費税額)
+- [ ] Total billing amount (請求金額)
+
+### Validation rules (API layer)
+
+- Registration number regex: `^T[0-9]{13}$`
+- Tax rates allowed: 1000 (10%), 800 (8% reduced) — extensible via ADR
+- Invoice cannot be marked qualified if issuer registration_number is empty
+- PDF totals must match API-calculated cents (single source: UseCase)
+
+---
+
+## 4. Document lifecycle
+
+| From | Action | To | Phase |
+| --- | --- | --- | --- |
+| — | Create quote | quote `draft` | 1 |
+| draft | Send / finalize | quote `sent` | 1 |
+| sent | Accept | quote `accepted` | 1 |
+| sent | Reject / expire | quote `rejected` / `expired` | 1 |
+| accepted | Convert | invoice `draft` | 1 |
+| — | Create invoice directly | invoice `draft` | 1 |
+| draft | Issue | invoice `issued` | 1 |
+| issued | Record full payment | invoice `paid` | 1 |
+| issued | Partial payment | invoice `partially_paid` | 2 |
+| issued | Past due_at unpaid | invoice `overdue` (computed) | 1 |
+
+Quote numbers and invoice numbers: auto-increment per organization with configurable prefix (e.g. `EST-2026-001`, `INV-2026-001`).
+
+---
+
+## 5. MVP features by phase
+
+### Phase 1 — API only
+
+- [ ] Company settings CRUD
+- [ ] Client CRUD + soft delete
+- [ ] Quote CRUD + line items + status transitions
+- [ ] Invoice CRUD + convert from quote + line items
+- [ ] Payment create + list by invoice
+- [ ] Qualified invoice field validation
+- [ ] Admin JWT auth
+- [ ] OpenAPI 3.1 + PHPUnit + PHPStan 8
+
+### Phase 2 — Admin UI + PDF
+
+- [ ] React admin SPA (clients, quotes, invoices, payments, settings)
+- [ ] Server-side qualified invoice PDF (Japanese layout)
+- [ ] Quote PDF (optional, simpler layout)
+- [ ] Email invoice PDF via SMTP
+- [ ] Public PDF download token URL
+- [ ] Dashboard: unpaid / overdue summary
+
+### Phase 3 — Tier A shared hosting
+
+- [ ] Web installer (MySQL credentials, admin user, company name)
+- [ ] Release ZIP build script
+- [ ] Operator guide (Japanese)
+- [ ] Same-origin admin on shared hosting
+
+### Phase 4 — Ecosystem + extensions
+
+- [ ] NeNe Records product import for line items
+- [ ] NeNe Concierge webhook → draft client / quote
+- [ ] MCP tool catalog (read + write with auth)
+- [ ] CSV export for accounting software
+- [ ] Payment gateway link (Stripe, etc.) — optional
+
+---
+
+## 6. API requirements
+
+- JSON API, OpenAPI 3.1 contract
+- RFC 9457 Problem Details for errors
+- snake_case JSON properties
+- Pagination: `limit`, `offset`, `items` envelope
+- Admin routes under `/admin/…`
+- `GET /health` unauthenticated
+
+---
+
+## 7. Security requirements
+
+- Admin JWT for mutating routes
+- PDF download tokens: random, time-limited, scoped to one invoice
+- No stack traces in production responses
+- Secrets in `.env` only — never committed
+- Audit log for invoice issue and payment record (Phase 2+)
+
+---
+
+## 8. Explicit non-goals
+
+| Item | Reason |
+| --- | --- |
+| General ledger / journal entries | Different product category; export to accounting SaaS instead |
+| Payroll / 給与 | Out of scope |
+| Expense receipts / 経費精算 | Out of scope |
+| Inventory / stock | NeNe Shop territory |
+| PEPPOL / 電子インボイス network | Phase 4+ research; PDF first |
+| Multi-currency | JPY only for Phase 1–3 |
+| Consumption tax filing (申告) | Operator exports data; no tax return generation |
+
+---
+
+## 9. Acceptance tests (Phase 3 smoke)
+
+1. Install on clean MySQL via web installer.
+2. Enter company profile with valid `T` registration number.
+3. Create client + quote with 2 line items (10% and 8% tax).
+4. Convert to invoice, issue, download qualified invoice PDF.
+5. Record payment → invoice status `paid`.
+6. List overdue invoices returns empty after payment.
+
+---
+
+## Related
+
+- Domain model: [`domain-model.md`](./domain-model.md)
+- Naming: [`../development/naming-conventions.md`](../development/naming-conventions.md)
+- Roadmap: [`../roadmap.md`](../roadmap.md)

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -1,26 +1,24 @@
 # Milestone: Governance and Foundation (2026-05)
 
-Goal: establish NeNe Invoice engineering discipline inherited from NENE2 and sibling NeNe products before billing features grow.
+Goal: establish NeNe Invoice engineering discipline and product design before billing features grow.
 
-**Status: in progress**
-
-> **Workflow note:** Phase 0 governance lands via Issue #1 → branch → PR → merge. All subsequent work uses the same pattern.
+**Status: complete (2026-05-29)**
 
 ## Acceptance Criteria
 
 - [x] GitHub repository created (`hideyukiMORI/nene-invoice`)
-- [ ] `docs/inheritance-from-nene2.md` documents local vs upstream rules
-- [ ] `docs/workflow.md` and commit conventions in place
-- [ ] `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` exist
-- [ ] `.cursor/rules/` summaries for always-on agent guidance
-- [ ] `docs/review/` initial self-review checklists
-- [ ] ADR 0001 and ADR 0002 accepted
-- [ ] `docs/roadmap.md`, `docs/todo/current.md` initialized
-- [ ] Product vision documented (Issue #2)
-- [ ] `composer check` green on `main` (runtime scaffold — follow-up Issue)
+- [x] `docs/inheritance-from-nene2.md` documents local vs upstream rules
+- [x] `docs/workflow.md` and commit conventions in place
+- [x] `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` exist
+- [x] `.cursor/rules/` summaries for always-on agent guidance
+- [x] `docs/review/` initial self-review checklists
+- [x] ADR 0001 and ADR 0002 accepted
+- [x] `docs/roadmap.md`, `docs/todo/current.md` initialized
+- [x] Product vision, requirements, domain model (Issue #3)
+- [ ] `composer check` green on `main` (Issue #4 — runtime scaffold)
 
 ## Follow-up Milestone
 
-Phase 0+ — NENE2 runtime scaffold, health endpoint, OpenAPI stub, CI.
+Phase 0+ — NENE2 runtime scaffold, health endpoint, OpenAPI stub, CI (Issues #4–#7).
 
 Then Phase 1 — Core billing API (clients, quotes, invoices, payments).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,44 +13,49 @@ Operators can self-host a billing platform that:
 - runs on **Tier A** shared hosting or **Tier B** Docker/VPS
 - optionally integrates with NeNe Records and NeNe Concierge via HTTP
 
-Detailed product scope: [`docs/explanation/product-vision.md`](./explanation/product-vision.md) (Issue #2).
+Full scope: [`docs/explanation/product-vision.md`](./explanation/product-vision.md), [`docs/explanation/requirements.md`](./explanation/requirements.md).
 
 ## Phase 0: Governance and Foundation
 
-Goal: engineering discipline before product features grow.
+Goal: engineering discipline and product design before runtime code.
 
-- Governance docs, ADR 0001/0002, inheritance map
-- Product vision and requirements documentation
-- NENE2 consumer scaffold, `GET /health`, OpenAPI, CI
-- Cursor rules and self-review checklists
+- Governance docs, ADR 0001/0002, inheritance map ✅
+- Product vision, requirements, domain model ✅ (Issue #3)
+- NENE2 consumer scaffold, `GET /health`, OpenAPI, CI 🔲 Issues #4–#7
+- ADR 0003 dual deployment 🔲 Issue #7
 
 Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
 
-**Status: in progress (2026-05-29).**
+**Status: product docs complete; runtime scaffold next.**
 
 ## Phase 1: Core Billing API
 
 Goal: client master, quotes, invoices, payments — API and DB only.
 
-- `clients`, `quotes`, `invoices`, `line_items`, `payments`, `company_settings` schema
-- Japan invoice field validation in UseCases
+- `company_settings`, `clients`, `quotes`, `invoices`, `line_items`, `payments`, `document_sequences`
+- Japan qualified invoice field validation in UseCases
+- Quote → invoice conversion
 - Admin JWT auth
-- OpenAPI + PHPUnit
+- OpenAPI + PHPUnit + PHPStan 8
+
+See [`docs/explanation/requirements.md#phase-1--api-only`](./explanation/requirements.md#phase-1--api-only).
 
 ## Phase 2: Admin UI + PDF
 
 Goal: operators manage billing without CLI.
 
 - React admin SPA
-- Server-side qualified invoice PDF generation
-- Email invoice delivery (SMTP)
+- Server-side qualified invoice PDF (Japanese layout)
+- Email delivery via SMTP
+- Public PDF download token
+- Dashboard: unpaid / overdue
 
 ## Phase 3: Tier A Shared Hosting
 
 Goal: Japan SMB install path.
 
 - Web installer + release ZIP
-- Operator documentation
+- Operator guide (Japanese)
 - Same-origin admin on shared hosting
 
 ## Phase 4: Ecosystem Integration
@@ -58,14 +63,10 @@ Goal: Japan SMB install path.
 Goal: connect to sibling products.
 
 - NeNe Records product catalog import
-- NeNe Concierge lead → draft quote webhook
-- MCP tool catalog for billing operations
+- NeNe Concierge lead → draft client / quote webhook
+- MCP tool catalog
+- CSV export; optional payment gateway
 
-## Non-goals (summary)
+## Non-goals
 
-See product vision for full list. Short version:
-
-- Not full double-entry accounting
-- Not payroll or expense reimbursement
-- Not a WordPress plugin
-- Not embedded inside NeNe Records
+See [`docs/explanation/product-vision.md#non-goals`](./explanation/product-vision.md#non-goals).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,36 +1,49 @@
 # Current Work
 
-Last updated: 2026-05-29
+Last updated: 2026-05-29 (Issue #3)
+
+## Recently merged
+
+- **Issue #1 / PR #2** — Governance and foundation (workflow, naming, ADRs, review checklists, Cursor rules)
+- **Issue #3** — Product vision, requirements, domain model (PR pending)
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #1 | `docs/1-governance-foundation` | Governance and foundation docs | 🔄 PR pending |
-| #2 | — | Product vision and requirements | 🔲 next |
+| #3 | `docs/3-product-vision` | Product vision and requirements | 🔄 PR pending |
 
-## Phase 0 Backlog (Issues to create after #1 merges)
+## Phase 0+ Backlog
 
-| Priority | Topic | Notes |
+| Issue | Topic | Priority |
 | --- | --- | --- |
-| P0 | NENE2 runtime scaffold + health endpoint | composer.json, docker compose, GET /health |
-| P0 | OpenAPI stub + MCP catalog | docs/openapi/openapi.yaml, docs/mcp/tools.json |
-| P0 | Backend CI workflow | GitHub Actions — PHPUnit, PHPStan, OpenAPI |
-| P1 | ADR 0003 dual deployment strategy | Tier A / Tier B — follow Corpus/Concierge pattern |
+| #4 | NENE2 runtime scaffold + health endpoint | P0 |
+| #5 | OpenAPI stub + MCP catalog | P0 |
+| #6 | Backend CI workflow | P0 |
+| #7 | ADR 0003 dual deployment (Tier A / Tier B) | P1 |
 
 ## State Summary
 
-**Phase 0 — Governance: in progress**
+**Phase 0 — Governance: ✅ complete**
 
-- GitHub repository created: `hideyukiMORI/nene-invoice`
-- Issue #1: governance initialization
-- Issue #2: product vision (queued)
+**Phase 0 — Product design: 🔄 merging**
 
-No runtime code yet. `composer check` lands with scaffold Issue.
+- Product vision, requirements, domain model documented
+- Glossary expanded
+- README updated
+
+**Runtime: not started** — begin with Issue #4 after #3 merges.
 
 ## Handoff Notes
 
 - Namespace: `NeneInvoice\`
 - Problem Details base: `https://nene-invoice.dev/problems/`
-- Money: integer cents everywhere
-- Sibling boundary: ADR 0002 — HTTP only, no shared DB
+- Money: integer cents; tax: basis points (1000 = 10%)
+- Qualified invoice: validate `T` + 13 digit registration number at API layer
+- Sibling boundary: ADR 0002 — HTTP only
+
+## Next steps
+
+1. Merge Issue #3 PR
+2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
+3. Issue #5–#6 can follow in parallel after #4 lands


### PR DESCRIPTION
## Summary

- Add product vision (north star, personas, philosophy, non-goals)
- Add requirements (MVP phases, Japan qualified invoice fields, entity list)
- Add domain model (ER diagram, quote/invoice state machines, tax calculation)
- Expand glossary, update README, roadmap, todo, milestone

## Test plan

- [x] Docs internally consistent with ADR 0002 sibling boundaries
- [x] Phase 1 MVP scope is explicit and testable
- [x] Non-goals documented to prevent scope creep

Self-review: docs-policy

Closes #3

Made with [Cursor](https://cursor.com)