### PR TITLE
feat(auth): JWT ログイン（POST /auth/login）とトークン発行を追加する (#26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ TENANT_RESOLUTION=single
 ORG_SLUG=
 BASE_DOMAIN=localhost
 
-# --- Auth (wired in a later PR) ---
-NENE_INVOICE_LOCAL_JWT_SECRET=
+# --- Auth: HMAC secret for local bearer tokens (set a strong random value in production) ---
+NENE2_LOCAL_JWT_SECRET=
 
 # --- Database (host / PHPUnit default: SQLite) ---
 DB_ADAPTER=sqlite

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -109,6 +109,8 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `client-not-found` | Client id not found |
 | `organization-not-found` | Organization id/slug not found |
 | `user-not-found` | User id not found |
+| `invalid-credentials` | Login failed — wrong email or password |
+| `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request |
 | `invalid-state-transition` | Disallowed status change |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #24)
+Last updated: 2026-05-29 (Issue #26)
 
 ## Recently merged
 
@@ -14,12 +14,13 @@ Last updated: 2026-05-29 (Issue #24)
 - **Issue #4 / PR #19** — ランタイム基盤: NENE2 consumer scaffold + `GET /health` ✅ merged
 - **Issue #20 / PR #21** — Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 ✅ merged
 - **Issue #22 / PR #23** — ランタイムに DB 接続（AppConfig）+ DatabaseHealthCheck を配線 ✅ merged
+- **Issue #24 / PR #25** — User 永続化 + Role/Capability(RBAC) ドメイン ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #24 | `feat/24-user-rbac-domain` | User 永続化 + Role/Capability(RBAC) ドメイン | 🔄 PR pending |
+| #26 | `feat/26-jwt-login` | JWT ログイン（POST /auth/login）+ トークン発行 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -89,11 +90,17 @@ Last updated: 2026-05-29 (Issue #24)
 - `src/Http/DatabaseHealthCheck` (copied from NENE2 reference) registered on `GET /health`
 - Verified: DB reachable → 200 `checks.database=ok`; unreachable → 503 `degraded`
 
-**Phase 1 — User identity & RBAC domain: 🔄 in progress** (Issue #24)
+**Phase 1 — User identity & RBAC domain: ✅ complete** (Issue #24)
 
 - `Auth/Role` + `Auth/Capability` enums with capability matrix (superadmin/admin/member/viewer)
 - `users` table (Phinx + SQLite snapshot); `User` entity + `PdoUserRepository` (org-scoped queries)
-- Tested: role matrix + repository on SQLite `:memory:`. No HTTP pipeline change yet
+- Tested: role matrix + repository on SQLite `:memory:`
+
+**Phase 1 — JWT login: 🔄 in progress** (Issue #26)
+
+- `POST /auth/login` (public): verifies email+password, issues HMAC bearer token (`LocalBearerTokenVerifier`)
+- Handler → `LoginUseCase` → `UserRepository`; token claims `sub`/`role`/`org`; `AuthServiceProvider` wiring; `ApplicationServiceProvider` aggregates route registrars
+- Verified live: valid → 200 + JWT; wrong → 401; missing → 422; `/health` still public. Token gate + `/me` + capability + org resolution next
 
 ## Handoff Notes
 
@@ -111,7 +118,7 @@ Last updated: 2026-05-29 (Issue #24)
 
 ## Next steps
 
-1. Merge Issue #24 PR (User + RBAC domain) — or current auth pipeline work
+1. Merge Issue #26 PR (JWT login). Next auth PR: `BearerTokenMiddleware` gate (protect `/admin/`) + `GET /admin/me` + `CapabilityMiddleware` + org resolution middleware (`single`)
 2. Complete Phase 1 core: clients, quotes, invoices, payments
 3. Phase 2 admin UI + PDF (minimum for overdue list)
 4. **Expansion #1** — payment reconciliation & dunning ([`expansion-roadmap.md`](./explanation/expansion-roadmap.md))

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace NeneInvoice;
 
+use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneInvoice\Auth\AuthRouteRegistrar;
 use Psr\Container\ContainerInterface;
 
 /**
  * Aggregates the application's route registrars and domain exception handlers.
  *
- * Both lists are empty in this scaffold — `GET /health` is provided by the
- * framework. Per-domain providers (Organization, Auth, User, Client, …) append
- * their registrars and handlers here as features land.
+ * `GET /health` is provided by the framework. Per-domain providers
+ * (Organization, Auth, User, Client, …) register their route registrars in the
+ * container; this provider collects them into the list the runtime consumes.
  */
 final readonly class ApplicationServiceProvider implements ServiceProviderInterface
 {
@@ -23,7 +25,18 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     public function register(ContainerBuilder $builder): void
     {
         $builder
-            ->set(self::ROUTE_REGISTRARS, static fn (ContainerInterface $container): array => [])
+            ->set(
+                self::ROUTE_REGISTRARS,
+                static function (ContainerInterface $container): array {
+                    $authRoutes = $container->get(AuthRouteRegistrar::class);
+
+                    if (!$authRoutes instanceof AuthRouteRegistrar) {
+                        throw new LogicException('Auth route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes];
+                },
+            )
             ->set(self::EXCEPTION_HANDLERS, static fn (ContainerInterface $container): array => []);
     }
 }

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Routing\Router;
+
+/**
+ * Registers authentication routes. Invoked with the {@see Router} during runtime
+ * assembly (see {@see \NeneInvoice\ApplicationServiceProvider}).
+ */
+final readonly class AuthRouteRegistrar
+{
+    public function __construct(
+        private LoginHandler $loginHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $router->post('/auth/login', fn ($request) => $this->loginHandler->handle($request));
+    }
+}

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use LogicException;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Config\AppConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\User\PdoUserRepository;
+use NeneInvoice\User\UserRepositoryInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires authentication services: token issuer/verifier, user repository, HTTP
+ * response factories, and the login use case / handler / route registrar.
+ */
+final readonly class AuthServiceProvider implements ServiceProviderInterface
+{
+    private const DEFAULT_DEV_SECRET = 'nene-invoice-dev-secret';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                LocalBearerTokenVerifier::class,
+                static function (ContainerInterface $container): LocalBearerTokenVerifier {
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new LocalBearerTokenVerifier($config->localJwtSecret ?? self::DEFAULT_DEV_SECRET);
+                },
+            )
+            ->set(
+                TokenIssuerInterface::class,
+                static function (ContainerInterface $container): TokenIssuerInterface {
+                    $verifier = $container->get(LocalBearerTokenVerifier::class);
+
+                    if (!$verifier instanceof TokenIssuerInterface) {
+                        throw new LogicException('Token issuer service is invalid.');
+                    }
+
+                    return $verifier;
+                },
+            )
+            ->set(
+                TokenVerifierInterface::class,
+                static function (ContainerInterface $container): TokenVerifierInterface {
+                    $verifier = $container->get(LocalBearerTokenVerifier::class);
+
+                    if (!$verifier instanceof TokenVerifierInterface) {
+                        throw new LogicException('Token verifier service is invalid.');
+                    }
+
+                    return $verifier;
+                },
+            )
+            ->set(
+                UserRepositoryInterface::class,
+                static function (ContainerInterface $container): UserRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoUserRepository($query);
+                },
+            )
+            ->set(
+                JsonResponseFactory::class,
+                static function (ContainerInterface $container): JsonResponseFactory {
+                    $psr17 = $container->get(Psr17Factory::class);
+
+                    if (!$psr17 instanceof Psr17Factory) {
+                        throw new LogicException('PSR-17 factory service is invalid.');
+                    }
+
+                    return new JsonResponseFactory($psr17, $psr17);
+                },
+            )
+            ->set(
+                ProblemDetailsResponseFactory::class,
+                static function (ContainerInterface $container): ProblemDetailsResponseFactory {
+                    $psr17 = $container->get(Psr17Factory::class);
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$psr17 instanceof Psr17Factory) {
+                        throw new LogicException('PSR-17 factory service is invalid.');
+                    }
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    return new ProblemDetailsResponseFactory($psr17, $psr17, $config->problemDetailsBaseUrl);
+                },
+            )
+            ->set(
+                LoginUseCaseInterface::class,
+                static function (ContainerInterface $container): LoginUseCaseInterface {
+                    $users = $container->get(UserRepositoryInterface::class);
+                    $tokenIssuer = $container->get(TokenIssuerInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('User repository service is invalid.');
+                    }
+
+                    if (!$tokenIssuer instanceof TokenIssuerInterface) {
+                        throw new LogicException('Token issuer service is invalid.');
+                    }
+
+                    return new LoginUseCase($users, $tokenIssuer);
+                },
+            )
+            ->set(
+                LoginHandler::class,
+                static function (ContainerInterface $container): LoginHandler {
+                    $useCase = $container->get(LoginUseCaseInterface::class);
+                    $json = $container->get(JsonResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$useCase instanceof LoginUseCaseInterface) {
+                        throw new LogicException('Login use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new LoginHandler($useCase, $json, $problemDetails);
+                },
+            )
+            ->set(
+                AuthRouteRegistrar::class,
+                static function (ContainerInterface $container): AuthRouteRegistrar {
+                    $loginHandler = $container->get(LoginHandler::class);
+
+                    if (!$loginHandler instanceof LoginHandler) {
+                        throw new LogicException('Login handler service is invalid.');
+                    }
+
+                    return new AuthRouteRegistrar($loginHandler);
+                },
+            );
+    }
+}

--- a/src/Auth/InvalidCredentialsException.php
+++ b/src/Auth/InvalidCredentialsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use DomainException;
+
+final class InvalidCredentialsException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid email or password.');
+    }
+}

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /auth/login` — public. Exchanges email + password for a bearer token.
+ */
+final readonly class LoginHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private LoginUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $email = $decoded['email'] ?? null;
+        $password = $decoded['password'] ?? null;
+
+        if (!is_string($email) || $email === '' || !is_string($password) || $password === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "email" and "password" are required.');
+        }
+
+        try {
+            $output = $this->useCase->execute(new LoginInput($email, $password));
+        } catch (InvalidCredentialsException $e) {
+            return $this->problemDetails->create($request, 'invalid-credentials', 'Invalid Credentials', 401, $e->getMessage());
+        }
+
+        return $this->json->create(['token' => $output->token]);
+    }
+}

