### PR TITLE
docs(i18n): 日英バイリンガル方針を宣言し多言語対応を非対象とする (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ NeNe Invoice is an open-source billing platform built on [NENE2](https://github.
 - **Quote-to-cash** — estimate → invoice → payment in one product
 - **Sibling to NeNe ecosystem** — optional HTTP link to Records / Concierge; never merged into CMS
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
+- **Bilingual, not multilingual** — Japanese + English admin UI for operators (incl. non-Japanese running businesses in Japan); other locales are a deliberate non-goal ([ADR 0005](./docs/adr/0005-bilingual-ja-en-scope.md))
 
 ## Quick Start
 

--- a/docs/adr/0005-bilingual-ja-en-scope.md
+++ b/docs/adr/0005-bilingual-ja-en-scope.md
@@ -1,0 +1,84 @@
+# ADR 0005: Bind Product Localization to Japanese and English Only
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Invoice is built around the Japan invoice system (適格請求書, consumption
+tax rates, per-rate rounding — see ADR 0004). The domain rules are
+Japan-specific and cannot be localized away.
+
+The operator base is shifting: more non-Japanese people now run businesses
+**inside Japan**. They operate under Japanese accounting and tax rules but are
+more comfortable driving the admin UI in English. So an English operator UI adds
+real value.
+
+Going further to arbitrary multilingual support (e.g. zh, ko, fr, es) does not.
+A non-Japanese-accounting locale serves no real operator, because every operator
+— regardless of native language — is subject to the same Japanese statutory
+rules. Each added UI locale increases translation surface, review burden, and
+the risk of mistranslating tax/legal terms, without serving the actual audience.
+
+Alternatives considered:
+
+1. **Japanese only** — rejected; excludes the growing non-Japanese operator
+   segment running businesses in Japan.
+2. **Full i18n / community-driven multilingual** — rejected; large maintenance
+   and translation-accuracy surface for locales that match no real operator
+   profile, since the domain is locked to Japanese rules.
+3. **Japanese + English only** (chosen) — covers the actual operator base at a
+   bounded, maintainable translation surface.
+
+## Decision
+
+NeNe Invoice localizes to **Japanese (primary) and English (secondary) only**.
+
+- **In scope:** admin UI strings, operator-facing guides, and operator-visible
+  labels in **ja and en**. Japanese is the default; English is a first-class
+  alternate.
+- **Out of scope:** any additional UI locale. Pull requests adding other locales
+  are declined unless a future ADR supersedes this decision. This is a
+  deliberate product non-goal, not a missing feature.
+- **Statutory document content stays Japanese.** The qualified invoice
+  (適格請求書) PDF renders its legally required fields in Japanese because it is
+  a legal document under Japanese law. English applies to the operator's working
+  UI chrome, navigation, and guides — not to the statutory invoice content.
+- **Development docs are unaffected.** Source-of-truth docs, OpenAPI text, and
+  API error metadata remain **English** per the existing language policy
+  (`docs/inheritance-from-nene2.md`); Issues, PRs, commits, and `.cursor/rules/`
+  continue to allow Japanese. This ADR governs **product localization**, not the
+  repository's documentation language.
+
+## Consequences
+
+**Benefits**
+
+- Serves the real operator base — Japanese SMB plus non-Japanese operators doing
+  business in Japan — without over-investing.
+- Bounded, maintainable translation surface; lower risk of mistranslated tax or
+  legal terminology.
+- Clear contributor expectation: locale additions beyond ja/en are out of scope.
+
+**Costs**
+
+- Explicitly turns away community multilingual contributions.
+- Frontend must carry a real ja/en locale catalog from Phase 2, not a
+  Japanese-only string set.
+
+**Follow-up**
+
+- Phase 2 admin UI ships ja + en locale catalogs (`docs/development/frontend-standards.md`).
+- If a concrete operator need for another locale ever appears, supersede this
+  ADR rather than quietly adding locales.
+
+## Related
+
+- Product vision: `docs/explanation/product-vision.md`
+- Requirements: `docs/explanation/requirements.md`
+- Frontend standards: `docs/development/frontend-standards.md`
+- Documentation language policy: `docs/inheritance-from-nene2.md`
+- Issue: `#11`
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -7,7 +7,10 @@ NeNe Invoice admin UI will follow sibling product conventions:
 - React + TypeScript + Vite
 - Strict mode enabled
 - API client maps **snake_case** JSON without renaming fields
-- UI strings in locale catalogs (Japanese primary for operators)
+- UI strings in locale catalogs — **ja (primary) + en (secondary) only**; no
+  hardcoded strings, no other locales (ADR 0005)
+- Statutory invoice content rendered in Japanese regardless of UI locale (legal
+  document); en applies to UI chrome and operator guides
 - No admin JWT in public document download pages
 
 When `frontend/` lands, expand this document with component layout, test strategy, and build output paths (`public_html/admin/`).

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -21,5 +21,6 @@ Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments
 | **use case** | Business logic class with `execute()` | "service" (UseCase sense) |
 | **sync PDF download** | Single HTTP response returning PDF bytes | "streaming PDF" |
 | **overdue** | Invoice past `due_at` with unpaid balance — computed status | stored status in Phase 1 (optional) |
+| **UI locale** | Admin UI / operator-facing language. Bound to **ja (primary) + en (secondary) only** — not multilingual (ADR 0005). Distinct from the English-only dev-docs language policy | adding locales beyond ja/en; conflating UI locale with statutory invoice language |
 
 When adding terms, update this table in the same PR.

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -37,6 +37,14 @@ Companies with 1–20 staff who already pay for shared hosting (Xserver, Sakura,
 
 Docker Compose for local development and production. Same API and admin UI as Tier A.
 
+**Non-Japanese operators doing business in Japan**
+
+A growing segment: founders and staff who are not native Japanese speakers but
+run a company registered in Japan. They are bound by the same Japanese invoice
+and tax rules, but operate the admin UI more comfortably in English. NeNe
+Invoice serves them with an **English admin UI**, while statutory documents
+remain Japanese — see [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
+
 **Multi-tenant hosting operators (later)**
 
 Agencies running one NeNe Invoice instance for multiple client organizations — same pattern as NeNe Records / Concierge multi-tenancy.
@@ -94,7 +102,18 @@ MIT license. Operators control data. SMTP for email delivery uses operator-provi
 
 MCP tools map to admin API operations ("list overdue invoices", "create quote for client X"). Client-facing PDF download uses tokenized URLs — not MCP.
 
-### 6. Separation from sibling products
+### 6. Japanese and English only — not multilingual
+
+The product localizes to **Japanese (primary) and English (secondary) only**.
+More non-Japanese operators now run businesses inside Japan; they work under
+Japanese accounting rules but prefer an English admin UI, so English is
+first-class. Arbitrary multilingual support is a deliberate **non-goal**: the
+domain is locked to Japanese invoice/tax rules, so additional locales add
+translation and maintenance surface without serving any real operator. The
+qualified invoice PDF's statutory content stays Japanese (legal document); en
+applies to the operator UI and guides. See [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
+
+### 7. Separation from sibling products
 
 NeNe Records owns CMS content. NeNe Corpus owns knowledge chat. NeNe Concierge owns scenario chat. NeNe Invoice owns billing documents. Integration is HTTP-only — ADR 0002.
 
@@ -127,6 +146,7 @@ See also [`requirements.md`](./requirements.md#explicit-non-goals).
 - **Not** embedded inside NeNe Records or other sibling repos
 - **Not** e-invoice (電子インボイス) PEPPOL network transmission in Phase 1–3 — PDF + email first
 - **Not** payment gateway integration in Phase 1 — manual payment recording first; Stripe/PayPay in Phase 4+
+- **Not** multilingual beyond Japanese and English — UI locales bound to ja/en by [ADR 0005](../adr/0005-bilingual-ja-en-scope.md)
 
 ## Success Criteria (Phase 3 complete)
 

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -105,6 +105,7 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 ### Phase 2 — Admin UI + PDF
 
 - [ ] React admin SPA (clients, quotes, invoices, payments, settings)
+- [ ] Admin UI locale catalogs: **ja (primary) + en (secondary)** — no other locales (ADR 0005)
 - [ ] Server-side qualified invoice PDF (Japanese layout)
 - [ ] Quote PDF (optional, simpler layout)
 - [ ] Email invoice PDF via SMTP
@@ -159,6 +160,7 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 | Inventory / stock | NeNe Shop territory |
 | PEPPOL / 電子インボイス network | Phase 4+ research; PDF first |
 | Multi-currency | JPY only for Phase 1–3 |
+| Multilingual UI beyond ja/en | Domain locked to Japanese rules; UI bound to Japanese + English (ADR 0005) |
 | Consumption tax filing (申告) | Operator exports data; no tax return generation |
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ See [`docs/explanation/requirements.md#phase-1--api-only`](./explanation/require
 
 Goal: operators manage billing without CLI.
 
-- React admin SPA
+- React admin SPA — ja + en locale catalogs (ADR 0005; no other locales)
 - Server-side qualified invoice PDF (Japanese layout)
 - Email delivery via SMTP
 - Public PDF download token

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,17 +1,18 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #3)
+Last updated: 2026-05-29 (Issue #11)
 
 ## Recently merged
 
 - **Issue #1 / PR #2** — Governance and foundation (workflow, naming, ADRs, review checklists, Cursor rules)
 - **Issue #3 / PR #8** — Product vision, requirements, domain model ✅ merged
+- **Issue #9 / PR #10** — 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名）✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #9 | `docs/9-invoice-compliance-accuracy` | 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名） | 🔄 PR pending |
+| #11 | `docs/11-bilingual-ja-en-scope` | 日英(ja/en)バイリンガル方針宣言（ADR 0005）・多言語非対象 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -32,11 +33,16 @@ Last updated: 2026-05-29 (Issue #3)
 - Glossary expanded
 - README updated
 
-**Phase 0 — Product design polish: 🔄 in progress** (Issue #9)
+**Phase 0 — Product design polish: ✅ complete** (Issue #9)
 
 - Tax rounding corrected to once-per-rate-per-document (ADR 0004)
 - Registration number documented as syntax-only validation
 - `cents` defined as smallest-currency-unit; naming inconsistency fixed
+
+**Phase 0 — Localization scope: 🔄 in progress** (Issue #11)
+
+- Product localization bound to ja (primary) + en (secondary); multilingual is a non-goal (ADR 0005)
+- Statutory invoice content stays Japanese; en applies to operator UI/guides
 
 **Runtime: not started** — begin with Issue #4.
 
@@ -47,10 +53,11 @@ Last updated: 2026-05-29 (Issue #3)
 - Money: integer cents (smallest currency unit; JPY ¥1 = 1 cent); tax: basis points (1000 = 10%)
 - Tax rounding: once per tax rate per document, half-up — ADR 0004
 - Qualified invoice: validate `T` + 13 digit registration number at API layer (syntax only)
+- UI locale: ja + en only — ADR 0005 (not multilingual)
 - Sibling boundary: ADR 0002 — HTTP only
 
 ## Next steps
 
-1. Merge Issue #9 PR (product design polish)
+1. Merge Issue #11 PR (localization scope)
 2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
 3. Issue #5–#6 can follow in parallel after #4 lands


### PR DESCRIPTION
Closes #11

## 目的

製品のローカライズ範囲を **日本語（主）+ 英語（副）の2言語に限定**し、それ以外の多言語対応を意図的に非対象とすることをドキュメントで宣言する。

## 背景

海外出身者が日本国内でビジネスを行うケースが増えている。彼らは日本の経理・税制（適格請求書・消費税率・端数処理）の下で運用するが、操作 UI は英語の方が扱いやすい。一方、製品ロジックは日本の経理ルールに固定されているため、任意の多言語（中・韓・仏 等）へ拡張しても運用者ニーズとずれ、翻訳面・保守コストだけが増える。

## 変更内容

- **ADR 0005（新規）**: 日英2言語限定の決定・却下案・影響を記録。法定記載（適格請求書 PDF）は日本語固定、en は運用 UI / ガイドに適用。開発正本ドキュメントの英語ポリシーとは区別する旨を明記。
- **product-vision**: 哲学 #6 にローカライズ方針、「日本でビジネスを行う海外出身運用者」ペルソナ、非対象項目を追記。
- **requirements**: Phase 2 に ja/en ロケール要件、非対象表に「ja/en 超の多言語」を追記。
- **frontend-standards**: ロケールカタログを ja+en 限定に明確化、法定記載は日本語固定。
- **glossary / README / roadmap**: UI locale 用語の定義と方針を反映。
- **current.md**: Issue #9 マージ済み・#11 進行中へ同期。

## 言語ポリシーの区別（重要）

本 ADR が縛るのは **製品（UI / 運用者向け）のローカライズ**。開発の正本ドキュメント・OpenAPI・API エラーメタデータの英語ポリシー（`inheritance-from-nene2.md`）は**不変**。

## 検証

- docs のみの変更。ランタイム未scaffoldのため `composer check` は対象外（Issue #4）。
- `git diff --check` 通過。ADR / 各ドキュメント間のクロスリンク整合を確認。

## セルフレビュー

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)