### PR TITLE
feat(organization): 組織 CRUD（superadmin・/admin/organizations）を追加する (#37)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -108,6 +108,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `quote-not-found` | Quote id not found |
 | `client-not-found` | Client id not found |
 | `organization-not-found` | Organization id/slug not found |
+| `organization-slug-conflict` | Organization slug already in use (409) |
 | `user-not-found` | User id not found |
 | `invalid-credentials` | Login failed — wrong email or password |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #35)
+Last updated: 2026-05-29 (Issue #37)
 
 ## Recently merged
 
@@ -18,13 +18,14 @@ Last updated: 2026-05-29 (Issue #35)
 - **Issue #26 / PR #29** — JWT ログイン（POST /auth/login）+ トークン発行 ✅ merged
 - **Issue #30** — Bearer トークンゲート（/admin/ 保護）+ GET /admin/me ✅ merged（commit `f412a52`）
 - **Issue #33 / PR #34** — 並行 Cursor 由来 #27/#31 の revert（NeNe Clear 等を除去）✅ merged
-- **Issue #35** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）⏳ this PR
+- **Issue #35 / PR #36** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）✅ merged
+- **Issue #37** — 組織 CRUD（superadmin・/admin/organizations）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #35 | `feat/35-capability-rbac` | CapabilityMiddleware + CapabilityResolver（ルート→capability RBAC） | 🔄 PR pending |
+| #37 | `feat/37-organization-crud` | 組織 CRUD（list/get/create/delete・superadmin） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -116,12 +117,17 @@ Last updated: 2026-05-29 (Issue #35)
 - Reverted Cursor-authored #27 (expansion-roadmap) and #31 (ADR 0007 NeNe Clear + philosophy)
 - NeNe Clear is a *separate* sibling product (入金消込/督促), not this repo — do not reintroduce here
 
-**Phase 1 — RBAC enforcement: 🔄 in progress** (Issue #35)
+**Phase 1 — RBAC enforcement: ✅ complete** (Issue #35 / PR #36)
 
 - `CapabilityResolver` (path+method → Capability) + `CapabilityMiddleware` (after BearerTokenMiddleware)
 - authMiddleware = [BearerTokenMiddleware, CapabilityMiddleware]
-- Verified live: member → /admin/organizations 403, superadmin → passes (404, no route yet), /admin/me 200, no token 401
-- Org scoping (`organization_id`) added with org-resolution middleware when tenant-scoped routes land
+
+**Phase 1 — Organization CRUD (superadmin): 🔄 in progress** (Issue #37)
+
+- `GET/POST /admin/organizations`, `GET/DELETE /admin/organizations/{id}` — Handler → UseCase → repo
+- Domain exceptions → Problem Details via `OrganizationNotFoundExceptionHandler` (404) / `OrganizationSlugConflictExceptionHandler` (409); wired into EXCEPTION_HANDLERS (no try/catch in handlers)
+- Verified live: create 201 / member 403 / dup-slug 409 / missing 422 / list+get 200 / not-found 404 / delete 204
+- First real feature guarded by RBAC. Org scoping (`organization_id`) lands with the org-resolution middleware
 
 ## Handoff Notes
 
@@ -139,7 +145,6 @@ Last updated: 2026-05-29 (Issue #35)
 
 ## Next steps
 
-1. Organization CRUD (superadmin, `/admin/organizations`) — exercises RBAC; cross-tenant so no org resolution needed
-2. User CRUD (admin, `/admin/users`) + org resolution middleware (`single`) + `organization_id` scoping
-3. Complete Phase 1 billing core: clients, quotes, invoices, payments
-4. Phase 2 admin UI + PDF (minimum for overdue list)
+1. User CRUD (admin, `/admin/users`) + org resolution middleware (`single`) + `organization_id` scoping
+2. Complete Phase 1 billing core: clients, quotes, invoices, payments
+3. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -8,6 +8,9 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneInvoice\Auth\AuthRouteRegistrar;
+use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
+use NeneInvoice\Organization\OrganizationRouteRegistrar;
+use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -29,14 +32,35 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $authRoutes = $container->get(AuthRouteRegistrar::class);
+                    $organizationRoutes = $container->get(OrganizationRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
                     }
 
-                    return [$authRoutes];
+                    if (!$organizationRoutes instanceof OrganizationRouteRegistrar) {
+                        throw new LogicException('Organization route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes];
                 },
             )
-            ->set(self::EXCEPTION_HANDLERS, static fn (ContainerInterface $container): array => []);
+            ->set(
+                self::EXCEPTION_HANDLERS,
+                static function (ContainerInterface $container): array {
+                    $notFound = $container->get(OrganizationNotFoundExceptionHandler::class);
+                    $slugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
+
+                    if (!$notFound instanceof OrganizationNotFoundExceptionHandler) {
+                        throw new LogicException('Organization not-found exception handler service is invalid.');
+                    }
+
+                    if (!$slugConflict instanceof OrganizationSlugConflictExceptionHandler) {
+                        throw new LogicException('Organization slug-conflict exception handler service is invalid.');
+                    }
+
+                    return [$notFound, $slugConflict];
+                },
+            );
     }
 }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -21,6 +21,7 @@ use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
+use NeneInvoice\Organization\OrganizationServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -40,6 +41,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
     {
         $builder->addProvider(new ApplicationServiceProvider());
         $builder->addProvider(new AuthServiceProvider());
+        $builder->addProvider(new OrganizationServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/organizations` — superadmin creates a tenant.
+ */
+final readonly class CreateOrganizationHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private CreateOrganizationUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $name = $decoded['name'] ?? null;
+        $slug = $decoded['slug'] ?? null;
+
+        if (!is_string($name) || $name === '' || !is_string($slug) || $slug === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "name" and "slug" are required.');
+        }
+
+        $plan = $decoded['plan'] ?? 'free';
+        $plan = is_string($plan) && $plan !== '' ? $plan : 'free';
+
+        $organization = $this->useCase->execute(new CreateOrganizationInput($name, $slug, $plan));
+
+        return $this->json->create(OrganizationResponse::toArray($organization), 201);
+    }
+}

--- a/src/Organization/CreateOrganizationInput.php
+++ b/src/Organization/CreateOrganizationInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+final readonly class CreateOrganizationInput
+{
+    public function __construct(
+        public string $name,
+        public string $slug,
+        public string $plan = 'free',
+    ) {
+    }
+}

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use LogicException;
+
+final readonly class CreateOrganizationUseCase
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    /** @throws OrganizationSlugConflictException */
+    public function execute(CreateOrganizationInput $input): Organization
+    {
+        $id = $this->organizations->save(new Organization(
+            name: $input->name,
+            slug: $input->slug,
+            plan: $input->plan,
+            isActive: true,
+        ));
+
+        $created = $this->organizations->findById($id);
+
+        if ($created === null) {
+            throw new LogicException('Organization disappeared immediately after creation.');
+        }
+
+        return $created;
+    }
+}

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `DELETE /admin/organizations/{id}` — superadmin removes a tenant.
+ * A missing organization surfaces as 404 via the domain exception handler.
+ */
+final readonly class DeleteOrganizationHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private DeleteOrganizationUseCase $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->useCase->execute($id);
+
+        return $this->json->createEmpty(204);
+    }
+}

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+final readonly class DeleteOrganizationUseCase
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    /** @throws OrganizationNotFoundException */
+    public function execute(int $id): void
+    {
+        $this->organizations->delete($id);
+    }
+}

--- a/src/Organization/GetOrganizationByIdHandler.php
+++ b/src/Organization/GetOrganizationByIdHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/organizations/{id}` — superadmin reads one tenant.
+ * A missing organization surfaces as 404 via the domain exception handler.
+ */
+final readonly class GetOrganizationByIdHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetOrganizationByIdUseCase $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $organization = $this->useCase->execute($id);
+
+        return $this->json->create(OrganizationResponse::toArray($organization));
+    }
+}

--- a/src/Organization/GetOrganizationByIdUseCase.php
+++ b/src/Organization/GetOrganizationByIdUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+final readonly class GetOrganizationByIdUseCase
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    /** @throws OrganizationNotFoundException */
+    public function execute(int $id): Organization
+    {
+        $organization = $this->organizations->findById($id);
+
+        if ($organization === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        return $organization;
+    }
+}

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/organizations` — superadmin lists tenants (paginated).
+ */
+final readonly class ListOrganizationsHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListOrganizationsUseCase $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (Organization $o): array => OrganizationResponse::toArray($o), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/Organization/ListOrganizationsResult.php
+++ b/src/Organization/ListOrganizationsResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+final readonly class ListOrganizationsResult
+{
+    /** @param list<Organization> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/Organization/ListOrganizationsUseCase.php
+++ b/src/Organization/ListOrganizationsUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+final readonly class ListOrganizationsUseCase
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(int $limit, int $offset): ListOrganizationsResult
+    {
+        return new ListOrganizationsResult(
+            $this->organizations->findAll($limit, $offset),
+            $this->organizations->count(),
+        );
+    }
+}

--- a/src/Organization/OrganizationNotFoundExceptionHandler.php
+++ b/src/Organization/OrganizationNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class OrganizationNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof OrganizationNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'organization-not-found', 'Not Found', 404, 'The requested organization was not found.');
+    }
+}

--- a/src/Organization/OrganizationResponse.php
+++ b/src/Organization/OrganizationResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+/**
+ * Serializes an {@see Organization} to its snake_case JSON representation.
+ */
+final class OrganizationResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Organization $organization): array
+    {
+        return [
+            'id' => $organization->id,
+            'name' => $organization->name,
+            'slug' => $organization->slug,
+            'plan' => $organization->plan,
+            'is_active' => $organization->isActive,
+            'external_id' => $organization->externalId,
+            'custom_domain' => $organization->customDomain,
+            'created_at' => $organization->createdAt,
+            'updated_at' => $organization->updatedAt,
+        ];
+    }
+}

--- a/src/Organization/OrganizationRouteRegistrar.php
+++ b/src/Organization/OrganizationRouteRegistrar.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers organization (tenant) management routes. All require the
+ * `manage_organizations` capability (superadmin), enforced by CapabilityMiddleware.
+ */
+final readonly class OrganizationRouteRegistrar
+{
+    public function __construct(
+        private ListOrganizationsHandler $listHandler,
+        private GetOrganizationByIdHandler $getHandler,
+        private CreateOrganizationHandler $createHandler,
+        private DeleteOrganizationHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+        $create = $this->createHandler;
+        $delete = $this->deleteHandler;
+
+        $router->get('/admin/organizations', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/organizations', static fn (ServerRequestInterface $r) => $create->handle($r));
+        $router->get('/admin/organizations/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->delete('/admin/organizations/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
+    }
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Organization (tenant) domain: repository, use cases, handlers,
+ * domain exception handlers, and the route registrar.
+ */
+final readonly class OrganizationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                OrganizationRepositoryInterface::class,
+                static function (ContainerInterface $container): OrganizationRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query);
+                },
+            )
+            ->set(ListOrganizationsUseCase::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
+            ->set(GetOrganizationByIdUseCase::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
+            ->set(CreateOrganizationUseCase::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c)))
+            ->set(DeleteOrganizationUseCase::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c)))
+            ->set(
+                ListOrganizationsHandler::class,
+                static fn (ContainerInterface $c): ListOrganizationsHandler => new ListOrganizationsHandler(
+                    self::listUseCase($c),
+                    self::json($c),
+                ),
+            )
+            ->set(
+                GetOrganizationByIdHandler::class,
+                static fn (ContainerInterface $c): GetOrganizationByIdHandler => new GetOrganizationByIdHandler(
+                    self::getUseCase($c),
+                    self::json($c),
+                ),
+            )
+            ->set(
+                CreateOrganizationHandler::class,
+                static fn (ContainerInterface $c): CreateOrganizationHandler => new CreateOrganizationHandler(
+                    self::createUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                DeleteOrganizationHandler::class,
+                static fn (ContainerInterface $c): DeleteOrganizationHandler => new DeleteOrganizationHandler(
+                    self::deleteUseCase($c),
+                    self::json($c),
+                ),
+            )
+            ->set(
+                OrganizationNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): OrganizationNotFoundExceptionHandler => new OrganizationNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                OrganizationSlugConflictExceptionHandler::class,
+                static fn (ContainerInterface $c): OrganizationSlugConflictExceptionHandler => new OrganizationSlugConflictExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                OrganizationRouteRegistrar::class,
+                static function (ContainerInterface $c): OrganizationRouteRegistrar {
+                    $list = $c->get(ListOrganizationsHandler::class);
+                    $get = $c->get(GetOrganizationByIdHandler::class);
+                    $create = $c->get(CreateOrganizationHandler::class);
+                    $delete = $c->get(DeleteOrganizationHandler::class);
+
+                    if (!$list instanceof ListOrganizationsHandler
+                        || !$get instanceof GetOrganizationByIdHandler
+                        || !$create instanceof CreateOrganizationHandler
+                        || !$delete instanceof DeleteOrganizationHandler
+                    ) {
+                        throw new LogicException('Organization handler services are invalid.');
+                    }
+
+                    return new OrganizationRouteRegistrar($list, $get, $create, $delete);
+                },
+            );
+    }
+
+    private static function repository(ContainerInterface $c): OrganizationRepositoryInterface
+    {
+        $repo = $c->get(OrganizationRepositoryInterface::class);
+
+        if (!$repo instanceof OrganizationRepositoryInterface) {
+            throw new LogicException('Organization repository service is invalid.');
+        }
+
+        return $repo;
+    }
+
+    private static function listUseCase(ContainerInterface $c): ListOrganizationsUseCase
+    {
+        $u = $c->get(ListOrganizationsUseCase::class);
+
+        if (!$u instanceof ListOrganizationsUseCase) {
+            throw new LogicException('List organizations use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function getUseCase(ContainerInterface $c): GetOrganizationByIdUseCase
+    {
+        $u = $c->get(GetOrganizationByIdUseCase::class);
+
+        if (!$u instanceof GetOrganizationByIdUseCase) {
+            throw new LogicException('Get organization use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function createUseCase(ContainerInterface $c): CreateOrganizationUseCase
+    {
+        $u = $c->get(CreateOrganizationUseCase::class);
+
+        if (!$u instanceof CreateOrganizationUseCase) {
+            throw new LogicException('Create organization use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function deleteUseCase(ContainerInterface $c): DeleteOrganizationUseCase
+    {
+        $u = $c->get(DeleteOrganizationUseCase::class);
+
+        if (!$u instanceof DeleteOrganizationUseCase) {
+            throw new LogicException('Delete organization use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JSON response factory service is invalid.');
+        }
+
+        return $j;
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        $p = $c->get(ProblemDetailsResponseFactory::class);
+
+        if (!$p instanceof ProblemDetailsResponseFactory) {
+            throw new LogicException('Problem details response factory service is invalid.');
+        }
+
+        return $p;
+    }
+}

--- a/src/Organization/OrganizationSlugConflictExceptionHandler.php
+++ b/src/Organization/OrganizationSlugConflictExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class OrganizationSlugConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof OrganizationSlugConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'organization-slug-conflict', 'Conflict', 409, $exception->getMessage());
+    }
+}

--- a/tests/Organization/OrganizationUseCasesTest.php
+++ b/tests/Organization/OrganizationUseCasesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Organization;
+
+use NeneInvoice\Organization\CreateOrganizationInput;
+use NeneInvoice\Organization\CreateOrganizationUseCase;
+use NeneInvoice\Organization\DeleteOrganizationUseCase;
+use NeneInvoice\Organization\GetOrganizationByIdUseCase;
+use NeneInvoice\Organization\ListOrganizationsUseCase;
+use NeneInvoice\Organization\OrganizationNotFoundException;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
+use PHPUnit\Framework\TestCase;
+
+final class OrganizationUseCasesTest extends TestCase
+{
+    private InMemoryOrganizationRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryOrganizationRepository();
+    }
+
+    public function test_create_persists_and_returns_organization_with_id(): void
+    {
+        $useCase = new CreateOrganizationUseCase($this->repo);
+
+        $org = $useCase->execute(new CreateOrganizationInput('Acme', 'acme'));
+
+        self::assertNotNull($org->id);
+        self::assertSame('Acme', $org->name);
+        self::assertSame('acme', $org->slug);
+        self::assertSame('free', $org->plan);
+        self::assertTrue($org->isActive);
+        self::assertNotNull($org->createdAt);
+    }
+
+    public function test_create_rejects_duplicate_slug(): void
+    {
+        $useCase = new CreateOrganizationUseCase($this->repo);
+        $useCase->execute(new CreateOrganizationInput('First', 'dup'));
+
+        $this->expectException(OrganizationSlugConflictException::class);
+        $useCase->execute(new CreateOrganizationInput('Second', 'dup'));
+    }
+
+    public function test_list_returns_items_and_total(): void
+    {
+        $create = new CreateOrganizationUseCase($this->repo);
+        $create->execute(new CreateOrganizationInput('A', 'a'));
+        $create->execute(new CreateOrganizationInput('B', 'b'));
+
+        $result = (new ListOrganizationsUseCase($this->repo))->execute(10, 0);
+
+        self::assertSame(2, $result->total);
+        self::assertCount(2, $result->items);
+    }
+
+    public function test_get_returns_organization_or_throws(): void
+    {
+        $id = (new CreateOrganizationUseCase($this->repo))->execute(new CreateOrganizationInput('A', 'a'))->id;
+        self::assertNotNull($id);
+
+        $get = new GetOrganizationByIdUseCase($this->repo);
+        self::assertSame('a', $get->execute($id)->slug);
+
+        $this->expectException(OrganizationNotFoundException::class);
+        $get->execute(999);
+    }
+
+    public function test_delete_removes_or_throws_when_missing(): void
+    {
+        $id = (new CreateOrganizationUseCase($this->repo))->execute(new CreateOrganizationInput('A', 'a'))->id;
+        self::assertNotNull($id);
+
+        $delete = new DeleteOrganizationUseCase($this->repo);
+        $delete->execute($id);
+        self::assertSame(0, $this->repo->count());
+
+        $this->expectException(OrganizationNotFoundException::class);
+        $delete->execute($id);
+    }
+}

--- a/tests/Support/InMemoryOrganizationRepository.php
+++ b/tests/Support/InMemoryOrganizationRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\OrganizationNotFoundException;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryOrganizationRepository implements OrganizationRepositoryInterface
+{
+    /** @var array<int, Organization> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?Organization
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findBySlug(string $slug): ?Organization
+    {
+        foreach ($this->byId as $organization) {
+            if ($organization->slug === $slug) {
+                return $organization;
+            }
+        }
+
+        return null;
+    }
+
+    public function findByCustomDomain(string $domain): ?Organization
+    {
+        foreach ($this->byId as $organization) {
+            if ($organization->customDomain === $domain) {
+                return $organization;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<Organization> */
+    public function findAll(int $limit, int $offset): array
+    {
+        return array_slice(array_values($this->byId), $offset, $limit);
+    }
+
+    public function count(): int
+    {
+        return count($this->byId);
+    }
+
+    public function save(Organization $organization): int
+    {
+        if ($this->findBySlug($organization->slug) !== null) {
+            throw new OrganizationSlugConflictException($organization->slug);
+        }
+
+        $id = $this->nextId++;
+        $now = '2026-05-29 00:00:00';
+
+        $this->byId[$id] = new Organization(
+            name: $organization->name,
+            slug: $organization->slug,
+            plan: $organization->plan,
+            isActive: $organization->isActive,
+            id: $id,
+            externalId: $organization->externalId,
+            customDomain: $organization->customDomain,
+            createdAt: $now,
+            updatedAt: $now,
+        );
+
+        return $id;
+    }
+
+    public function update(Organization $organization): void
+    {
+        if ($organization->id === null || !isset($this->byId[$organization->id])) {
+            throw new OrganizationNotFoundException($organization->id ?? 0);
+        }
+
+        $this->byId[$organization->id] = $organization;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->byId[$id])) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        unset($this->byId[$id]);
+    }
+}


### PR DESCRIPTION
Closes #37

## 目的

RBAC（`manage_organizations`）が守る**最初の実機能**。superadmin がテナント（組織）を管理する CRUD。

## エンドポイント

| Method | Path | operationId | 結果 |
| --- | --- | --- | --- |
| GET | `/admin/organizations` | listOrganizations | 200 `{items,total,limit,offset}` |
| POST | `/admin/organizations` | createOrganization | 201（slug 重複 409・欠落 422） |
| GET | `/admin/organizations/{id}` | getOrganizationById | 200 / 404 |
| DELETE | `/admin/organizations/{id}` | deleteOrganization | 204 / 404 |

## 実装

- Handler → UseCase → `OrganizationRepository`（既存）。`OrganizationResponse` で snake_case 整形
- ドメイン例外ハンドラ（`DomainExceptionHandlerInterface`）: NotFound→404 `organization-not-found`、SlugConflict→409 `organization-slug-conflict`。`ErrorHandlerMiddleware` 経由でハンドラに try/catch 不要。`EXCEPTION_HANDLERS` に登録
- `OrganizationServiceProvider` 配線、`ApplicationServiceProvider` が route registrar / exception handler を集約

## 検証

- **`composer check` green**: PHPUnit **36 tests / 124 assertions**・PHPStan level 8 **no errors**・cs clean
- UseCase テスト（`InMemoryOrganizationRepository`）
- ライブ（RBAC込み）: create **201** / member **403** / dup-slug **409** / 欠落 **422** / list・get **200** / not-found **404** / delete **204**

## 非範囲

- 組織 update（operationId 未登録）
- ユーザー CRUD・org 解決ミドルウェア（次 PR）

## セルフレビュー

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)