### PR TITLE
feat(auth): User 永続化と Role/Capability(RBAC) ドメインを追加する (#24)

### DIFF
--- a/database/migrations/20260529130000_create_users_table.php
+++ b/database/migrations/20260529130000_create_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUsersTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('users')
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('password_hash', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('role', 'string', ['limit' => 32, 'null' => false, 'default' => 'admin'])
+            ->addColumn('organization_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false, 'default' => 'active'])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['email'], ['unique' => true, 'name' => 'uniq_users_email'])
+            ->addIndex(['organization_id'], ['name' => 'idx_users_organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -1,0 +1,14 @@
+-- Schema snapshot for the users table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    role VARCHAR(32) NOT NULL DEFAULT 'admin',
+    organization_id INTEGER NULL DEFAULT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'active',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX uniq_users_email ON users (email);
+CREATE INDEX idx_users_organization_id ON users (organization_id);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #22)
+Last updated: 2026-05-29 (Issue #24)
 
 ## Recently merged
 
@@ -13,12 +13,13 @@ Last updated: 2026-05-29 (Issue #22)
 - **Issue #17 / PR #18** — マルチテナント基盤＋ロール階層を土台採用（ADR 0006） ✅ merged
 - **Issue #4 / PR #19** — ランタイム基盤: NENE2 consumer scaffold + `GET /health` ✅ merged
 - **Issue #20 / PR #21** — Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 ✅ merged
+- **Issue #22 / PR #23** — ランタイムに DB 接続（AppConfig）+ DatabaseHealthCheck を配線 ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #22 | `feat/22-runtime-db-healthcheck` | ランタイムに DB 接続（AppConfig）+ DatabaseHealthCheck を配線 | 🔄 PR pending |
+| #24 | `feat/24-user-rbac-domain` | User 永続化 + Role/Capability(RBAC) ドメイン | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -82,11 +83,17 @@ Last updated: 2026-05-29 (Issue #22)
 - Phinx wired (`phinx.php`, `composer migrations:*`); `suffix => ''` so SQLite migrate/app share one file
 - Repository tested on SQLite `:memory:`
 
-**Phase 1 — Runtime DB connectivity: 🔄 in progress** (Issue #22)
+**Phase 1 — Runtime DB connectivity: ✅ complete** (Issue #22)
 
 - `RuntimeServiceProvider` wires ConfigLoader → AppConfig → PdoConnectionFactory → PdoDatabaseQueryExecutor
 - `src/Http/DatabaseHealthCheck` (copied from NENE2 reference) registered on `GET /health`
-- Verified: DB reachable → 200 `checks.database=ok`; unreachable → 503 `degraded`. `debug` now from AppConfig (not getenv)
+- Verified: DB reachable → 200 `checks.database=ok`; unreachable → 503 `degraded`
+
+**Phase 1 — User identity & RBAC domain: 🔄 in progress** (Issue #24)
+
+- `Auth/Role` + `Auth/Capability` enums with capability matrix (superadmin/admin/member/viewer)
+- `users` table (Phinx + SQLite snapshot); `User` entity + `PdoUserRepository` (org-scoped queries)
+- Tested: role matrix + repository on SQLite `:memory:`. No HTTP pipeline change yet
 
 ## Handoff Notes
 
@@ -104,6 +111,6 @@ Last updated: 2026-05-29 (Issue #22)
 
 ## Next steps
 
-1. Merge Issue #22 PR (runtime DB connectivity + DatabaseHealthCheck)
-2. Next PR: JWT auth + `Role`/`Capability` RBAC + `users` table, paired with org resolution middleware (default `single`) + `organization_id` query scoping — these share the request pipeline and tenant/auth context
+1. Merge Issue #24 PR (User + RBAC domain)
+2. Next PR: HTTP auth pipeline — JWT login + token verifier, auth middleware, `CapabilityMiddleware` (route → capability), org resolution middleware (default `single`) + `organization_id` request scoping
 3. Then PR-C+: organization CRUD (superadmin), user CRUD (admin)

--- a/src/Auth/Capability.php
+++ b/src/Auth/Capability.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Billing-specific capabilities enforced per route (ADR 0006).
+ *
+ * String values are registered in `docs/explanation/terminology.md` (binding).
+ */
+enum Capability: string
+{
+    case ManageOrganizations = 'manage_organizations';
+    case ManageUsers = 'manage_users';
+    case ManageCompanySettings = 'manage_company_settings';
+    case ManageBilling = 'manage_billing';
+    case ViewBilling = 'view_billing';
+}

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Operator roles and their capabilities (ADR 0006).
+ *
+ * - superadmin: cross-tenant; manages organizations (all capabilities)
+ * - admin: organization-scoped; everything except managing organizations
+ * - member: organization-scoped billing operator
+ * - viewer: organization-scoped read-only
+ *
+ * String values are registered in `docs/explanation/terminology.md` (binding).
+ */
+enum Role: string
+{
+    case Superadmin = 'superadmin';
+    case Admin = 'admin';
+    case Member = 'member';
+    case Viewer = 'viewer';
+
+    public function hasCapability(Capability $capability): bool
+    {
+        return match ($this) {
+            self::Superadmin => true,
+            self::Admin => $capability !== Capability::ManageOrganizations,
+            self::Member => match ($capability) {
+                Capability::ManageBilling,
+                Capability::ViewBilling => true,
+                Capability::ManageOrganizations,
+                Capability::ManageUsers,
+                Capability::ManageCompanySettings => false,
+            },
+            self::Viewer => $capability === Capability::ViewBilling,
+        };
+    }
+}

--- a/src/User/PdoUserRepository.php
+++ b/src/User/PdoUserRepository.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneInvoice\Auth\Role;
+
+final readonly class PdoUserRepository implements UserRepositoryInterface
+{
+    private const COLUMNS = 'id, email, password_hash, role, organization_id, status, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE email = ?',
+            [$email],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<User> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): User => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM users WHERE organization_id = ?',
+            [$organizationId],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function save(User $user): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        try {
+            $this->query->execute(
+                'INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $user->email,
+                    $user->passwordHash,
+                    $user->role->value,
+                    $user->organizationId,
+                    $user->status,
+                    $now,
+                    $now,
+                ],
+            );
+        } catch (DatabaseConstraintException $e) {
+            throw new UserEmailConflictException($user->email, $e);
+        }
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(User $user): void
+    {
+        if ($user->id === null) {
+            throw new UserNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE users SET email = ?, password_hash = ?, role = ?, organization_id = ?, status = ?, updated_at = ? WHERE id = ?',
+            [
+                $user->email,
+                $user->passwordHash,
+                $user->role->value,
+                $user->organizationId,
+                $user->status,
+                $now,
+                $user->id,
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($user->id) === null) {
+            throw new UserNotFoundException($user->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new UserNotFoundException($id);
+        }
+
+        $this->query->execute('DELETE FROM users WHERE id = ?', [$id]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): User
+    {
+        return new User(
+            email: (string) $row['email'],
+            passwordHash: (string) $row['password_hash'],
+            role: Role::from((string) $row['role']),
+            organizationId: isset($row['organization_id']) ? (int) $row['organization_id'] : null,
+            status: (string) $row['status'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use NeneInvoice\Auth\Role;
+
+/**
+ * An operator account.
+ *
+ * `organizationId` is the tenant the user belongs to. It is `null` only for
+ * superadmin, which operates cross-tenant (ADR 0006). `status` is one of
+ * `active` / `invited` (see `docs/explanation/terminology.md`).
+ */
+final readonly class User
+{
+    public function __construct(
+        public string $email,
+        public string $passwordHash,
+        public Role $role,
+        public ?int $organizationId = null,
+        public string $status = 'active',
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/User/UserEmailConflictException.php
+++ b/src/User/UserEmailConflictException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use DomainException;
+use Throwable;
+
+final class UserEmailConflictException extends DomainException
+{
+    public function __construct(string $email, ?Throwable $previous = null)
+    {
+        parent::__construct(sprintf('A user with email "%s" already exists.', $email), 0, $previous);
+    }
+}

--- a/src/User/UserNotFoundException.php
+++ b/src/User/UserNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use RuntimeException;
+
+final class UserNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("User {$id} not found.");
+    }
+}

--- a/src/User/UserRepositoryInterface.php
+++ b/src/User/UserRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface UserRepositoryInterface
+{
+    public function findById(int $id): ?User;
+
+    public function findByEmail(string $email): ?User;
+
+    /** @return list<User> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+
+    /** @throws UserEmailConflictException */
+    public function save(User $user): int;
+
+    /** @throws UserNotFoundException */
+    public function update(User $user): void;
+
+    /** @throws UserNotFoundException */
+    public function delete(int $id): void;
+}

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\Capability;
+use NeneInvoice\Auth\Role;
+use PHPUnit\Framework\TestCase;
+
+final class RoleTest extends TestCase
+{
+    public function test_superadmin_has_every_capability(): void
+    {
+        foreach (Capability::cases() as $capability) {
+            self::assertTrue(Role::Superadmin->hasCapability($capability), $capability->value);
+        }
+    }
+
+    public function test_admin_has_all_capabilities_except_managing_organizations(): void
+    {
+        self::assertFalse(Role::Admin->hasCapability(Capability::ManageOrganizations));
+        self::assertTrue(Role::Admin->hasCapability(Capability::ManageUsers));
+        self::assertTrue(Role::Admin->hasCapability(Capability::ManageCompanySettings));
+        self::assertTrue(Role::Admin->hasCapability(Capability::ManageBilling));
+        self::assertTrue(Role::Admin->hasCapability(Capability::ViewBilling));
+    }
+
+    public function test_member_can_only_operate_billing(): void
+    {
+        self::assertTrue(Role::Member->hasCapability(Capability::ManageBilling));
+        self::assertTrue(Role::Member->hasCapability(Capability::ViewBilling));
+        self::assertFalse(Role::Member->hasCapability(Capability::ManageUsers));
+        self::assertFalse(Role::Member->hasCapability(Capability::ManageCompanySettings));
+        self::assertFalse(Role::Member->hasCapability(Capability::ManageOrganizations));
+    }
+
+    public function test_viewer_is_read_only(): void
+    {
+        self::assertTrue(Role::Viewer->hasCapability(Capability::ViewBilling));
+        self::assertFalse(Role::Viewer->hasCapability(Capability::ManageBilling));
+        self::assertFalse(Role::Viewer->hasCapability(Capability::ManageUsers));
+        self::assertFalse(Role::Viewer->hasCapability(Capability::ManageCompanySettings));
+        self::assertFalse(Role::Viewer->hasCapability(Capability::ManageOrganizations));
+    }
+}

--- a/tests/User/PdoUserRepositoryTest.php
+++ b/tests/User/PdoUserRepositoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\User;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\User\PdoUserRepository;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+use NeneInvoice\User\UserNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class PdoUserRepositoryTest extends TestCase
+{
+    private PdoUserRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/users.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoUserRepository(
+            new PdoDatabaseQueryExecutor($factory, $pdo),
+        );
+    }
+
+    public function test_finds_user_by_email_and_id_after_save(): void
+    {
+        $id = $this->repository->save(new User(
+            email: 'admin@example.com',
+            passwordHash: 'hashed',
+            role: Role::Admin,
+            organizationId: 1,
+        ));
+
+        self::assertGreaterThan(0, $id);
+
+        $byEmail = $this->repository->findByEmail('admin@example.com');
+        self::assertNotNull($byEmail);
+        self::assertSame($id, $byEmail->id);
+        self::assertSame(Role::Admin, $byEmail->role);
+        self::assertSame(1, $byEmail->organizationId);
+        self::assertSame('active', $byEmail->status);
+
+        $byId = $this->repository->findById($id);
+        self::assertNotNull($byId);
+        self::assertSame('admin@example.com', $byId->email);
+    }
+
+    public function test_superadmin_may_have_null_organization(): void
+    {
+        $id = $this->repository->save(new User(
+            email: 'root@example.com',
+            passwordHash: 'hashed',
+            role: Role::Superadmin,
+            organizationId: null,
+        ));
+
+        $user = $this->repository->findById($id);
+        self::assertNotNull($user);
+        self::assertNull($user->organizationId);
+        self::assertSame(Role::Superadmin, $user->role);
+    }
+
+    public function test_lists_and_counts_users_scoped_to_organization(): void
+    {
+        $this->repository->save(new User(email: 'a@org1', passwordHash: 'h', role: Role::Admin, organizationId: 1));
+        $this->repository->save(new User(email: 'b@org1', passwordHash: 'h', role: Role::Member, organizationId: 1));
+        $this->repository->save(new User(email: 'c@org2', passwordHash: 'h', role: Role::Member, organizationId: 2));
+
+        self::assertSame(2, $this->repository->countByOrganization(1));
+        self::assertSame(1, $this->repository->countByOrganization(2));
+
+        $org1 = $this->repository->findAllByOrganization(1, 10, 0);
+        self::assertCount(2, $org1);
+        self::assertSame('a@org1', $org1[0]->email);
+    }
+
+    public function test_rejects_duplicate_email_when_saving(): void
+    {
+        $this->repository->save(new User(email: 'dup@example.com', passwordHash: 'h', role: Role::Admin, organizationId: 1));
+
+        $this->expectException(UserEmailConflictException::class);
+        $this->repository->save(new User(email: 'dup@example.com', passwordHash: 'h', role: Role::Member, organizationId: 1));
+    }
+
+    public function test_updates_user_role_and_status(): void
+    {
+        $id = $this->repository->save(new User(email: 'u@example.com', passwordHash: 'h', role: Role::Member, organizationId: 1, status: 'invited'));
+
+        $this->repository->update(new User(
+            email: 'u@example.com',
+            passwordHash: 'h',
+            role: Role::Admin,
+            organizationId: 1,
+            status: 'active',
+            id: $id,
+        ));
+
+        $updated = $this->repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame(Role::Admin, $updated->role);
+        self::assertSame('active', $updated->status);
+    }
+
+    public function test_throws_when_deleting_unknown_user(): void
+    {
+        $this->expectException(UserNotFoundException::class);
+        $this->repository->delete(987654);
+    }
+
+    public function test_deletes_existing_user(): void
+    {
+        $id = $this->repository->save(new User(email: 'tmp@example.com', passwordHash: 'h', role: Role::Member, organizationId: 1));
+
+        $this->repository->delete($id);
+
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->countByOrganization(1));
+    }
+}


### PR DESCRIPTION
Closes #24

## 目的

認証・認可の土台として、User の永続化と Role/Capability(RBAC) ドメインを追加する（ADR 0006）。HTTP パイプライン（認証/解決ミドルウェア）は次 PR。

## 変更内容

- **`Auth/Capability`** enum: `manage_organizations` / `manage_users` / `manage_company_settings` / `manage_billing` / `view_billing`
- **`Auth/Role`** enum: `superadmin` / `admin` / `member` / `viewer` + `hasCapability()` マトリクス
  - superadmin=全権、admin=organizations 管理以外、member=billing のみ、viewer=閲覧のみ
- **`users` テーブル**（Phinx + `database/schema/users.sql`）: email グローバル一意、organization_id（superadmin は NULL）、status
- **User ドメイン**: エンティティ + `UserRepositoryInterface` + `PdoUserRepository`（findById/findByEmail/findAllByOrganization/countByOrganization/save/update/delete、**org スコープ**）
- 例外: `UserNotFoundException` / `UserEmailConflictException`

## 検証

- **`composer check` green**: PHPUnit **19 tests / 85 assertions**・PHPStan level 8 **no errors**・cs clean
- `composer migrations:migrate` を SQLite で実行 → `organizations` / `users` 作成を確認
- 用語レジストリ（binding）の roles/capabilities 値に厳密一致

## 非範囲（次 PR）

- JWT ログイン・トークン検証、認証ミドルウェア、`CapabilityMiddleware`、org 解決ミドルウェア
- パスワードハッシュ生成（UseCase 層）

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)