--- a/src/Auth/LoginInput.php
+++ b/src/Auth/LoginInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+final readonly class LoginInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+    ) {
+    }
+}

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+final readonly class LoginOutput
+{
+    public function __construct(
+        public string $token,
+    ) {
+    }
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use NeneInvoice\User\UserRepositoryInterface;
+
+/**
+ * Authenticates an operator by email + password and issues a bearer token.
+ *
+ * The token carries the user id (`sub`), role, and organization id so that the
+ * auth and capability middleware (later PRs) can authorize requests without a
+ * database round-trip on every call.
+ */
+final readonly class LoginUseCase implements LoginUseCaseInterface
+{
+    private const TOKEN_TTL_SECONDS = 3600;
+
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface $tokenIssuer,
+    ) {
+    }
+
+    public function execute(LoginInput $input): LoginOutput
+    {
+        $user = $this->users->findByEmail($input->email);
+
+        if ($user === null || !password_verify($input->password, $user->passwordHash)) {
+            throw new InvalidCredentialsException();
+        }
+
+        $now = time();
+
+        $token = $this->tokenIssuer->issue([
+            'sub' => $user->id,
+            'role' => $user->role->value,
+            'org' => $user->organizationId,
+            'iat' => $now,
+            'exp' => $now + self::TOKEN_TTL_SECONDS,
+        ]);
+
+        return new LoginOutput($token);
+    }
+}

