### PR TITLE
docs(philosophy): NeNe Clear の理念・哲学と製品名を定義する (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,12 @@
 # Agent / AI Guide
 
-This file is the entry point for AI agents working on NeNe Invoice.
+This file is the entry point for AI agents working on **NeNe Clear** (repo: `nene-invoice`).
 
 ## Read First
 
 - **Current work & status:** `docs/todo/current.md`
 - **Accounting & tax compliance (binding):** `docs/explanation/accounting-compliance.md`
+- **Philosophy & name:** `docs/explanation/philosophy.md` — **NeNe Clear** ([ADR 0007](../adr/0007-product-identity-nene-clear.md))
 - **Product vision:** `docs/explanation/product-vision.md`
 - **Requirements:** `docs/explanation/requirements.md`
 - **Domain model:** `docs/explanation/domain-model.md`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# NeNe Invoice
+# NeNe Clear
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
 
-**Quote, invoice, and payment tracking for Japan SMB — self-hosted on your stack.**
+**Clear billing from quote to cash — self-hosted for Japan SMB.**
 
-NeNe Invoice is an open-source billing platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). Create quotes, issue **qualified invoice** (適格請求書) PDFs, track payments, and run everything on shared hosting or Docker — without a monthly SaaS fee.
+**NeNe Clear** (*見積から入金まで、明快に。*) is an open-source billing platform on [NENE2](https://github.com/hideyukiMORI/NENE2): quotes, **qualified invoice** (適格請求書) PDFs, payment tracking, and (post-MVP) reconciliation and dunning — on shared hosting or Docker, without a monthly SaaS fee.
+
+> Repository slug: `nene-invoice` (rename to `nene-clear` planned — [ADR 0007](./docs/adr/0007-product-identity-nene-clear.md)).
+
+> **Philosophy:** [`docs/explanation/philosophy.md`](./docs/explanation/philosophy.md) — ideals, AI-era dual surface, what we refuse to become.
 
 > **Example operator:** an office manager on shared hosting issues invoice-compliant PDFs from admin UI instead of Excel + manual PDF — see [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md#primary-persona).
 
@@ -36,7 +40,7 @@ curl http://127.0.0.1:8080/health       # {"status":"ok",...}
 ## Architecture (planned)
 
 ```
-Admin UI (React)  ──→  NeNe Invoice API (NENE2)  ──→  MySQL
+Admin UI (React)  ──→  NeNe Clear API (NENE2)  ──→  MySQL
 Ops / MCP           ──→         │
                                 ↓ HTTP (optional)
                     NeNe Records / NeNe Concierge
@@ -74,6 +78,7 @@ Full list: [`docs/explanation/product-vision.md#non-goals`](./docs/explanation/p
 | Topic | Document |
 | --- | --- |
 | **Compliance (binding)** | [`docs/explanation/accounting-compliance.md`](./docs/explanation/accounting-compliance.md) |
+| **Philosophy & product name** | [`docs/explanation/philosophy.md`](./docs/explanation/philosophy.md) · [ADR 0007](./docs/adr/0007-product-identity-nene-clear.md) |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
 | **Domain model** | [`docs/explanation/domain-model.md`](./docs/explanation/domain-model.md) |
@@ -92,7 +97,7 @@ Part of the [hideyukiMORI NeNe portfolio](https://github.com/hideyukiMORI):
 | [nene-records](https://github.com/hideyukiMORI/nene-records) | CMS · optional product catalog |
 | [nene-corpus](https://github.com/hideyukiMORI/nene-corpus) | Knowledge chat |
 | [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Scenario chat · optional leads |
-| **nene-invoice** | Quote · invoice · payment (this repo) |
+| **NeNe Clear** (`nene-invoice`) | Quote · invoice · payment · clear (this repo) |
 
 ## Contributing
 

--- a/docs/adr/0007-product-identity-nene-clear.md
+++ b/docs/adr/0007-product-identity-nene-clear.md
@@ -1,0 +1,73 @@
+# ADR 0007: Product Identity — NeNe Clear
+
+## Status
+
+accepted
+
+## Context
+
+The repository launched as **NeNe Invoice** (`hideyukiMORI/nene-invoice`) — a
+descriptive working title. As the product scope grew (quote-to-cash, payment
+reconciliation, dunning, and five post-MVP expansions), the name "Invoice" became
+too narrow: it sounds like a PDF generator, not a **billing operations platform**
+for humans and AI agents.
+
+Sibling products use short English nouns with layered meaning:
+
+| Product | Name layer |
+| --- | --- |
+| NeNe Records | archive / registry of typed content |
+| NeNe Corpus | body of knowledge |
+| NeNe Concierge | guided conversion service |
+
+Alternatives considered:
+
+| Name | Pros | Cons |
+| --- | --- | --- |
+| **NeNe Clear** | Clearing (消込) + clarity + AI-readable; short | "Clear" can mean delete in UI — use carefully in copy |
+| NeNe Collect | Emphasizes receivables / dunning | Sounds like debt collection agency |
+| NeNe Receivable | Accurate B2B term (売掛) | Dry; long; narrow for future PO/expense expansions |
+| NeNe Settle | Settlement | Generic fintech; less distinctive |
+| NeNe Invoice (keep) | Already known; matches repo slug | Undersells reconciliation and quote-to-cash loop |
+
+## Decision
+
+Adopt **NeNe Clear** as the **public product name**.
+
+- **Tagline (EN):** *Clear billing from quote to cash.*
+- **Tagline (JA, marketing):** *見積から入金まで、明快に。*
+
+**Repository slug** remains `nene-invoice` until a dedicated rename Issue
+(Packagist, redirects, sibling doc links). Code namespace remains `NeneInvoice\`
+until a rename ADR — avoid churn before Phase 1 stabilizes.
+
+**Problem Details base URL** remains `https://nene-invoice.dev/problems/` until
+domain/branding Issue lands.
+
+Philosophy and ideals: `docs/explanation/philosophy.md` (companion to
+`product-vision.md` — *what* we build vs *why* and *how we think*).
+
+## Consequences
+
+**Benefits**
+
+- Name grows with Expansion #1 (消込) without rebranding again.
+- Distinct from "invoice SaaS" competitors.
+- Fits NeNe naming family (noun, one word, layered meaning).
+
+**Costs**
+
+- Temporary mismatch between display name and repo slug until rename.
+- UI copy must not use "Clear" as a verb for delete without context.
+
+**Follow-up**
+
+- Optional: GitHub repo rename to `nene-clear`, namespace migration ADR.
+- Register product name in `terminology.md` when identifiers are affected.
+
+## Related
+
+- Philosophy: `docs/explanation/philosophy.md`
+- Product vision: `docs/explanation/product-vision.md`
+- Expansion roadmap: `docs/explanation/expansion-roadmap.md`
+- Issue: #31

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -23,6 +23,7 @@ docs/adr/
 ├── 0000-template.md
 ├── 0001-inherit-nene2-governance.md
 ├── 0002-separate-from-sibling-products.md
+├── 0007-product-identity-nene-clear.md
 └── NNNN-short-title.md
 ```
 

--- a/docs/explanation/philosophy.md
+++ b/docs/explanation/philosophy.md
@@ -1,0 +1,206 @@
+# Philosophy — NeNe Clear
+
+**NeNe Clear** (*Clear billing from quote to cash.*)
+
+This document records **ideals** (理想), **philosophy** (理念・哲学), and
+**non‑negotiable beliefs** for the product. It complements
+[`product-vision.md`](./product-vision.md) (scope and personas) and
+[`expansion-roadmap.md`](./expansion-roadmap.md) (feature sequence).
+
+Canonical language: **English**. Maintainer intent in Japanese appears in
+§8 where it aids nuance; public API and OpenAPI remain English.
+
+Product name: [ADR 0007](../adr/0007-product-identity-nene-clear.md).
+
+---
+
+## 1. What we believe
+
+### 1.1 Every SMB deserves a clear money trail
+
+Small businesses do not fail because they lack features — they fail because
+**money movement is opaque**. Quotes live in email, invoices in Excel, payments
+in bank CSV, reminders in someone's memory.
+
+**Ideal:** One self-hosted place where *what was promised*, *what was billed*,
+*what arrived*, and *what is still owed* are **visible and auditable** — for
+the office manager **and** for any AI assistant the team already uses.
+
+### 1.2 Self-hosting is a feature, not nostalgia
+
+Japan SMB on shared hosting (FTP, MySQL, no Docker) is not "legacy." It is a
+**deliberate choice**: data stays on infrastructure the operator already pays for,
+beside WordPress or a static site, without another SaaS bill.
+
+**Ideal:** Tier A install feels as approachable as uploading a CMS — not as
+punishment for being small.
+
+### 1.3 Compliance is structure, not paperwork
+
+適格請求書 and tax rules are not PDF decoration. They are **validation rules**
+in the API — the same rules whether a human clicks "Issue" or an agent calls
+`createInvoice` via MCP.
+
+**Ideal:** A tax reviewer finds **zero deviations** from documented compliance
+([`accounting-compliance.md`](./accounting-compliance.md)); any change requires
+ADR and professional sign-off.
+
+### 1.4 AI everywhere — but responsibility stays in the system
+
+By the time this product reaches operators, many teams will use Claude, Codex, or
+similar tools daily. That does **not** replace the product. It changes **how**
+operators interact with it.
+
+**Ideal — dual surface:**
+
+| Actor | Surface | Responsibility |
+| --- | --- | --- |
+| **Human operator** | Admin UI | Confirms matches, sends dunning, owns decisions |
+| **AI assistant** | OpenAPI + MCP | Proposes matches, drafts quotes, lists overdue — **never silent writes without audit** |
+| **End client** | PDF / email | Receives documents; no account required |
+
+FTP install does not mean "no AI." It means **AI runs on the client side**
+(browser, desktop, MCP host) while **billing truth lives in MySQL** on the
+server.
+
+### 1.5 Small scope, long horizon
+
+We refuse to become freee. We **embrace** being the narrow, excellent layer:
+**quote → invoice → collect → clear** — then carefully add PO, contracts,
+subscriptions, and minimal expenses ([expansion roadmap](./expansion-roadmap.md)).
+
+**Ideal:** A wholesaler with eight staff gets 80% of their billing pain solved
+without learning double-entry accounting.
+
+---
+
+## 2. Philosophy (how we build)
+
+### 2.1 Clear over clever
+
+- Explicit layers (Handler → UseCase → Repository), not magic.
+- Integer cents, not floats. Registered terms, not synonyms
+  ([`terminology.md`](./terminology.md)).
+- OpenAPI before UI assumptions.
+
+If an agent or junior developer cannot find the rule in docs, the design failed.
+
+### 2.2 Human confirms, AI proposes
+
+Especially for **payment reconciliation** (Expansion #1):
+
+- Import and structure bank data in the system.
+- Rules and AI **suggest** matches.
+- A human **confirms** → audit log → `payment` + invoice status update.
+
+Automatic clearing without confirmation is a liability, not a feature, until
+explicitly ADR'd for a defined low-risk subset.
+
+### 2.3 Same contract for GUI and MCP
+
+Everything an operator can do in admin UI must be reachable via documented HTTP
+(and MCP where appropriate). No hidden SQL paths for agents.
+
+This mirrors NeNe Concierge's "GUI parity with API" principle — applied to
+**back-office billing**.
+
+### 2.4 Sibling products, separate repos
+
+NeNe Records, Corpus, and Concierge remain upstream/downstream **via HTTP only**
+(ADR 0002). Clear owns billing data; it never merges into CMS or chat repos.
+
+### 2.5 Bilingual operators, Japanese law
+
+Admin UI: **Japanese + English** (ADR 0005). Statutory invoice content:
+**Japanese**. The product serves non-Japanese founders running Japan-registered
+entities — compliance is fixed; UI language is flexible.
+
+---
+
+## 3. Ideals checklist (north star behaviors)
+
+When evaluating a feature or PR, ask:
+
+1. Does it make the **quote-to-cash loop clearer** for a non-engineer?
+2. Does it work on **Tier A** without Redis, without CLI, without Codex on the server?
+3. Does it leave an **audit trail** suitable for "who matched this deposit?"
+4. Can an **AI agent** perform the same action through OpenAPI/MCP?
+5. Does it stay **out of full accounting** territory unless the expansion roadmap says otherwise?
+6. Does it **register terms** before shipping identifiers?
+
+If most answers are no, reconsider or split the work.
+
+---
+
+## 4. What we refuse to become
+
+| We are not | Why |
+| --- | --- |
+| A general ledger | freee / MF territory; we export CSV instead |
+| A bank | We import CSV; we do not hold deposits |
+| A payment gateway (Phase 1–3 core) | Manual record first; PSP optional later |
+| A WordPress plugin | Sibling app on same origin is fine |
+| An AI chatbot | MCP proposes; UI and logs confirm |
+| A debt collection agency | Dunning is operator-controlled professional reminder |
+
+---
+
+## 5. Name — why *Clear*
+
+| Reading | Meaning |
+| --- | --- |
+| **Clear (verb)** | 消込 — reconcile bank lines to invoices |
+| **Clear (adjective)** | 明快 — transparent status: draft, issued, overdue, paid |
+| **Clear (verb)** | クリア — remove Excel chaos; one system of record |
+
+One word, three readings — same as Records / Corpus / Concierge in the NeNe
+family.
+
+---
+
+## 6. Relationship to the NeNe portfolio
+
+```
+Website (WordPress / static)
+    ├── NeNe Corpus      — visitor asks questions (public knowledge)
+    ├── NeNe Concierge   — visitor converts (scenario chat)
+    └── NeNe Records     — content & catalog (CMS)
+
+Back office (same server or VPS)
+    └── NeNe Clear       — quote, bill, collect, clear (this product)
+```
+
+**Front office** attracts and informs. **Clear** closes the commercial loop.
+
+---
+
+## 7. Document map
+
+| Question | Read |
+| --- | --- |
+| Why does the product exist? | This file + `product-vision.md` |
+| What do we build in v1? | `requirements.md` |
+| What comes after MVP? | `expansion-roadmap.md` |
+| What is the product called? | ADR 0007 — **NeNe Clear** |
+| What are exact spellings? | `terminology.md` |
+
+---
+
+## 8. Maintainer intent (理念 — 日本語)
+
+> **見積から入金までを、Excel と記憶から解放する。**
+>
+> 適格請求書は「PDF の体裁」ではなく、API が守るルール。データは自分のレンタルサーバーに置き、SaaS 月額を増やさない。AI 時代だからこそ、人間が確定し、AI が提案し、記録が残る — その三つを同時に満たすバックオフィス OSS。
+>
+> 名前 **Clear** は「消込」と「明快」の両方。請求書 PDF だけのツールにはならない。
+
+---
+
+## Related
+
+- ADR 0007: Product identity
+- [`product-vision.md`](./product-vision.md)
+- [`expansion-roadmap.md`](./expansion-roadmap.md)
+- [`accounting-compliance.md`](./accounting-compliance.md)
+
+Last updated: 2026-05-29 (Issue #31)

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -1,12 +1,16 @@
 # Product Vision
 
-NeNe Invoice is a self-hosted quote and invoice platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). This document records why the product exists, what it optimizes for, and how it relates to the NeNe ecosystem.
+> **Product name:** **NeNe Clear** — see [`philosophy.md`](./philosophy.md) and
+> [ADR 0007](../adr/0007-product-identity-nene-clear.md). Repository slug
+> `nene-invoice` is provisional.
+
+NeNe Clear is a self-hosted quote and invoice platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). This document records why the product exists, what it optimizes for, and how it relates to the NeNe ecosystem.
 
 ## Origin
 
 Every Japan SMB must issue **qualified invoices** (適格請求書) under the invoice system (インボイス制度). SaaS accounting tools (freee, Money Forward, Yayoi) solve this well but charge recurring fees and hold financial data on vendor infrastructure. Many micro-businesses on **shared hosting** already run their website on the same server — they want billing documents without another monthly subscription.
 
-NeNe Invoice offers an alternative: **run quote and invoice management on infrastructure you control**, with source code you can audit, and optional integration with sibling NeNe products for catalog and lead capture.
+NeNe Clear offers an alternative: **run quote and invoice management on infrastructure you control**, with source code you can audit, and optional integration with sibling NeNe products for catalog and lead capture.
 
 The product showcases NENE2's strengths — OpenAPI-first APIs, Clean Architecture, MCP-ready ops boundaries, and field-trial-grade security — in a **back-office application** every SMB needs, not a demo endpoint.
 

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -28,7 +28,19 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 
 ---
 
-## 1. Domain entities
+## 0. Product identity (display names)
+
+| Concept | Canonical | Notes |
+| --- | --- | --- |
+| Public product name | **NeNe Clear** | ADR 0007; not "NeNe Invoice" in marketing copy |
+| Repository slug (provisional) | `nene-invoice` | Rename to `nene-clear` via future Issue |
+| PHP namespace (provisional) | `NeneInvoice\` | Rename via future ADR |
+| Problem Details base | `https://nene-invoice.dev/problems/` | Until branding domain Issue |
+
+Code identifiers (`NeneInvoice\`, table prefixes) stay as registered until a
+rename ADR; **prose** in README and philosophy uses **NeNe Clear**.
+
+---
 
 | Concept | PHP class / domain folder | Table | Primary FK in JSON/DB |
 | --- | --- | --- | --- |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #26)
+Last updated: 2026-05-29 (Issue #30)
 
 ## Recently merged
 
@@ -15,12 +15,13 @@ Last updated: 2026-05-29 (Issue #26)
 - **Issue #20 / PR #21** — Organization 永続化レイヤ（テナント）+ Phinx マイグレーション基盤 ✅ merged
 - **Issue #22 / PR #23** — ランタイムに DB 接続（AppConfig）+ DatabaseHealthCheck を配線 ✅ merged
 - **Issue #24 / PR #25** — User 永続化 + Role/Capability(RBAC) ドメイン ✅ merged
+- **Issue #26 / PR #29** — JWT ログイン（POST /auth/login）+ トークン発行 ✅ merged
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #26 | `feat/26-jwt-login` | JWT ログイン（POST /auth/login）+ トークン発行 | 🔄 PR pending |
+| #30 | `feat/30-auth-gate-me` | Bearer トークンゲート（/admin/ 保護）+ GET /admin/me | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -96,11 +97,16 @@ Last updated: 2026-05-29 (Issue #26)
 - `users` table (Phinx + SQLite snapshot); `User` entity + `PdoUserRepository` (org-scoped queries)
 - Tested: role matrix + repository on SQLite `:memory:`
 
-**Phase 1 — JWT login: 🔄 in progress** (Issue #26)
+**Phase 1 — JWT login: ✅ complete** (Issue #26)
 
 - `POST /auth/login` (public): verifies email+password, issues HMAC bearer token (`LocalBearerTokenVerifier`)
-- Handler → `LoginUseCase` → `UserRepository`; token claims `sub`/`role`/`org`; `AuthServiceProvider` wiring; `ApplicationServiceProvider` aggregates route registrars
-- Verified live: valid → 200 + JWT; wrong → 401; missing → 422; `/health` still public. Token gate + `/me` + capability + org resolution next
+- Handler → `LoginUseCase` → `UserRepository`; token claims `sub`/`role`/`org`
+
+**Phase 1 — Auth gate + current user: 🔄 in progress** (Issue #30)
+
+- `BearerTokenMiddleware` (prefix `/admin/`) wired into the runtime authMiddleware; `/health`, `/auth/login`, `/` stay public
+- `GET /admin/me` returns the authenticated user from token claims (`sub`)
+- Verified live: no/invalid token → 401, valid → 200 + user; `/health` public. CapabilityMiddleware + org resolution next
 
 ## Handoff Notes
 
@@ -118,7 +124,7 @@ Last updated: 2026-05-29 (Issue #26)
 
 ## Next steps
 
-1. Merge Issue #26 PR (JWT login). Next auth PR: `BearerTokenMiddleware` gate (protect `/admin/`) + `GET /admin/me` + `CapabilityMiddleware` + org resolution middleware (`single`)
+1. Merge Issue #30 PR (auth gate + `/admin/me`). Next auth PR: `CapabilityMiddleware` (route → capability RBAC) + org resolution middleware (`single`) + `organization_id` request scoping
 2. Complete Phase 1 core: clients, quotes, invoices, payments
 3. Phase 2 admin UI + PDF (minimum for overdue list)
 4. **Expansion #1** — payment reconciliation & dunning ([`expansion-roadmap.md`](./explanation/expansion-roadmap.md))

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -14,11 +14,13 @@ final readonly class AuthRouteRegistrar
 {
     public function __construct(
         private LoginHandler $loginHandler,
+        private GetCurrentUserHandler $getCurrentUserHandler,
     ) {
     }
 
     public function __invoke(Router $router): void
     {
         $router->post('/auth/login', fn ($request) => $this->loginHandler->handle($request));
+        $router->get('/admin/me', fn ($request) => $this->getCurrentUserHandler->handle($request));
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Auth;
 
 use LogicException;
+use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Auth\TokenVerifierInterface;
@@ -108,6 +109,29 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                BearerTokenMiddleware::class,
+                static function (ContainerInterface $container): BearerTokenMiddleware {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    $verifier = $container->get(TokenVerifierInterface::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    if (!$verifier instanceof TokenVerifierInterface) {
+                        throw new LogicException('Token verifier service is invalid.');
+                    }
+
+                    // Protect everything under /admin/. Public routes (/, /health,
+                    // /auth/login) are not matched by the prefix and pass through.
+                    return new BearerTokenMiddleware(
+                        $problemDetails,
+                        $verifier,
+                        protectedPathPrefixes: ['/admin/'],
+                    );
+                },
+            )
+            ->set(
                 LoginUseCaseInterface::class,
                 static function (ContainerInterface $container): LoginUseCaseInterface {
                     $users = $container->get(UserRepositoryInterface::class);
@@ -147,15 +171,54 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                GetCurrentUserUseCaseInterface::class,
+                static function (ContainerInterface $container): GetCurrentUserUseCaseInterface {
+                    $users = $container->get(UserRepositoryInterface::class);
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('User repository service is invalid.');
+                    }
+
+                    return new GetCurrentUserUseCase($users);
+                },
+            )
+            ->set(
+                GetCurrentUserHandler::class,
+                static function (ContainerInterface $container): GetCurrentUserHandler {
+                    $useCase = $container->get(GetCurrentUserUseCaseInterface::class);
+                    $json = $container->get(JsonResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$useCase instanceof GetCurrentUserUseCaseInterface) {
+                        throw new LogicException('Get current user use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new GetCurrentUserHandler($useCase, $json, $problemDetails);
+                },
+            )
+            ->set(
                 AuthRouteRegistrar::class,
                 static function (ContainerInterface $container): AuthRouteRegistrar {
                     $loginHandler = $container->get(LoginHandler::class);
+                    $getCurrentUserHandler = $container->get(GetCurrentUserHandler::class);
 
                     if (!$loginHandler instanceof LoginHandler) {
                         throw new LogicException('Login handler service is invalid.');
                     }
 
-                    return new AuthRouteRegistrar($loginHandler);
+                    if (!$getCurrentUserHandler instanceof GetCurrentUserHandler) {
+                        throw new LogicException('Get current user handler service is invalid.');
+                    }
+
+                    return new AuthRouteRegistrar($loginHandler, $getCurrentUserHandler);
                 },
             );
     }

--- a/src/Auth/GetCurrentUserHandler.php
+++ b/src/Auth/GetCurrentUserHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/me` — returns the authenticated operator.
+ *
+ * Reads the verified token claims set by the framework `BearerTokenMiddleware`
+ * (attribute `nene2.auth.claims`). Any authenticated user may read their own
+ * record, so no capability check is required here.
+ */
+final readonly class GetCurrentUserHandler implements RequestHandlerInterface
+{
+    private const CLAIMS_ATTRIBUTE = 'nene2.auth.claims';
+
+    public function __construct(
+        private GetCurrentUserUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $claims = $request->getAttribute(self::CLAIMS_ATTRIBUTE);
+        $userId = is_array($claims) && isset($claims['sub']) && is_int($claims['sub']) ? $claims['sub'] : 0;
+
+        $user = $userId > 0 ? $this->useCase->execute($userId) : null;
+
+        if ($user === null) {
+            return $this->problemDetails->create($request, 'unauthorized', 'Unauthorized', 401, 'The authenticated user no longer exists.');
+        }
+
+        return $this->json->create([
+            'id' => $user->id,
+            'email' => $user->email,
+            'role' => $user->role->value,
+            'organization_id' => $user->organizationId,
+        ]);
+    }
+}

--- a/src/Auth/GetCurrentUserUseCase.php
+++ b/src/Auth/GetCurrentUserUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserRepositoryInterface;
+
+final readonly class GetCurrentUserUseCase implements GetCurrentUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(int $userId): ?User
+    {
+        return $this->users->findById($userId);
+    }
+}

--- a/src/Auth/GetCurrentUserUseCaseInterface.php
+++ b/src/Auth/GetCurrentUserUseCaseInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use NeneInvoice\User\User;
+
+interface GetCurrentUserUseCaseInterface
+{
+    public function execute(int $userId): ?User;
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Http;
 
 use LogicException;
+use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
@@ -25,10 +26,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Wires the NENE2 HTTP runtime for NeNe Invoice: configuration, database
- * connectivity, and the request handler.
+ * connectivity, bearer-token authentication, and the request handler.
  *
- * Tenant resolution, JWT auth, and RBAC middleware are added in following PRs by
- * extending {@see RuntimeApplicationFactory} construction here.
+ * Tenant resolution and capability (RBAC) middleware are added in following PRs
+ * by extending {@see RuntimeApplicationFactory} construction here.
  */
 final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 {
@@ -122,6 +123,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database health check service is invalid.');
                     }
 
+                    $bearerTokenMiddleware = $container->get(BearerTokenMiddleware::class);
+
+                    if (!$bearerTokenMiddleware instanceof BearerTokenMiddleware) {
+                        throw new LogicException('Bearer token middleware service is invalid.');
+                    }
+
                     $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
 
                     if (!is_array($routeRegistrars) || !array_is_list($routeRegistrars)) {
@@ -143,6 +150,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         streamFactory: $psr17,
                         domainExceptionHandlers: $exceptionHandlers,
                         routeRegistrars: $routeRegistrars,
+                        authMiddleware: [$bearerTokenMiddleware],
                         healthChecks: [$databaseHealthCheck],
                         debug: $config->debug,
                     );

--- a/tests/Auth/GetCurrentUserUseCaseTest.php
+++ b/tests/Auth/GetCurrentUserUseCaseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\GetCurrentUserUseCase;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class GetCurrentUserUseCaseTest extends TestCase
+{
+    public function test_returns_user_for_known_id(): void
+    {
+        $useCase = new GetCurrentUserUseCase($this->repositoryWith(7));
+
+        $user = $useCase->execute(7);
+
+        self::assertNotNull($user);
+        self::assertSame('admin@example.com', $user->email);
+        self::assertSame(Role::Admin, $user->role);
+    }
+
+    public function test_returns_null_for_unknown_id(): void
+    {
+        $useCase = new GetCurrentUserUseCase($this->repositoryWith(7));
+
+        self::assertNull($useCase->execute(999));
+    }
+
+    private function repositoryWith(int $id): UserRepositoryInterface
+    {
+        $user = new User(
+            email: 'admin@example.com',
+            passwordHash: 'hashed',
+            role: Role::Admin,
+            organizationId: 1,
+            status: 'active',
+            id: $id,
+        );
+
+        return new class ($user) implements UserRepositoryInterface {
+            public function __construct(private readonly User $user)
+            {
+            }
+
+            public function findById(int $id): ?User
+            {
+                return $this->user->id === $id ? $this->user : null;
+            }
+
+            public function findByEmail(string $email): ?User
+            {
+                return $this->user->email === $email ? $this->user : null;
+            }
+
+            /** @return list<User> */
+            public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+            {
+                return [];
+            }
+
+            public function countByOrganization(int $organizationId): int
+            {
+                return 0;
+            }
+
+            public function save(User $user): int
+            {
+                return 0;
+            }
+
+            public function update(User $user): void
+            {
+            }
+
+            public function delete(int $id): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adopt **NeNe Clear** as public product name (ADR 0007)
- Add `docs/explanation/philosophy.md` — ideals, AI-era dual surface, non-goals, maintainer intent (JA)
- Update README, AGENTS.md, product-vision, terminology registry

Repo slug `nene-invoice` unchanged until optional rename Issue.

## Test plan

- [x] Philosophy aligns with expansion roadmap and compliance docs
- [x] Name rationale documented with rejected alternatives

Self-review: docs-policy

Closes #31

Made with [Cursor](https://cursor.com)