### PR TITLE
docs(invoice): 適格請求書ドキュメントの精度を修正する (#9)

### DIFF
--- a/docs/adr/0004-tax-rounding-per-rate.md
+++ b/docs/adr/0004-tax-rounding-per-rate.md
@@ -1,0 +1,88 @@
+# ADR 0004: Consumption Tax Rounding Once Per Rate Per Document
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Invoice calculates consumption tax for quotes and invoices. The early
+domain model draft (`docs/explanation/domain-model.md`) rounded tax **per line
+item** and then summed the rounded line amounts into the document tax total.
+
+Under the Japan qualified invoice system (適格請求書等保存方式), consumption tax
+rounding is constrained: for **one qualified invoice**, the tax amount may be
+rounded **once per tax rate** (税率ごとに1回). Rounding each line item and then
+summing is **not** permitted, because it can round more than once per rate
+within a single document and produce a tax total that does not match the
+rate-grouped statutory figure.
+
+The rounding direction itself (round half-up / floor / ceil) is the issuer's
+choice, but it must be applied at the rate-group level, not per line, and stay
+consistent across a document.
+
+Alternatives considered:
+
+1. **Round per line item, then sum** — rejected; rounds more than once per rate
+   and is non-compliant with the qualified invoice rule.
+2. **No rounding until the grand total** — rejected; the qualified invoice
+   requires the consumption tax **per tax rate category** (税率ごとの消費税額)
+   to be a displayed, rounded figure, so rounding must happen at the rate group.
+3. **Round once per tax rate per document** (chosen) — compliant and matches the
+   rate-category figures the PDF must render.
+
+## Decision
+
+Compute consumption tax by grouping line items by `tax_rate_bps`, summing the
+taxable amount per rate, and rounding **once per rate** to integer minimum
+currency units. Do not round individual line item tax amounts.
+
+```
+# Group line items by tax_rate_bps:
+for each rate group:
+    taxable_amount_cents[rate] = sum(quantity * unit_price_cents) in that group
+    tax_cents[rate]            = round(taxable_amount_cents[rate] * rate / 10000)   # ROUND ONCE here
+
+subtotal_cents = sum(taxable_amount_cents[rate] for all rates)
+tax_cents      = sum(tax_cents[rate] for all rates)
+total_cents    = subtotal_cents + tax_cents
+```
+
+- Rounding direction: **half-up** to integer minimum currency units, applied per
+  rate group. A future ADR may make the direction configurable per issuer if a
+  real operator requires floor/ceil; until then half-up is the single rule.
+- This calculation is the **single source of truth** in the UseCase layer. The
+  PDF and API responses both render these exact values; neither recalculates.
+- `tax_rate_bps` is in basis points (1000 = 10%, 800 = 8% reduced). See
+  `docs/explanation/glossary.md`.
+
+## Consequences
+
+**Benefits**
+
+- Compliant with the qualified invoice "round once per tax rate per document"
+  rule.
+- The per-rate `tax_cents[rate]` figures are exactly the
+  税率ごとの消費税額 the qualified invoice PDF must display.
+- API and PDF totals are guaranteed equal — one calculation, no per-line drift.
+
+**Costs**
+
+- Line items no longer carry an independently rounded tax amount; any per-line
+  tax shown in the UI is illustrative and must be labeled as such, not summed.
+- Changing the rounding direction later is an issuer-visible behavior change and
+  needs its own ADR.
+
+**Follow-up**
+
+- Implement in the `Quote` / `Invoice` tax calculation UseCase (Phase 1) with
+  unit tests covering mixed 10% / 8% documents and half-up boundary cases.
+
+## Related
+
+- Domain model: `docs/explanation/domain-model.md`
+- Requirements (qualified invoice fields): `docs/explanation/requirements.md`
+- Backend standards (money and tax): `docs/development/backend-standards.md`
+- Issue: `#9`
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -114,7 +114,7 @@ Do not mix camelCase in public JSON. Do not use floats for money.
 | --- | --- | --- |
 | Base URL | `https://nene-invoice.dev/problems/` | — |
 | Type slug | kebab-case | `validation-failed`, `invoice-not-found` |
-| Validation `errors[].field` | snake_case path | `body.tax_registration_number` |
+| Validation `errors[].field` | snake_case path | `body.registration_number` |
 | Validation `errors[].code` | snake_case | `required`, `invalid_invoice_number` |
 
 Problem Details `title` and `detail`: English.

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -88,23 +88,27 @@ erDiagram
 
 ## Tax calculation (UseCase)
 
-Single source of truth for API and PDF:
+Single source of truth for API and PDF. Consumption tax is rounded **once per
+tax rate per document** — never per line item — to comply with the qualified
+invoice system. See [ADR 0004](../adr/0004-tax-rounding-per-rate.md).
 
 ```
 For each line_item:
-  line_subtotal_cents = quantity * unit_price_cents
-  line_tax_cents = round(line_subtotal_cents * tax_rate_bps / 10000)
+  line_subtotal_cents = quantity * unit_price_cents   # not rounded for tax
 
 Group by tax_rate_bps:
   taxable_amount_cents[rate] += line_subtotal_cents
-  tax_cents[rate] += line_tax_cents
+  tax_cents[rate] = round(taxable_amount_cents[rate] * rate / 10000)   # round ONCE per rate
 
-subtotal_cents = sum(line_subtotal_cents)
-tax_cents = sum(line_tax_cents)
+subtotal_cents = sum(taxable_amount_cents[rate])
+tax_cents = sum(tax_cents[rate])
 total_cents = subtotal_cents + tax_cents
 ```
 
-Rounding: half-up to integer cents per line (document choice — record in ADR when implementing).
+Rounding: half-up to integer minimum currency units, applied per rate group, not
+per line. Any per-line tax shown in the UI is illustrative only and must not be
+summed into the document total. Rationale and rejected alternatives:
+[ADR 0004](../adr/0004-tax-rounding-per-rate.md).
 
 ---
 
@@ -165,3 +169,4 @@ UseCase never calls PDF library directly. Handler never recalculates tax.
 - Requirements: [`requirements.md`](./requirements.md)
 - Backend standards: [`../development/backend-standards.md`](../development/backend-standards.md)
 - ADR 0002: [`../adr/0002-separate-from-sibling-products.md`](../adr/0002-separate-from-sibling-products.md)
+- ADR 0004 (tax rounding): [`../adr/0004-tax-rounding-per-rate.md`](../adr/0004-tax-rounding-per-rate.md)

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -11,7 +11,8 @@ Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments
 | **client** | Customer / buyer (取引先) in the billing system | "customer" in code identifiers |
 | **line item** | A single row on a quote or invoice (品名, quantity, unit price, tax rate) | "row", "detail" |
 | **payment** | A recorded receipt against an invoice (入金) | "receipt" (PDF noun) |
-| **registration number** | Japan invoice registration number (インボイス登録番号), format `T` + 13 digits | "T-number" without context |
+| **registration number** | Japan invoice registration number (インボイス登録番号), format `T` + 13 digits. API validation is **syntax only** — format, not existence or check digit | "T-number" without context; treating regex pass as proof of validity |
+| **cents** | Integer amount in the **smallest currency unit**. For JPY (the only Phase 1–3 currency) one "cent" is one 円, so `total_cents = 1000` means ¥1,000. The suffix is a fixed internal convention, not a sub-yen unit | float or DECIMAL money; reading `_cents` as 1/100 yen |
 | **tax rate bps** | Tax rate in basis points (1000 = 10.00%, 800 = 8.00%) | float percentages in DB |
 | **quote-to-cash** | Flow from estimate through invoice to payment | "order-to-cash" (ERP term) |
 | **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server" in code |

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -58,9 +58,14 @@ When `is_qualified_invoice = true`, the system must enforce and render:
 
 ### Validation rules (API layer)
 
-- Registration number regex: `^T[0-9]{13}$`
+- Registration number regex: `^T[0-9]{13}$` — **syntax check only**. This
+  validates format, not existence; the system does **not** verify the number
+  against the National Tax Agency registry or compute a check digit. Passing the
+  regex does not mean the number is registered or valid.
 - Tax rates allowed: 1000 (10%), 800 (8% reduced) — extensible via ADR
 - Invoice cannot be marked qualified if issuer registration_number is empty
+- Consumption tax is rounded **once per tax rate per document**, never per line
+  item — see [ADR 0004](../adr/0004-tax-rounding-per-rate.md)
 - PDF totals must match API-calculated cents (single source: UseCase)
 
 ---

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,13 +5,13 @@ Last updated: 2026-05-29 (Issue #3)
 ## Recently merged
 
 - **Issue #1 / PR #2** — Governance and foundation (workflow, naming, ADRs, review checklists, Cursor rules)
-- **Issue #3** — Product vision, requirements, domain model (PR pending)
+- **Issue #3 / PR #8** — Product vision, requirements, domain model ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #3 | `docs/3-product-vision` | Product vision and requirements | 🔄 PR pending |
+| #9 | `docs/9-invoice-compliance-accuracy` | 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -26,24 +26,31 @@ Last updated: 2026-05-29 (Issue #3)
 
 **Phase 0 — Governance: ✅ complete**
 
-**Phase 0 — Product design: 🔄 merging**
+**Phase 0 — Product design: ✅ complete** (Issue #3 merged)
 
 - Product vision, requirements, domain model documented
 - Glossary expanded
 - README updated
 
-**Runtime: not started** — begin with Issue #4 after #3 merges.
+**Phase 0 — Product design polish: 🔄 in progress** (Issue #9)
+
+- Tax rounding corrected to once-per-rate-per-document (ADR 0004)
+- Registration number documented as syntax-only validation
+- `cents` defined as smallest-currency-unit; naming inconsistency fixed
+
+**Runtime: not started** — begin with Issue #4.
 
 ## Handoff Notes
 
 - Namespace: `NeneInvoice\`
 - Problem Details base: `https://nene-invoice.dev/problems/`
-- Money: integer cents; tax: basis points (1000 = 10%)
-- Qualified invoice: validate `T` + 13 digit registration number at API layer
+- Money: integer cents (smallest currency unit; JPY ¥1 = 1 cent); tax: basis points (1000 = 10%)
+- Tax rounding: once per tax rate per document, half-up — ADR 0004
+- Qualified invoice: validate `T` + 13 digit registration number at API layer (syntax only)
 - Sibling boundary: ADR 0002 — HTTP only
 
 ## Next steps
 
-1. Merge Issue #3 PR
+1. Merge Issue #9 PR (product design polish)
 2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
 3. Issue #5–#6 can follow in parallel after #4 lands


### PR DESCRIPTION
Closes #9

## 目的

Phase 0 のプロダクト設計ドキュメントに残る精度上の問題を、ランタイム実装（Phase 1+）前に正本レベルで解消する。

## 変更内容

- **端数処理（compliance）**: `domain-model.md` の税計算を「行ごとに丸めて合算」から **「税率ごとに課税対象額を合算 → 1回丸める」** に修正。適格請求書制度の「1請求書につき税率ごとに端数処理1回」要件に準拠させ、判断根拠と却下案を **ADR 0004** に記録。
- **登録番号の検証範囲**: `^T[0-9]{13}$` は **構文検証のみ**（実在性・検算ではない）と `requirements.md` / `glossary.md` に明記。regex 通過＝有効と誤認させない。
- **`cents` 用語**: グロッサリに「最小通貨単位の整数（JPY では ¥1 = 1 cent）」と定義を追加。`_cents` を 1/100 円と誤読させない。
- **命名ゆれ**: `naming-conventions.md` のバリデーション例 `tax_registration_number` を実フィールド名 `registration_number` に統一。
- **TODO 同期**: `current.md` を Issue #3 マージ済み・#9 進行中の状態へ更新。

## 検証

- ランタイム未scaffoldのため `composer check` は対象外（Issue #4）。docs のみの変更。
- `git diff --check` 通過（whitespace エラーなし）。
- 既存ドキュメント間のクロスリンク・用語整合を確認。

## セルフレビュー

Self-review: docs-policy, backend-api

## 残課題 / フォローアップ

- 端数処理の実装とテスト（Phase 1、ADR 0004 フォローアップ）
- 日英バイリンガル方針の宣言は別 Issue / PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)