### PR TITLE
feat(client): Client（取引先）永続化＋読み取りを追加する (#43)

### DIFF
--- a/database/migrations/20260529140000_create_clients_table.php
+++ b/database/migrations/20260529140000_create_clients_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateClientsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('clients')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('contact_name', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('billing_address', 'text', ['null' => true, 'default' => null])
+            ->addColumn('registration_number', 'string', ['limit' => 14, 'null' => true, 'default' => null])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_clients_organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/clients.sql
+++ b/database/schema/clients.sql
@@ -1,0 +1,16 @@
+-- Schema snapshot for the clients table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS clients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    contact_name VARCHAR(255) NULL DEFAULT NULL,
+    email VARCHAR(255) NULL DEFAULT NULL,
+    billing_address TEXT NULL DEFAULT NULL,
+    registration_number VARCHAR(14) NULL DEFAULT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_clients_organization_id ON clients (organization_id);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #41)
+Last updated: 2026-05-29 (Issue #43)
 
 ## Recently merged
 
@@ -21,13 +21,14 @@ Last updated: 2026-05-29 (Issue #41)
 - **Issue #35 / PR #36** — CapabilityMiddleware + CapabilityResolver（RBAC 強制）✅ merged
 - **Issue #37 / PR #38** — 組織 CRUD（superadmin・/admin/organizations）✅ merged
 - **Issue #39 / PR #40** — ユーザー読み取り（/admin/users）+ org スコープ ✅ merged
-- **Issue #41** — ユーザー write（create/update/delete）⏳ this PR
+- **Issue #41 / PR #42** — ユーザー write（create/update/delete）✅ merged
+- **Issue #43** — Client（取引先）永続化 + 読み取り ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #41 | `feat/41-user-write` | ユーザー write（create/update/delete・ロール昇格防止・クロス組織防止） | 🔄 PR pending |
+| #43 | `feat/43-client-read` | Client 永続化（ソフト削除）+ 読み取り（list/get・org スコープ） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -135,12 +136,17 @@ Last updated: 2026-05-29 (Issue #41)
 - Cross-org reads → 404; `password_hash` never serialized
 - **Decision:** admin self-service scoped by token `org` claim; URL-addressed OrgResolverMiddleware deferred
 
-**Phase 1 — User write: 🔄 in progress** (Issue #41)
+**Phase 1 — User write: ✅ complete** (Issue #41 / PR #42)
 
-- `POST /admin/users` (create), `PATCH /admin/users/{id}` (update), `DELETE /admin/users/{id}` (delete)
-- Security: password hashed; org forced to caller (no cross-org create); cross-org update/delete → 404; superadmin cannot be assigned (422); cannot delete self (409); email conflict (409)
-- Verified live: create 201 (org forced) / superadmin 422 / dup-email 409 / patch 200 / patch→superadmin 422 / delete-self 409 / delete-other 204 / delete-again 404
+- `POST/PATCH/DELETE /admin/users` — password hashing, org forced to caller, cross-org → 404, superadmin not assignable (422), self-delete (409), email conflict (409)
 - User management complete (CRUD + tenant isolation + escalation prevention)
+
+**Phase 1 — Client persistence + read: 🔄 in progress** (Issue #43)
+
+- `clients` table (Phinx + SQLite snapshot) with **soft delete** (`is_deleted`/`deleted_at`); `Client` entity + `PdoClientRepository` (reads exclude deleted)
+- `GET /admin/clients`, `GET /admin/clients/{id}` — org-scoped (`view_billing`); cross-org/missing → 404
+- Repo tests (incl. soft delete) + use-case tests; verified live: member sees only own-org clients, org-2 client → 404
+- Write endpoints (create/update/delete + `registration_number` T+13 validation) land next
 
 ## Handoff Notes
 
@@ -158,5 +164,6 @@ Last updated: 2026-05-29 (Issue #41)
 
 ## Next steps
 
-1. Phase 1 billing core — Client CRUD (org-scoped) → company settings → quotes → invoices → payments
-2. Phase 2 admin UI + PDF (minimum for overdue list)
+1. Client write (create/update/delete) — `registration_number` T+13 syntax validation, soft delete
+2. Company settings (issuer profile, per organization) → quotes → invoices → payments
+3. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -8,6 +8,8 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneInvoice\Auth\AuthRouteRegistrar;
+use NeneInvoice\Client\ClientNotFoundExceptionHandler;
+use NeneInvoice\Client\ClientRouteRegistrar;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -39,6 +41,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $authRoutes = $container->get(AuthRouteRegistrar::class);
                     $organizationRoutes = $container->get(OrganizationRouteRegistrar::class);
                     $userRoutes = $container->get(UserRouteRegistrar::class);
+                    $clientRoutes = $container->get(ClientRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -52,7 +55,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('User route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes];
+                    if (!$clientRoutes instanceof ClientRouteRegistrar) {
+                        throw new LogicException('Client route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes];
                 },
             )
             ->set(
@@ -64,6 +71,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $userEmailConflict = $container->get(UserEmailConflictExceptionHandler::class);
                     $roleNotAssignable = $container->get(RoleNotAssignableExceptionHandler::class);
                     $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
+                    $clientNotFound = $container->get(ClientNotFoundExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -89,7 +97,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Cannot-delete-self exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf];
+                    if (!$clientNotFound instanceof ClientNotFoundExceptionHandler) {
+                        throw new LogicException('Client not-found exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound];
                 },
             );
     }

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+/**
+ * A buyer (取引先) in the billing system, scoped to one organization.
+ *
+ * `registrationNumber` is the buyer's Japan invoice registration number
+ * (optional; format `T` + 13 digits when present — see accounting-compliance).
+ * Clients are soft-deleted so issued documents that reference them stay intact.
+ */
+final readonly class Client
+{
+    public function __construct(
+        public int $organizationId,
+        public string $name,
+        public ?string $contactName = null,
+        public ?string $email = null,
+        public ?string $billingAddress = null,
+        public ?string $registrationNumber = null,
+        public bool $isDeleted = false,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Client/ClientNotFoundException.php
+++ b/src/Client/ClientNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use RuntimeException;
+
+final class ClientNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Client {$id} not found.");
+    }
+}

--- a/src/Client/ClientNotFoundExceptionHandler.php
+++ b/src/Client/ClientNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ClientNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ClientNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'client-not-found', 'Not Found', 404, 'The requested client was not found.');
+    }
+}

--- a/src/Client/ClientRepositoryInterface.php
+++ b/src/Client/ClientRepositoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+/**
+ * Persistence for clients. All reads exclude soft-deleted rows; `delete` is a
+ * soft delete (sets `is_deleted`).
+ */
+interface ClientRepositoryInterface
+{
+    public function findById(int $id): ?Client;
+
+    /** @return list<Client> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+
+    public function save(Client $client): int;
+
+    /** @throws ClientNotFoundException */
+    public function update(Client $client): void;
+
+    /** @throws ClientNotFoundException */
+    public function delete(int $id): void;
+}

--- a/src/Client/ClientResponse.php
+++ b/src/Client/ClientResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+/**
+ * Serializes a {@see Client} to its snake_case JSON representation.
+ */
+final class ClientResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Client $client): array
+    {
+        return [
+            'id' => $client->id,
+            'organization_id' => $client->organizationId,
+            'name' => $client->name,
+            'contact_name' => $client->contactName,
+            'email' => $client->email,
+            'billing_address' => $client->billingAddress,
+            'registration_number' => $client->registrationNumber,
+            'created_at' => $client->createdAt,
+            'updated_at' => $client->updatedAt,
+        ];
+    }
+}

--- a/src/Client/ClientRouteRegistrar.php
+++ b/src/Client/ClientRouteRegistrar.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers client (取引先) routes. Reads require `view_billing`, mutations
+ * require `manage_billing` (CapabilityMiddleware); all scoped to the caller's
+ * organization. Write routes are added in a later PR.
+ */
+final readonly class ClientRouteRegistrar
+{
+    public function __construct(
+        private ListClientsHandler $listHandler,
+        private GetClientByIdHandler $getHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+
+        $router->get('/admin/clients', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->get('/admin/clients/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+    }
+}

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Client (取引先) domain: repository, read use cases, handlers, the
+ * not-found exception handler, and the route registrar.
+ */
+final readonly class ClientServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ClientRepositoryInterface::class,
+                static function (ContainerInterface $c): ClientRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoClientRepository($query);
+                },
+            )
+            ->set(ListClientsUseCase::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
+            ->set(GetClientByIdUseCase::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
+            ->set(
+                ListClientsHandler::class,
+                static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
+                    self::listUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                GetClientByIdHandler::class,
+                static fn (ContainerInterface $c): GetClientByIdHandler => new GetClientByIdHandler(
+                    self::getUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                ClientNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): ClientNotFoundExceptionHandler => new ClientNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                ClientRouteRegistrar::class,
+                static function (ContainerInterface $c): ClientRouteRegistrar {
+                    $list = $c->get(ListClientsHandler::class);
+                    $get = $c->get(GetClientByIdHandler::class);
+
+                    if (!$list instanceof ListClientsHandler || !$get instanceof GetClientByIdHandler) {
+                        throw new LogicException('Client handler services are invalid.');
+                    }
+
+                    return new ClientRouteRegistrar($list, $get);
+                },
+            );
+    }
+
+    private static function repository(ContainerInterface $c): ClientRepositoryInterface
+    {
+        $repo = $c->get(ClientRepositoryInterface::class);
+
+        if (!$repo instanceof ClientRepositoryInterface) {
+            throw new LogicException('Client repository service is invalid.');
+        }
+
+        return $repo;
+    }
+
+    private static function listUseCase(ContainerInterface $c): ListClientsUseCase
+    {
+        $u = $c->get(ListClientsUseCase::class);
+
+        if (!$u instanceof ListClientsUseCase) {
+            throw new LogicException('List clients use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function getUseCase(ContainerInterface $c): GetClientByIdUseCase
+    {
+        $u = $c->get(GetClientByIdUseCase::class);
+
+        if (!$u instanceof GetClientByIdUseCase) {
+            throw new LogicException('Get client use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JSON response factory service is invalid.');
+        }
+
+        return $j;
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        $p = $c->get(ProblemDetailsResponseFactory::class);
+
+        if (!$p instanceof ProblemDetailsResponseFactory) {
+            throw new LogicException('Problem details response factory service is invalid.');
+        }
+
+        return $p;
+    }
+}

--- a/src/Client/GetClientByIdHandler.php
+++ b/src/Client/GetClientByIdHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/clients/{id}` — reads one client in the caller's organization.
+ * Clients outside the caller's organization (or missing) return 404.
+ */
+final readonly class GetClientByIdHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetClientByIdUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $client = $this->useCase->execute($organizationId, $id);
+
+        return $this->json->create(ClientResponse::toArray($client));
+    }
+}

--- a/src/Client/GetClientByIdUseCase.php
+++ b/src/Client/GetClientByIdUseCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class GetClientByIdUseCase
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+    ) {
+    }
+
+    /**
+     * Fetches a client that belongs to the given organization. A client from
+     * another organization (or a missing/soft-deleted id) is reported as not
+     * found so cross-tenant existence is not leaked.
+     *
+     * @throws ClientNotFoundException
+     */
+    public function execute(int $organizationId, int $id): Client
+    {
+        $client = $this->clients->findById($id);
+
+        if ($client === null || $client->organizationId !== $organizationId) {
+            throw new ClientNotFoundException($id);
+        }
+
+        return $client;
+    }
+}

--- a/src/Client/ListClientsHandler.php
+++ b/src/Client/ListClientsHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/clients` — lists clients in the caller's organization.
+ */
+final readonly class ListClientsHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListClientsUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (Client $c): array => ClientResponse::toArray($c), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/Client/ListClientsResult.php
+++ b/src/Client/ListClientsResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class ListClientsResult
+{
+    /** @param list<Client> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/Client/ListClientsUseCase.php
+++ b/src/Client/ListClientsUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class ListClientsUseCase
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $limit, int $offset): ListClientsResult
+    {
+        return new ListClientsResult(
+            $this->clients->findAllByOrganization($organizationId, $limit, $offset),
+            $this->clients->countByOrganization($organizationId),
+        );
+    }
+}

--- a/src/Client/PdoClientRepository.php
+++ b/src/Client/PdoClientRepository.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoClientRepository implements ClientRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, name, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Client
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM clients WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<Client> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM clients WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): Client => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM clients WHERE organization_id = ? AND is_deleted = 0',
+            [$organizationId],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function save(Client $client): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO clients (organization_id, name, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [
+                $client->organizationId,
+                $client->name,
+                $client->contactName,
+                $client->email,
+                $client->billingAddress,
+                $client->registrationNumber,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Client $client): void
+    {
+        if ($client->id === null) {
+            throw new ClientNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE clients SET name = ?, contact_name = ?, email = ?, billing_address = ?, registration_number = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [
+                $client->name,
+                $client->contactName,
+                $client->email,
+                $client->billingAddress,
+                $client->registrationNumber,
+                $now,
+                $client->id,
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($client->id) === null) {
+            throw new ClientNotFoundException($client->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new ClientNotFoundException($id);
+        }
+
+        $this->query->execute(
+            'UPDATE clients SET is_deleted = 1, deleted_at = ? WHERE id = ?',
+            [date('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Client
+    {
+        return new Client(
+            organizationId: (int) $row['organization_id'],
+            name: (string) $row['name'],
+            contactName: isset($row['contact_name']) && $row['contact_name'] !== '' ? (string) $row['contact_name'] : null,
+            email: isset($row['email']) && $row['email'] !== '' ? (string) $row['email'] : null,
+            billingAddress: isset($row['billing_address']) && $row['billing_address'] !== '' ? (string) $row['billing_address'] : null,
+            registrationNumber: isset($row['registration_number']) && $row['registration_number'] !== '' ? (string) $row['registration_number'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -21,6 +21,7 @@ use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
+use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -44,6 +45,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new AuthServiceProvider());
         $builder->addProvider(new OrganizationServiceProvider());
         $builder->addProvider(new UserServiceProvider());
+        $builder->addProvider(new ClientServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Client/ClientQueryUseCasesTest.php
+++ b/tests/Client/ClientQueryUseCasesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Client;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\GetClientByIdUseCase;
+use NeneInvoice\Client\ListClientsUseCase;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ClientQueryUseCasesTest extends TestCase
+{
+    private InMemoryClientRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryClientRepository();
+        $this->repo->save(new Client(organizationId: 1, name: 'A'));
+        $this->repo->save(new Client(organizationId: 1, name: 'B'));
+        $this->repo->save(new Client(organizationId: 2, name: 'C'));
+    }
+
+    public function test_list_is_scoped_to_organization(): void
+    {
+        $result = (new ListClientsUseCase($this->repo))->execute(1, 10, 0);
+
+        self::assertSame(2, $result->total);
+        self::assertCount(2, $result->items);
+        foreach ($result->items as $client) {
+            self::assertSame(1, $client->organizationId);
+        }
+    }
+
+    public function test_get_returns_client_in_same_organization(): void
+    {
+        $client = (new GetClientByIdUseCase($this->repo))->execute(1, 1);
+
+        self::assertSame('A', $client->name);
+    }
+
+    public function test_get_hides_client_from_another_organization(): void
+    {
+        // id 3 belongs to org 2; an org-1 caller must not see it.
+        $this->expectException(ClientNotFoundException::class);
+        (new GetClientByIdUseCase($this->repo))->execute(1, 3);
+    }
+}

--- a/tests/Client/PdoClientRepositoryTest.php
+++ b/tests/Client/PdoClientRepositoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Client;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\PdoClientRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoClientRepositoryTest extends TestCase
+{
+    private PdoClientRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/clients.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoClientRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_saves_and_reads_back_a_client(): void
+    {
+        $id = $this->repository->save(new Client(
+            organizationId: 1,
+            name: 'Acme Foods',
+            contactName: 'Taro',
+            email: 'taro@acme.test',
+            registrationNumber: 'T1234567890123',
+        ));
+
+        $client = $this->repository->findById($id);
+        self::assertNotNull($client);
+        self::assertSame('Acme Foods', $client->name);
+        self::assertSame('Taro', $client->contactName);
+        self::assertSame('T1234567890123', $client->registrationNumber);
+        self::assertFalse($client->isDeleted);
+    }
+
+    public function test_list_and_count_are_scoped_to_organization(): void
+    {
+        $this->repository->save(new Client(organizationId: 1, name: 'A'));
+        $this->repository->save(new Client(organizationId: 1, name: 'B'));
+        $this->repository->save(new Client(organizationId: 2, name: 'C'));
+
+        self::assertSame(2, $this->repository->countByOrganization(1));
+        self::assertCount(2, $this->repository->findAllByOrganization(1, 10, 0));
+        self::assertSame(1, $this->repository->countByOrganization(2));
+    }
+
+    public function test_soft_delete_hides_client_from_reads(): void
+    {
+        $id = $this->repository->save(new Client(organizationId: 1, name: 'Temp'));
+
+        $this->repository->delete($id);
+
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->countByOrganization(1));
+        self::assertCount(0, $this->repository->findAllByOrganization(1, 10, 0));
+    }
+
+    public function test_delete_throws_for_unknown_client(): void
+    {
+        $this->expectException(ClientNotFoundException::class);
+        $this->repository->delete(4242);
+    }
+}

--- a/tests/Support/InMemoryClientRepository.php
+++ b/tests/Support/InMemoryClientRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\ClientRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database). Soft-deleted clients are
+ * excluded from reads, matching the PDO implementation.
+ */
+final class InMemoryClientRepository implements ClientRepositoryInterface
+{
+    /** @var array<int, Client> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?Client
+    {
+        $client = $this->byId[$id] ?? null;
+
+        return $client !== null && !$client->isDeleted ? $client : null;
+    }
+
+    /** @return list<Client> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (Client $c): bool => $c->organizationId === $organizationId && !$c->isDeleted,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (Client $c): bool => $c->organizationId === $organizationId && !$c->isDeleted,
+        ));
+    }
+
+    public function save(Client $client): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = new Client(
+            organizationId: $client->organizationId,
+            name: $client->name,
+            contactName: $client->contactName,
+            email: $client->email,
+            billingAddress: $client->billingAddress,
+            registrationNumber: $client->registrationNumber,
+            isDeleted: false,
+            id: $id,
+            createdAt: '2026-05-29 00:00:00',
+            updatedAt: '2026-05-29 00:00:00',
+        );
+
+        return $id;
+    }
+
+    public function update(Client $client): void
+    {
+        if ($client->id === null || $this->findById($client->id) === null) {
+            throw new ClientNotFoundException($client->id ?? 0);
+        }
+
+        $this->byId[$client->id] = $client;
+    }
+
+    public function delete(int $id): void
+    {
+        $existing = $this->findById($id);
+
+        if ($existing === null) {
+            throw new ClientNotFoundException($id);
+        }
+
+        $this->byId[$id] = new Client(
+            organizationId: $existing->organizationId,
+            name: $existing->name,
+            contactName: $existing->contactName,
+            email: $existing->email,
+            billingAddress: $existing->billingAddress,
+            registrationNumber: $existing->registrationNumber,
+            isDeleted: true,
+            id: $existing->id,
+            createdAt: $existing->createdAt,
+            updatedAt: $existing->updatedAt,
+        );
+    }
+}


### PR DESCRIPTION
Closes #43

## 目的

請求ドメインの起点となる**取引先マスタ**を追加。組織スコープ・**ソフト削除**（請求書から参照されるため履歴保持）。本 PR は永続化レイヤ（write メソッド含む完全なリポジトリ）と読み取りエンドポイント。

## 変更内容

- **`clients` テーブル**（Phinx + SQLite snapshot）: organization_id(index), name, contact_name, email, billing_address, registration_number(任意・適格請求書 buyer 用), is_deleted, deleted_at, timestamps
- **Client ドメイン**: エンティティ + `ClientRepositoryInterface` + `PdoClientRepository`（ソフト削除対応: 取得/一覧は `is_deleted=0`、delete は `is_deleted=1`）
- **`GET /admin/clients` / `GET /admin/clients/{id}`** — 自組織のみ（`view_billing`）、`AuthContext` の org claim でスコープ、他組織/不在は 404
- `ClientNotFound`→404、`ClientServiceProvider` 配線

## 検証

- **`composer check` green**: PHPUnit **54 tests / 164 assertions**・PHPStan level 8 **no errors**・cs clean
- リポジトリテスト（SQLite、**ソフト削除**で読み取りから除外を確認）+ UseCase テスト（org スコープ）
- `phinx migrate` で `clients` 作成確認
- ライブ: member は自組織 clients のみ list、org2 client get→**404**、no token→**401**

## 非範囲（次 PR）

- create/update/delete エンドポイント（`registration_number` の T+13 形式検証含む）

## セルフレビュー

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)