### PR TITLE
feat(organization): テナント永続化レイヤと Phinx マイグレーション基盤を追加する (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_ENV=local
 APP_DEBUG=false
-APP_NAME=NeNe Invoice
+APP_NAME="NeNe Invoice"
 PROBLEM_DETAILS_BASE_URL=https://nene-invoice.dev/problems/
 
 # --- Tenancy (ADR 0006) — default single-organization install ---

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "analyse": "phpstan analyse --memory-limit 512M",
         "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
+        "migrations:status": "phinx status -c phinx.php",
+        "migrations:migrate": "phinx migrate -c phinx.php",
+        "migrations:rollback": "phinx rollback -c phinx.php",
         "check": [
             "@test",
             "@analyse",
@@ -34,6 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^13.1"
+        "phpunit/phpunit": "^13.1",
+        "robmorgan/phinx": "^0.16.11"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "094d145a9879cfe503ebfa385d3d0a5f",
+    "content-hash": "b14c605343b8b3a5db561b3c2de8457c",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -1105,6 +1105,330 @@
     ],
     "packages-dev": [
         {
+            "name": "cakephp/chronos",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/chronos.git",
+                "reference": "e6e777b534244911566face8a5dbdbd7f7bda5a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/e6e777b534244911566face8a5dbdbd7f7bda5a6",
+                "reference": "e6e777b534244911566face8a5dbdbd7f7bda5a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^5.0",
+                "phpunit/phpunit": "^10.5.58 || ^11.5.3 || ^12.1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Chronos\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "The CakePHP Team",
+                    "homepage": "https://cakephp.org"
+                }
+            ],
+            "description": "A simple API extension for DateTime.",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/chronos/issues",
+                "source": "https://github.com/cakephp/chronos"
+            },
+            "time": "2026-04-10T02:50:39+00:00"
+        },
+        {
+            "name": "cakephp/core",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/core.git",
+                "reference": "9c458b0e9322ec88bc4c758b33cde6a0abf49d12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/9c458b0e9322ec88bc4c758b33cde6a0abf49d12",
+                "reference": "9c458b0e9322ec88bc4c758b33cde6a0abf49d12",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/utility": "^5.3.0",
+                "league/container": "^5.1",
+                "php": ">=8.2",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^2.0"
+            },
+            "suggest": {
+                "cakephp/cache": "To use Configure::store() and restore().",
+                "cakephp/event": "To use PluginApplicationInterface or plugin applications.",
+                "league/container": "To use Container and ServiceProvider classes"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Cake\\Core\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/core/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Framework Core classes",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "core",
+                "framework"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/core"
+            },
+            "time": "2026-05-15T03:31:14+00:00"
+        },
+        {
+            "name": "cakephp/database",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/database.git",
+                "reference": "442d12bf0a1edeffc555a59de9f955cb0619c7ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/442d12bf0a1edeffc555a59de9f955cb0619c7ca",
+                "reference": "442d12bf0a1edeffc555a59de9f955cb0619c7ca",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/chronos": "^3.3",
+                "cakephp/core": "^5.3.0",
+                "cakephp/datasource": "^5.3.0",
+                "php": ">=8.2",
+                "psr/log": "^3.0"
+            },
+            "require-dev": {
+                "cakephp/i18n": "^5.3.0",
+                "cakephp/log": "^5.3.0"
+            },
+            "suggest": {
+                "cakephp/i18n": "If you are using locale-aware datetime formats.",
+                "cakephp/log": "If you want to use query logging without providing a logger yourself."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Database\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/database/graphs/contributors"
+                }
+            ],
+            "description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "abstraction",
+                "cakephp",
+                "database",
+                "database abstraction",
+                "pdo"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/database"
+            },
+            "time": "2026-05-21T19:38:13+00:00"
+        },
+        {
+            "name": "cakephp/datasource",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/datasource.git",
+                "reference": "b768f0c0bf0fca815f83c4caef14e7fbb2409bf5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/b768f0c0bf0fca815f83c4caef14e7fbb2409bf5",
+                "reference": "b768f0c0bf0fca815f83c4caef14e7fbb2409bf5",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^5.3.0",
+                "php": ">=8.2",
+                "psr/simple-cache": "^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "cakephp/cache": "^5.3.0",
+                "cakephp/collection": "^5.3.0",
+                "cakephp/utility": "^5.3.0"
+            },
+            "suggest": {
+                "cakephp/cache": "If you decide to use Query caching.",
+                "cakephp/collection": "If you decide to use ResultSetInterface.",
+                "cakephp/utility": "If you decide to use EntityTrait."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Datasource\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/datasource/graphs/contributors"
+                }
+            ],
+            "description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "connection management",
+                "datasource",
+                "entity",
+                "query"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/datasource"
+            },
+            "time": "2026-05-20T10:27:33+00:00"
+        },
+        {
+            "name": "cakephp/utility",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/utility.git",
+                "reference": "4c703a010b9d955fed44731669e35d3043425cc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/4c703a010b9d955fed44731669e35d3043425cc7",
+                "reference": "4c703a010b9d955fed44731669e35d3043425cc7",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^5.3.0",
+                "php": ">=8.2"
+            },
+            "suggest": {
+                "ext-intl": "To use Text::transliterate() or Text::slug()",
+                "lib-ICU": "To use Text::transliterate() or Text::slug()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Cake\\Utility\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/utility/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "hash",
+                "inflector",
+                "security",
+                "string",
+                "utility"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/utility"
+            },
+            "time": "2026-05-21T19:38:13+00:00"
+        },
+        {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
             "source": {
@@ -1671,6 +1995,90 @@
                 }
             ],
             "time": "2026-05-15T09:20:44+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "58accbc032f0090a9bd08326f93062c5a658b2c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/58accbc032f0090a9bd08326f93062c5a658b2c5",
