### PR TITLE
feat(client): Client write（create/update/delete）を追加する (#45)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -107,6 +107,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `invoice-not-found` | Invoice id/token not found |
 | `quote-not-found` | Quote id not found |
 | `client-not-found` | Client id not found |
+| `invalid-registration-number` | Registration number not `T` + 13 digits (422) |
 | `organization-not-found` | Organization id/slug not found |
 | `organization-slug-conflict` | Organization slug already in use (409) |
 | `user-not-found` | User id not found |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #43)
+Last updated: 2026-05-29 (Issue #45)
 
 ## Recently merged
 
@@ -22,13 +22,14 @@ Last updated: 2026-05-29 (Issue #43)
 - **Issue #37 / PR #38** — 組織 CRUD（superadmin・/admin/organizations）✅ merged
 - **Issue #39 / PR #40** — ユーザー読み取り（/admin/users）+ org スコープ ✅ merged
 - **Issue #41 / PR #42** — ユーザー write（create/update/delete）✅ merged
-- **Issue #43** — Client（取引先）永続化 + 読み取り ⏳ this PR
+- **Issue #43 / PR #44** — Client（取引先）永続化 + 読み取り ✅ merged
+- **Issue #45** — Client write（create/update/delete）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #43 | `feat/43-client-read` | Client 永続化（ソフト削除）+ 読み取り（list/get・org スコープ） | 🔄 PR pending |
+| #45 | `feat/45-client-write` | Client write（create/update/delete・registration_number T+13 検証） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -141,12 +142,16 @@ Last updated: 2026-05-29 (Issue #43)
 - `POST/PATCH/DELETE /admin/users` — password hashing, org forced to caller, cross-org → 404, superadmin not assignable (422), self-delete (409), email conflict (409)
 - User management complete (CRUD + tenant isolation + escalation prevention)
 
-**Phase 1 — Client persistence + read: 🔄 in progress** (Issue #43)
+**Phase 1 — Client persistence + read: ✅ complete** (Issue #43 / PR #44)
 
-- `clients` table (Phinx + SQLite snapshot) with **soft delete** (`is_deleted`/`deleted_at`); `Client` entity + `PdoClientRepository` (reads exclude deleted)
-- `GET /admin/clients`, `GET /admin/clients/{id}` — org-scoped (`view_billing`); cross-org/missing → 404
-- Repo tests (incl. soft delete) + use-case tests; verified live: member sees only own-org clients, org-2 client → 404
-- Write endpoints (create/update/delete + `registration_number` T+13 validation) land next
+- `clients` table with soft delete; `PdoClientRepository` (reads exclude deleted); `GET /admin/clients[/{id}]` org-scoped
+
+**Phase 1 — Client write: 🔄 in progress** (Issue #45)
+
+- `POST/PATCH/DELETE /admin/clients` — `manage_billing`, org-scoped; create forces caller org; cross-org → 404; delete is soft
+- `registration_number` (buyer) syntax-validated `^T[0-9]{13}$` in the UseCase → 422 `invalid-registration-number` (accounting-compliance §4)
+- Verified live: create 201 (org forced) / bad-reg 422 / no-name 422 / patch 200 / patch-other-org 404 / delete 204→get 404 / delete-other-org 404
+- Client CRUD complete
 
 ## Handoff Notes
 
@@ -164,6 +169,6 @@ Last updated: 2026-05-29 (Issue #43)
 
 ## Next steps
 
-1. Client write (create/update/delete) — `registration_number` T+13 syntax validation, soft delete
-2. Company settings (issuer profile, per organization) → quotes → invoices → payments
+1. Company settings (issuer profile, per organization) — incl. issuer `registration_number` (T+13), bank info
+2. Quotes (見積) → Invoices (請求書) → Payments (入金) + tax calc (ADR 0004) + qualified-invoice field validation
 3. Phase 2 admin UI + PDF (minimum for overdue list)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneInvoice\Auth\AuthRouteRegistrar;
 use NeneInvoice\Client\ClientNotFoundExceptionHandler;
 use NeneInvoice\Client\ClientRouteRegistrar;
+use NeneInvoice\Client\InvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -72,6 +73,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $roleNotAssignable = $container->get(RoleNotAssignableExceptionHandler::class);
                     $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
                     $clientNotFound = $container->get(ClientNotFoundExceptionHandler::class);
+                    $invalidRegNumber = $container->get(InvalidRegistrationNumberExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -101,7 +103,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Client not-found exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound];
+                    if (!$invalidRegNumber instanceof InvalidRegistrationNumberExceptionHandler) {
+                        throw new LogicException('Invalid registration number exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber];
                 },
             );
     }

--- a/src/Client/ClientField.php
+++ b/src/Client/ClientField.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+/**
+ * Small helpers for parsing optional client fields from a decoded JSON body.
+ */
+final class ClientField
+{
+    /**
+     * Returns a trimmed non-empty string for the key, or null when the value is
+     * missing, not a string, or empty.
+     *
+     * @param array<string, mixed> $body
+     */
+    public static function optionalString(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Client/ClientRouteRegistrar.php
+++ b/src/Client/ClientRouteRegistrar.php
@@ -10,13 +10,16 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Registers client (取引先) routes. Reads require `view_billing`, mutations
  * require `manage_billing` (CapabilityMiddleware); all scoped to the caller's
- * organization. Write routes are added in a later PR.
+ * organization.
  */
 final readonly class ClientRouteRegistrar
 {
     public function __construct(
         private ListClientsHandler $listHandler,
         private GetClientByIdHandler $getHandler,
+        private CreateClientHandler $createHandler,
+        private UpdateClientHandler $updateHandler,
+        private DeleteClientHandler $deleteHandler,
     ) {
     }
 
@@ -24,8 +27,14 @@ final readonly class ClientRouteRegistrar
     {
         $list = $this->listHandler;
         $get = $this->getHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
 
         $router->get('/admin/clients', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/clients', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->get('/admin/clients/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->patch('/admin/clients/{id}', static fn (ServerRequestInterface $r) => $update->handle($r));
+        $router->delete('/admin/clients/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
     }
 }

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -35,6 +35,9 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
             )
             ->set(ListClientsUseCase::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
             ->set(GetClientByIdUseCase::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
+            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c)))
+            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c)))
+            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c)))
             ->set(
                 ListClientsHandler::class,
                 static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
@@ -52,22 +55,91 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                CreateClientHandler::class,
+                static fn (ContainerInterface $c): CreateClientHandler => new CreateClientHandler(
+                    self::createUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                UpdateClientHandler::class,
+                static fn (ContainerInterface $c): UpdateClientHandler => new UpdateClientHandler(
+                    self::updateUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                DeleteClientHandler::class,
+                static fn (ContainerInterface $c): DeleteClientHandler => new DeleteClientHandler(
+                    self::deleteUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 ClientNotFoundExceptionHandler::class,
                 static fn (ContainerInterface $c): ClientNotFoundExceptionHandler => new ClientNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                InvalidRegistrationNumberExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidRegistrationNumberExceptionHandler => new InvalidRegistrationNumberExceptionHandler(self::problemDetails($c)),
             )
             ->set(
                 ClientRouteRegistrar::class,
                 static function (ContainerInterface $c): ClientRouteRegistrar {
                     $list = $c->get(ListClientsHandler::class);
                     $get = $c->get(GetClientByIdHandler::class);
+                    $create = $c->get(CreateClientHandler::class);
+                    $update = $c->get(UpdateClientHandler::class);
+                    $delete = $c->get(DeleteClientHandler::class);
 
-                    if (!$list instanceof ListClientsHandler || !$get instanceof GetClientByIdHandler) {
+                    if (!$list instanceof ListClientsHandler
+                        || !$get instanceof GetClientByIdHandler
+                        || !$create instanceof CreateClientHandler
+                        || !$update instanceof UpdateClientHandler
+                        || !$delete instanceof DeleteClientHandler
+                    ) {
                         throw new LogicException('Client handler services are invalid.');
                     }
 
-                    return new ClientRouteRegistrar($list, $get);
+                    return new ClientRouteRegistrar($list, $get, $create, $update, $delete);
                 },
             );
+    }
+
+    private static function createUseCase(ContainerInterface $c): CreateClientUseCase
+    {
+        $u = $c->get(CreateClientUseCase::class);
+
+        if (!$u instanceof CreateClientUseCase) {
+            throw new LogicException('Create client use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function updateUseCase(ContainerInterface $c): UpdateClientUseCase
+    {
+        $u = $c->get(UpdateClientUseCase::class);
+
+        if (!$u instanceof UpdateClientUseCase) {
+            throw new LogicException('Update client use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function deleteUseCase(ContainerInterface $c): DeleteClientUseCase
+    {
+        $u = $c->get(DeleteClientUseCase::class);
+
+        if (!$u instanceof DeleteClientUseCase) {
+            throw new LogicException('Delete client use case service is invalid.');
+        }
+
+        return $u;
     }
 
     private static function repository(ContainerInterface $c): ClientRepositoryInterface

--- a/src/Client/CreateClientHandler.php
+++ b/src/Client/CreateClientHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/clients` — creates a client in the caller's organization.
+ */
+final readonly class CreateClientHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private CreateClientUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $name = $decoded['name'] ?? null;
+
+        if (!is_string($name) || $name === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
+        }
+
+        $client = $this->useCase->execute($organizationId, new CreateClientInput(
+            name: $name,
+            contactName: ClientField::optionalString($decoded, 'contact_name'),
+            email: ClientField::optionalString($decoded, 'email'),
+            billingAddress: ClientField::optionalString($decoded, 'billing_address'),
+            registrationNumber: ClientField::optionalString($decoded, 'registration_number'),
+        ));
+
+        return $this->json->create(ClientResponse::toArray($client), 201);
+    }
+}

--- a/src/Client/CreateClientInput.php
+++ b/src/Client/CreateClientInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class CreateClientInput
+{
+    public function __construct(
+        public string $name,
+        public ?string $contactName = null,
+        public ?string $email = null,
+        public ?string $billingAddress = null,
+        public ?string $registrationNumber = null,
+    ) {
+    }
+}

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use LogicException;
+
+final readonly class CreateClientUseCase
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+    ) {
+    }
+
+    /**
+     * Creates a client in the caller's organization. The organization is taken
+     * from the authenticated caller, never from request input.
+     *
+     * @throws InvalidRegistrationNumberException
+     */
+    public function execute(int $organizationId, CreateClientInput $input): Client
+    {
+        if ($input->registrationNumber !== null && preg_match(InvalidRegistrationNumberException::PATTERN, $input->registrationNumber) !== 1) {
+            throw new InvalidRegistrationNumberException($input->registrationNumber);
+        }
+
+        $id = $this->clients->save(new Client(
+            organizationId: $organizationId,
+            name: $input->name,
+            contactName: $input->contactName,
+            email: $input->email,
+            billingAddress: $input->billingAddress,
+            registrationNumber: $input->registrationNumber,
+        ));
+
+        $created = $this->clients->findById($id);
+
+        if ($created === null) {
+            throw new LogicException('Client disappeared immediately after creation.');
+        }
+
+        return $created;
+    }
+}

--- a/src/Client/DeleteClientHandler.php
+++ b/src/Client/DeleteClientHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `DELETE /admin/clients/{id}` — soft-deletes a client in the caller's organization.
+ */
+final readonly class DeleteClientHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private DeleteClientUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->useCase->execute($organizationId, $id);
+
+        return $this->json->createEmpty(204);
+    }
+}

--- a/src/Client/DeleteClientUseCase.php
+++ b/src/Client/DeleteClientUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class DeleteClientUseCase
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+    ) {
+    }
+
+    /**
+     * Soft-deletes a client within the caller's organization. Cross-organization
+     * targets are reported as not found.
+     *
+     * @throws ClientNotFoundException
+     */
+    public function execute(int $organizationId, int $id): void
+    {
+        $existing = $this->clients->findById($id);
+
+        if ($existing === null || $existing->organizationId !== $organizationId) {
+            throw new ClientNotFoundException($id);
+        }
+
+        $this->clients->delete($id);
+    }
+}

--- a/src/Client/InvalidRegistrationNumberException.php
+++ b/src/Client/InvalidRegistrationNumberException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use DomainException;
+
+/**
+ * Thrown when a client's Japan invoice registration number is present but does
+ * not match the required syntax `T` + 13 digits. This is a **syntax** check only
+ * (it does not verify existence) — see accounting-compliance.md §4.
+ */
+final class InvalidRegistrationNumberException extends DomainException
+{
+    public const PATTERN = '/^T[0-9]{13}$/';
+
+    public function __construct(string $value)
+    {
+        parent::__construct(sprintf('Registration number "%s" must be "T" followed by 13 digits.', $value));
+    }
+}

--- a/src/Client/InvalidRegistrationNumberExceptionHandler.php
+++ b/src/Client/InvalidRegistrationNumberExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidRegistrationNumberExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidRegistrationNumberException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invalid-registration-number', 'Unprocessable Entity', 422, $exception->getMessage());
+    }
+}

--- a/src/Client/UpdateClientHandler.php
+++ b/src/Client/UpdateClientHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `PATCH /admin/clients/{id}` — updates a client in the caller's organization.
+ */
+final readonly class UpdateClientHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private UpdateClientUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $name = $decoded['name'] ?? null;
+
+        if (!is_string($name) || $name === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
+        }
+
+        $client = $this->useCase->execute($organizationId, $id, new UpdateClientInput(
+            name: $name,
+            contactName: ClientField::optionalString($decoded, 'contact_name'),
+            email: ClientField::optionalString($decoded, 'email'),
+            billingAddress: ClientField::optionalString($decoded, 'billing_address'),
+            registrationNumber: ClientField::optionalString($decoded, 'registration_number'),
+        ));
+
+        return $this->json->create(ClientResponse::toArray($client));
+    }
+}

--- a/src/Client/UpdateClientInput.php
+++ b/src/Client/UpdateClientInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+final readonly class UpdateClientInput
+{
+    public function __construct(
+        public string $name,
+        public ?string $contactName = null,
+        public ?string $email = null,
+        public ?string $billingAddress = null,
+        public ?string $registrationNumber = null,
+    ) {
+    }
+}

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+use LogicException;
+
+final readonly class UpdateClientUseCase
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+    ) {
+    }
+
+    /**
+     * Updates a client within the caller's organization. A client from another
+     * organization (or soft-deleted) is reported as not found.
+     *
+     * @throws ClientNotFoundException
+     * @throws InvalidRegistrationNumberException
+     */
+    public function execute(int $organizationId, int $id, UpdateClientInput $input): Client
+    {
+        $existing = $this->clients->findById($id);
+
+        if ($existing === null || $existing->organizationId !== $organizationId) {
+            throw new ClientNotFoundException($id);
+        }
+
+        if ($input->registrationNumber !== null && preg_match(InvalidRegistrationNumberException::PATTERN, $input->registrationNumber) !== 1) {
+            throw new InvalidRegistrationNumberException($input->registrationNumber);
+        }
+
+        $this->clients->update(new Client(
+            organizationId: $existing->organizationId,
+            name: $input->name,
+            contactName: $input->contactName,
+            email: $input->email,
+            billingAddress: $input->billingAddress,
+            registrationNumber: $input->registrationNumber,
+            isDeleted: false,
+            id: $existing->id,
+            createdAt: $existing->createdAt,
+            updatedAt: $existing->updatedAt,
+        ));
+
+        $updated = $this->clients->findById($id);
+
+        if ($updated === null) {
+            throw new LogicException('Client disappeared immediately after update.');
+        }
+
+        return $updated;
+    }
+}

--- a/tests/Client/ClientWriteUseCasesTest.php
+++ b/tests/Client/ClientWriteUseCasesTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Client;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\CreateClientInput;
+use NeneInvoice\Client\CreateClientUseCase;
+use NeneInvoice\Client\DeleteClientUseCase;
+use NeneInvoice\Client\InvalidRegistrationNumberException;
+use NeneInvoice\Client\UpdateClientInput;
+use NeneInvoice\Client\UpdateClientUseCase;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ClientWriteUseCasesTest extends TestCase
+{
+    private InMemoryClientRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryClientRepository();
+    }
+
+    public function test_create_forces_caller_organization(): void
+    {
+        $client = (new CreateClientUseCase($this->repo))->execute(7, new CreateClientInput(name: 'Acme'));
+
+        self::assertSame(7, $client->organizationId);
+        self::assertSame('Acme', $client->name);
+    }
+
+    public function test_create_accepts_valid_registration_number(): void
+    {
+        $client = (new CreateClientUseCase($this->repo))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: 'T1234567890123'));
+
+        self::assertSame('T1234567890123', $client->registrationNumber);
+    }
+
+    public function test_create_rejects_malformed_registration_number(): void
+    {
+        $this->expectException(InvalidRegistrationNumberException::class);
+        (new CreateClientUseCase($this->repo))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
+    }
+
+    public function test_update_blocks_cross_organization_target(): void
+    {
+        $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
+
+        $this->expectException(ClientNotFoundException::class);
+        (new UpdateClientUseCase($this->repo))->execute(1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
+    }
+
+    public function test_update_changes_fields_in_same_organization(): void
+    {
+        $id = $this->repo->save(new Client(organizationId: 1, name: 'Before'));
+
+        $updated = (new UpdateClientUseCase($this->repo))->execute(1, $id, new UpdateClientInput(name: 'After', email: 'a@x'));
+
+        self::assertSame('After', $updated->name);
+        self::assertSame('a@x', $updated->email);
+    }
+
+    public function test_delete_soft_deletes_in_same_organization(): void
+    {
+        $id = $this->repo->save(new Client(organizationId: 1, name: 'Temp'));
+
+        (new DeleteClientUseCase($this->repo))->execute(1, $id);
+
+        self::assertNull($this->repo->findById($id));
+    }
+
+    public function test_delete_blocks_cross_organization_target(): void
+    {
+        $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
+
+        $this->expectException(ClientNotFoundException::class);
+        (new DeleteClientUseCase($this->repo))->execute(1, $otherOrg);
+    }
+}


### PR DESCRIPTION
Closes #45

## 目的

取引先 CRUD を完結させる。組織スコープ・ソフト削除・適格請求書 buyer 登録番号の構文検証。

## エンドポイント（`manage_billing` / org スコープ）

| Method | Path | 結果 |
| --- | --- | --- |
| POST | `/admin/clients` | 201（name 必須、org は呼出元に固定） |
| PATCH | `/admin/clients/{id}` | 200（他組織 404） |
| DELETE | `/admin/clients/{id}` | 204（ソフト削除、他組織 404） |

## コンプライアンス

`registration_number`（buyer・任意）は指定時 UseCase で **`^T[0-9]{13}$`** を構文検証（accounting-compliance §4、実在性検証ではない）→ 不正は **422 `invalid-registration-number`**。

## 検証

- **`composer check` green**: PHPUnit **61 tests / 173 assertions**・PHPStan level 8 **no errors**・cs clean
- UseCase テスト（org強制 / 登録番号検証 / クロス組織404 / ソフト削除）
- ライブ: create **201**(org固定) / bad-reg **422** / no-name **422** / patch **200** / patch-other-org **404** / delete **204**→get **404** / delete-other-org **404**

## セルフレビュー

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)