### PR TITLE
feat(user): ユーザー write（create/update/delete）を追加する (#41)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -110,6 +110,9 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `organization-not-found` | Organization id/slug not found |
 | `organization-slug-conflict` | Organization slug already in use (409) |
 | `user-not-found` | User id not found |
+| `user-email-conflict` | User email already in use (409) |
+| `role-not-assignable` | Role cannot be assigned via user management, e.g. superadmin (422) |
+| `cannot-delete-self` | A user cannot delete their own account (409) |
 | `invalid-credentials` | Login failed — wrong email or password |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `insufficient-capability` | Authenticated but lacks required capability |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #39)
+Last updated: 2026-05-29 (Issue #41)
 
 ## Recently merged
 
@@ -20,13 +20,14 @@ Last updated: 2026-05-29 (Issue #39)
 - **Issue #33 / PR #34** — 並行 Cursor 由来 #27/#31 の revert（NeNe Clear 等を除去）✅ merged
 - **Issue #35 / PR #36** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）✅ merged
 - **Issue #37 / PR #38** — 組織 CRUD（superadmin・/admin/organizations）✅ merged
-- **Issue #39** — ユーザー読み取り（/admin/users）+ org スコープ ⏳ this PR
+- **Issue #39 / PR #40** — ユーザー読み取り（/admin/users）+ org スコープ ✅ merged
+- **Issue #41** — ユーザー write（create/update/delete）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #39 | `feat/39-user-read-org-scope` | ユーザー read（list/get）+ テナント分離（claims.org スコープ） | 🔄 PR pending |
+| #41 | `feat/41-user-write` | ユーザー write（create/update/delete・ロール昇格防止・クロス組織防止） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -128,13 +129,18 @@ Last updated: 2026-05-29 (Issue #39)
 - `GET/POST /admin/organizations`, `GET/DELETE /admin/organizations/{id}` — Handler → UseCase → repo
 - Domain exceptions → Problem Details (404 / 409) via EXCEPTION_HANDLERS
 
-**Phase 1 — User read + tenant isolation: 🔄 in progress** (Issue #39)
+**Phase 1 — User read + tenant isolation: ✅ complete** (Issue #39 / PR #40)
 
-- `GET /admin/users`, `GET /admin/users/{id}` — admin-only (`manage_users`), scoped to the caller's org
-- `Auth/AuthContext` reads `sub`/`role`/`org` from token claims; queries scoped by `org`
-- Cross-org reads return 404 (no existence leak); `password_hash` never serialized; no org context → 400
-- Verified live: org-1 admin sees only org-1 users; org-2 user → 404; no password_hash in output
-- **Decision:** admin self-service is scoped by the token's `org` claim. The URL-addressed OrgResolverMiddleware (path/subdomain) is deferred until a tenant-addressed route needs it
+- `GET /admin/users`, `GET /admin/users/{id}` — admin-only, scoped to caller's org via `Auth/AuthContext`
+- Cross-org reads → 404; `password_hash` never serialized
+- **Decision:** admin self-service scoped by token `org` claim; URL-addressed OrgResolverMiddleware deferred
+
+**Phase 1 — User write: 🔄 in progress** (Issue #41)
+
+- `POST /admin/users` (create), `PATCH /admin/users/{id}` (update), `DELETE /admin/users/{id}` (delete)
+- Security: password hashed; org forced to caller (no cross-org create); cross-org update/delete → 404; superadmin cannot be assigned (422); cannot delete self (409); email conflict (409)
+- Verified live: create 201 (org forced) / superadmin 422 / dup-email 409 / patch 200 / patch→superadmin 422 / delete-self 409 / delete-other 204 / delete-again 404
+- User management complete (CRUD + tenant isolation + escalation prevention)
 
 ## Handoff Notes
 
@@ -152,6 +158,5 @@ Last updated: 2026-05-29 (Issue #39)
 
 ## Next steps
 
-1. User write (create/update/delete `/admin/users`) — password hashing, role-escalation prevention (no superadmin), cross-org write protection
-2. Complete Phase 1 billing core: clients, quotes, invoices, payments
-3. Phase 2 admin UI + PDF (minimum for overdue list)
+1. Phase 1 billing core — Client CRUD (org-scoped) → company settings → quotes → invoices → payments
+2. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -11,6 +11,9 @@ use NeneInvoice\Auth\AuthRouteRegistrar;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\User\CannotDeleteSelfExceptionHandler;
+use NeneInvoice\User\RoleNotAssignableExceptionHandler;
+use NeneInvoice\User\UserEmailConflictExceptionHandler;
 use NeneInvoice\User\UserNotFoundExceptionHandler;
 use NeneInvoice\User\UserRouteRegistrar;
 use Psr\Container\ContainerInterface;
@@ -58,6 +61,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $orgNotFound = $container->get(OrganizationNotFoundExceptionHandler::class);
                     $orgSlugConflict = $container->get(OrganizationSlugConflictExceptionHandler::class);
                     $userNotFound = $container->get(UserNotFoundExceptionHandler::class);
+                    $userEmailConflict = $container->get(UserEmailConflictExceptionHandler::class);
+                    $roleNotAssignable = $container->get(RoleNotAssignableExceptionHandler::class);
+                    $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -71,7 +77,19 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('User not-found exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound];
+                    if (!$userEmailConflict instanceof UserEmailConflictExceptionHandler) {
+                        throw new LogicException('User email-conflict exception handler service is invalid.');
+                    }
+
+                    if (!$roleNotAssignable instanceof RoleNotAssignableExceptionHandler) {
+                        throw new LogicException('Role not-assignable exception handler service is invalid.');
+                    }
+
+                    if (!$cannotDeleteSelf instanceof CannotDeleteSelfExceptionHandler) {
+                        throw new LogicException('Cannot-delete-self exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf];
                 },
             );
     }

--- a/src/User/CannotDeleteSelfException.php
+++ b/src/User/CannotDeleteSelfException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use DomainException;
+
+final class CannotDeleteSelfException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('You cannot delete your own account.');
+    }
+}

--- a/src/User/CannotDeleteSelfExceptionHandler.php
+++ b/src/User/CannotDeleteSelfExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CannotDeleteSelfExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof CannotDeleteSelfException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'cannot-delete-self', 'Conflict', 409, $exception->getMessage());
+    }
+}

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\Auth\Role;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/users` — admin creates a user in their own organization.
+ */
+final readonly class CreateUserHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private CreateUserUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $email = $decoded['email'] ?? null;
+        $password = $decoded['password'] ?? null;
+        $roleValue = $decoded['role'] ?? null;
+
+        if (!is_string($email) || $email === '' || !is_string($password) || $password === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "email" and "password" are required.');
+        }
+
+        $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
+
+        if ($role === null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
+        }
+
+        $user = $this->useCase->execute($organizationId, new CreateUserInput($email, $password, $role));
+
+        return $this->json->create(UserResponse::toArray($user), 201);
+    }
+}

--- a/src/User/CreateUserInput.php
+++ b/src/User/CreateUserInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use NeneInvoice\Auth\Role;
+
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+        public Role $role,
+    ) {
+    }
+}

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use LogicException;
+use NeneInvoice\Auth\Role;
+
+final readonly class CreateUserUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    /**
+     * Creates a user in the caller's organization. The organization is taken
+     * from the authenticated caller, never from request input, so a user cannot
+     * be created in another tenant.
+     *
+     * @throws RoleNotAssignableException   when attempting to assign superadmin
+     * @throws UserEmailConflictException   when the email is already in use
+     */
+    public function execute(int $organizationId, CreateUserInput $input): User
+    {
+        if ($input->role === Role::Superadmin) {
+            throw new RoleNotAssignableException($input->role);
+        }
+
+        $id = $this->users->save(new User(
+            email: $input->email,
+            passwordHash: password_hash($input->password, PASSWORD_DEFAULT),
+            role: $input->role,
+            organizationId: $organizationId,
+            status: 'active',
+        ));
+
+        $created = $this->users->findById($id);
+
+        if ($created === null) {
+            throw new LogicException('User disappeared immediately after creation.');
+        }
+
+        return $created;
+    }
+}

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `DELETE /admin/users/{id}` — admin removes a user in their own organization.
+ * Callers cannot delete their own account.
+ */
+final readonly class DeleteUserHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private DeleteUserUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+        $callerUserId = AuthContext::userId($request);
+
+        if ($organizationId === null || $callerUserId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->useCase->execute($organizationId, $callerUserId, $id);
+
+        return $this->json->createEmpty(204);
+    }
+}

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+final readonly class DeleteUserUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    /**
+     * Deletes a user within the caller's organization. Cross-organization targets
+     * are reported as not found, and a caller cannot delete their own account.
+     *
+     * @throws CannotDeleteSelfException
+     * @throws UserNotFoundException
+     */
+    public function execute(int $organizationId, int $callerUserId, int $userId): void
+    {
+        if ($userId === $callerUserId) {
+            throw new CannotDeleteSelfException();
+        }
+
+        $existing = $this->users->findById($userId);
+
+        if ($existing === null || $existing->organizationId !== $organizationId) {
+            throw new UserNotFoundException($userId);
+        }
+
+        $this->users->delete($userId);
+    }
+}

--- a/src/User/RoleNotAssignableException.php
+++ b/src/User/RoleNotAssignableException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use DomainException;
+use NeneInvoice\Auth\Role;
+
+final class RoleNotAssignableException extends DomainException
+{
+    public function __construct(Role $role)
+    {
+        parent::__construct(sprintf('The role "%s" cannot be assigned through user management.', $role->value));
+    }
+}

--- a/src/User/RoleNotAssignableExceptionHandler.php
+++ b/src/User/RoleNotAssignableExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class RoleNotAssignableExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof RoleNotAssignableException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'role-not-assignable', 'Unprocessable Entity', 422, $exception->getMessage());
+    }
+}

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\Auth\Role;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `PATCH /admin/users/{id}` — admin updates a user's role / status / password
+ * within their own organization.
+ */
+final readonly class UpdateUserHandler implements RequestHandlerInterface
+{
+    private const ALLOWED_STATUSES = ['active', 'invited'];
+
+    public function __construct(
+        private UpdateUserUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $roleValue = $decoded['role'] ?? null;
+        $status = $decoded['status'] ?? null;
+
+        $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
+
+        if ($role === null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
+        }
+
+        if (!is_string($status) || !in_array($status, self::ALLOWED_STATUSES, true)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"status" must be one of: active, invited.');
+        }
+
+        $passwordValue = $decoded['password'] ?? null;
+        $password = is_string($passwordValue) && $passwordValue !== '' ? $passwordValue : null;
+
+        $user = $this->useCase->execute($organizationId, $id, new UpdateUserInput($role, $status, $password));
+
+        return $this->json->create(UserResponse::toArray($user));
+    }
+}

--- a/src/User/UpdateUserInput.php
+++ b/src/User/UpdateUserInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use NeneInvoice\Auth\Role;
+
+final readonly class UpdateUserInput
+{
+    public function __construct(
+        public Role $role,
+        public string $status,
+        public ?string $password = null,
+    ) {
+    }
+}

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use LogicException;
+use NeneInvoice\Auth\Role;
+
+final readonly class UpdateUserUseCase
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    /**
+     * Updates a user's role, status, and (optionally) password — only within the
+     * caller's organization. A user from another organization is reported as not
+     * found. Email is immutable here.
+     *
+     * @throws UserNotFoundException        when the user is missing or in another org
+     * @throws RoleNotAssignableException   when attempting to assign superadmin
+     */
+    public function execute(int $organizationId, int $userId, UpdateUserInput $input): User
+    {
+        $existing = $this->users->findById($userId);
+
+        if ($existing === null || $existing->organizationId !== $organizationId) {
+            throw new UserNotFoundException($userId);
+        }
+
+        if ($input->role === Role::Superadmin) {
+            throw new RoleNotAssignableException($input->role);
+        }
+
+        $this->users->update(new User(
+            email: $existing->email,
+            passwordHash: $input->password !== null ? password_hash($input->password, PASSWORD_DEFAULT) : $existing->passwordHash,
+            role: $input->role,
+            organizationId: $existing->organizationId,
+            status: $input->status,
+            id: $existing->id,
+            createdAt: $existing->createdAt,
+            updatedAt: $existing->updatedAt,
+        ));
+
+        $updated = $this->users->findById($userId);
+
+        if ($updated === null) {
+            throw new LogicException('User disappeared immediately after update.');
+        }
+
+        return $updated;
+    }
+}

--- a/src/User/UserEmailConflictExceptionHandler.php
+++ b/src/User/UserEmailConflictExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserEmailConflictExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserEmailConflictException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'user-email-conflict', 'Conflict', 409, $exception->getMessage());
+    }
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -17,6 +17,9 @@ final readonly class UserRouteRegistrar
     public function __construct(
         private ListUsersHandler $listHandler,
         private GetUserByIdHandler $getHandler,
+        private CreateUserHandler $createHandler,
+        private UpdateUserHandler $updateHandler,
+        private DeleteUserHandler $deleteHandler,
     ) {
     }
 
@@ -24,8 +27,14 @@ final readonly class UserRouteRegistrar
     {
         $list = $this->listHandler;
         $get = $this->getHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
 
         $router->get('/admin/users', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/users', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->get('/admin/users/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->patch('/admin/users/{id}', static fn (ServerRequestInterface $r) => $update->handle($r));
+        $router->delete('/admin/users/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
     }
 }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -12,8 +12,8 @@ use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the User domain read side: use cases, handlers, the not-found exception
- * handler, and the route registrar. `UserRepositoryInterface` is provided by
+ * Wires the User domain: use cases, handlers, domain exception handlers, and the
+ * route registrar. `UserRepositoryInterface` is provided by
  * {@see \NeneInvoice\Auth\AuthServiceProvider}.
  */
 final readonly class UserServiceProvider implements ServiceProviderInterface
@@ -23,6 +23,9 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         $builder
             ->set(ListUsersUseCase::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
             ->set(GetUserByIdUseCase::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
+            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c)))
+            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c)))
+            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c)))
             ->set(
                 ListUsersHandler::class,
                 static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
@@ -40,20 +43,64 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                CreateUserHandler::class,
+                static fn (ContainerInterface $c): CreateUserHandler => new CreateUserHandler(
+                    self::createUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                UpdateUserHandler::class,
+                static fn (ContainerInterface $c): UpdateUserHandler => new UpdateUserHandler(
+                    self::updateUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                DeleteUserHandler::class,
+                static fn (ContainerInterface $c): DeleteUserHandler => new DeleteUserHandler(
+                    self::deleteUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 UserNotFoundExceptionHandler::class,
                 static fn (ContainerInterface $c): UserNotFoundExceptionHandler => new UserNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                UserEmailConflictExceptionHandler::class,
+                static fn (ContainerInterface $c): UserEmailConflictExceptionHandler => new UserEmailConflictExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                RoleNotAssignableExceptionHandler::class,
+                static fn (ContainerInterface $c): RoleNotAssignableExceptionHandler => new RoleNotAssignableExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                CannotDeleteSelfExceptionHandler::class,
+                static fn (ContainerInterface $c): CannotDeleteSelfExceptionHandler => new CannotDeleteSelfExceptionHandler(self::problemDetails($c)),
             )
             ->set(
                 UserRouteRegistrar::class,
                 static function (ContainerInterface $c): UserRouteRegistrar {
                     $list = $c->get(ListUsersHandler::class);
                     $get = $c->get(GetUserByIdHandler::class);
+                    $create = $c->get(CreateUserHandler::class);
+                    $update = $c->get(UpdateUserHandler::class);
+                    $delete = $c->get(DeleteUserHandler::class);
 
-                    if (!$list instanceof ListUsersHandler || !$get instanceof GetUserByIdHandler) {
+                    if (!$list instanceof ListUsersHandler
+                        || !$get instanceof GetUserByIdHandler
+                        || !$create instanceof CreateUserHandler
+                        || !$update instanceof UpdateUserHandler
+                        || !$delete instanceof DeleteUserHandler
+                    ) {
                         throw new LogicException('User handler services are invalid.');
                     }
 
-                    return new UserRouteRegistrar($list, $get);
+                    return new UserRouteRegistrar($list, $get, $create, $update, $delete);
                 },
             );
     }
@@ -86,6 +133,39 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
         if (!$u instanceof GetUserByIdUseCase) {
             throw new LogicException('Get user use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function createUseCase(ContainerInterface $c): CreateUserUseCase
+    {
+        $u = $c->get(CreateUserUseCase::class);
+
+        if (!$u instanceof CreateUserUseCase) {
+            throw new LogicException('Create user use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function updateUseCase(ContainerInterface $c): UpdateUserUseCase
+    {
+        $u = $c->get(UpdateUserUseCase::class);
+
+        if (!$u instanceof UpdateUserUseCase) {
+            throw new LogicException('Update user use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function deleteUseCase(ContainerInterface $c): DeleteUserUseCase
+    {
+        $u = $c->get(DeleteUserUseCase::class);
+
+        if (!$u instanceof DeleteUserUseCase) {
+            throw new LogicException('Delete user use case service is invalid.');
         }
 
         return $u;

--- a/tests/User/UserWriteUseCasesTest.php
+++ b/tests/User/UserWriteUseCasesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\User;
+
+use NeneInvoice\Auth\Role;
+use NeneInvoice\Tests\Support\InMemoryUserRepository;
+use NeneInvoice\User\CannotDeleteSelfException;
+use NeneInvoice\User\CreateUserInput;
+use NeneInvoice\User\CreateUserUseCase;
+use NeneInvoice\User\DeleteUserUseCase;
+use NeneInvoice\User\RoleNotAssignableException;
+use NeneInvoice\User\UpdateUserInput;
+use NeneInvoice\User\UpdateUserUseCase;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+use NeneInvoice\User\UserNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class UserWriteUseCasesTest extends TestCase
+{
+    private InMemoryUserRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryUserRepository();
+    }
+
+    public function test_create_hashes_password_and_forces_caller_organization(): void
+    {
+        $user = (new CreateUserUseCase($this->repo))->execute(1, new CreateUserInput('m@org1', 'secret', Role::Member));
+
+        self::assertSame(1, $user->organizationId);
+        self::assertSame(Role::Member, $user->role);
+        self::assertNotSame('secret', $user->passwordHash);
+        self::assertTrue(password_verify('secret', $user->passwordHash));
+    }
+
+    public function test_create_blocks_superadmin_role(): void
+    {
+        $this->expectException(RoleNotAssignableException::class);
+        (new CreateUserUseCase($this->repo))->execute(1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
+    }
+
+    public function test_create_rejects_duplicate_email(): void
+    {
+        $create = new CreateUserUseCase($this->repo);
+        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Member));
+
+        $this->expectException(UserEmailConflictException::class);
+        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Admin));
+    }
+
+    public function test_update_blocks_cross_organization_target(): void
+    {
+        $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
+
+        $this->expectException(UserNotFoundException::class);
+        (new UpdateUserUseCase($this->repo))->execute(1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
+    }
+
+    public function test_update_blocks_superadmin_escalation(): void
+    {
+        $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
+
+        $this->expectException(RoleNotAssignableException::class);
+        (new UpdateUserUseCase($this->repo))->execute(1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
+    }
+
+    public function test_delete_blocks_self(): void
+    {
+        $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
+
+        $this->expectException(CannotDeleteSelfException::class);
+        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $caller);
+    }
+
+    public function test_delete_blocks_cross_organization_target(): void
+    {
+        $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
+        $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
+
+        $this->expectException(UserNotFoundException::class);
+        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $otherOrgUser);
+    }
+
+    public function test_delete_removes_user_in_same_organization(): void
+    {
+        $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
+        $target = $this->repo->save(new User('t@org1', 'h', Role::Member, 1));
+
+        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $target);
+
+        self::assertNull($this->repo->findById($target));
+    }
+}


### PR DESCRIPTION
Closes #41

## 目的

admin が自組織のユーザーを作成・更新・削除する write を追加し、ユーザー管理を完結させる。

## エンドポイント（admin-only / `manage_users` / org スコープ）

| Method | Path | 結果 |
| --- | --- | --- |
| POST | `/admin/users` | 201（dup-email 409・superadmin 422・欠落 422） |
| PATCH | `/admin/users/{id}` | 200（他組織 404・superadmin 422） |
| DELETE | `/admin/users/{id}` | 204（他組織 404・自己削除 409） |

## セキュリティ規則（UseCase 層で強制）

- **パスワードハッシュ**: `password_hash(PASSWORD_DEFAULT)`
- **クロス組織防止**: 作成は呼び出し元 org に固定（body 指定不可）、更新/削除は自組織のみ（他組織は存在を漏らさず 404）
- **ロール昇格防止**: `superadmin` を付与不可 → 422 `role-not-assignable`
- **自己削除防止** → 409 `cannot-delete-self`
- email 重複 → 409 `user-email-conflict`

## 検証

- **`composer check` green**: PHPUnit **47 tests / 142 assertions**・PHPStan level 8 **no errors**・cs clean
- UseCase テスト（hash/org強制/superadmin拒否/email重複/クロス組織404/昇格422/自己削除/正常削除）
- ライブ: create **201**(org固定) / superadmin **422** / dup-email **409** / patch **200** / patch→superadmin **422** / delete-self **409** / delete-other **204** / delete-again **404**

## セルフレビュー

Self-review: backend-api, middleware-security, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)