### PR TITLE
docs(tenancy): マルチテナント基盤とロール階層を土台として採用する (#17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Claude Code / AI エージェント向け実行ガイド。詳細ポリシーの
 
 ## プロダクト一言要約
 
-自己ホスト型 **見積・請求・入金管理** OSS（MIT）。日本 SMB 向け **適格請求書** 対応。NENE2 上の sibling product — Records / Corpus / Concierge と HTTP 連携のみ。
+自己ホスト型 **見積・請求・入金管理** OSS（MIT）。日本 SMB 向け **適格請求書** 対応。**マルチテナント前提**（組織＝テナント、superadmin が組織を / admin がユーザーを管理 — ADR 0006）。NENE2 上の sibling product — Records / Corpus / Concierge と HTTP 連携のみ。
 
 ```
 Admin UI (React)  ──→  NeNe Invoice API (NENE2/PHP 8.4)  ──→  MySQL
@@ -62,10 +62,11 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 ```
 
 - Namespace: `NeneInvoice\`
-- ドメイン別フォルダ（`Client/`, `Quote/`, `Invoice/`, `Payment/` 等）
+- ドメイン別フォルダ（`Organization/`, `Auth/`, `User/`, `Client/`, `Quote/`, `Invoice/`, `Payment/` 等）
 - レイヤー別フォルダ禁止（`src/Handlers/` 等）
 - JSON: **snake_case** 固定
 - 金額: **integer cents**（float 禁止）
+- **マルチテナント**: テナントスコープの全テーブル/クエリに `organization_id`。superadmin のみクロステナント（ADR 0006）
 - SQL: `Pdo*Repository` 内のみ
 
 詳細: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`, `docs/explanation/terminology.md`（用語レジストリ＝唯一の真実）

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ NeNe Invoice is an open-source billing platform built on [NENE2](https://github.
 - **Japan invoice compliance** — registration number, tax rates, qualified invoice PDF fields
 - **Self-hosted OSS** — MIT licensed; Tier A shared hosting or Tier B Docker/VPS
 - **Quote-to-cash** — estimate → invoice → payment in one product
+- **Multi-tenant from the foundation** — superadmin manages organizations, admin manages users; single-SMB installs run in `single` mode ([ADR 0006](./docs/adr/0006-multi-tenancy-and-roles.md))
 - **Sibling to NeNe ecosystem** — optional HTTP link to Records / Concierge; never merged into CMS
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
 - **Bilingual, not multilingual** — Japanese + English admin UI for operators (incl. non-Japanese running businesses in Japan); other locales are a deliberate non-goal ([ADR 0005](./docs/adr/0005-bilingual-ja-en-scope.md))

--- a/docs/adr/0006-multi-tenancy-and-roles.md
+++ b/docs/adr/0006-multi-tenancy-and-roles.md
@@ -1,0 +1,117 @@
+# ADR 0006: Adopt Multi-Tenancy and Role Hierarchy as Foundational
+
+## Status
+
+accepted
+
+## Context
+
+The early product docs assumed Phase 1 was single-tenant, with multi-tenancy
+deferred ("`company_settings` singleton per organization (Phase 1 single-tenant;
+multi-tenant adds `organization_id`)"). In practice the product must support, from
+the foundation:
+
+- agencies and hosting operators running **one install for multiple client
+  organizations**, and
+- a **role hierarchy** where a platform operator manages organizations and an
+  organization administrator manages that organization's users.
+
+Sibling product [NeNe Records](https://github.com/hideyukiMORI/nene-records)
+already implements exactly this on NENE2 (per-request organization resolution,
+`Role`/`Capability` enums, `CapabilityMiddleware`, `organization_id` on
+tenant-scoped tables). Retrofitting tenancy later would touch every table,
+repository, and route — far more costly than building tenant-aware from day one.
+
+Alternatives considered:
+
+1. **Single-tenant first, retrofit later** — rejected; a later `organization_id`
+   migration across all billing tables plus auth rework is high-risk and
+   re-opens compliance-sensitive code (issued documents, numbering).
+2. **Separate install per tenant only** — rejected; does not serve agencies and
+   duplicates operations; the data model should still be tenant-aware.
+3. **Multi-tenant foundation, mirroring NeNe Records** (chosen) — tenant-aware
+   schema and middleware from the start; a single install may still run as one
+   organization via the `single` resolution mode.
+
+## Decision
+
+NeNe Invoice is **multi-tenant from the foundation**, adopting the NeNe Records
+architecture.
+
+### Tenancy
+
+- Every tenant-scoped table carries **`organization_id`** (`company_settings`,
+  `clients`, `quotes`, `invoices`, `line_items`, `payments`,
+  `document_sequences`, `users`).
+- The **organization** (`organizations` table) is the tenant. Each organization
+  is an independent **issuer** of qualified invoices, with its own
+  `company_settings` (legal name, address, **registration number**, bank info).
+- Per-request **organization resolution** runs in middleware before authorization
+  (mirroring `OrgResolverMiddleware`). Supported modes: **`single`** (default —
+  one organization per install), `path` (`/{org-slug}/…`), `subdomain`, and
+  `custom_domain`. The resolved organization id is held in a request-scoped holder
+  and **every repository query is org-scoped**.
+- Document numbering sequences are **per organization and year** (already in
+  `domain-model.md`); tenancy makes the scope explicit.
+
+### Roles and capabilities
+
+A `Role` enum and a `Capability` enum, resolved per route by a capability
+resolver and enforced by `CapabilityMiddleware` (mirroring NeNe Records):
+
+| Role | Scope | Capabilities |
+| --- | --- | --- |
+| **`superadmin`** | Cross-tenant (platform operator) | All, **including `manage_organizations`**. `organization_id` may be `NULL`. |
+| **`admin`** | Single organization | All **except** `manage_organizations` — manages the org's **users**, **company settings** (issuer profile), and billing. |
+| **`member`** | Single organization | Billing operator — create/edit/send quotes & invoices, record payments (`manage_billing`, `view_billing`). **Cannot** manage users or settings. |
+| **`viewer`** | Single organization | Read-only (`view_billing`). Optional; Phase 3+. |
+
+Capabilities (billing-specific; the set differs from NeNe Records' content
+capabilities): `manage_organizations`, `manage_users`, `manage_company_settings`,
+`manage_billing`, `view_billing`.
+
+- **Superadmin manages organizations** (`/admin/organizations` — create, list,
+  delete tenants).
+- **Admin manages users** within the organization (`/admin/users`).
+- Role and capability string values are registered in
+  [`../explanation/terminology.md`](../explanation/terminology.md) (binding).
+
+### Compliance interaction
+
+- Each organization's issuer registration number and issued documents are scoped
+  to that organization; cross-tenant reads are prohibited. This does not relax any
+  rule in [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) —
+  immutability, numbering, and retention apply **per organization**.
+
+## Consequences
+
+**Benefits**
+
+- Serves agencies/hosting operators and single SMBs from one codebase; `single`
+  mode keeps the simple case simple.
+- Avoids a high-risk tenancy retrofit across compliance-sensitive billing tables.
+- Consistent with the NeNe ecosystem; patterns and reviews transfer.
+
+**Costs**
+
+- Every repository query must be org-scoped — a standing review item
+  (`docs/review/database.md`, `docs/review/middleware-security.md`).
+- Auth, org resolution, and RBAC are part of the runtime foundation (Issue #4),
+  enlarging it beyond a bare health endpoint.
+
+**Follow-up**
+
+- **PR-B (Issue #4 expanded):** runtime foundation — org resolution + JWT auth +
+  RBAC wiring + `GET /health`.
+- **PR-C+:** organization CRUD (superadmin) and user CRUD (admin).
+
+## Related
+
+- Reference implementation: NeNe Records `src/Organization/`, `src/Auth/` (Role, Capability, CapabilityResolver, CapabilityMiddleware), `src/Organization/Resolution/`
+- Requirements: `docs/explanation/requirements.md`
+- Domain model: `docs/explanation/domain-model.md`
+- Terminology registry: `docs/explanation/terminology.md`
+- Compliance: `docs/explanation/accounting-compliance.md`
+- Issue: `#17`
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -32,8 +32,10 @@ Organize by **domain**, not technical layer:
 src/
   ApplicationServiceProvider.php
   Http/
-  AdminAuth/
-  Company/          # issuer profile, tax registration, bank info
+  Organization/     # tenants + per-request resolution (Organization/Resolution/)
+  Auth/             # JWT login, Role / Capability, capability middleware
+  User/             # operator accounts within an organization
+  Company/          # issuer profile, tax registration, bank info (per organization)
   Client/           # customer master
   Quote/            # estimates
   Invoice/          # issued invoices, qualified invoice fields
@@ -42,6 +44,9 @@ src/
   Pdf/              # server-side PDF generation
   Upstream/         # optional HTTP clients (Records, Concierge)
 ```
+
+Every tenant-scoped table and query carries `organization_id` (ADR 0006). Only
+superadmin operates cross-tenant.
 
 **Zero-tolerance placement:** handlers live in their domain folder (`Invoice/CreateInvoiceHandler.php`), not `src/Handlers/`.
 

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -53,7 +53,7 @@ All application classes: `final` and `readonly` where applicable. Every PHP file
 
 Use only domain-grouped top-level folders. Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
 
-Planned domains (Phase 1+): `Client/`, `Quote/`, `Invoice/`, `Payment/`, `Company/`, `LineItem/`, `Pdf/`, `AdminAuth/`, `Http/`.
+Planned domains (Phase 1+): `Organization/`, `Auth/`, `User/`, `Client/`, `Quote/`, `Invoice/`, `Payment/`, `Company/`, `LineItem/`, `Pdf/`, `Http/`.
 
 ### Methods and properties
 

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -10,8 +10,12 @@ See also: [`requirements.md`](./requirements.md), [`glossary.md`](./glossary.md)
 
 ```mermaid
 erDiagram
-    company_settings ||--o{ quote : "issuer"
-    company_settings ||--o{ invoice : "issuer"
+    organization ||--o{ user : "has"
+    organization ||--|| company_settings : "issuer profile"
+    organization ||--o{ client : "owns"
+    organization ||--o{ quote : "owns"
+    organization ||--o{ invoice : "owns"
+    organization ||--o{ payment : "owns"
     client ||--o{ quote : "buyer"
     client ||--o{ invoice : "buyer"
     quote ||--o| invoice : "converts_to"
@@ -20,7 +24,9 @@ erDiagram
     invoice ||--o{ payment : "receives"
 ```
 
-- **company_settings**: singleton per organization (Phase 1 single-tenant; multi-tenant adds `organization_id`).
+- **organization**: the tenant (ADR 0006). Every tenant-scoped table carries `organization_id`. Default resolution mode `single`; agencies use path/subdomain/custom_domain.
+- **user**: operator account with a `role` (superadmin/admin/member/viewer). superadmin is cross-tenant (`organization_id` NULL); all others belong to one organization.
+- **company_settings**: one issuer profile **per organization** (each org issues its own qualified invoices under its own registration number).
 - **line_item**: polymorphic parent — `parent_type` + `parent_id` (`quote` or `invoice`).
 - **payment**: always linked to one invoice; partial payments sum to `amount_cents` on invoice.
 
@@ -141,15 +147,17 @@ UseCase never calls PDF library directly. Handler never recalculates tax.
 
 | Module | Responsibility |
 | --- | --- |
-| `Company/` | Issuer profile settings |
+| `Organization/` | Tenants + per-request resolution (`Organization/Resolution/`) — superadmin CRUD |
+| `Auth/` | JWT login, `Role` / `Capability`, capability middleware |
+| `User/` | Operator accounts within an organization — admin CRUD |
+| `Company/` | Issuer profile settings (per organization) |
 | `Client/` | Buyer master |
 | `Quote/` | Quote CRUD, status transitions |
 | `Invoice/` | Invoice CRUD, issue, convert from quote |
 | `LineItem/` | Shared line item attach/detach |
 | `Payment/` | Payment recording |
 | `Pdf/` | PDF rendering adapters |
-| `DocumentSequence/` | Auto-number generation |
-| `AdminAuth/` | JWT login |
+| `DocumentSequence/` | Auto-number generation (per organization) |
 | `Upstream/` | Optional Records / Concierge HTTP clients |
 
 ---

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -9,6 +9,11 @@ Canonical English terms for NeNe Invoice public docs, OpenAPI, and code comments
 
 | Term | Definition | Avoid |
 | --- | --- | --- |
+| **organization** | The tenant — an independent issuer with its own users, issuer profile, and billing data (ADR 0006) | "tenant" / "account" / "company" in code identifiers |
+| **superadmin** | Cross-tenant platform role; manages organizations (`manage_organizations`) | "root", "owner", "superuser" in code |
+| **admin** | Organization-scoped role; manages the org's users, issuer settings, and billing | "manager" |
+| **member** | Organization-scoped billing operator; creates/sends documents and records payments; no user/settings management | "user", "staff" in code identifiers |
+| **organization resolution** | Per-request selection of the tenant; modes `single` (default) / `path` / `subdomain` / `custom_domain` | "tenant detection" |
 | **quote** | An estimate (見積書) sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers |
 | **invoice** | A billing document (請求書) issued to a client | "bill" |
 | **qualified invoice** | Japan invoice system compliant document (適格請求書) with required issuer, tax, and registration fields | mixing Japanese in API field names |

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -45,9 +45,16 @@ and tax rules, but operate the admin UI more comfortably in English. NeNe
 Invoice serves them with an **English admin UI**, while statutory documents
 remain Japanese — see [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
 
-**Multi-tenant hosting operators (later)**
+**Multi-tenant hosting operators**
 
-Agencies running one NeNe Invoice instance for multiple client organizations — same pattern as NeNe Records / Concierge multi-tenancy.
+Agencies running one NeNe Invoice instance for multiple client organizations.
+Multi-tenancy is **foundational, not deferred** — every tenant-scoped table
+carries `organization_id` and a per-request resolver selects the tenant
+([ADR 0006](../adr/0006-multi-tenancy-and-roles.md)). A single-SMB install simply
+runs in the default `single` resolution mode. A **superadmin** manages
+organizations; an organization **admin** manages that organization's users and
+issuer settings; **members** operate billing. Same pattern as NeNe Records /
+Concierge multi-tenancy.
 
 ## Primary Persona
 

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -6,23 +6,38 @@ See also: [`product-vision.md`](./product-vision.md), [`domain-model.md`](./doma
 
 ---
 
-## 1. User roles
+## 1. Tenancy and user roles
 
-| Role | Capabilities | Phase |
-| --- | --- | --- |
-| **admin** | Full CRUD on clients, quotes, invoices, payments, company settings | 1 |
-| **viewer** (optional) | Read-only access to documents and reports | 3+ |
-| **public client** | Download invoice PDF via time-limited token URL — no login | 2 |
+NeNe Invoice is **multi-tenant from the foundation** — see
+[ADR 0006](../adr/0006-multi-tenancy-and-roles.md). The **organization** is the
+tenant; every tenant-scoped table carries `organization_id`. A single install may
+run as one organization via the default `single` resolution mode; agencies use
+`path` / `subdomain` / `custom_domain`.
 
-Phase 1: single admin user (JWT). Multi-user RBAC is Phase 3+.
+| Role | Scope | Capabilities | Phase |
+| --- | --- | --- | --- |
+| **superadmin** | Cross-tenant | Everything, incl. `manage_organizations` (create/list/delete tenants). `organization_id` may be `NULL` | 1 |
+| **admin** | One organization | Everything except `manage_organizations` — manages the org's **users**, **company settings** (issuer profile), and billing | 1 |
+| **member** | One organization | Billing operator: create/edit/send quotes & invoices, record payments (`manage_billing`, `view_billing`). Cannot manage users/settings | 1 |
+| **viewer** (optional) | One organization | Read-only documents and reports (`view_billing`) | 3+ |
+| **public client** | — | Download invoice PDF via time-limited token URL — no login | 2 |
+
+Authorization: a `Role` enum + `Capability` enum resolved per route and enforced
+by capability middleware. Role/capability string values are registered in
+[`../development/naming-conventions.md`](../development/naming-conventions.md) and
+[`terminology.md`](./terminology.md) (binding). Admin JWT for mutating routes.
 
 ---
 
 ## 2. Core entities (MVP)
 
+All tenant-scoped entities below carry **`organization_id`** (ADR 0006).
+
 | Entity | Purpose | Key fields |
 | --- | --- | --- |
-| **company_settings** | Issuer (自社) profile | legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
+| **organization** | Tenant | name, slug (unique), plan, is_active, custom_domain (optional), external_id (optional) |
+| **user** | Operator account | email (unique), password_hash, role (superadmin/admin/member/viewer), organization_id (NULL for superadmin), status (active/invited) |
+| **company_settings** | Issuer (自社) profile — **per organization** | organization_id, legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
 | **client** | Buyer (取引先) | name, contact_name, email, billing_address, **registration_number** (optional for B2B qualified invoice) |
 | **quote** | Estimate (見積書) | client_id, quote_number, issued_at, valid_until, status, subtotal_cents, tax_cents, total_cents, notes |
 | **invoice** | Bill (請求書) | client_id, quote_id (optional), invoice_number, issued_at, due_at, status, subtotal_cents, tax_cents, total_cents, **is_qualified_invoice** |
@@ -98,13 +113,16 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 
 ### Phase 1 — API only
 
-- [ ] Company settings CRUD
+- [ ] Organization resolution middleware (default `single`; path/subdomain/custom_domain) + `organization_id` scoping on every query (ADR 0006)
+- [ ] Admin JWT auth + `Role`/`Capability` RBAC (capability middleware)
+- [ ] Organization CRUD — superadmin (`/admin/organizations`)
+- [ ] User CRUD — admin within organization (`/admin/users`)
+- [ ] Company settings CRUD (per organization)
 - [ ] Client CRUD + soft delete
 - [ ] Quote CRUD + line items + status transitions
 - [ ] Invoice CRUD + convert from quote + line items
 - [ ] Payment create + list by invoice
 - [ ] Qualified invoice field validation
-- [ ] Admin JWT auth
 - [ ] OpenAPI 3.1 + PHPUnit + PHPStan 8
 
 ### Phase 2 — Admin UI + PDF
@@ -147,7 +165,8 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 
 ## 7. Security requirements
 
-- Admin JWT for mutating routes
+- Admin JWT for mutating routes; `Capability` enforced per route (ADR 0006)
+- **Tenant isolation**: every query scoped by resolved `organization_id`; cross-tenant reads/writes prohibited. Only superadmin operates cross-tenant
 - PDF download tokens: random, time-limited, scoped to one invoice
 - No stack traces in production responses
 - Secrets in `.env` only — never committed

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -32,7 +32,9 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 
 | Concept | PHP class / domain folder | Table | Primary FK in JSON/DB |
 | --- | --- | --- | --- |
-| Issuer profile | `Company` (folder); `CompanySettings` (entity) | `company_settings` | — (singleton) |
+| Tenant | `Organization` | `organizations` | `organization_id` |
+| Operator account | `User` | `users` | `user_id` |
+| Issuer profile | `Company` (folder); `CompanySettings` (entity) | `company_settings` | — (one per `organization_id`) |
 | Buyer | `Client` | `clients` | `client_id` |
 | Estimate | `Quote` | `quotes` | `quote_id` |
 | Bill | `Invoice` | `invoices` | `invoice_id` |
@@ -55,6 +57,10 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
 | `payment.method` | `bank_transfer`, `cash`, `other` |
 | `line_item.parent_type` | `quote`, `invoice` |
+| `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
+| `user.status` | `active`, `invited` |
+| Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
+| Org resolution mode | `single` (default), `path`, `subdomain`, `custom_domain` |
 
 Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering them here first.
 
@@ -64,6 +70,10 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 
 | Term | Canonical | Never |
 | --- | --- | --- |
+| Tenant foreign key | `organization_id` | `org_id`, `tenant_id`, `organizationId` |
+| Organization slug | `slug` | `org_slug`, `code` |
+| User role | `role` (values in §2) | `user_role`, `permission` |
+| User credential | `password_hash` | `password`, `pass_hash` |
 | Invoice registration number | `registration_number` | `tax_registration_number`, `invoice_registration_number`, `t_number` |
 | Qualified-invoice flag | `is_qualified_invoice` | `qualified`, `is_qualified` |
 | Soft-delete flag / time | `is_deleted`, `deleted_at` | `deleted`, `is_del` |
@@ -97,6 +107,10 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `invoice-not-found` | Invoice id/token not found |
 | `quote-not-found` | Quote id not found |
 | `client-not-found` | Client id not found |
+| `organization-not-found` | Organization id/slug not found |
+| `user-not-found` | User id not found |
+| `insufficient-capability` | Authenticated but lacks required capability |
+| `organization-not-resolved` | Tenant could not be resolved for the request |
 | `invalid-state-transition` | Disallowed status change |
 | `qualified-invoice-incomplete` | Missing required qualified-invoice field |
 
@@ -114,6 +128,9 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | operationId | Resource |
 | --- | --- |
 | `getHealth` | System |
+| `login`, `getCurrentUser` | Auth |
+| `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
+| `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
 | `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,7 +21,8 @@ Goal: engineering discipline and product design before runtime code.
 
 - Governance docs, ADR 0001/0002, inheritance map ✅
 - Product vision, requirements, domain model ✅ (Issue #3)
-- NENE2 consumer scaffold, `GET /health`, OpenAPI, CI 🔲 Issues #4–#7
+- Multi-tenancy + role hierarchy adopted as foundational ✅ ADR 0006 (Issue #17)
+- NENE2 consumer scaffold (tenant resolution + JWT auth + RBAC + `GET /health`), OpenAPI, CI 🔲 Issues #4–#7
 - ADR 0003 dual deployment 🔲 Issue #7
 
 Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
@@ -30,12 +31,13 @@ Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
 
 ## Phase 1: Core Billing API
 
-Goal: client master, quotes, invoices, payments — API and DB only.
+Goal: tenancy, auth, client master, quotes, invoices, payments — API and DB only.
 
-- `company_settings`, `clients`, `quotes`, `invoices`, `line_items`, `payments`, `document_sequences`
+- `organizations`, `users`, `company_settings`, `clients`, `quotes`, `invoices`, `line_items`, `payments`, `document_sequences` — all tenant-scoped by `organization_id` (ADR 0006)
+- Organization resolution (default `single`) + JWT auth + `Role`/`Capability` RBAC
+- Organization CRUD (superadmin); user CRUD (admin)
 - Japan qualified invoice field validation in UseCases
 - Quote → invoice conversion
-- Admin JWT auth
 - OpenAPI + PHPUnit + PHPStan 8
 
 See [`docs/explanation/requirements.md#phase-1--api-only`](./explanation/requirements.md#phase-1--api-only).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #15)
+Last updated: 2026-05-29 (Issue #17)
 
 ## Recently merged
 
@@ -9,21 +9,24 @@ Last updated: 2026-05-29 (Issue #15)
 - **Issue #9 / PR #10** — 適格請求書ドキュメント精度修正（端数処理 ADR 0004・登録番号・用語・命名）✅ merged
 - **Issue #11 / PR #12** — 日英(ja/en)バイリンガル方針宣言（ADR 0005）・多言語非対象 ✅ merged
 - **Issue #13 / PR #14** — 会計・税務コンプライアンス完全順守を拘束ルール化（accounting-compliance.md・compliance チェックリスト）✅ merged
+- **Issue #15 / PR #16** — 命名規則の絶対順守・用語レジストリ（唯一の真実）・タイポ厳禁 ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #15 | `docs/15-terminology-registry-naming-strict` | 命名規則の絶対順守・用語レジストリ（唯一の真実）・タイポ厳禁 | 🔄 PR pending |
+| #17 | `docs/17-adopt-multi-tenancy` | マルチテナント基盤＋ロール階層（superadmin/admin/member）を土台採用（ADR 0006） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
 | Issue | Topic | Priority |
 | --- | --- | --- |
-| #4 | NENE2 runtime scaffold + health endpoint | P0 |
+| #4 | ランタイム基盤: テナント解決＋JWT認証＋RBAC＋`GET /health`（ADR 0006 で拡張） | P0 |
 | #5 | OpenAPI stub + MCP catalog | P0 |
 | #6 | Backend CI workflow | P0 |
 | #7 | ADR 0003 dual deployment (Tier A / Tier B) | P1 |
+
+> マルチテナント前提のため、Issue #4 は単なる health から **テナント解決＋認証＋RBAC を含むランタイム基盤** に拡張。組織/ユーザー CRUD は後続 PR。
 
 ## State Summary
 
@@ -52,13 +55,20 @@ Last updated: 2026-05-29 (Issue #15)
 - Compliance self-review checklist added (`docs/review/compliance.md`)
 - Deviations require ADR + tax-professional sign-off
 
-**Phase 0 — Terminology & naming hardening: 🔄 in progress** (Issue #15)
+**Phase 0 — Terminology & naming hardening: ✅ complete** (Issue #15)
 
 - Terminology registry added as single source of truth (`terminology.md`)
 - Naming made absolute; typos / unregistered terms block merge
 - Registry update required in the same PR as any term add/rename
 
-**Runtime: not started** — begin with Issue #4.
+**Phase 0 — Multi-tenancy adoption: 🔄 in progress** (Issue #17, docs/ADR only)
+
+- ADR 0006: multi-tenant + role hierarchy (superadmin/admin/member/viewer) adopted as foundational
+- Tenant-scoped `organization_id` on all billing tables; per-org issuer profile
+- Org resolution default `single`; superadmin manages orgs, admin manages users
+- terminology registry extended (roles, capabilities, resolution modes, org/user)
+
+**Runtime: not started** — Issue #4 builds the tenant-aware foundation (PR-B) after #17 merges.
 
 ## Handoff Notes
 
@@ -66,6 +76,8 @@ Last updated: 2026-05-29 (Issue #15)
 - Problem Details base: `https://nene-invoice.dev/problems/`
 - **Compliance (binding):** `docs/explanation/accounting-compliance.md` — zero deviations; deviation needs ADR + 税理士 sign-off
 - **Terminology (single source of truth):** `docs/explanation/terminology.md` — identifiers match exactly; typos block merge
+- **Multi-tenant (binding):** ADR 0006 — `organization_id` on every tenant-scoped table/query; superadmin cross-tenant only; org resolution default `single`
+- Roles: `superadmin` (orgs) / `admin` (users + settings) / `member` (billing) / `viewer` (read); reference impl = nene-records `src/Auth/`, `src/Organization/`
 - Money: integer cents (smallest currency unit; JPY ¥1 = 1 cent); tax: basis points (1000 = 10%)
 - Tax rounding: once per tax rate per document, half-up — ADR 0004
 - Qualified invoice: validate `T` + 13 digit registration number at API layer (syntax only)
@@ -74,6 +86,6 @@ Last updated: 2026-05-29 (Issue #15)
 
 ## Next steps
 
-1. Merge Issue #15 PR (terminology & naming hardening)
-2. Start Issue #4 (runtime scaffold) on branch `feat/4-runtime-scaffold`
-3. Issue #5–#6 can follow in parallel after #4 lands
+1. Merge Issue #17 PR (multi-tenancy adoption — docs/ADR)
+2. PR-B (Issue #4): tenant-aware runtime foundation — org resolution + JWT auth + RBAC + `GET /health`, mirroring nene-records bootstrap (`RuntimeContainerFactory` → `RuntimeServiceProvider` → `ApplicationServiceProvider`)
+3. PR-C+: organization CRUD (superadmin), user CRUD (admin)


### PR DESCRIPTION
Closes #17

## 目的

NeNe Invoice を**当初からマルチテナント前提**で構築する方針へ docs を更新する（nene-records の実装を正典として参照）。コード着手（PR-B / Issue #4）の前に、binding 化したガバナンスに従い ADR と正本ドキュメントを先行整備する。

## 決定（ADR 0006）

- **組織＝テナント**。`organization_id` を全テナントスコープ表に付与。各組織が独立した適格請求書の**発行者**（自前の登録番号・`company_settings`）。
- **org 解決**: リクエスト毎にミドルウェアで解決。既定 `single`（1インストール=1組織）、`path` / `subdomain` / `custom_domain` も対応。
- **RBAC**: `Role`(superadmin/admin/member/viewer) + `Capability` + capability middleware。
  - `superadmin` → 組織を管理（`manage_organizations`、クロステナント）
  - `admin` → 自組織のユーザー・発行者設定・請求を管理
  - `member` → 請求 operator（見積/請求書作成・送付、入金記録）
- コンプライアンス（accounting-compliance.md）は**組織ごと**に同様に適用（緩和なし）。

## 変更ファイル

- 新規 `docs/adr/0006-multi-tenancy-and-roles.md`
- `requirements` / `domain-model` / `terminology`(唯一の真実) / `product-vision` / `glossary` / `roadmap` / `backend-standards` / `naming-conventions` / `CLAUDE.md` / `README.md` を整合（`AdminAuth/`→`Auth/` 統一含む）
- `current.md` 同期、Issue #4 を「テナント基盤」へ拡張と明記

## 検証

- docs のみ。`git diff --check` 通過。残存する single-tenant 表現は ADR 0006 内の旧記述引用のみ。用語レジストリに新規識別子（roles/capabilities/解決モード/organization/user/operationId/slug）を登録済み。

## 後続

- **PR-B（Issue #4）**: ランタイム基盤 — org 解決＋JWT＋RBAC＋`GET /health`（nene-records bootstrap を踏襲）
- **PR-C 以降**: 組織 CRUD（superadmin）・ユーザー CRUD（admin）

## セルフレビュー

Self-review: docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)