### PR TITLE
feat(user): ユーザー読み取り（/admin/users）と org スコープでテナント分離する (#39)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #37)
+Last updated: 2026-05-29 (Issue #39)
 
 ## Recently merged
 
@@ -19,13 +19,14 @@ Last updated: 2026-05-29 (Issue #37)
 - **Issue #30** — Bearer トークンゲート（/admin/ 保護）+ GET /admin/me ✅ merged（commit `f412a52`）
 - **Issue #33 / PR #34** — 並行 Cursor 由来 #27/#31 の revert（NeNe Clear 等を除去）✅ merged
 - **Issue #35 / PR #36** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）✅ merged
-- **Issue #37** — 組織 CRUD（superadmin・/admin/organizations）⏳ this PR
+- **Issue #37 / PR #38** — 組織 CRUD（superadmin・/admin/organizations）✅ merged
+- **Issue #39** — ユーザー読み取り（/admin/users）+ org スコープ ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #37 | `feat/37-organization-crud` | 組織 CRUD（list/get/create/delete・superadmin） | 🔄 PR pending |
+| #39 | `feat/39-user-read-org-scope` | ユーザー read（list/get）+ テナント分離（claims.org スコープ） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -122,12 +123,18 @@ Last updated: 2026-05-29 (Issue #37)
 - `CapabilityResolver` (path+method → Capability) + `CapabilityMiddleware` (after BearerTokenMiddleware)
 - authMiddleware = [BearerTokenMiddleware, CapabilityMiddleware]
 
-**Phase 1 — Organization CRUD (superadmin): 🔄 in progress** (Issue #37)
+**Phase 1 — Organization CRUD (superadmin): ✅ complete** (Issue #37 / PR #38)
 
 - `GET/POST /admin/organizations`, `GET/DELETE /admin/organizations/{id}` — Handler → UseCase → repo
-- Domain exceptions → Problem Details via `OrganizationNotFoundExceptionHandler` (404) / `OrganizationSlugConflictExceptionHandler` (409); wired into EXCEPTION_HANDLERS (no try/catch in handlers)
-- Verified live: create 201 / member 403 / dup-slug 409 / missing 422 / list+get 200 / not-found 404 / delete 204
-- First real feature guarded by RBAC. Org scoping (`organization_id`) lands with the org-resolution middleware
+- Domain exceptions → Problem Details (404 / 409) via EXCEPTION_HANDLERS
+
+**Phase 1 — User read + tenant isolation: 🔄 in progress** (Issue #39)
+
+- `GET /admin/users`, `GET /admin/users/{id}` — admin-only (`manage_users`), scoped to the caller's org
+- `Auth/AuthContext` reads `sub`/`role`/`org` from token claims; queries scoped by `org`
+- Cross-org reads return 404 (no existence leak); `password_hash` never serialized; no org context → 400
+- Verified live: org-1 admin sees only org-1 users; org-2 user → 404; no password_hash in output
+- **Decision:** admin self-service is scoped by the token's `org` claim. The URL-addressed OrgResolverMiddleware (path/subdomain) is deferred until a tenant-addressed route needs it
 
 ## Handoff Notes
 
@@ -145,6 +152,6 @@ Last updated: 2026-05-29 (Issue #37)
 
 ## Next steps
 
-1. User CRUD (admin, `/admin/users`) + org resolution middleware (`single`) + `organization_id` scoping
+1. User write (create/update/delete `/admin/users`) — password hashing, role-escalation prevention (no superadmin), cross-org write protection
 2. Complete Phase 1 billing core: clients, quotes, invoices, payments
 3. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -11,6 +11,8 @@ use NeneInvoice\Auth\AuthRouteRegistrar;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\User\UserNotFoundExceptionHandler;
+use NeneInvoice\User\UserRouteRegistrar;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -33,6 +35,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 static function (ContainerInterface $container): array {
                     $authRoutes = $container->get(AuthRouteRegistrar::class);
                     $organizationRoutes = $container->get(OrganizationRouteRegistrar::class);
+                    $userRoutes = $container->get(UserRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -42,24 +45,33 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Organization route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes];
+                    if (!$userRoutes instanceof UserRouteRegistrar) {
+                        throw new LogicException('User route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes];
                 },
             )
             ->set(
                 self::EXCEPTION_HANDLERS,
                 static function (ContainerInterface $container): array {
-                    $notFound = $container->get(OrganizationNotFoundExceptionHandler::class);
-                    $slugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
+                    $orgNotFound = $container->get(OrganizationNotFoundExceptionHandler::class);
+                    $orgSlugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
+                    $userNotFound = $container->get(UserNotFoundExceptionHandler::class);
 
-                    if (!$notFound instanceof OrganizationNotFoundExceptionHandler) {
+                    if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
                     }
 
-                    if (!$slugConflict instanceof OrganizationSlugConflictExceptionHandler) {
+                    if (!$orgSlugConflict instanceof OrganizationSlugConflictExceptionHandler) {
                         throw new LogicException('Organization slug-conflict exception handler service is invalid.');
                     }
 
-                    return [$notFound, $slugConflict];
+                    if (!$userNotFound instanceof UserNotFoundExceptionHandler) {
+                        throw new LogicException('User not-found exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound];
                 },
             );
     }

--- a/src/Auth/AuthContext.php
+++ b/src/Auth/AuthContext.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Reads the authenticated principal from the verified token claims that the
+ * framework `BearerTokenMiddleware` stores on the request (`nene2.auth.claims`).
+ *
+ * The token is issued by {@see LoginUseCase} with claims `sub` (user id),
+ * `role`, and `org` (organization id; null for superadmin).
+ */
+final class AuthContext
+{
+    private const CLAIMS_ATTRIBUTE = 'nene2.auth.claims';
+
+    public static function userId(ServerRequestInterface $request): ?int
+    {
+        $value = self::claim($request, 'sub');
+
+        return is_int($value) ? $value : null;
+    }
+
+    public static function role(ServerRequestInterface $request): ?Role
+    {
+        $value = self::claim($request, 'role');
+
+        return is_string($value) ? Role::tryFrom($value) : null;
+    }
+
+    public static function organizationId(ServerRequestInterface $request): ?int
+    {
+        $value = self::claim($request, 'org');
+
+        return is_int($value) ? $value : null;
+    }
+
+    private static function claim(ServerRequestInterface $request, string $key): mixed
+    {
+        $claims = $request->getAttribute(self::CLAIMS_ATTRIBUTE);
+
+        return is_array($claims) ? ($claims[$key] ?? null) : null;
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -22,6 +22,7 @@ use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Organization\OrganizationServiceProvider;
+use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -42,6 +43,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new ApplicationServiceProvider());
         $builder->addProvider(new AuthServiceProvider());
         $builder->addProvider(new OrganizationServiceProvider());
+        $builder->addProvider(new UserServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/users/{id}` — admin reads one user in their own organization.
+ * Users outside the caller's organization (or missing) return 404.
+ */
+final readonly class GetUserByIdHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetUserByIdUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $user = $this->useCase->execute($organizationId, $id);
+
+        return $this->json->create(UserResponse::toArray($user));
+    }
+}

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+final readonly class GetUserByIdUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    /**
+     * Fetches a user that belongs to the given organization. A user from another
+     * organization (or a missing id) is reported as not found so cross-tenant
+     * existence is not leaked.
+     *
+     * @throws UserNotFoundException
+     */
+    public function execute(int $organizationId, int $id): User
+    {
+        $user = $this->users->findById($id);
+
+        if ($user === null || $user->organizationId !== $organizationId) {
+            throw new UserNotFoundException($id);
+        }
+
+        return $user;
+    }
+}

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/users` — admin lists users in their own organization.
+ */
+final readonly class ListUsersHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListUsersUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (User $u): array => UserResponse::toArray($u), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/User/ListUsersResult.php
+++ b/src/User/ListUsersResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+final readonly class ListUsersResult
+{
+    /** @param list<User> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+final readonly class ListUsersUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $limit, int $offset): ListUsersResult
+    {
+        return new ListUsersResult(
+            $this->users->findAllByOrganization($organizationId, $limit, $offset),
+            $this->users->countByOrganization($organizationId),
+        );
+    }
+}

--- a/src/User/UserNotFoundExceptionHandler.php
+++ b/src/User/UserNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'user-not-found', 'Not Found', 404, 'The requested user was not found.');
+    }
+}

--- a/src/User/UserResponse.php
+++ b/src/User/UserResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+/**
+ * Serializes a {@see User} to its snake_case JSON representation.
+ * Never exposes `password_hash`.
+ */
+final class UserResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'email' => $user->email,
+            'role' => $user->role->value,
+            'organization_id' => $user->organizationId,
+            'status' => $user->status,
+            'created_at' => $user->createdAt,
+            'updated_at' => $user->updatedAt,
+        ];
+    }
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers user management routes. All require the `manage_users` capability
+ * (admin), enforced by CapabilityMiddleware, and are scoped to the caller's
+ * organization.
+ */
+final readonly class UserRouteRegistrar
+{
+    public function __construct(
+        private ListUsersHandler $listHandler,
+        private GetUserByIdHandler $getHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+
+        $router->get('/admin/users', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->get('/admin/users/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+    }
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the User domain read side: use cases, handlers, the not-found exception
+ * handler, and the route registrar. `UserRepositoryInterface` is provided by
+ * {@see \NeneInvoice\Auth\AuthServiceProvider}.
+ */
+final readonly class UserServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(ListUsersUseCase::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
+            ->set(GetUserByIdUseCase::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
+            ->set(
+                ListUsersHandler::class,
+                static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
+                    self::listUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                GetUserByIdHandler::class,
+                static fn (ContainerInterface $c): GetUserByIdHandler => new GetUserByIdHandler(
+                    self::getUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                UserNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): UserNotFoundExceptionHandler => new UserNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                UserRouteRegistrar::class,
+                static function (ContainerInterface $c): UserRouteRegistrar {
+                    $list = $c->get(ListUsersHandler::class);
+                    $get = $c->get(GetUserByIdHandler::class);
+
+                    if (!$list instanceof ListUsersHandler || !$get instanceof GetUserByIdHandler) {
+                        throw new LogicException('User handler services are invalid.');
+                    }
+
+                    return new UserRouteRegistrar($list, $get);
+                },
+            );
+    }
+
+    private static function repository(ContainerInterface $c): UserRepositoryInterface
+    {
+        $repo = $c->get(UserRepositoryInterface::class);
+
+        if (!$repo instanceof UserRepositoryInterface) {
+            throw new LogicException('User repository service is invalid.');
+        }
+
+        return $repo;
+    }
+
+    private static function listUseCase(ContainerInterface $c): ListUsersUseCase
+    {
+        $u = $c->get(ListUsersUseCase::class);
+
+        if (!$u instanceof ListUsersUseCase) {
+            throw new LogicException('List users use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function getUseCase(ContainerInterface $c): GetUserByIdUseCase
+    {
+        $u = $c->get(GetUserByIdUseCase::class);
+
+        if (!$u instanceof GetUserByIdUseCase) {
+            throw new LogicException('Get user use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JSON response factory service is invalid.');
+        }
+
+        return $j;
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        $p = $c->get(ProblemDetailsResponseFactory::class);
+
+        if (!$p instanceof ProblemDetailsResponseFactory) {
+            throw new LogicException('Problem details response factory service is invalid.');
+        }
+
+        return $p;
+    }
+}

--- a/tests/Support/InMemoryUserRepository.php
+++ b/tests/Support/InMemoryUserRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+use NeneInvoice\User\UserNotFoundException;
+use NeneInvoice\User\UserRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryUserRepository implements UserRepositoryInterface
+{
+    /** @var array<int, User> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?User
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        foreach ($this->byId as $user) {
+            if ($user->email === $email) {
+                return $user;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<User> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (User $u): bool => $u->organizationId === $organizationId,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (User $u): bool => $u->organizationId === $organizationId,
+        ));
+    }
+
+    public function save(User $user): int
+    {
+        if ($this->findByEmail($user->email) !== null) {
+            throw new UserEmailConflictException($user->email);
+        }
+
+        $id = $this->nextId++;
+        $now = '2026-05-29 00:00:00';
+
+        $this->byId[$id] = new User(
+            email: $user->email,
+            passwordHash: $user->passwordHash,
+            role: $user->role,
+            organizationId: $user->organizationId,
+            status: $user->status,
+            id: $id,
+            createdAt: $now,
+            updatedAt: $now,
+        );
+
+        return $id;
+    }
+
+    public function update(User $user): void
+    {
+        if ($user->id === null || !isset($this->byId[$user->id])) {
+            throw new UserNotFoundException($user->id ?? 0);
+        }
+
+        $this->byId[$user->id] = $user;
+    }
+
+    public function delete(int $id): void
+    {
+        if (!isset($this->byId[$id])) {
+            throw new UserNotFoundException($id);
+        }
+
+        unset($this->byId[$id]);
+    }
+}

--- a/tests/User/UserQueryUseCasesTest.php
+++ b/tests/User/UserQueryUseCasesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\User;
+
+use NeneInvoice\Auth\Role;
+use NeneInvoice\Tests\Support\InMemoryUserRepository;
+use NeneInvoice\User\GetUserByIdUseCase;
+use NeneInvoice\User\ListUsersUseCase;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class UserQueryUseCasesTest extends TestCase
+{
+    private InMemoryUserRepository $repo;
+    private int $org1User;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryUserRepository();
+        $this->org1User = $this->repo->save(new User('a@org1', 'h', Role::Admin, 1));
+        $this->repo->save(new User('b@org1', 'h', Role::Member, 1));
+        $this->repo->save(new User('c@org2', 'h', Role::Admin, 2));
+    }
+
+    public function test_list_is_scoped_to_organization(): void
+    {
+        $result = (new ListUsersUseCase($this->repo))->execute(1, 10, 0);
+
+        self::assertSame(2, $result->total);
+        self::assertCount(2, $result->items);
+        foreach ($result->items as $user) {
+            self::assertSame(1, $user->organizationId);
+        }
+    }
+
+    public function test_get_returns_user_in_same_organization(): void
+    {
+        $user = (new GetUserByIdUseCase($this->repo))->execute(1, $this->org1User);
+
+        self::assertSame('a@org1', $user->email);
+    }
+
+    public function test_get_hides_user_from_another_organization_as_not_found(): void
+    {
+        // org-2 user exists, but an org-1 admin must not see it.
+        $org2UserId = $this->repo->findByEmail('c@org2')?->id;
+        self::assertNotNull($org2UserId);
+
+        $this->expectException(UserNotFoundException::class);
+        (new GetUserByIdUseCase($this->repo))->execute(1, $org2UserId);
+    }
+}


### PR DESCRIPTION
Closes #39

## 目的

**テナント分離を初めて実働**させる。admin が自組織のユーザーを参照する read を追加し、認証トークンの `org` claim で全クエリをスコープする。

## エンドポイント（admin-only / `manage_users`）

| Method | Path | 結果 |
| --- | --- | --- |
| GET | `/admin/users` | 200 `{items,total,limit,offset}`（自組織のみ） |
| GET | `/admin/users/{id}` | 200 / 404（他組織・不在は存在を漏らさず 404） |

## 実装

- `Auth/AuthContext`: request の `nene2.auth.claims` から `sub`/`role`/`org` を抽出
- 全クエリを claims の `org` でスコープ。org context 無し（superadmin 等）→ 400 `organization-not-resolved`
- `UserResponse` は `password_hash` を出力しない
- Handler → UseCase → `UserRepository`（既存）。`UserNotFound` → 404

## 設計判断

admin の自組織管理は**トークンの `org` claim でスコープ**するのが正しい機構。URL でテナントを指す `OrgResolverMiddleware`（path/subdomain）は、それ専用ルートが登場した時に別途導入（今回は不要）。

## 検証

- **`composer check` green**: PHPUnit **39 tests / 131 assertions**・PHPStan level 8 **no errors**・cs clean
- UseCase テスト: クロス組織 get→`UserNotFound`、list が org スコープ
- ライブ: org1 admin は org1 の **2件のみ** list、org2 user get→**404**、`password_hash` **非出力**

## 非範囲（次 PR）

- createUser / updateUser / deleteUser（パスワードハッシュ・ロール昇格防止・クロス組織書き込み防止）

## セルフレビュー

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)