+                "reference": "58accbc032f0090a9bd08326f93062c5a658b2c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "psr/container": "^2.0.2",
+                "psr/event-dispatcher": "^1.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "nette/php-generator": "^4.1",
+                "nikic/php-parser": "^5.0",
+                "phpstan/phpstan": "^2.1.11",
+                "phpunit/phpunit": "^10.5.45|^11.5.15|^12.0",
+                "roave/security-advisories": "dev-latest",
+                "scrutinizer/ocular": "^1.9",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev",
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "mail@philbennett.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-19T18:52:39+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2447,6 +2855,54 @@
             "time": "2026-05-27T14:03:08+00:00"
         },
         {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
             "name": "psr/event-dispatcher",
             "version": "1.0.0",
             "source": {
@@ -2495,6 +2951,57 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "react/cache",
@@ -3021,6 +3528,93 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "robmorgan/phinx",
+            "version": "0.16.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/phinx.git",
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/a03014fea316ba021fc0776982e5bed2d10228d4",
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/database": "^5.0.2",
+                "composer-runtime-api": "^2.0",
+                "php-64bit": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/config": "^4.0|^5.0|^6.0|^7.0|^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^5.0",
+                "cakephp/i18n": "^5.0",
+                "ext-json": "*",
+                "ext-pdo": "*",
+                "phpunit/phpunit": "^10.5",
+                "symfony/yaml": "^4.0|^5.0|^6.0|^7.0|^8.0"
+            },
+            "suggest": {
+                "ext-json": "Install if using JSON configuration format",
+                "ext-pdo": "PDO extension is needed",
+                "symfony/yaml": "Install if using YAML configuration format"
+            },
+            "bin": [
+                "bin/phinx"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phinx\\": "src/Phinx/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Morgan",
+                    "email": "robbym@gmail.com",
+                    "homepage": "https://robmorgan.id.au",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com",
+                    "homepage": "https://shadowhand.me",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/phinx/graphs/contributors",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Phinx makes it ridiculously easy to manage the database migrations for your PHP app.",
+            "homepage": "https://phinx.org",
+            "keywords": [
+                "database",
+                "database migrations",
+                "db",
+                "migrations",
+                "phinx"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/phinx/issues",
+                "source": "https://github.com/cakephp/phinx/tree/0.16.11"
+            },
+            "time": "2026-03-15T00:04:32+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4111,6 +4705,84 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "429783a0c649696f2058ea5ab5315f082dba6de9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/429783a0c649696f2058ea5ab5315f082dba6de9",
+                "reference": "429783a0c649696f2058ea5ab5315f082dba6de9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",

--- a/database/migrations/20260529120000_create_organizations_table.php
+++ b/database/migrations/20260529120000_create_organizations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateOrganizationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('organizations')
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('slug', 'string', ['limit' => 100, 'null' => false])
+            ->addColumn('external_id', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('custom_domain', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('plan', 'string', ['limit' => 32, 'null' => false, 'default' => 'free'])
+            ->addColumn('is_active', 'boolean', ['null' => false, 'default' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['slug'], ['unique' => true, 'name' => 'uniq_organizations_slug'])
+            ->addIndex(['external_id'], ['unique' => true, 'name' => 'uniq_organizations_external_id'])
+            ->create();
+    }
+}

--- a/database/schema/organizations.sql
+++ b/database/schema/organizations.sql
@@ -1,0 +1,15 @@
+-- Schema snapshot for the organizations table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS organizations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(100) NOT NULL,
+    external_id VARCHAR(255) NULL DEFAULT NULL,
+    custom_domain VARCHAR(255) NULL DEFAULT NULL,
+    plan VARCHAR(32) NOT NULL DEFAULT 'free',
+    is_active BOOLEAN NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX uniq_organizations_slug ON organizations (slug);
+CREATE UNIQUE INDEX uniq_organizations_external_id ON organizations (external_id);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #4)
+Last updated: 2026-05-29 (Issue #20)
 
 ## Recently merged
 
@@ -11,12 +11,13 @@ Last updated: 2026-05-29 (Issue #4)
 - **Issue #13 / PR #14** — 会計・税務コンプライアンス完全順守を拘束ルール化（accounting-compliance.md・compliance チェックリスト）✅ merged
 - **Issue #15 / PR #16** — 命名規則の絶対順守・用語レジストリ（唯一の真実）・タイポ厳禁 ✅ merged
 - **Issue #17 / PR #18** — マルチテナント基盤＋ロール階層を土台採用（ADR 0006） ✅ merged
+- **Issue #4 / PR #19** — ランタイム基盤: NENE2 consumer scaffold + `GET /health` ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #4 | `feat/4-runtime-scaffold` | ランタイム基盤 PR-B: NENE2 consumer scaffold + `GET /health` + composer check green | 🔄 PR pending |
+| #20 | `feat/20-organization-persistence` | Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -69,11 +70,16 @@ Last updated: 2026-05-29 (Issue #4)
 - Org resolution default `single`; superadmin manages orgs, admin manages users
 - terminology registry extended (roles, capabilities, resolution modes, org/user)
 
-**Phase 0+ — Runtime scaffold (PR-B): 🔄 in progress** (Issue #4)
+**Phase 0+ — Runtime scaffold (PR-B): ✅ complete** (Issue #4)
 
 - NENE2 consumer bootstrap: `composer.json` (require `hideyukimori/nene2 ^1.5`), `public_html/index.php`, `RuntimeContainerFactory` → `RuntimeServiceProvider` → `ApplicationServiceProvider`
 - `GET /health` (framework built-in) verified end-to-end; `composer check` green (PHPUnit + PHPStan 8 + php-cs-fixer)
-- Module layout is tenant-ready; org resolution + JWT auth + RBAC wired in the next PRs
+
+**Phase 1 — Organization persistence: 🔄 in progress** (Issue #20)
+
+- `organizations` table (Phinx migration + SQLite schema snapshot); `Organization` entity + `PdoOrganizationRepository`
+- Phinx wired (`phinx.php`, `composer migrations:*`); `suffix => ''` so SQLite migrate/app share one file
+- Repository tested on SQLite `:memory:`; HTTP runtime unchanged (org resolution + auth in next PRs)
 
 ## Handoff Notes
 
@@ -91,7 +97,7 @@ Last updated: 2026-05-29 (Issue #4)
 
 ## Next steps
 
-1. Merge Issue #4 PR-B (runtime scaffold + health)
-2. Next PR: organization resolution middleware (default `single`) + `organization_id` query scoping + `organizations` migration (SQLite/MySQL) + DatabaseHealthCheck
+1. Merge Issue #20 PR (Organization persistence layer)
+2. Next PR: organization resolution middleware (default `single`) + container wiring (ConfigLoader/AppConfig/DB executor/OrganizationRepository) + `organization_id` query scoping + DatabaseHealthCheck
 3. Then: JWT auth + `Role`/`Capability` RBAC wiring (`Auth/`), `users` migration
 4. Then PR-C+: organization CRUD (superadmin), user CRUD (admin)

--- a/phinx.php
+++ b/phinx.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Nene2\Config\ConfigLoader;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$database = (new ConfigLoader(__DIR__))->load()->database;
+
+return [
+    'paths' => [
+        'migrations' => 'database/migrations',
+        'seeds' => 'database/seeds',
+    ],
+    'environments' => [
+        'default_environment' => $database->environment,
+        $database->environment => $database->usesUrl()
+            ? ['url' => $database->url]
+            : [
+                'adapter' => $database->adapter,
+                'host' => $database->host,
+                'name' => $database->name,
+                'user' => $database->user,
+                'pass' => $database->password,
+                'port' => $database->port,
+                'charset' => $database->charset,
+                // SQLite only: use DB_NAME verbatim as the file path so Phinx and
+                // the application connect to the same file (Phinx otherwise appends
+                // a `.sqlite3` suffix). Ignored by the MySQL / PostgreSQL adapters.
+                'suffix' => '',
+            ],
+    ],
+    'version_order' => 'creation',
+];

--- a/src/Organization/Organization.php
+++ b/src/Organization/Organization.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+/**
+ * A tenant. Each organization is an independent issuer of qualified invoices
+ * with its own users, issuer profile (`company_settings`), and billing data.
+ *
+ * See ADR 0006 (multi-tenancy).
+ */
+final readonly class Organization
+{
+    public function __construct(
+        public string $name,
+        public string $slug,
+        public string $plan,
+        public bool $isActive,
+        public ?int $id = null,
+        public ?string $externalId = null,
+        public ?string $customDomain = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Organization/OrganizationNotFoundException.php
+++ b/src/Organization/OrganizationNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use RuntimeException;
+
+final class OrganizationNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Organization {$id} not found.");
+    }
+}

--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface OrganizationRepositoryInterface
+{
+    public function findById(int $id): ?Organization;
+
+    public function findBySlug(string $slug): ?Organization;
+
+    public function findByCustomDomain(string $domain): ?Organization;
+
+    /** @return list<Organization> */
+    public function findAll(int $limit, int $offset): array;
+
+    public function count(): int;
+
+    /** @throws OrganizationSlugConflictException */
+    public function save(Organization $organization): int;
+
+    /** @throws OrganizationNotFoundException */
+    public function update(Organization $organization): void;
+
+    /** @throws OrganizationNotFoundException */
+    public function delete(int $id): void;
+}

--- a/src/Organization/OrganizationSlugConflictException.php
+++ b/src/Organization/OrganizationSlugConflictException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use RuntimeException;
+use Throwable;
+
+final class OrganizationSlugConflictException extends RuntimeException
+{
+    public function __construct(string $slug, ?Throwable $previous = null)
+    {
+        parent::__construct("Organization slug '{$slug}' is already in use.", 0, $previous);
+    }
+}

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
+{
+    private const COLUMNS = 'id, name, slug, external_id, custom_domain, plan, is_active, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findBySlug(string $slug): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE slug = ?',
+            [$slug],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findByCustomDomain(string $domain): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE custom_domain = ?',
+            [$domain],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<Organization> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM organizations ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(fn (array $row): Organization => $this->mapRow($row), $rows);
+    }
+
+    public function count(): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM organizations', []);
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function save(Organization $organization): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        try {
+            $this->query->execute(
+                'INSERT INTO organizations (name, slug, external_id, custom_domain, plan, is_active, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $organization->name,
+                    $organization->slug,
+                    $organization->externalId,
+                    $organization->customDomain,
+                    $organization->plan,
+                    $organization->isActive ? 1 : 0,
+                    $now,
+                    $now,
+                ],
+            );
+        } catch (DatabaseConstraintException $e) {
+            // The only business-unique key on save is the slug (external_id is
+            // optional and usually null), so a constraint violation here maps to
+            // a slug conflict.
+            throw new OrganizationSlugConflictException($organization->slug, $e);
+        }
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Organization $organization): void
+    {
+        if ($organization->id === null) {
+            throw new OrganizationNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE organizations SET name = ?, slug = ?, external_id = ?, custom_domain = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',
+            [
+                $organization->name,
+                $organization->slug,
+                $organization->externalId,
+                $organization->customDomain,
+                $organization->plan,
+                $organization->isActive ? 1 : 0,
+                $now,
+                $organization->id,
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($organization->id) === null) {
+            throw new OrganizationNotFoundException($organization->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Organization
+    {
+        return new Organization(
+            name: (string) $row['name'],
+            slug: (string) $row['slug'],
+            plan: (string) $row['plan'],
+            isActive: (bool) $row['is_active'],
+            id: (int) $row['id'],
+            externalId: isset($row['external_id']) && $row['external_id'] !== '' ? (string) $row['external_id'] : null,
+            customDomain: isset($row['custom_domain']) && $row['custom_domain'] !== '' ? (string) $row['custom_domain'] : null,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/tests/Organization/PdoOrganizationRepositoryTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Organization;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\OrganizationNotFoundException;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\Organization\PdoOrganizationRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoOrganizationRepositoryTest extends TestCase
+{
+    private PdoOrganizationRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/organizations.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoOrganizationRepository(
+            new PdoDatabaseQueryExecutor($factory, $pdo),
+        );
+    }
+
+    public function test_finds_organization_by_id_and_slug_after_save(): void
+    {
+        $id = $this->repository->save(new Organization(
+            name: 'Acme Foods',
+            slug: 'acme-foods',
+            plan: 'free',
+            isActive: true,
+        ));
+
+        self::assertGreaterThan(0, $id);
+
+        $byId = $this->repository->findById($id);
+        self::assertNotNull($byId);
+        self::assertSame('Acme Foods', $byId->name);
+        self::assertSame('acme-foods', $byId->slug);
+        self::assertTrue($byId->isActive);
+        self::assertNotNull($byId->createdAt);
+
+        $bySlug = $this->repository->findBySlug('acme-foods');
+        self::assertNotNull($bySlug);
+        self::assertSame($id, $bySlug->id);
+    }
+
+    public function test_returns_null_when_organization_not_found(): void
+    {
+        self::assertNull($this->repository->findById(999));
+        self::assertNull($this->repository->findBySlug('missing'));
+    }
+
+    public function test_counts_and_lists_organizations(): void
+    {
+        $this->repository->save(new Organization(name: 'Org A', slug: 'org-a', plan: 'free', isActive: true));
+        $this->repository->save(new Organization(name: 'Org B', slug: 'org-b', plan: 'free', isActive: true));
+
+        self::assertSame(2, $this->repository->count());
+
+        $all = $this->repository->findAll(10, 0);
+        self::assertCount(2, $all);
+        self::assertSame('org-a', $all[0]->slug);
+    }
+
+    public function test_rejects_duplicate_slug_when_saving(): void
+    {
+        $this->repository->save(new Organization(name: 'First', slug: 'dup', plan: 'free', isActive: true));
+
+        $this->expectException(OrganizationSlugConflictException::class);
+        $this->repository->save(new Organization(name: 'Second', slug: 'dup', plan: 'free', isActive: true));
+    }
+
+    public function test_updates_existing_organization(): void
+    {
+        $id = $this->repository->save(new Organization(name: 'Before', slug: 'org', plan: 'free', isActive: true));
+
+        $this->repository->update(new Organization(
+            name: 'After',
+            slug: 'org',
+            plan: 'pro',
+            isActive: false,
+            id: $id,
+        ));
+
+        $updated = $this->repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame('After', $updated->name);
+        self::assertSame('pro', $updated->plan);
+        self::assertFalse($updated->isActive);
+    }
+
+    public function test_throws_when_deleting_unknown_organization(): void
+    {
+        $this->expectException(OrganizationNotFoundException::class);
+        $this->repository->delete(424242);
+    }
+
+    public function test_deletes_existing_organization(): void
+    {
+        $id = $this->repository->save(new Organization(name: 'Temp', slug: 'temp', plan: 'free', isActive: true));
+
+        $this->repository->delete($id);
+
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->count());
+    }
+}


### PR DESCRIPTION
Closes #20

## 目的

マルチテナント（ADR 0006）の中核 **organization（テナント）の永続化レイヤ** と Phinx マイグレーション基盤を追加する。HTTP ランタイム（health 挙動）は変更しない。

## 変更内容

- **`organizations` テーブル**: Phinx マイグレーション + `database/schema/organizations.sql`（SQLite スナップショット）
- **Organization ドメイン**: エンティティ + `OrganizationRepositoryInterface` + `PdoOrganizationRepository`（findById/findBySlug/findByCustomDomain/findAll/count/save/update/delete）
- **例外**: `OrganizationNotFoundException` / `OrganizationSlugConflictException`（NENE2 `DatabaseConstraintException` を変換、原因例外を保持）
- **Phinx**: `phinx.php` + `composer migrations:migrate/status/rollback`
- **テスト**: リポジトリテスト（SQLite `:memory:`、スキーマスナップショット読込）

## 検証

- **`composer check` green**: PHPUnit **8 tests / 33 assertions**・PHPStan level 8 **no errors**・php-cs-fixer **clean**
- `composer migrations:migrate` を SQLite で実行 → `organizations` 作成を確認（status `up`）

### 検証中に発見・修正した実バグ 2 件
1. **`.env.example` の `APP_NAME` 未引用**: 空白を含む値で dotenv 解析が失敗（`cp .env.example .env` が壊れる）→ `"NeNe Invoice"` に引用
2. **Phinx の SQLite suffix**: phinx が `.sqlite3` を付与し、マイグレーション（`name.sqlite3`）とアプリ（`name`）が**別ファイル**を使用 → `phinx.php` に `suffix => ''` を設定し同一ファイルを使うよう修正（確認済み）

## 非範囲（後続 PR）

- org 解決ミドルウェア（single）・コンテナ配線・`organization_id` スコープ・DatabaseHealthCheck
- 組織 CRUD（superadmin）、users・認証・RBAC

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)