### PR TITLE
feat(http): ランタイムに DB 接続と DatabaseHealthCheck を配線する (#22)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #20)
+Last updated: 2026-05-29 (Issue #22)
 
 ## Recently merged
 
@@ -12,12 +12,13 @@ Last updated: 2026-05-29 (Issue #20)
 - **Issue #15 / PR #16** — 命名規則の絶対順守・用語レジストリ（唯一の真実）・タイポ厳禁 ✅ merged
 - **Issue #17 / PR #18** — マルチテナント基盤＋ロール階層を土台採用（ADR 0006） ✅ merged
 - **Issue #4 / PR #19** — ランタイム基盤: NENE2 consumer scaffold + `GET /health` ✅ merged
+- **Issue #20 / PR #21** — Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #20 | `feat/20-organization-persistence` | Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 | 🔄 PR pending |
+| #22 | `feat/22-runtime-db-healthcheck` | ランタイムに DB 接続（AppConfig）+ DatabaseHealthCheck を配線 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -75,11 +76,17 @@ Last updated: 2026-05-29 (Issue #20)
 - NENE2 consumer bootstrap: `composer.json` (require `hideyukimori/nene2 ^1.5`), `public_html/index.php`, `RuntimeContainerFactory` → `RuntimeServiceProvider` → `ApplicationServiceProvider`
 - `GET /health` (framework built-in) verified end-to-end; `composer check` green (PHPUnit + PHPStan 8 + php-cs-fixer)
 
-**Phase 1 — Organization persistence: 🔄 in progress** (Issue #20)
+**Phase 1 — Organization persistence: ✅ complete** (Issue #20)
 
 - `organizations` table (Phinx migration + SQLite schema snapshot); `Organization` entity + `PdoOrganizationRepository`
 - Phinx wired (`phinx.php`, `composer migrations:*`); `suffix => ''` so SQLite migrate/app share one file
-- Repository tested on SQLite `:memory:`; HTTP runtime unchanged (org resolution + auth in next PRs)
+- Repository tested on SQLite `:memory:`
+
+**Phase 1 — Runtime DB connectivity: 🔄 in progress** (Issue #22)
+
+- `RuntimeServiceProvider` wires ConfigLoader → AppConfig → PdoConnectionFactory → PdoDatabaseQueryExecutor
+- `src/Http/DatabaseHealthCheck` (copied from NENE2 reference) registered on `GET /health`
+- Verified: DB reachable → 200 `checks.database=ok`; unreachable → 503 `degraded`. `debug` now from AppConfig (not getenv)
 
 ## Handoff Notes
 
@@ -97,7 +104,6 @@ Last updated: 2026-05-29 (Issue #20)
 
 ## Next steps
 
-1. Merge Issue #20 PR (Organization persistence layer)
-2. Next PR: organization resolution middleware (default `single`) + container wiring (ConfigLoader/AppConfig/DB executor/OrganizationRepository) + `organization_id` query scoping + DatabaseHealthCheck
-3. Then: JWT auth + `Role`/`Capability` RBAC wiring (`Auth/`), `users` migration
-4. Then PR-C+: organization CRUD (superadmin), user CRUD (admin)
+1. Merge Issue #22 PR (runtime DB connectivity + DatabaseHealthCheck)
+2. Next PR: JWT auth + `Role`/`Capability` RBAC + `users` table, paired with org resolution middleware (default `single`) + `organization_id` query scoping — these share the request pipeline and tenant/auth context
+3. Then PR-C+: organization CRUD (superadmin), user CRUD (admin)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,11 @@
   colors="true"
   cacheDirectory=".phpunit.cache"
 >
+  <php>
+    <env name="APP_ENV" value="test" force="true"/>
+    <env name="DB_ADAPTER" value="sqlite" force="true"/>
+    <env name="DB_NAME" value=":memory:" force="true"/>
+  </php>
   <testsuites>
     <testsuite name="NeneInvoice">
       <directory>tests</directory>

--- a/src/Http/DatabaseHealthCheck.php
+++ b/src/Http/DatabaseHealthCheck.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Http\HealthCheckInterface;
+use Nene2\Http\HealthStatus;
+use Throwable;
+
+/**
+ * Reports database connectivity on `GET /health`.
+ *
+ * Adapted from the NENE2 reference implementation (`Nene2\Example\Health\
+ * DatabaseHealthCheck`), which is outside the framework's public API stability
+ * guarantee and intended to be copied into the consuming application.
+ */
+final readonly class DatabaseHealthCheck implements HealthCheckInterface
+{
+    public function __construct(
+        private DatabaseConnectionFactoryInterface $connectionFactory,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'database';
+    }
+
+    public function check(): HealthStatus
+    {
+        try {
+            $this->connectionFactory->create()->query('SELECT 1');
+
+            return HealthStatus::Ok;
+        } catch (Throwable) {
+            return HealthStatus::Error;
+        }
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace NeneInvoice\Http;
 
 use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\ConfigLoader;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
@@ -17,11 +23,11 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * Wires the minimal NENE2 HTTP runtime for NeNe Invoice.
+ * Wires the NENE2 HTTP runtime for NeNe Invoice: configuration, database
+ * connectivity, and the request handler.
  *
- * This scaffold registers only what `GET /health` (provided by the framework)
- * needs. Tenant resolution, JWT auth, and RBAC middleware are added in
- * following PRs by extending {@see RuntimeApplicationFactory} construction here.
+ * Tenant resolution, JWT auth, and RBAC middleware are added in following PRs by
+ * extending {@see RuntimeApplicationFactory} construction here.
  */
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
@@ -34,12 +40,84 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())
             ->set(
+                ConfigLoader::class,
+                static function (ContainerInterface $container): ConfigLoader {
+                    $projectRoot = $container->get(self::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new ConfigLoader($projectRoot);
+                },
+            )
+            ->set(
+                AppConfig::class,
+                static function (ContainerInterface $container): AppConfig {
+                    $loader = $container->get(ConfigLoader::class);
+
+                    if (!$loader instanceof ConfigLoader) {
+                        throw new LogicException('Config loader service is invalid.');
+                    }
+
+                    return $loader->load();
+                },
+            )
+            ->set(
+                DatabaseConnectionFactoryInterface::class,
+                static function (ContainerInterface $container): DatabaseConnectionFactoryInterface {
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new PdoConnectionFactory($config->database);
+                },
+            )
+            ->set(
+                DatabaseQueryExecutorInterface::class,
+                static function (ContainerInterface $container): DatabaseQueryExecutorInterface {
+                    $connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+
+                    if (!$connectionFactory instanceof DatabaseConnectionFactoryInterface) {
+                        throw new LogicException('Database connection factory service is invalid.');
+                    }
+
+                    return new PdoDatabaseQueryExecutor($connectionFactory);
+                },
+            )
+            ->set(
+                DatabaseHealthCheck::class,
+                static function (ContainerInterface $container): DatabaseHealthCheck {
+                    $connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+
+                    if (!$connectionFactory instanceof DatabaseConnectionFactoryInterface) {
+                        throw new LogicException('Database connection factory service is invalid.');
+                    }
+
+                    return new DatabaseHealthCheck($connectionFactory);
+                },
+            )
+            ->set(
                 RuntimeApplicationFactory::class,
                 static function (ContainerInterface $container): RuntimeApplicationFactory {
                     $psr17 = $container->get(Psr17Factory::class);
 
                     if (!$psr17 instanceof Psr17Factory) {
                         throw new LogicException('PSR-17 factory service is invalid.');
+                    }
+
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    $databaseHealthCheck = $container->get(DatabaseHealthCheck::class);
+
+                    if (!$databaseHealthCheck instanceof DatabaseHealthCheck) {
+                        throw new LogicException('Database health check service is invalid.');
                     }
 
                     $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
@@ -63,7 +141,8 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         streamFactory: $psr17,
                         domainExceptionHandlers: $exceptionHandlers,
                         routeRegistrars: $routeRegistrars,
-                        debug: getenv('APP_DEBUG') === 'true',
+                        healthChecks: [$databaseHealthCheck],
+                        debug: $config->debug,
                     );
                 },
             )

--- a/tests/Http/HealthEndpointTest.php
+++ b/tests/Http/HealthEndpointTest.php
@@ -15,8 +15,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class HealthEndpointTest extends TestCase
 {
-    public function test_health_returns_ok_status_when_application_is_booted(): void
+    public function test_health_reports_ok_with_database_check_when_booted(): void
     {
+        // phpunit.xml.dist configures a SQLite :memory: database, so the
+        // DatabaseHealthCheck passes and the overall status is "ok".
         $container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
 
         $application = $container->get(RequestHandlerInterface::class);
@@ -31,5 +33,10 @@ final class HealthEndpointTest extends TestCase
         self::assertIsArray($payload);
         self::assertSame('ok', $payload['status'] ?? null);
         self::assertArrayHasKey('service', $payload);
+
+        self::assertArrayHasKey('checks', $payload);
+        $checks = $payload['checks'];
+        self::assertIsArray($checks);
+        self::assertSame('ok', $checks['database'] ?? null);
     }
 }


### PR DESCRIPTION
Closes #22

## 目的

アプリが自身のデータベースに接続できることを `GET /health` が示すよう、ランタイムに設定読込（AppConfig）と DB 接続・DatabaseHealthCheck を配線する。

## 変更内容

- `RuntimeServiceProvider`: ConfigLoader → AppConfig → `PdoConnectionFactory`（DatabaseConnectionFactoryInterface）→ `PdoDatabaseQueryExecutor`（DatabaseQueryExecutorInterface）を配線
- `src/Http/DatabaseHealthCheck`（NENE2 参照実装をアプリへコピー）を追加し `RuntimeApplicationFactory` の healthChecks に登録
- `debug` を `getenv` ハックから AppConfig へ移行
- phpunit を SQLite(:memory:) で実行する env を設定、health テストで `checks.database=ok` を検証

## 検証

- **`composer check` green**: PHPUnit **8 tests / 36 assertions**・PHPStan level 8 **no errors**・cs clean
- ライブ確認:
  - DB 接続可（sqlite） → `GET /health` **200** `{"status":"ok","checks":{"database":"ok"}}`
  - DB 不通 → **503** `{"status":"degraded","checks":{"database":"error"}}`

## 非範囲（次 PR）

- org 解決ミドルウェア（single）・`organization_id` スコープ・JWT 認証・RBAC（リクエストパイプラインとテナント/認証文脈を共有するため次 PR でまとめて）

## セルフレビュー

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)