### PR TITLE
feat(auth): CapabilityMiddleware と CapabilityResolver で RBAC を強制する (#35)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #33)
+Last updated: 2026-05-29 (Issue #35)
 
 ## Recently merged
 
@@ -17,12 +17,14 @@ Last updated: 2026-05-29 (Issue #33)
 - **Issue #24 / PR #25** — User 永続化 + Role/Capability(RBAC) ドメイン ✅ merged
 - **Issue #26 / PR #29** — JWT ログイン（POST /auth/login）+ トークン発行 ✅ merged
 - **Issue #30** — Bearer トークンゲート（/admin/ 保護）+ GET /admin/me ✅ merged（commit `f412a52`）
+- **Issue #33 / PR #34** — 並行 Cursor 由来 #27/#31 の revert（NeNe Clear 等を除去）✅ merged
+- **Issue #35** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #33 | `fix/33-revert-cursor-merges` | 並行 Cursor エージェント由来 #27/#31 の revert（expansion-roadmap・ADR 0007 NeNe Clear・philosophy） | 🔄 PR pending |
+| #35 | `feat/35-capability-rbac` | CapabilityMiddleware + CapabilityResolver（ルート→capability RBAC） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -109,10 +111,17 @@ Last updated: 2026-05-29 (Issue #33)
 - `GET /admin/me` returns the authenticated user from token claims (`sub`)
 - Verified live: no/invalid token → 401, valid → 200 + user; `/health` public
 
-**Cleanup — revert parallel-agent merges: 🔄 in progress** (Issue #33)
+**Cleanup — revert parallel-agent merges: ✅ complete** (Issue #33 / PR #34)
 
-- Reverts Cursor-authored #27 (expansion-roadmap) and #31 (ADR 0007 NeNe Clear + philosophy); not part of the agreed plan
-- NeNe Clear rename / expansion roadmap can be re-adopted later via a proper Issue/ADR if wanted
+- Reverted Cursor-authored #27 (expansion-roadmap) and #31 (ADR 0007 NeNe Clear + philosophy)
+- NeNe Clear is a *separate* sibling product (入金消込/督促), not this repo — do not reintroduce here
+
+**Phase 1 — RBAC enforcement: 🔄 in progress** (Issue #35)
+
+- `CapabilityResolver` (path+method → Capability) + `CapabilityMiddleware` (after BearerTokenMiddleware)
+- authMiddleware = [BearerTokenMiddleware, CapabilityMiddleware]
+- Verified live: member → /admin/organizations 403, superadmin → passes (404, no route yet), /admin/me 200, no token 401
+- Org scoping (`organization_id`) added with org-resolution middleware when tenant-scoped routes land
 
 ## Handoff Notes
 
@@ -130,6 +139,7 @@ Last updated: 2026-05-29 (Issue #33)
 
 ## Next steps
 
-1. Next auth PR: `CapabilityMiddleware` (route → capability RBAC) + org resolution middleware (`single`) + `organization_id` request scoping
-2. Complete Phase 1 core: clients, quotes, invoices, payments
-3. Phase 2 admin UI + PDF (minimum for overdue list)
+1. Organization CRUD (superadmin, `/admin/organizations`) — exercises RBAC; cross-tenant so no org resolution needed
+2. User CRUD (admin, `/admin/users`) + org resolution middleware (`single`) + `organization_id` scoping
+3. Complete Phase 1 billing core: clients, quotes, invoices, payments
+4. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -132,6 +132,18 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                CapabilityMiddleware::class,
+                static function (ContainerInterface $container): CapabilityMiddleware {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new CapabilityMiddleware($problemDetails);
+                },
+            )
+            ->set(
                 LoginUseCaseInterface::class,
                 static function (ContainerInterface $container): LoginUseCaseInterface {
                     $users = $container->get(UserRepositoryInterface::class);

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Enforces role-based capabilities on authenticated requests (ADR 0006).
+ *
+ * Runs after the framework `BearerTokenMiddleware`. Requests without verified
+ * claims (public routes) and routes that need no specific capability pass
+ * through. Organization scoping is added with the org-resolution middleware in a
+ * later PR.
+ */
+final readonly class CapabilityMiddleware implements MiddlewareInterface
+{
+    private const CLAIMS_ATTRIBUTE = 'nene2.auth.claims';
+
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $claims = $request->getAttribute(self::CLAIMS_ATTRIBUTE);
+
+        if (!is_array($claims)) {
+            return $handler->handle($request);
+        }
+
+        $required = CapabilityResolver::resolve($request->getUri()->getPath() ?: '/', $request->getMethod());
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        $roleValue = $claims['role'] ?? null;
+        $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
+
+        if ($role === null || !$role->hasCapability($required)) {
+            return $this->problemDetails->create(
+                $request,
+                'insufficient-capability',
+                'Forbidden',
+                403,
+                'You do not have permission to perform this action.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Maps an HTTP request (path + method) to the {@see Capability} it requires.
+ *
+ * Returns `null` when a route needs no specific capability (public routes, or
+ * authenticated self-service such as `GET /admin/me`).
+ */
+final class CapabilityResolver
+{
+    public static function resolve(string $path, string $method): ?Capability
+    {
+        $method = strtoupper($method);
+
+        if (str_starts_with($path, '/admin/organizations')) {
+            return Capability::ManageOrganizations;
+        }
+
+        if (str_starts_with($path, '/admin/users')) {
+            return Capability::ManageUsers;
+        }
+
+        if (str_starts_with($path, '/admin/company-settings')) {
+            return Capability::ManageCompanySettings;
+        }
+
+        foreach (['/admin/clients', '/admin/quotes', '/admin/invoices', '/admin/payments'] as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return self::isReadMethod($method) ? Capability::ViewBilling : Capability::ManageBilling;
+            }
+        }
+
+        // /admin/me and any other route: no specific capability required.
+        return null;
+    }
+
+    private static function isReadMethod(string $method): bool
+    {
+        return in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -20,6 +20,7 @@ use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
+use NeneInvoice\Auth\CapabilityMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -129,6 +130,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Bearer token middleware service is invalid.');
                     }
 
+                    $capabilityMiddleware = $container->get(CapabilityMiddleware::class);
+
+                    if (!$capabilityMiddleware instanceof CapabilityMiddleware) {
+                        throw new LogicException('Capability middleware service is invalid.');
+                    }
+
                     $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
 
                     if (!is_array($routeRegistrars) || !array_is_list($routeRegistrars)) {
@@ -150,7 +157,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         streamFactory: $psr17,
                         domainExceptionHandlers: $exceptionHandlers,
                         routeRegistrars: $routeRegistrars,
-                        authMiddleware: [$bearerTokenMiddleware],
+                        authMiddleware: [$bearerTokenMiddleware, $capabilityMiddleware],
                         healthChecks: [$databaseHealthCheck],
                         debug: $config->debug,
                     );

--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneInvoice\Auth\CapabilityMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CapabilityMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private CapabilityMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->middleware = new CapabilityMiddleware(
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_blocks_role_lacking_capability_with_403(): void
+    {
+        $request = $this->request('GET', '/admin/organizations', ['role' => 'member']);
+
+        $response = $this->middleware->process($request, $this->passThroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_allows_role_with_capability(): void
+    {
+        $request = $this->request('GET', '/admin/organizations', ['role' => 'superadmin']);
+
+        $response = $this->middleware->process($request, $this->passThroughHandler());
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_passes_through_unauthenticated_requests(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/health');
+
+        $response = $this->middleware->process($request, $this->passThroughHandler());
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_passes_through_routes_needing_no_capability(): void
+    {
+        $request = $this->request('GET', '/admin/me', ['role' => 'member']);
+
+        $response = $this->middleware->process($request, $this->passThroughHandler());
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /** @param array<string, mixed> $claims */
+    private function request(string $method, string $path, array $claims): ServerRequestInterface
+    {
+        return $this->psr17->createServerRequest($method, $path)->withAttribute('nene2.auth.claims', $claims);
+    }
+
+    private function passThroughHandler(): RequestHandlerInterface
+    {
+        return new class ($this->psr17) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $psr17)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->psr17->createResponse(200);
+            }
+        };
+    }
+}

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\Capability;
+use NeneInvoice\Auth\CapabilityResolver;
+use PHPUnit\Framework\TestCase;
+
+final class CapabilityResolverTest extends TestCase
+{
+    public function test_maps_admin_paths_to_capabilities(): void
+    {
+        self::assertSame(Capability::ManageOrganizations, CapabilityResolver::resolve('/admin/organizations', 'GET'));
+        self::assertSame(Capability::ManageOrganizations, CapabilityResolver::resolve('/admin/organizations/5', 'DELETE'));
+        self::assertSame(Capability::ManageUsers, CapabilityResolver::resolve('/admin/users', 'POST'));
+        self::assertSame(Capability::ManageCompanySettings, CapabilityResolver::resolve('/admin/company-settings', 'PUT'));
+    }
+
+    public function test_billing_paths_split_read_and_write(): void
+    {
+        self::assertSame(Capability::ViewBilling, CapabilityResolver::resolve('/admin/invoices', 'GET'));
+        self::assertSame(Capability::ManageBilling, CapabilityResolver::resolve('/admin/invoices', 'POST'));
+        self::assertSame(Capability::ViewBilling, CapabilityResolver::resolve('/admin/quotes/1', 'GET'));
+        self::assertSame(Capability::ManageBilling, CapabilityResolver::resolve('/admin/payments', 'POST'));
+    }
+
+    public function test_self_service_and_public_paths_need_no_capability(): void
+    {
+        self::assertNull(CapabilityResolver::resolve('/admin/me', 'GET'));
+        self::assertNull(CapabilityResolver::resolve('/health', 'GET'));
+        self::assertNull(CapabilityResolver::resolve('/auth/login', 'POST'));
+    }
+}


### PR DESCRIPTION
Closes #35

## 目的

認証パイプラインの**認可層**を追加する。ルート→必要 capability を解決し、`Role`（トークン claims）の権限を強制する（ADR 0006）。

## 変更内容

- **`Auth/CapabilityResolver`**（path+method → ?Capability）: `/admin/organizations`→`manage_organizations`、`/admin/users`→`manage_users`、`/admin/company-settings`→`manage_company_settings`、`/admin/{clients,quotes,invoices,payments}`→ GET=`view_billing` / 変更=`manage_billing`、`/admin/me`・公開→`null`
- **`Auth/CapabilityMiddleware`**（`BearerTokenMiddleware` の後）: claims の role が必要 capability を持たなければ **403 `insufficient-capability`**。公開/capability 不要ルートは通過
- `authMiddleware = [BearerTokenMiddleware, CapabilityMiddleware]`

## 検証

- **`composer check` green**: PHPUnit **31 tests / 109 assertions**・PHPStan level 8 **no errors**・cs clean
- 単体: Resolver マッピング、Middleware（superadmin 通過 / member 403 / 公開通過 / capability 不要通過）
- ライブ: member→`/admin/organizations` **403**、superadmin→capability 通過（**404**＝ルート未実装）、`/admin/me` **200**、トークン無→**401**

## 非範囲（次 PR）

- org 解決ミドルウェア（`single`）+ `organization_id` 突合（テナント別データルート導入時）
- 組織/ユーザー CRUD ハンドラ

## セルフレビュー

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)