### PR TITLE
docs(naming): 命名規則を絶対順守化し用語レジストリとタイポ厳禁を明文化する (#15)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -14,4 +14,5 @@ alwaysApply: true
 - NeNe Invoice はセルフホスト OSS の見積・請求・入金管理 — 適格請求書対応、Admin UI、PDF。
 - **会計・税務コンプライアンスは拘束ルール（非交渉）。** 請求・税・採番・PDF・保存の変更は `docs/explanation/accounting-compliance.md` 順守必須。逸脱は ADR ＋ 税理士確認なしに禁止。専門家がレビューしても逸脱ゼロを満たす。
 - 金額は **integer cents**（float 禁止）。実装は疎結合、型安全、OpenAPI/MCP 境界を優先（NENE2 継承）。
+- **命名規則は絶対順守・タイポ厳禁。** 全識別子は用語レジストリ `docs/explanation/terminology.md`（唯一の真実）と完全一致。スペルゆれ・未登録語はマージ禁止、追加/改名は同一 PR でレジストリ更新。
 - Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This file is the entry point for AI agents working on NeNe Invoice.
 - **Requirements:** `docs/explanation/requirements.md`
 - **Domain model:** `docs/explanation/domain-model.md`
 - **Glossary:** `docs/explanation/glossary.md`
+- **Terminology registry (canonical spellings — single source of truth):** `docs/explanation/terminology.md`
 - **Naming conventions:** `docs/development/naming-conventions.md`
 - Inheritance map: `docs/inheritance-from-nene2.md`
 - Human and AI collaboration: `docs/CONTRIBUTING.md`
@@ -34,6 +35,7 @@ This file is the entry point for AI agents working on NeNe Invoice.
 - Keep changes focused. Do not mix governance, feature work, and unrelated cleanup in one PR.
 - Do not commit secrets, credentials, local `.env` files, or generated build outputs.
 - Prefer explicit, typed, testable code over hidden framework behavior.
+- **Naming is absolute; zero typos.** Every identifier must match `docs/explanation/terminology.md` exactly. Spelling variants and unregistered terms block merge. Adding/renaming a term updates the registry in the same PR. Grep for stray variants before committing.
 - When docs and Cursor rules conflict, update the docs first and keep `.cursor/rules/` concise.
 
 ## Project Direction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Ops / MCP         ──→         │
 
 **絶対順守:**
 - **会計・税務コンプライアンス完全順守**（非交渉）。請求・税・採番・PDF・保存に関わる変更は `docs/explanation/accounting-compliance.md` と `docs/review/compliance.md` で確認必須。逸脱は ADR ＋ 税理士確認なしに禁止。正本: `docs/explanation/accounting-compliance.md`
+- **命名規則の絶対順守・タイポ厳禁**。全識別子（エンティティ／状態値／JSON・DB フィールド／Problem Details slug／operationId）は用語レジストリ `docs/explanation/terminology.md` と **完全一致**。スペルゆれ・未登録語はマージ禁止。追加・改名は同一 PR でレジストリ更新必須。
 
 ---
 
@@ -67,7 +68,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 - 金額: **integer cents**（float 禁止）
 - SQL: `Pdo*Repository` 内のみ
 
-詳細: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`
+詳細: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`, `docs/explanation/terminology.md`（用語レジストリ＝唯一の真実）
 
 ---
 
@@ -76,6 +77,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 | 目的 | ドキュメント |
 | --- | --- |
 | **会計・税務コンプライアンス（拘束）** | `docs/explanation/accounting-compliance.md` |
+| **用語レジストリ（識別子の正準スペル）** | `docs/explanation/terminology.md` |
 | 現在のタスク | `docs/todo/current.md` |
 | ロードマップ | `docs/roadmap.md` |
 | プロダクトビジョン | `docs/explanation/product-vision.md` |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Full list: [`docs/explanation/product-vision.md#non-goals`](./docs/explanation/p
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
 | **Domain model** | [`docs/explanation/domain-model.md`](./docs/explanation/domain-model.md) |
 | **Glossary** | [`docs/explanation/glossary.md`](./docs/explanation/glossary.md) |
+| **Terminology registry** | [`docs/explanation/terminology.md`](./docs/explanation/terminology.md) |
 | **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | **Workflow** | [`docs/workflow.md`](./docs/workflow.md) |
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -6,7 +6,8 @@ NeNe Invoice coding standards split by surface. **Full policies live in the dedi
 | --- | --- |
 | **PHP / API / database** | [`backend-standards.md`](./backend-standards.md) |
 | **Naming (code, API, DB, tests)** | [`naming-conventions.md`](./naming-conventions.md) |
-| **Product terms (glossary)** | [`../explanation/glossary.md`](../explanation/glossary.md) |
+| **Canonical term/identifier spellings** | [`../explanation/terminology.md`](../explanation/terminology.md) |
+| **Product term meanings (glossary)** | [`../explanation/glossary.md`](../explanation/glossary.md) |
 | **React / TypeScript admin** | [`frontend-standards.md`](./frontend-standards.md) (Phase 2+) |
 | **NENE2 inheritance map** | [`../inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
 
@@ -16,6 +17,9 @@ NeNe Invoice coding standards split by surface. **Full policies live in the dedi
 
 ## Shared rules (all surfaces)
 
+- **Naming conventions are absolute (non-negotiable).** Violations and typos block merge — see [`naming-conventions.md`](./naming-conventions.md).
+- **Terminology has one source of truth:** [`../explanation/terminology.md`](../explanation/terminology.md). Every identifier must match it exactly; adding/renaming a term updates the registry in the same PR.
+- **Zero typos in identifiers.** Spelling variants of registered terms are defects, not style preferences.
 - GitHub Issue-driven work; focused PRs; no direct commits to `main`
 - **Strict typing** at boundaries — PHP readonly DTOs; TypeScript strict mode (when frontend exists)
 - **OpenAPI** is the public API contract; MCP maps to the same HTTP operations

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -2,7 +2,18 @@
 
 Authoritative naming rules for NeNe Invoice code, API contracts, database objects, tests, and English documentation.
 
-**Glossary (product terms):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
+> **Absolute adherence — non-negotiable.** These rules are **MUST**, not
+> suggestions. A name that violates a rule here, or a typo / spelling variant of
+> a registered term, is a defect and **blocks merge**. There is no "close
+> enough." When in doubt, match the registry exactly.
+>
+> The concrete canonical spelling of every term and identifier lives in the
+> **single source of truth**: [`../explanation/terminology.md`](../explanation/terminology.md).
+> This document defines the *patterns*; the registry defines the *exact strings*.
+> Introducing or renaming any identifier **MUST** update the registry in the same PR.
+
+**Terminology registry (canonical spellings):** [`docs/explanation/terminology.md`](../explanation/terminology.md)
+**Glossary (product term meanings):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
 
 **Framework baseline:** NENE2 [`domain-layer.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/domain-layer.md) and [`database-migrations.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/database-migrations.md). This document is the NeNe Invoice override and extension list.
 
@@ -198,12 +209,14 @@ Full frontend standards: **`docs/development/frontend-standards.md`** (Phase 2).
 | Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
 | ADR file | `NNNN-kebab-title.md` | `0002-separate-from-sibling-products.md` |
 
-When adding a new public term, update [`glossary.md`](../explanation/glossary.md) in the same PR.
+When adding or renaming any identifier, update [`terminology.md`](../explanation/terminology.md) in the same PR; if it is a product concept, also update [`glossary.md`](../explanation/glossary.md).
 
 ---
 
 ## 11. Prohibited patterns
 
+- **Typos or spelling variants of any term registered in `terminology.md`** (e.g. `tax_registration_number` for `registration_number`, `sub_total_cents` for `subtotal_cents`) — blocks merge
+- **Unregistered identifiers** — using an entity, status, field, slug, or `operationId` not present in `terminology.md` without adding it in the same PR
 - Layer-first folders (`src/Handlers/`, `src/Repositories/`)
 - SQL outside `Pdo*Repository`
 - camelCase in public JSON property names

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -2,6 +2,11 @@
 
 Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments.
 
+> This file defines the **meaning** of product concepts. The authoritative
+> **spelling** of every term and identifier (entities, fields, status values,
+> slugs) lives in the single source of truth
+> [`terminology.md`](./terminology.md) — spellings here MUST conform to it.
+
 | Term | Definition | Avoid |
 | --- | --- | --- |
 | **quote** | An estimate (見積書) sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers |

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -1,0 +1,132 @@
+# Terminology Registry — Single Source of Truth
+
+**Status: binding.** This file is the **single source of truth** for the
+canonical spelling and form of every NeNe Invoice term and identifier:
+entities, status values, JSON/DB field names, enums, Problem Details slugs, and
+`operationId` stems.
+
+If an identifier appears anywhere in the codebase, OpenAPI, database, tests, or
+docs, its spelling **MUST** match this registry **exactly** — same characters,
+same case, same separators. There is no "close enough."
+
+## Authority and absolute rules
+
+1. **Exact match is mandatory.** Any spelling variant or typo of a registered
+   term is a defect and **blocks merge** — there are no acceptable synonyms or
+   abbreviations outside this registry.
+2. **Register before you use.** Introducing a new term/identifier, or renaming
+   an existing one, **MUST** update this registry in the **same PR**. Code that
+   uses an unregistered term does not merge.
+3. **No renaming after release.** Shipped `operationId` values and public JSON
+   field names are stable; deprecate, do not rename (see `naming-conventions.md`).
+4. **Roles of the three docs — do not duplicate, cross-reference:**
+   - **`terminology.md`** (this file) — the authoritative **spelling/form** of every identifier.
+   - **`glossary.md`** — the **meaning** of product concepts. Its spellings MUST conform to this registry.
+   - **`naming-conventions.md`** — the **patterns/rules** that generate names. This registry is the concrete instantiation of those rules.
+
+See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](../development/naming-conventions.md).
+
+---
+
+## 1. Domain entities
+
+| Concept | PHP class / domain folder | Table | Primary FK in JSON/DB |
+| --- | --- | --- | --- |
+| Issuer profile | `Company` (folder); `CompanySettings` (entity) | `company_settings` | — (singleton) |
+| Buyer | `Client` | `clients` | `client_id` |
+| Estimate | `Quote` | `quotes` | `quote_id` |
+| Bill | `Invoice` | `invoices` | `invoice_id` |
+| Document row | `LineItem` | `line_items` | `line_item_id` |
+| Receipt | `Payment` | `payments` | `payment_id` |
+| Number generator | `DocumentSequence` | `document_sequences` | — |
+
+Domain folders are **PascalCase singular**; tables are **snake_case plural**.
+
+---
+
+## 2. Status values (exact strings)
+
+Stored and transmitted **exactly** as written (lowercase snake_case).
+
+| Owner | Allowed values |
+| --- | --- |
+| `quote.status` | `draft`, `sent`, `accepted`, `rejected`, `expired` |
+| `invoice.status` | `draft`, `issued`, `partially_paid`, `paid` |
+| invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
+| `payment.method` | `bank_transfer`, `cash`, `other` |
+| `line_item.parent_type` | `quote`, `invoice` |
+
+Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering them here first.
+
+---
+
+## 3. Canonical field / column names (snake_case)
+
+| Term | Canonical | Never |
+| --- | --- | --- |
+| Invoice registration number | `registration_number` | `tax_registration_number`, `invoice_registration_number`, `t_number` |
+| Qualified-invoice flag | `is_qualified_invoice` | `qualified`, `is_qualified` |
+| Soft-delete flag / time | `is_deleted`, `deleted_at` | `deleted`, `is_del` |
+| Subtotal (pre-tax) | `subtotal_cents` | `sub_total_cents`, `subtotal` |
+| Tax amount | `tax_cents` | `tax`, `tax_amount` |
+| Total | `total_cents` | `amount_cents` (on documents), `grand_total` |
+| Unit price | `unit_price_cents` | `price_cents`, `unitprice_cents` |
+| Payment amount | `amount_cents` | `paid_cents`, `payment_cents` |
+| Tax rate | `tax_rate_bps` | `tax_rate`, `rate`, `tax_rate_percent` |
+| Foreign keys | `client_id`, `quote_id`, `invoice_id` | `clientId`, `client` |
+| Polymorphic parent | `parent_type`, `parent_id` | `parentType`, `owner_id` |
+| Numbers | `quote_number`, `invoice_number` | `number`, `quote_no` |
+| Timestamps | `issued_at`, `due_at`, `paid_at`, `valid_until`, `deleted_at` | `issue_date`, `due_date`, `paidAt` |
+| Issuer fields | `legal_name`, `bank_name`, `bank_branch`, `account_type`, `account_number`, `logo_url` | `company_name`, `branch`, `acct_no` |
+| Client fields | `contact_name`, `billing_address` | `contact`, `address` |
+| List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
+
+Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
+the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are
+`{singular_entity}_id`. See `naming-conventions.md` for the full pattern set.
+
+---
+
+## 4. Problem Details type slugs (kebab-case)
+
+Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
+
+| Slug | Use |
+| --- | --- |
+| `validation-failed` | Request body/field validation error |
+| `invoice-not-found` | Invoice id/token not found |
+| `quote-not-found` | Quote id not found |
+| `client-not-found` | Client id not found |
+| `invalid-state-transition` | Disallowed status change |
+| `qualified-invoice-incomplete` | Missing required qualified-invoice field |
+
+Add new slugs here before using them. Validation `errors[].field` uses
+snake_case paths (e.g. `body.registration_number`); `errors[].code` is
+snake_case (e.g. `required`, `invalid_invoice_number`).
+
+---
+
+## 5. operationId stems (camelCase)
+
+Shape `{verb}{Resource}` / `{verb}{Resource}ById`. Stable after release. Must
+match between OpenAPI, route registration, and `docs/mcp/tools.json`.
+
+| operationId | Resource |
+| --- | --- |
+| `getHealth` | System |
+| `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
+| `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
+| `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
+| `listPayments`, `createPayment` | Payment |
+
+Extend this list (do not improvise) when adding operations.
+
+---
+
+## How to add or change a term
+
+1. Add/rename the entry **here** in the same PR as the code.
+2. Update `glossary.md` if it is a product concept; update `naming-conventions.md`
+   if it introduces a new pattern.
+3. Run the docs-policy and backend-api self-review checklists.
+4. Confirm no spelling variant of the term remains anywhere (grep before commit).

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -11,6 +11,7 @@ Source policies: `docs/development/backend-standards.md`, `docs/development/nami
 - [ ] Business rules live in UseCase, not Handler or Repository.
 - [ ] Money fields use integer cents — no floats.
 - [ ] Japan invoice validation rules enforced in UseCase before persistence/PDF.
+- [ ] All identifiers (fields, status values, `operationId`, slugs) match `docs/explanation/terminology.md` exactly — no typos, no unregistered terms.
 - [ ] New routes documented in OpenAPI with `operationId`.
 - [ ] Problem Details used for errors; no stack traces in responses.
 - [ ] Admin mutating routes require auth when applicable.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -23,5 +23,6 @@ Source policies:
 - [ ] Issue and PR references included where useful.
 - [ ] Wording is concrete enough for humans and AI agents to follow.
 - [ ] English docs use canonical terms from `docs/explanation/glossary.md`.
-- [ ] New public terms added to glossary and/or `naming-conventions.md` when introduced.
+- [ ] All identifiers match `docs/explanation/terminology.md` exactly — no typos or spelling variants.
+- [ ] New or renamed terms/identifiers registered in `docs/explanation/terminology.md` in this PR (and glossary if a product concept).
 - [ ] `git diff --check` reviewed for whitespace errors.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #13)
+Last updated: 2026-05-29 (Issue #15)
 
 ## Recently merged
 
@@ -8,12 +8,13 @@ Last updated: 2026-05-29 (Issue #13)
 - **Issue #3 / PR #8** — Product vision, requirements, domain model ✅ merged
 - **Issue #9 / PR #10** — 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名）✅ merged
 - **Issue #11 / PR #12** — 日英(ja/en)バイリンガル方針宣言（ADR 0005）・多言語非対象 ✅ merged
+- **Issue #13 / PR #14** — 会計・税務コンプライアンス完全順守を拘束ルール化（accounting-compliance.md・compliance チェックリスト）✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #13 | `docs/13-accounting-compliance-binding` | 会計・税務コンプライアンス完全順守を拘束ルール化（accounting-compliance.md・compliance チェックリスト） | 🔄 PR pending |
+| #15 | `docs/15-terminology-registry-naming-strict` | 命名規則の絶対順守・用語レジストリ（唯一の真実）・タイポ厳禁 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -45,11 +46,17 @@ Last updated: 2026-05-29 (Issue #13)
 - Product localization bound to ja (primary) + en (secondary); multilingual is a non-goal (ADR 0005)
 - Statutory invoice content stays Japanese; en applies to operator UI/guides
 
-**Phase 0 — Compliance hardening: 🔄 in progress** (Issue #13)
+**Phase 0 — Compliance hardening: ✅ complete** (Issue #13)
 
 - Accounting/tax compliance made binding & non-negotiable (`accounting-compliance.md`)
 - Compliance self-review checklist added (`docs/review/compliance.md`)
 - Deviations require ADR + tax-professional sign-off
+
+**Phase 0 — Terminology & naming hardening: 🔄 in progress** (Issue #15)
+
+- Terminology registry added as single source of truth (`terminology.md`)
+- Naming made absolute; typos / unregistered terms block merge
+- Registry update required in the same PR as any term add/rename
 
 **Runtime: not started** — begin with Issue #4.
 
@@ -58,6 +65,7 @@ Last updated: 2026-05-29 (Issue #13)
 - Namespace: `NeneInvoice\`
 - Problem Details base: `https://nene-invoice.dev/problems/`
 - **Compliance (binding):** `docs/explanation/accounting-compliance.md` — zero deviations; deviation needs ADR + 税理士 sign-off
+- **Terminology (single source of truth):** `docs/explanation/terminology.md` — identifiers match exactly; typos block merge
 - Money: integer cents (smallest currency unit; JPY ¥1 = 1 cent); tax: basis points (1000 = 10%)
 - Tax rounding: once per tax rate per document, half-up — ADR 0004
 - Qualified invoice: validate `T` + 13 digit registration number at API layer (syntax only)
@@ -66,6 +74,6 @@ Last updated: 2026-05-29 (Issue #13)
 
 ## Next steps
 
-1. Merge Issue #13 PR (compliance hardening)
+1. Merge Issue #15 PR (terminology & naming hardening)
 2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
 3. Issue #5–#6 can follow in parallel after #4 lands


### PR DESCRIPTION
Closes #15

## 目的

識別子のスペルゆれ・タイポを構造的に排除する。命名規則を「推奨」から **絶対順守** へ引き上げ、全用語・識別子の正準スペルを集約した **単一の真実** を新設する。

## 変更内容

- **`docs/explanation/terminology.md`（新規・唯一の真実）**: エンティティ／状態値／JSON・DB フィールド／Problem Details slug／operationId の **正準スペル** を規定。**完全一致必須**、スペルゆれ・未登録語は **マージ禁止**、追加・改名は **同一 PR でレジストリ更新を MUST** 化。
- **役割分離**: glossary＝概念の意味 / naming-conventions＝命名パターン / terminology＝正準スペル。三者を相互参照し重複させない。
- **naming-conventions**: 絶対順守バナー＋禁止パターンに「登録語のタイポ／未登録識別子」を追加。
- **coding-standards**: 共通ルールに命名絶対順守・用語 SoT・タイポ厳禁を追加。
- **glossary**: terminology との関係（意味 vs スペル）を明記。
- **CLAUDE.md / AGENTS.md / .cursor/rules / README**: 拘束ルールとレジストリ参照を各エントリポイントに反映。
- **docs-policy / backend-api セルフレビュー**: 用語一致・タイポ確認項目を追加。
- **current.md**: Issue #13 マージ済み・#15 進行中へ同期。

## 検証

- docs のみ。`git diff --check` 通過。レジストリの正準スペルが既存ドキュメント（requirements / domain-model / naming-conventions）と矛盾しないことを確認（例: `registration_number`、payment method `bank_transfer/cash/other`、quote/invoice status 値）。

## セルフレビュー

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)