### PR TITLE
docs(compliance): 会計・税務コンプライアンスの完全順守を拘束ルール化する (#13)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -12,5 +12,6 @@ alwaysApply: true
 - 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
 - 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
 - NeNe Invoice はセルフホスト OSS の見積・請求・入金管理 — 適格請求書対応、Admin UI、PDF。
+- **会計・税務コンプライアンスは拘束ルール（非交渉）。** 請求・税・採番・PDF・保存の変更は `docs/explanation/accounting-compliance.md` 順守必須。逸脱は ADR ＋ 税理士確認なしに禁止。専門家がレビューしても逸脱ゼロを満たす。
 - 金額は **integer cents**（float 禁止）。実装は疎結合、型安全、OpenAPI/MCP 境界を優先（NENE2 継承）。
 - Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This file is the entry point for AI agents working on NeNe Invoice.
 ## Read First
 
 - **Current work & status:** `docs/todo/current.md`
+- **Accounting & tax compliance (binding):** `docs/explanation/accounting-compliance.md`
 - **Product vision:** `docs/explanation/product-vision.md`
 - **Requirements:** `docs/explanation/requirements.md`
 - **Domain model:** `docs/explanation/domain-model.md`
@@ -28,6 +29,7 @@ This file is the entry point for AI agents working on NeNe Invoice.
 - **Full lifecycle** (unless user limits scope): Issue → branch → implement → verify → commit → push → PR → merge → sync `main`.
 - Read NENE2 upstream docs for framework behavior; read local docs for product rules.
 - **Never integrate billing into NeNe Records or other sibling repos.** Dependency direction is `NeNe Invoice → upstream APIs`, never the reverse. See ADR 0002.
+- **Accounting/tax compliance is binding and non-negotiable.** Any change touching quotes, invoices, payments, tax, numbering, PDF, or retention must comply with `docs/explanation/accounting-compliance.md` and pass `docs/review/compliance.md`. A finance professional must find zero deviations. Deviations require an ADR with tax-professional sign-off — never merge one without it. When a rule is unclear, stop and consult a 税理士; do not guess.
 - Keep `docs/todo/current.md` and milestones aligned with Issues and PRs.
 - Keep changes focused. Do not mix governance, feature work, and unrelated cleanup in one PR.
 - Do not commit secrets, credentials, local `.env` files, or generated build outputs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Ops / MCP         ──→         │
 | フェーズ | 状態 |
 | --- | --- |
 | Phase 0 ガバナンス | ✅ 完了（Issue #1） |
-| Phase 0 プロダクト設計 | 🔄 Issue #3 PR 待ち |
+| Phase 0 プロダクト設計 | ✅ 完了（Issue #3 / #9 / #11） |
 | Phase 0+ ランタイム scaffold | 🔲 Issue #4 以降 |
 
 ---
@@ -49,6 +49,9 @@ Ops / MCP         ──→         │
 - `.env` / トークン / パスワードのコミット
 - sibling 製品への請求ロジック統合（ADR 0002）
 
+**絶対順守:**
+- **会計・税務コンプライアンス完全順守**（非交渉）。請求・税・採番・PDF・保存に関わる変更は `docs/explanation/accounting-compliance.md` と `docs/review/compliance.md` で確認必須。逸脱は ADR ＋ 税理士確認なしに禁止。正本: `docs/explanation/accounting-compliance.md`
+
 ---
 
 ## アーキテクチャ規約（概要）
@@ -72,6 +75,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 
 | 目的 | ドキュメント |
 | --- | --- |
+| **会計・税務コンプライアンス（拘束）** | `docs/explanation/accounting-compliance.md` |
 | 現在のタスク | `docs/todo/current.md` |
 | ロードマップ | `docs/roadmap.md` |
 | プロダクトビジョン | `docs/explanation/product-vision.md` |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Full list: [`docs/explanation/product-vision.md#non-goals`](./docs/explanation/p
 
 | Topic | Document |
 | --- | --- |
+| **Compliance (binding)** | [`docs/explanation/accounting-compliance.md`](./docs/explanation/accounting-compliance.md) |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
 | **Domain model** | [`docs/explanation/domain-model.md`](./docs/explanation/domain-model.md) |

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -75,9 +75,18 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
 ## 5. Money and tax
 
-- Store all amounts as **integer cents** (`subtotal_cents`, `tax_cents`, `total_cents`).
+> **Compliance is binding (non-negotiable).** All billing, tax, numbering, PDF,
+> and retention behavior **MUST** comply with
+> [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+> Where compliance conflicts with convenience, compliance wins. Deviations
+> require an ADR with tax-professional sign-off. Run
+> [`../review/compliance.md`](../review/compliance.md) for any change in this area.
+
+- Store all amounts as **integer cents** (`subtotal_cents`, `tax_cents`, `total_cents`). Float / DECIMAL for money is prohibited.
 - Tax rates: store as basis points or documented enum — never float percentages in persisted data.
-- Japan qualified invoice fields validated in UseCase layer before PDF generation.
+- Consumption tax is rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
+- Japan qualified invoice fields validated in UseCase layer before PDF generation; missing required fields block issuance.
+- Issued documents are immutable; corrections via credit note, not edit/delete. No hard delete of billing records.
 - PDF totals must match API-calculated cents — single source of truth in UseCase.
 
 ---
@@ -108,4 +117,4 @@ composer openapi
 composer mcp
 ```
 
-Self-review: [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md).
+Self-review: [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md), [`docs/review/compliance.md`](../review/compliance.md).

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -22,6 +22,7 @@ If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist
 
 | File | Use for |
 | --- | --- |
+| `compliance.md` | **Binding.** Any change touching quotes, invoices, payments, tax, numbering, PDF, or retention |
 | `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
 | `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
 | `database.md` | Migrations, repositories, soft delete |

--- a/docs/explanation/accounting-compliance.md
+++ b/docs/explanation/accounting-compliance.md
@@ -1,0 +1,161 @@
+# Accounting & Tax Compliance — Binding Rules
+
+**Status: binding (non-negotiable).** This document is the source of truth for
+NeNe Invoice's adherence to Japanese accounting, consumption tax, and qualified
+invoice law. A finance or accounting professional reviewing the system must be
+able to find **zero deviations** from the rules below.
+
+These are not guidelines. They are **MUST** requirements. Where a rule here
+conflicts with UX, performance, implementation convenience, or any other
+concern, **compliance wins** — every time, without exception.
+
+See also: [`requirements.md`](./requirements.md), [`domain-model.md`](./domain-model.md),
+[ADR 0004](../adr/0004-tax-rounding-per-rate.md), self-review checklist
+[`../review/compliance.md`](../review/compliance.md).
+
+---
+
+## 0. Governing principle
+
+1. **Compliance is non-negotiable.** Correct adherence to the law takes
+   precedence over every other product goal.
+2. **No silent deviation.** Any departure from the rules in this document — even
+   temporary — requires an **ADR** and **explicit review sign-off by a tax/
+   accounting professional (税理士)** recorded in that ADR. Code may not merge a
+   deviation without it.
+3. **Engineering is not the legal authority.** This document is engineering's
+   binding interpretation of the rules. When a requirement is unclear, **stop
+   and consult a 税理士** — do not guess. Record the resolved interpretation here.
+4. **Single source of truth for figures.** Every monetary and tax figure is
+   computed once in the UseCase layer. The PDF, API, and stored copy render the
+   exact same values; no layer recalculates independently.
+
+---
+
+## 1. Statutory basis
+
+NeNe Invoice targets the following Japanese rules. This list states *what we
+comply with*; it is not legal advice.
+
+| Area | Rule set |
+| --- | --- |
+| Consumption tax | 消費税法（標準税率 10% / 軽減税率 8%） |
+| Qualified invoice | 適格請求書等保存方式（インボイス制度） |
+| Stored records | 電子帳簿保存法（電子取引データ・写しの保存） |
+
+When any of these change (rate changes, new statutory fields, retention rule
+changes), treat it as a compliance defect until the product is updated, and open
+a P0 Issue.
+
+---
+
+## 2. Qualified invoice (適格請求書) — mandatory content
+
+When `is_qualified_invoice = true`, the system **MUST** enforce and render **all**
+of the following. Missing any required field **MUST** block issuance.
+
+### Issuer (供給者)
+- Legal name (氏名又は名称)
+- Address (住所又は所在地)
+- **Registration number** (登録番号), format `T` + 13 digits — see §4
+- Transaction / issue date (取引年月日・交付年月日)
+
+### Buyer (交付を受ける者)
+- Name (氏名又は名称)
+- Address when applicable
+
+### Transaction details
+- Description per line (取引内容); reduced-rate items (軽減税率対象) **MUST** be
+  clearly marked
+- **Taxable amount per tax rate** (税率ごとに区分して合計した対価の額)
+- **Consumption tax amount per tax rate** (税率ごとの消費税額)
+- Total billed amount (請求金額)
+
+These figures are statutory. They are not cosmetic PDF fields — they are
+validated in the UseCase before any document is issued or rendered.
+
+---
+
+## 3. Consumption tax calculation
+
+- Allowed rates: **10% (1000 bps)** and **8% reduced (800 bps)**. Adding or
+  changing a rate is a compliance change → requires an ADR.
+- **Rounding: once per tax rate per document**, never per line item.
+  Direction: half-up. This is binding — see
+  [ADR 0004](../adr/0004-tax-rounding-per-rate.md). Per-line rounding is
+  **prohibited** because it can round more than once per rate within one
+  document.
+- The per-rate consumption tax figure produced here is exactly the
+  税率ごとの消費税額 the qualified invoice must display.
+
+---
+
+## 4. Registration number
+
+- Format check: `^T[0-9]{13}$`. This is **syntax only** — it does **not** prove
+  the number exists or is registered, and the system does **not** perform a
+  check-digit or registry lookup. UI and docs **MUST NOT** present a format pass
+  as proof of validity.
+- An invoice **MUST NOT** be markable as qualified while the issuer registration
+  number is empty.
+
+---
+
+## 5. Document integrity, numbering, and immutability
+
+- **Issued documents are immutable.** Once an invoice is `issued`, its line
+  items, tax figures, totals, dates, and number **MUST NOT** be edited or
+  deleted. Corrections are made by issuing a **credit note / 修正適格請求書**
+  (Phase 4+), never by mutating or removing the original.
+- **Sequential numbering with no compliance-breaking gaps.** Quote and invoice
+  numbers are assigned in sequence per organization and year. The system **MUST
+  NOT** silently reuse, back-fill, or delete numbers in a way that hides a
+  voided document. A voided document is recorded as voided, not erased.
+- **No hard delete of billing records.** Quotes, invoices, payments, and issued
+  PDFs use soft delete / void semantics; financial history is preserved.
+
+---
+
+## 6. Retention of issued copies (写しの保存)
+
+- The system **MUST** retain a copy of every **issued** qualified invoice (and
+  the figures used to produce it).
+- Retained copies are **tamper-evident**: a stored issued document **MUST NOT**
+  be silently mutated. Reissuing produces a new versioned record, not an
+  in-place overwrite.
+- Statutory retention is **7 years** (and may extend to **10 years** in certain
+  loss-carryforward situations). The product **MUST NOT** auto-purge issued
+  billing records before the statutory period. Operators are warned before any
+  destructive retention action.
+
+---
+
+## 7. Money representation
+
+- All amounts are stored and transmitted as **integer minimum currency units**
+  (`*_cents`; for JPY, ¥1 = 1 unit). **Float and DECIMAL for money are
+  prohibited** in DB, API JSON, and tests.
+- Phase 1–3 currency is **JPY only**.
+
+---
+
+## 8. Audit trail
+
+- Invoice **issuance** and **payment recording** are auditable events
+  (who / when / what), from Phase 2.
+- Audit records follow the same no-silent-mutation rule as §6.
+
+---
+
+## 9. How this rule applies to every change
+
+Any change that touches quotes, invoices, payments, tax calculation, document
+numbering, PDF rendering, or retention **MUST**:
+
+1. Be reviewed against this document and [`../review/compliance.md`](../review/compliance.md).
+2. State compliance impact in the PR.
+3. If it deviates from any rule here, carry an ADR with professional sign-off
+   (§0.2). No exceptions.
+
+If you are unsure whether a change has compliance impact, **assume it does** and
+run the checklist.

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -35,6 +35,11 @@ All money: **integer cents**. Tax rate: **basis points** (1000 = 10.00%).
 
 ## 3. Japan qualified invoice (適格請求書) — required fields
 
+> **Binding compliance.** The rules in this section are governed by
+> [`accounting-compliance.md`](./accounting-compliance.md) (non-negotiable). A
+> finance professional reviewing the system must find zero deviations. Any
+> departure requires an ADR with tax-professional sign-off.
+
 When `is_qualified_invoice = true`, the system must enforce and render:
 
 ### Issuer (supplier)
@@ -178,6 +183,7 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 
 ## Related
 
+- **Compliance (binding):** [`accounting-compliance.md`](./accounting-compliance.md)
 - Domain model: [`domain-model.md`](./domain-model.md)
 - Naming: [`../development/naming-conventions.md`](../development/naming-conventions.md)
 - Roadmap: [`../roadmap.md`](../roadmap.md)

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -1,0 +1,25 @@
+# Accounting & Tax Compliance Self-Review
+
+**Binding.** Use for **any** change touching quotes, invoices, payments, tax
+calculation, document numbering, PDF rendering, or record retention. If unsure
+whether a change has compliance impact, assume it does and run this list.
+
+Source of truth: [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
+
+## Checklist
+
+- [ ] Change reviewed against `docs/explanation/accounting-compliance.md`; compliance impact stated in the PR.
+- [ ] Qualified invoice required fields enforced before issuance (issuer name/address/`T`+13 registration number/date, per-rate taxable amount, per-rate consumption tax, total, buyer name).
+- [ ] Reduced-rate (軽減税率 8%) items clearly marked.
+- [ ] Consumption tax rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
+- [ ] Allowed tax rates only (10% / 8%); any rate change carries an ADR.
+- [ ] Registration number treated as **syntax-only** validation; no UI/doc implies it proves existence/validity.
+- [ ] Issued documents are immutable; corrections via credit note, not edit/delete.
+- [ ] Document numbering sequential; no silent gap, reuse, or hard delete that hides a voided document.
+- [ ] No hard delete of billing records (soft delete / void only).
+- [ ] Issued copies retained and tamper-evident; no auto-purge before the statutory period (7y, up to 10y).
+- [ ] All money is integer minimum currency units; no float/DECIMAL in DB, JSON, or tests.
+- [ ] Monetary/tax figures computed once in the UseCase; PDF/API/stored copy do not recalculate independently.
+- [ ] Audit trail recorded for issuance and payment (Phase 2+).
+- [ ] Any deviation from the binding rules carries an ADR with tax/accounting professional sign-off.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,18 +1,19 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #11)
+Last updated: 2026-05-29 (Issue #13)
 
 ## Recently merged
 
 - **Issue #1 / PR #2** — Governance and foundation (workflow, naming, ADRs, review checklists, Cursor rules)
 - **Issue #3 / PR #8** — Product vision, requirements, domain model ✅ merged
 - **Issue #9 / PR #10** — 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名）✅ merged
+- **Issue #11 / PR #12** — 日英(ja/en)バイリンガル方針宣言（ADR 0005）・多言語非対象 ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #11 | `docs/11-bilingual-ja-en-scope` | 日英(ja/en)バイリンガル方針宣言（ADR 0005）・多言語非対象 | 🔄 PR pending |
+| #13 | `docs/13-accounting-compliance-binding` | 会計・税務コンプライアンス完全順守を拘束ルール化（accounting-compliance.md・compliance チェックリスト） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -39,10 +40,16 @@ Last updated: 2026-05-29 (Issue #11)
 - Registration number documented as syntax-only validation
 - `cents` defined as smallest-currency-unit; naming inconsistency fixed
 
-**Phase 0 — Localization scope: 🔄 in progress** (Issue #11)
+**Phase 0 — Localization scope: ✅ complete** (Issue #11)
 
 - Product localization bound to ja (primary) + en (secondary); multilingual is a non-goal (ADR 0005)
 - Statutory invoice content stays Japanese; en applies to operator UI/guides
+
+**Phase 0 — Compliance hardening: 🔄 in progress** (Issue #13)
+
+- Accounting/tax compliance made binding & non-negotiable (`accounting-compliance.md`)
+- Compliance self-review checklist added (`docs/review/compliance.md`)
+- Deviations require ADR + tax-professional sign-off
 
 **Runtime: not started** — begin with Issue #4.
 
@@ -50,6 +57,7 @@ Last updated: 2026-05-29 (Issue #11)
 
 - Namespace: `NeneInvoice\`
 - Problem Details base: `https://nene-invoice.dev/problems/`
+- **Compliance (binding):** `docs/explanation/accounting-compliance.md` — zero deviations; deviation needs ADR + 税理士 sign-off
 - Money: integer cents (smallest currency unit; JPY ¥1 = 1 cent); tax: basis points (1000 = 10%)
 - Tax rounding: once per tax rate per document, half-up — ADR 0004
 - Qualified invoice: validate `T` + 13 digit registration number at API layer (syntax only)
@@ -58,6 +66,6 @@ Last updated: 2026-05-29 (Issue #11)
 
 ## Next steps
 
-1. Merge Issue #11 PR (localization scope)
+1. Merge Issue #13 PR (compliance hardening)
 2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
 3. Issue #5–#6 can follow in parallel after #4 lands


### PR DESCRIPTION
Closes #13

## 目的

経理・会計の専門家がレビューしても **逸脱ゼロ** で確信を持って運用できるよう、日本の会計・消費税・適格請求書制度の順守を **非交渉の拘束ルール** として明文化する。

## 変更内容

- **`docs/explanation/accounting-compliance.md`（新規・正本）**: 拘束ルール集。コンプライアンス最優先／無断逸脱禁止／逸脱は ADR ＋ **税理士確認** 必須。適格請求書必須項目、税率・端数処理（税率ごと1回・ADR 0004）、登録番号の構文検証限定、発行済み文書の不変性、連番・ハード削除禁止、写しの保存（7〜10年・改ざん検知）、integer cents、監査証跡を **MUST** として規定。
- **`docs/review/compliance.md`（新規）**: 請求・税・採番・PDF・保存に関わる変更で必須のセルフレビューチェックリスト。
- **requirements / backend-standards**: 拘束バナーと参照を追加。
- **self-review.md**: チェックリスト一覧に `compliance.md` を登録。
- **CLAUDE.md / AGENTS.md / .cursor/rules / README**: コンプライアンス拘束ルールを各エントリポイントに反映。CLAUDE.md の stale な状況表も現状へ更新。
- **current.md**: Issue #11 マージ済み・#13 進行中へ同期。

## 設計上の注意

- 本ドキュメントは **エンジニアリングによる拘束的解釈** であり法的助言ではない旨を明記。不明点は推測せず 税理士 に確認する運用を規定。
- 既存の ADR 0004（端数処理）を参照し矛盾なく接続。

## 検証

- docs のみ。`git diff --check` 通過。エントリポイント（CLAUDE/AGENTS/cursor/README）とレビュー一覧の相互リンク整合を確認。

## セルフレビュー

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)