### PR TITLE
feat(company): 発行者プロフィール（company settings）と登録番号検証の共有化 (#47)

### DIFF
--- a/database/migrations/20260529150000_create_company_settings_table.php
+++ b/database/migrations/20260529150000_create_company_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateCompanySettingsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('company_settings')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('legal_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('address', 'text', ['null' => true, 'default' => null])
+            ->addColumn('phone', 'string', ['limit' => 32, 'null' => true, 'default' => null])
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('registration_number', 'string', ['limit' => 14, 'null' => true, 'default' => null])
+            ->addColumn('bank_name', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('bank_branch', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('account_type', 'string', ['limit' => 32, 'null' => true, 'default' => null])
+            ->addColumn('account_number', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('logo_url', 'string', ['limit' => 1024, 'null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['unique' => true, 'name' => 'uniq_company_settings_organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/company_settings.sql
+++ b/database/schema/company_settings.sql
@@ -1,0 +1,19 @@
+-- Schema snapshot for the company_settings table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS company_settings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    legal_name VARCHAR(255) NOT NULL,
+    address TEXT NULL DEFAULT NULL,
+    phone VARCHAR(32) NULL DEFAULT NULL,
+    email VARCHAR(255) NULL DEFAULT NULL,
+    registration_number VARCHAR(14) NULL DEFAULT NULL,
+    bank_name VARCHAR(255) NULL DEFAULT NULL,
+    bank_branch VARCHAR(255) NULL DEFAULT NULL,
+    account_type VARCHAR(32) NULL DEFAULT NULL,
+    account_number VARCHAR(64) NULL DEFAULT NULL,
+    logo_url VARCHAR(1024) NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX uniq_company_settings_organization_id ON company_settings (organization_id);

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -119,6 +119,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request |
 | `invalid-state-transition` | Disallowed status change |
+| `company-settings-not-found` | Issuer profile not configured for the organization (404) |
 | `qualified-invoice-incomplete` | Missing required qualified-invoice field |
 
 Add new slugs here before using them. Validation `errors[].field` uses
@@ -138,6 +139,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `login`, `getCurrentUser` | Auth |
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
+| `getCompanySettings`, `updateCompanySettings` | Company (issuer profile, per org) |
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
 | `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #45)
+Last updated: 2026-05-29 (Issue #47)
 
 ## Recently merged
 
@@ -23,13 +23,14 @@ Last updated: 2026-05-29 (Issue #45)
 - **Issue #39 / PR #40** — ユーザー読み取り（/admin/users）+ org スコープ ✅ merged
 - **Issue #41 / PR #42** — ユーザー write（create/update/delete）✅ merged
 - **Issue #43 / PR #44** — Client（取引先）永続化 + 読み取り ✅ merged
-- **Issue #45** — Client write（create/update/delete）⏳ this PR
+- **Issue #45 / PR #46** — Client write（create/update/delete）✅ merged
+- **Issue #47** — 発行者プロフィール（company settings）+ 登録番号検証の共有化 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #45 | `feat/45-client-write` | Client write（create/update/delete・registration_number T+13 検証） | 🔄 PR pending |
+| #47 | `feat/47-company-settings` | 発行者プロフィール（GET/PUT）+ Compliance\RegistrationNumber 共有化 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -146,12 +147,16 @@ Last updated: 2026-05-29 (Issue #45)
 
 - `clients` table with soft delete; `PdoClientRepository` (reads exclude deleted); `GET /admin/clients[/{id}]` org-scoped
 
-**Phase 1 — Client write: 🔄 in progress** (Issue #45)
+**Phase 1 — Client write: ✅ complete** (Issue #45 / PR #46)
 
-- `POST/PATCH/DELETE /admin/clients` — `manage_billing`, org-scoped; create forces caller org; cross-org → 404; delete is soft
-- `registration_number` (buyer) syntax-validated `^T[0-9]{13}$` in the UseCase → 422 `invalid-registration-number` (accounting-compliance §4)
-- Verified live: create 201 (org forced) / bad-reg 422 / no-name 422 / patch 200 / patch-other-org 404 / delete 204→get 404 / delete-other-org 404
-- Client CRUD complete
+- `POST/PATCH/DELETE /admin/clients` — org-scoped, soft delete, buyer `registration_number` T+13 validated
+
+**Phase 1 — Company settings (issuer profile): 🔄 in progress** (Issue #47)
+
+- `GET /admin/company-settings` (404 if unconfigured) / `PUT` (upsert) — `manage_company_settings`, org-scoped, one row per org
+- `Compliance\RegistrationNumber` is now the single home of the T+13 rule; Client and the issuer both use it
+- Verified live: GET-before 404 / bad-reg 422 / no-legal-name 422 / PUT 200 / GET-after 200 / PUT-again upsert (1 row); per-org scoping
+- Issuer side of qualified invoices is ready
 
 ## Handoff Notes
 
@@ -169,6 +174,6 @@ Last updated: 2026-05-29 (Issue #45)
 
 ## Next steps
 
-1. Company settings (issuer profile, per organization) — incl. issuer `registration_number` (T+13), bank info
-2. Quotes (見積) → Invoices (請求書) → Payments (入金) + tax calc (ADR 0004) + qualified-invoice field validation
-3. Phase 2 admin UI + PDF (minimum for overdue list)
+1. Quotes (見積) — line items (quantity / unit_price_cents / tax_rate_bps), tax calc per ADR 0004 (round once per rate), status machine
+2. Invoices (請求書) — convert from quote, issue, qualified-invoice field validation (accounting-compliance)
+3. Payments (入金) → overdue; then Phase 2 admin UI + PDF

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -11,6 +11,9 @@ use NeneInvoice\Auth\AuthRouteRegistrar;
 use NeneInvoice\Client\ClientNotFoundExceptionHandler;
 use NeneInvoice\Client\ClientRouteRegistrar;
 use NeneInvoice\Client\InvalidRegistrationNumberExceptionHandler;
+use NeneInvoice\Company\CompanyRouteRegistrar;
+use NeneInvoice\Company\CompanySettingsNotFoundExceptionHandler;
+use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -43,6 +46,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $organizationRoutes = $container->get(OrganizationRouteRegistrar::class);
                     $userRoutes = $container->get(UserRouteRegistrar::class);
                     $clientRoutes = $container->get(ClientRouteRegistrar::class);
+                    $companyRoutes = $container->get(CompanyRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -60,7 +64,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Client route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes];
+                    if (!$companyRoutes instanceof CompanyRouteRegistrar) {
+                        throw new LogicException('Company route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes];
                 },
             )
             ->set(
@@ -74,6 +82,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $cannotDeleteSelf = $container->get(CannotDeleteSelfExceptionHandler::class);
                     $clientNotFound = $container->get(ClientNotFoundExceptionHandler::class);
                     $invalidRegNumber = $container->get(InvalidRegistrationNumberExceptionHandler::class);
+                    $companySettingsNotFound = $container->get(CompanySettingsNotFoundExceptionHandler::class);
+                    $companyInvalidRegNumber = $container->get(CompanyInvalidRegistrationNumberExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -107,7 +117,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Invalid registration number exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber];
+                    if (!$companySettingsNotFound instanceof CompanySettingsNotFoundExceptionHandler) {
+                        throw new LogicException('Company settings not-found exception handler service is invalid.');
+                    }
+
+                    if (!$companyInvalidRegNumber instanceof CompanyInvalidRegistrationNumberExceptionHandler) {
+                        throw new LogicException('Company invalid registration number exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber];
                 },
             );
     }

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class CreateClientUseCase
 {
@@ -21,7 +22,7 @@ final readonly class CreateClientUseCase
      */
     public function execute(int $organizationId, CreateClientInput $input): Client
     {
-        if ($input->registrationNumber !== null && preg_match(InvalidRegistrationNumberException::PATTERN, $input->registrationNumber) !== 1) {
+        if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
 

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class UpdateClientUseCase
 {
@@ -28,7 +29,7 @@ final readonly class UpdateClientUseCase
             throw new ClientNotFoundException($id);
         }
 
-        if ($input->registrationNumber !== null && preg_match(InvalidRegistrationNumberException::PATTERN, $input->registrationNumber) !== 1) {
+        if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
 

--- a/src/Company/CompanyRouteRegistrar.php
+++ b/src/Company/CompanyRouteRegistrar.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the issuer-profile routes. Both require `manage_company_settings`
+ * (admin), scoped to the caller's organization.
+ */
+final readonly class CompanyRouteRegistrar
+{
+    public function __construct(
+        private GetCompanySettingsHandler $getHandler,
+        private UpdateCompanySettingsHandler $updateHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $get = $this->getHandler;
+        $update = $this->updateHandler;
+
+        $router->get('/admin/company-settings', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->put('/admin/company-settings', static fn (ServerRequestInterface $r) => $update->handle($r));
+    }
+}

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Company (issuer profile) domain: repository, use cases, handlers,
+ * domain exception handlers, and the route registrar.
+ */
+final readonly class CompanyServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                CompanySettingsRepositoryInterface::class,
+                static function (ContainerInterface $c): CompanySettingsRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoCompanySettingsRepository($query);
+                },
+            )
+            ->set(GetCompanySettingsUseCase::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c)))
+            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c)))
+            ->set(
+                GetCompanySettingsHandler::class,
+                static fn (ContainerInterface $c): GetCompanySettingsHandler => new GetCompanySettingsHandler(
+                    self::getUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                UpdateCompanySettingsHandler::class,
+                static fn (ContainerInterface $c): UpdateCompanySettingsHandler => new UpdateCompanySettingsHandler(
+                    self::updateUseCase($c),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                CompanySettingsNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): CompanySettingsNotFoundExceptionHandler => new CompanySettingsNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                InvalidRegistrationNumberExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidRegistrationNumberExceptionHandler => new InvalidRegistrationNumberExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                CompanyRouteRegistrar::class,
+                static function (ContainerInterface $c): CompanyRouteRegistrar {
+                    $get = $c->get(GetCompanySettingsHandler::class);
+                    $update = $c->get(UpdateCompanySettingsHandler::class);
+
+                    if (!$get instanceof GetCompanySettingsHandler || !$update instanceof UpdateCompanySettingsHandler) {
+                        throw new LogicException('Company settings handler services are invalid.');
+                    }
+
+                    return new CompanyRouteRegistrar($get, $update);
+                },
+            );
+    }
+
+    private static function repository(ContainerInterface $c): CompanySettingsRepositoryInterface
+    {
+        $repo = $c->get(CompanySettingsRepositoryInterface::class);
+
+        if (!$repo instanceof CompanySettingsRepositoryInterface) {
+            throw new LogicException('Company settings repository service is invalid.');
+        }
+
+        return $repo;
+    }
+
+    private static function getUseCase(ContainerInterface $c): GetCompanySettingsUseCase
+    {
+        $u = $c->get(GetCompanySettingsUseCase::class);
+
+        if (!$u instanceof GetCompanySettingsUseCase) {
+            throw new LogicException('Get company settings use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function updateUseCase(ContainerInterface $c): UpdateCompanySettingsUseCase
+    {
+        $u = $c->get(UpdateCompanySettingsUseCase::class);
+
+        if (!$u instanceof UpdateCompanySettingsUseCase) {
+            throw new LogicException('Update company settings use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        $j = $c->get(JsonResponseFactory::class);
+
+        if (!$j instanceof JsonResponseFactory) {
+            throw new LogicException('JSON response factory service is invalid.');
+        }
+
+        return $j;
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        $p = $c->get(ProblemDetailsResponseFactory::class);
+
+        if (!$p instanceof ProblemDetailsResponseFactory) {
+            throw new LogicException('Problem details response factory service is invalid.');
+        }
+
+        return $p;
+    }
+}

--- a/src/Company/CompanySettings.php
+++ b/src/Company/CompanySettings.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+/**
+ * Issuer (自社) profile for one organization — the supplier side of a qualified
+ * invoice. One record per organization.
+ *
+ * `registrationNumber` is the issuer's Japan invoice registration number
+ * (登録番号, `T` + 13 digits). It may be null until the operator registers; an
+ * invoice can only be marked qualified when it is present (enforced later, at
+ * invoice level — see accounting-compliance.md).
+ */
+final readonly class CompanySettings
+{
+    public function __construct(
+        public int $organizationId,
+        public string $legalName,
+        public ?string $address = null,
+        public ?string $phone = null,
+        public ?string $email = null,
+        public ?string $registrationNumber = null,
+        public ?string $bankName = null,
+        public ?string $bankBranch = null,
+        public ?string $accountType = null,
+        public ?string $accountNumber = null,
+        public ?string $logoUrl = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Company/CompanySettingsNotFoundException.php
+++ b/src/Company/CompanySettingsNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use RuntimeException;
+
+final class CompanySettingsNotFoundException extends RuntimeException
+{
+    public function __construct(int $organizationId)
+    {
+        parent::__construct("Company settings for organization {$organizationId} have not been configured.");
+    }
+}

--- a/src/Company/CompanySettingsNotFoundExceptionHandler.php
+++ b/src/Company/CompanySettingsNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CompanySettingsNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof CompanySettingsNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'company-settings-not-found', 'Not Found', 404, 'Company settings have not been configured yet.');
+    }
+}

--- a/src/Company/CompanySettingsRepositoryInterface.php
+++ b/src/Company/CompanySettingsRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+/**
+ * Persistence for the per-organization issuer profile. There is at most one row
+ * per organization; {@see save()} upserts.
+ */
+interface CompanySettingsRepositoryInterface
+{
+    public function findByOrganization(int $organizationId): ?CompanySettings;
+
+    public function save(CompanySettings $settings): void;
+}

--- a/src/Company/CompanySettingsResponse.php
+++ b/src/Company/CompanySettingsResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+/**
+ * Serializes {@see CompanySettings} to its snake_case JSON representation.
+ */
+final class CompanySettingsResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(CompanySettings $settings): array
+    {
+        return [
+            'organization_id' => $settings->organizationId,
+            'legal_name' => $settings->legalName,
+            'address' => $settings->address,
+            'phone' => $settings->phone,
+            'email' => $settings->email,
+            'registration_number' => $settings->registrationNumber,
+            'bank_name' => $settings->bankName,
+            'bank_branch' => $settings->bankBranch,
+            'account_type' => $settings->accountType,
+            'account_number' => $settings->accountNumber,
+            'logo_url' => $settings->logoUrl,
+            'created_at' => $settings->createdAt,
+            'updated_at' => $settings->updatedAt,
+        ];
+    }
+}

--- a/src/Company/GetCompanySettingsHandler.php
+++ b/src/Company/GetCompanySettingsHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/company-settings` — the issuer profile for the caller's organization.
+ * Returns 404 when settings have not been configured yet.
+ */
+final readonly class GetCompanySettingsHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetCompanySettingsUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $settings = $this->useCase->execute($organizationId);
+
+        return $this->json->create(CompanySettingsResponse::toArray($settings));
+    }
+}

--- a/src/Company/GetCompanySettingsUseCase.php
+++ b/src/Company/GetCompanySettingsUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+final readonly class GetCompanySettingsUseCase
+{
+    public function __construct(
+        private CompanySettingsRepositoryInterface $repository,
+    ) {
+    }
+
+    /** @throws CompanySettingsNotFoundException */
+    public function execute(int $organizationId): CompanySettings
+    {
+        $settings = $this->repository->findByOrganization($organizationId);
+
+        if ($settings === null) {
+            throw new CompanySettingsNotFoundException($organizationId);
+        }
+
+        return $settings;
+    }
+}

--- a/src/Company/InvalidRegistrationNumberException.php
+++ b/src/Company/InvalidRegistrationNumberException.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace NeneInvoice\Client;
+namespace NeneInvoice\Company;
 
 use DomainException;
 
 /**
- * Thrown when a client's Japan invoice registration number is present but does
- * not match the required syntax. The rule itself lives in
- * {@see \NeneInvoice\Compliance\RegistrationNumber} (single source of truth).
+ * Thrown when the issuer's registration number is present but malformed. The
+ * rule lives in {@see \NeneInvoice\Compliance\RegistrationNumber}.
  */
 final class InvalidRegistrationNumberException extends DomainException
 {

--- a/src/Company/InvalidRegistrationNumberExceptionHandler.php
+++ b/src/Company/InvalidRegistrationNumberExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidRegistrationNumberExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidRegistrationNumberException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invalid-registration-number', 'Unprocessable Entity', 422, $exception->getMessage());
+    }
+}

--- a/src/Company/PdoCompanySettingsRepository.php
+++ b/src/Company/PdoCompanySettingsRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoCompanySettingsRepository implements CompanySettingsRepositoryInterface
+{
+    private const COLUMNS = 'organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findByOrganization(int $organizationId): ?CompanySettings
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM company_settings WHERE organization_id = ?',
+            [$organizationId],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function save(CompanySettings $settings): void
+    {
+        $now = date('Y-m-d H:i:s');
+        $exists = $this->findByOrganization($settings->organizationId) !== null;
+
+        if ($exists) {
+            $this->query->execute(
+                'UPDATE company_settings SET legal_name = ?, address = ?, phone = ?, email = ?, registration_number = ?, bank_name = ?, bank_branch = ?, account_type = ?, account_number = ?, logo_url = ?, updated_at = ? WHERE organization_id = ?',
+                [
+                    $settings->legalName,
+                    $settings->address,
+                    $settings->phone,
+                    $settings->email,
+                    $settings->registrationNumber,
+                    $settings->bankName,
+                    $settings->bankBranch,
+                    $settings->accountType,
+                    $settings->accountNumber,
+                    $settings->logoUrl,
+                    $now,
+                    $settings->organizationId,
+                ],
+            );
+
+            return;
+        }
+
+        $this->query->execute(
+            'INSERT INTO company_settings (organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $settings->organizationId,
+                $settings->legalName,
+                $settings->address,
+                $settings->phone,
+                $settings->email,
+                $settings->registrationNumber,
+                $settings->bankName,
+                $settings->bankBranch,
+                $settings->accountType,
+                $settings->accountNumber,
+                $settings->logoUrl,
+                $now,
+                $now,
+            ],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): CompanySettings
+    {
+        return new CompanySettings(
+            organizationId: (int) $row['organization_id'],
+            legalName: (string) $row['legal_name'],
+            address: $this->nullableString($row['address'] ?? null),
+            phone: $this->nullableString($row['phone'] ?? null),
+            email: $this->nullableString($row['email'] ?? null),
+            registrationNumber: $this->nullableString($row['registration_number'] ?? null),
+            bankName: $this->nullableString($row['bank_name'] ?? null),
+            bankBranch: $this->nullableString($row['bank_branch'] ?? null),
+            accountType: $this->nullableString($row['account_type'] ?? null),
+            accountNumber: $this->nullableString($row['account_number'] ?? null),
+            logoUrl: $this->nullableString($row['logo_url'] ?? null),
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `PUT /admin/company-settings` — upserts the issuer profile for the caller's
+ * organization.
+ */
+final readonly class UpdateCompanySettingsHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private UpdateCompanySettingsUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $legalName = $decoded['legal_name'] ?? null;
+
+        if (!is_string($legalName) || $legalName === '') {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"legal_name" is required.');
+        }
+
+        $settings = $this->useCase->execute($organizationId, new UpdateCompanySettingsInput(
+            legalName: $legalName,
+            address: $this->optional($decoded, 'address'),
+            phone: $this->optional($decoded, 'phone'),
+            email: $this->optional($decoded, 'email'),
+            registrationNumber: $this->optional($decoded, 'registration_number'),
+            bankName: $this->optional($decoded, 'bank_name'),
+            bankBranch: $this->optional($decoded, 'bank_branch'),
+            accountType: $this->optional($decoded, 'account_type'),
+            accountNumber: $this->optional($decoded, 'account_number'),
+            logoUrl: $this->optional($decoded, 'logo_url'),
+        ));
+
+        return $this->json->create(CompanySettingsResponse::toArray($settings));
+    }
+
+    /** @param array<string, mixed> $body */
+    private function optional(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Company/UpdateCompanySettingsInput.php
+++ b/src/Company/UpdateCompanySettingsInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+final readonly class UpdateCompanySettingsInput
+{
+    public function __construct(
+        public string $legalName,
+        public ?string $address = null,
+        public ?string $phone = null,
+        public ?string $email = null,
+        public ?string $registrationNumber = null,
+        public ?string $bankName = null,
+        public ?string $bankBranch = null,
+        public ?string $accountType = null,
+        public ?string $accountNumber = null,
+        public ?string $logoUrl = null,
+    ) {
+    }
+}

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use LogicException;
+use NeneInvoice\Compliance\RegistrationNumber;
+
+final readonly class UpdateCompanySettingsUseCase
+{
+    public function __construct(
+        private CompanySettingsRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * Upserts the issuer profile for the caller's organization.
+     *
+     * @throws InvalidRegistrationNumberException
+     */
+    public function execute(int $organizationId, UpdateCompanySettingsInput $input): CompanySettings
+    {
+        if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
+            throw new InvalidRegistrationNumberException($input->registrationNumber);
+        }
+
+        $this->repository->save(new CompanySettings(
+            organizationId: $organizationId,
+            legalName: $input->legalName,
+            address: $input->address,
+            phone: $input->phone,
+            email: $input->email,
+            registrationNumber: $input->registrationNumber,
+            bankName: $input->bankName,
+            bankBranch: $input->bankBranch,
+            accountType: $input->accountType,
+            accountNumber: $input->accountNumber,
+            logoUrl: $input->logoUrl,
+        ));
+
+        $saved = $this->repository->findByOrganization($organizationId);
+
+        if ($saved === null) {
+            throw new LogicException('Company settings disappeared immediately after save.');
+        }
+
+        return $saved;
+    }
+}

--- a/src/Compliance/RegistrationNumber.php
+++ b/src/Compliance/RegistrationNumber.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Compliance;
+
+/**
+ * Single source of truth for the Japan invoice registration number (登録番号)
+ * **syntax** rule: `T` followed by 13 digits. This validates format only — it
+ * does not verify the number exists or compute a check digit
+ * (see `docs/explanation/accounting-compliance.md` §4).
+ *
+ * Used by both the buyer (Client) and the issuer (CompanySettings).
+ */
+final class RegistrationNumber
+{
+    public const PATTERN = '/^T[0-9]{13}$/';
+
+    public static function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -22,6 +22,7 @@ use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
+use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -46,6 +47,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new OrganizationServiceProvider());
         $builder->addProvider(new UserServiceProvider());
         $builder->addProvider(new ClientServiceProvider());
+        $builder->addProvider(new CompanyServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/Company/CompanySettingsTest.php
+++ b/tests/Company/CompanySettingsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Company;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Company\CompanySettingsNotFoundException;
+use NeneInvoice\Company\GetCompanySettingsUseCase;
+use NeneInvoice\Company\InvalidRegistrationNumberException;
+use NeneInvoice\Company\PdoCompanySettingsRepository;
+use NeneInvoice\Company\UpdateCompanySettingsInput;
+use NeneInvoice\Company\UpdateCompanySettingsUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class CompanySettingsTest extends TestCase
+{
+    private PdoCompanySettingsRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/company_settings.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_get_throws_when_not_configured(): void
+    {
+        $this->expectException(CompanySettingsNotFoundException::class);
+        (new GetCompanySettingsUseCase($this->repository))->execute(1);
+    }
+
+    public function test_update_upserts_and_get_returns_settings(): void
+    {
+        $update = new UpdateCompanySettingsUseCase($this->repository);
+
+        $created = $update->execute(1, new UpdateCompanySettingsInput(
+            legalName: '株式会社あやね',
+            registrationNumber: 'T1234567890123',
+            bankName: 'みずほ',
+        ));
+        self::assertSame('株式会社あやね', $created->legalName);
+        self::assertSame('T1234567890123', $created->registrationNumber);
+
+        // Upsert: a second update replaces, not duplicates.
+        $update->execute(1, new UpdateCompanySettingsInput(legalName: '株式会社あやね（改）'));
+
+        $fetched = (new GetCompanySettingsUseCase($this->repository))->execute(1);
+        self::assertSame('株式会社あやね（改）', $fetched->legalName);
+        self::assertNull($fetched->registrationNumber);
+    }
+
+    public function test_update_rejects_malformed_registration_number(): void
+    {
+        $this->expectException(InvalidRegistrationNumberException::class);
+        (new UpdateCompanySettingsUseCase($this->repository))->execute(1, new UpdateCompanySettingsInput(
+            legalName: 'X',
+            registrationNumber: 'bad',
+        ));
+    }
+
+    public function test_settings_are_scoped_per_organization(): void
+    {
+        $update = new UpdateCompanySettingsUseCase($this->repository);
+        $update->execute(1, new UpdateCompanySettingsInput(legalName: 'Org One'));
+        $update->execute(2, new UpdateCompanySettingsInput(legalName: 'Org Two'));
+
+        self::assertSame('Org One', (new GetCompanySettingsUseCase($this->repository))->execute(1)->legalName);
+        self::assertSame('Org Two', (new GetCompanySettingsUseCase($this->repository))->execute(2)->legalName);
+    }
+}

--- a/tests/Compliance/RegistrationNumberTest.php
+++ b/tests/Compliance/RegistrationNumberTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Compliance;
+
+use NeneInvoice\Compliance\RegistrationNumber;
+use PHPUnit\Framework\TestCase;
+
+final class RegistrationNumberTest extends TestCase
+{
+    public function test_accepts_t_plus_13_digits(): void
+    {
+        self::assertTrue(RegistrationNumber::isValid('T1234567890123'));
+    }
+
+    public function test_rejects_malformed_values(): void
+    {
+        self::assertFalse(RegistrationNumber::isValid('1234567890123'));   // no T
+        self::assertFalse(RegistrationNumber::isValid('T123456789012'));   // 12 digits
+        self::assertFalse(RegistrationNumber::isValid('T12345678901234')); // 14 digits
+        self::assertFalse(RegistrationNumber::isValid('TABCDEFGHIJKLM'));  // letters
+        self::assertFalse(RegistrationNumber::isValid(''));
+    }
+}


### PR DESCRIPTION
Closes #47

## 目的

適格請求書の**発行者（自社）情報**を組織ごとに管理。登録番号 T+13 規則を単一の正本へ共有化。

## エンドポイント（`manage_company_settings` / org スコープ）

| Method | Path | 結果 |
| --- | --- | --- |
| GET | `/admin/company-settings` | 200 / 404 `company-settings-not-found`（未設定） |
| PUT | `/admin/company-settings` | 200（upsert・legal_name 必須・reg は T+13 検証→422） |

## 共有化

- **`Compliance\RegistrationNumber`** が `^T[0-9]{13}$` 規則の**単一の正本**（`isValid()`）。Client（buyer）と発行者の両方がこれを使用（規則の単一ソース化、accounting-compliance §4）。

## 検証

- **`composer check` green**: PHPUnit **67 tests / 191 assertions**・PHPStan level 8 **no errors**・cs clean
- リポジトリ/UseCase テスト（**upsert**・登録番号検証・組織別スコープ）+ `RegistrationNumber` 単体
- ライブ: GET-before **404** / bad-reg **422** / no-legal-name **422** / PUT **200** / GET-after **200** / PUT-again **upsert（DB 1行）**

## セルフレビュー

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)