--- a/src/Auth/LoginUseCaseInterface.php
+++ b/src/Auth/LoginUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+interface LoginUseCaseInterface
+{
+    /** @throws InvalidCredentialsException */
+    public function execute(LoginInput $input): LoginOutput;
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -18,6 +18,7 @@ use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Auth\AuthServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -36,6 +37,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder->addProvider(new ApplicationServiceProvider());
+        $builder->addProvider(new AuthServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+use NeneInvoice\Auth\InvalidCredentialsException;
+use NeneInvoice\Auth\LoginInput;
+use NeneInvoice\Auth\LoginUseCase;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LoginUseCaseTest extends TestCase
+{
+    private const SECRET = 'test-secret';
+
+    public function test_issues_token_with_identity_claims_on_valid_credentials(): void
+    {
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier);
+
+        $output = $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
+
+        $claims = $verifier->verify($output->token);
+        self::assertSame(7, $claims['sub'] ?? null);
+        self::assertSame('admin', $claims['role'] ?? null);
+        self::assertSame(1, $claims['org'] ?? null);
+    }
+
+    public function test_rejects_wrong_password(): void
+    {
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET));
+
+        $this->expectException(InvalidCredentialsException::class);
+        $useCase->execute(new LoginInput('admin@example.com', 'wrong'));
+    }
+
+    public function test_rejects_unknown_email(): void
+    {
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET));
+
+        $this->expectException(InvalidCredentialsException::class);
+        $useCase->execute(new LoginInput('nobody@example.com', 'correct-horse'));
+    }
+
+    private function repositoryWithUser(string $plainPassword): UserRepositoryInterface
+    {
+        $user = new User(
+            email: 'admin@example.com',
+            passwordHash: password_hash($plainPassword, PASSWORD_DEFAULT),
+            role: Role::Admin,
+            organizationId: 1,
+            status: 'active',
+            id: 7,
+        );
+
+        return new class ($user) implements UserRepositoryInterface {
+            public function __construct(private readonly User $user)
+            {
+            }
+
+            public function findById(int $id): ?User
+            {
+                return $this->user->id === $id ? $this->user : null;
+            }
+
+            public function findByEmail(string $email): ?User
+            {
+                return $this->user->email === $email ? $this->user : null;
+            }
+
+            /** @return list<User> */
+            public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+            {
+                return [];
+            }
+
+            public function countByOrganization(int $organizationId): int
+            {
+                return 0;
+            }
+
+            public function save(User $user): int
+            {
+                return 0;
+            }
+
+            public function update(User $user): void
+            {
+            }
+
+            public function delete(int $id): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #26

## 目的

HTTP 認証の第一段として、公開のログインルートとトークン発行を追加する。保護ミドルウェア・`/me`・capability・org 解決は次 PR。

## 変更内容

- **`POST /auth/login`（公開）**: email/password を `password_verify` で検証し、NENE2 `LocalBearerTokenVerifier`（HMAC-HS256）で Bearer トークンを発行（claims: `sub`/`role`/`org`/`iat`/`exp`、TTL 1h）
- **Handler → UseCase → Repository**: `LoginInput`/`LoginOutput` DTO、`LoginUseCase`（`execute`）、`LoginHandler`（不正→401 `invalid-credentials`、欠落→422 `validation-failed`）
- **`AuthServiceProvider`** でコンテナ配線（TokenIssuer/Verifier、UserRepository、JsonResponseFactory、ProblemDetailsResponseFactory、LoginUseCase、LoginHandler、AuthRouteRegistrar）。`ApplicationServiceProvider` が route registrar を集約
- terminology に `invalid-credentials` / `unauthorized` slug を追加
- **修正**: `.env.example` の JWT 秘密鍵キーを ConfigLoader が実際に読む `NENE2_LOCAL_JWT_SECRET` に修正（旧 `NENE_INVOICE_LOCAL_JWT_SECRET` は読まれず無効だった）

## 検証

- **`composer check` green**: PHPUnit **22 tests / 90 assertions**・PHPStan level 8 **no errors**・cs clean
- LoginUseCase をテスト（偽リポジトリ：トークン claims 検証 / 誤パスワード / 未知 email）
- ライブ: 正→**200**+JWT（payload `sub`/`role`/`org` 確認）、誤→**401**、欠落→**422**、`/health` は公開のまま **200**

## 非範囲（次 PR）

- `BearerTokenMiddleware` による `/admin/` 保護、`GET /admin/me`、`CapabilityMiddleware`、org 解決ミドルウェア

## セルフレビュー

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)