### PR TITLE
feat(tax): 税計算エンジン（ADR 0004: 税率ごと1回丸め）を追加する (#49)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #47)
+Last updated: 2026-05-29 (Issue #49)
 
 ## Recently merged
 
@@ -24,13 +24,14 @@ Last updated: 2026-05-29 (Issue #47)
 - **Issue #41 / PR #42** — ユーザー write（create/update/delete）✅ merged
 - **Issue #43 / PR #44** — Client（取引先）永続化 + 読み取り ✅ merged
 - **Issue #45 / PR #46** — Client write（create/update/delete）✅ merged
-- **Issue #47** — 発行者プロフィール（company settings）+ 登録番号検証の共有化 ⏳ this PR
+- **Issue #47 / PR #48** — 発行者プロフィール（company settings）+ 登録番号検証共有化 ✅ merged
+- **Issue #49** — 税計算エンジン（ADR 0004）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #47 | `feat/47-company-settings` | 発行者プロフィール（GET/PUT）+ Compliance\RegistrationNumber 共有化 | 🔄 PR pending |
+| #49 | `feat/49-tax-calculator` | 税計算エンジン（ADR 0004: 税率ごと1回丸め）純粋ドメイン | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -151,12 +152,16 @@ Last updated: 2026-05-29 (Issue #47)
 
 - `POST/PATCH/DELETE /admin/clients` — org-scoped, soft delete, buyer `registration_number` T+13 validated
 
-**Phase 1 — Company settings (issuer profile): 🔄 in progress** (Issue #47)
+**Phase 1 — Company settings (issuer profile): ✅ complete** (Issue #47 / PR #48)
 
-- `GET /admin/company-settings` (404 if unconfigured) / `PUT` (upsert) — `manage_company_settings`, org-scoped, one row per org
-- `Compliance\RegistrationNumber` is now the single home of the T+13 rule; Client and the issuer both use it
-- Verified live: GET-before 404 / bad-reg 422 / no-legal-name 422 / PUT 200 / GET-after 200 / PUT-again upsert (1 row); per-org scoping
-- Issuer side of qualified invoices is ready
+- `GET/PUT /admin/company-settings` (upsert, one row per org); `Compliance\RegistrationNumber` single home of the T+13 rule
+
+**Phase 1 — Tax calculation engine: 🔄 in progress** (Issue #49)
+
+- `LineItem\TaxCalculator` (pure, integer-only): groups line subtotals by `tax_rate_bps`, rounds **once per rate** half-up (ADR 0004)
+- Returns subtotal / tax / total + per-rate breakdown (税率ごとの対価の額・消費税額 for qualified invoices)
+- Unit-tested incl. the round-once-per-rate proof (8% × ¥105 + ¥105 → 17, not 8+8=16), mixed 10/8, half-up boundary
+- Single source of truth for document totals; quotes/invoices will use it
 
 ## Handoff Notes
 
@@ -174,6 +179,6 @@ Last updated: 2026-05-29 (Issue #47)
 
 ## Next steps
 
-1. Quotes (見積) — line items (quantity / unit_price_cents / tax_rate_bps), tax calc per ADR 0004 (round once per rate), status machine
-2. Invoices (請求書) — convert from quote, issue, qualified-invoice field validation (accounting-compliance)
-3. Payments (入金) → overdue; then Phase 2 admin UI + PDF
+1. Quote persistence — `quotes` + `line_items` tables, `document_sequences` numbering (EST-YYYY-NNN), repository
+2. Quote CRUD + status machine (draft→sent→accepted/rejected/expired), using `TaxCalculator` for totals
+3. Invoices (convert from quote, issue, qualified-invoice validation) → Payments → overdue

--- a/src/LineItem/LineItemInput.php
+++ b/src/LineItem/LineItemInput.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * One line on a quote or invoice, used as input to tax calculation.
+ *
+ * Money is integer cents (smallest currency unit); the tax rate is basis points
+ * (1000 = 10%, 800 = 8%). The line subtotal is intentionally **not** rounded —
+ * rounding happens once per tax rate at the document level (ADR 0004).
+ */
+final readonly class LineItemInput
+{
+    public function __construct(
+        public string $description,
+        public int $quantity,
+        public int $unitPriceCents,
+        public int $taxRateBps,
+    ) {
+    }
+
+    public function lineSubtotalCents(): int
+    {
+        return $this->quantity * $this->unitPriceCents;
+    }
+}

--- a/src/LineItem/TaxBreakdownLine.php
+++ b/src/LineItem/TaxBreakdownLine.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Per-tax-rate breakdown: the taxable amount and the consumption tax for one
+ * rate. These are the 税率ごとの対価の額 / 税率ごとの消費税額 a qualified
+ * invoice must display.
+ */
+final readonly class TaxBreakdownLine
+{
+    public function __construct(
+        public int $taxRateBps,
+        public int $taxableAmountCents,
+        public int $taxCents,
+    ) {
+    }
+}

--- a/src/LineItem/TaxCalculationResult.php
+++ b/src/LineItem/TaxCalculationResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * The single source of truth for a document's monetary totals. The API response
+ * and the PDF both render these exact values; neither recalculates (ADR 0004,
+ * accounting-compliance.md).
+ */
+final readonly class TaxCalculationResult
+{
+    /** @param list<TaxBreakdownLine> $breakdown ordered by ascending tax rate */
+    public function __construct(
+        public int $subtotalCents,
+        public int $taxCents,
+        public int $totalCents,
+        public array $breakdown,
+    ) {
+    }
+}

--- a/src/LineItem/TaxCalculator.php
+++ b/src/LineItem/TaxCalculator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Computes consumption tax for a set of line items.
+ *
+ * Per ADR 0004 / accounting-compliance.md §3, tax is rounded **once per tax
+ * rate per document** — never per line. Line subtotals are summed per rate
+ * first, then a single half-up rounding is applied to each rate group. All
+ * arithmetic is integer-only (no floats for money).
+ */
+final class TaxCalculator
+{
+    /** @param list<LineItemInput> $lines */
+    public function calculate(array $lines): TaxCalculationResult
+    {
+        // Sum taxable amounts per rate, preserving first-seen order, then sort by rate.
+        /** @var array<int, int> $taxableByRate */
+        $taxableByRate = [];
+
+        foreach ($lines as $line) {
+            $taxableByRate[$line->taxRateBps] = ($taxableByRate[$line->taxRateBps] ?? 0) + $line->lineSubtotalCents();
+        }
+
+        ksort($taxableByRate);
+
+        $breakdown = [];
+        $subtotalCents = 0;
+        $taxCents = 0;
+
+        foreach ($taxableByRate as $rateBps => $taxableAmountCents) {
+            $rateTaxCents = self::roundHalfUp($taxableAmountCents, $rateBps);
+
+            $breakdown[] = new TaxBreakdownLine($rateBps, $taxableAmountCents, $rateTaxCents);
+            $subtotalCents += $taxableAmountCents;
+            $taxCents += $rateTaxCents;
+        }
+
+        return new TaxCalculationResult(
+            subtotalCents: $subtotalCents,
+            taxCents: $taxCents,
+            totalCents: $subtotalCents + $taxCents,
+            breakdown: $breakdown,
+        );
+    }
+
+    /**
+     * Half-up rounding of `taxableAmountCents * rateBps / 10000`, integer-only.
+     * Valid for non-negative amounts (billing amounts are non-negative).
+     */
+    private static function roundHalfUp(int $taxableAmountCents, int $rateBps): int
+    {
+        return intdiv($taxableAmountCents * $rateBps + 5000, 10000);
+    }
+}

--- a/tests/LineItem/TaxCalculatorTest.php
+++ b/tests/LineItem/TaxCalculatorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\LineItem;
+
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\TaxCalculator;
+use PHPUnit\Framework\TestCase;
+
+final class TaxCalculatorTest extends TestCase
+{
+    private TaxCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new TaxCalculator();
+    }
+
+    public function test_empty_document_is_all_zero(): void
+    {
+        $result = $this->calculator->calculate([]);
+
+        self::assertSame(0, $result->subtotalCents);
+        self::assertSame(0, $result->taxCents);
+        self::assertSame(0, $result->totalCents);
+        self::assertSame([], $result->breakdown);
+    }
+
+    public function test_single_rate_10_percent(): void
+    {
+        // 3 × ¥1,000 = ¥3,000 ; tax 10% = ¥300 ; total ¥3,300
+        $result = $this->calculator->calculate([
+            new LineItemInput('Widget', 3, 1000, 1000),
+        ]);
+
+        self::assertSame(3000, $result->subtotalCents);
+        self::assertSame(300, $result->taxCents);
+        self::assertSame(3300, $result->totalCents);
+        self::assertCount(1, $result->breakdown);
+        self::assertSame(1000, $result->breakdown[0]->taxRateBps);
+        self::assertSame(3000, $result->breakdown[0]->taxableAmountCents);
+        self::assertSame(300, $result->breakdown[0]->taxCents);
+    }
+
+    public function test_rounds_once_per_rate_not_per_line(): void
+    {
+        // Two 8% lines of ¥105 each.
+        // Per-line rounding: round(8.4)+round(8.4) = 8+8 = 16 (WRONG).
+        // Per-rate (ADR 0004): round(210 × 8%) = round(16.8) = 17 (CORRECT).
+        $result = $this->calculator->calculate([
+            new LineItemInput('A', 1, 105, 800),
+            new LineItemInput('B', 1, 105, 800),
+        ]);
+
+        self::assertSame(210, $result->subtotalCents);
+        self::assertSame(17, $result->taxCents);
+        self::assertSame(227, $result->totalCents);
+    }
+
+    public function test_mixed_10_and_8_percent_breakdown(): void
+    {
+        // 10%: ¥2,000 → tax ¥200 ; 8%: ¥1,500 → tax ¥120
+        $result = $this->calculator->calculate([
+            new LineItemInput('Standard', 2, 1000, 1000),
+            new LineItemInput('Reduced', 1, 1500, 800),
+        ]);
+
+        self::assertSame(3500, $result->subtotalCents);
+        self::assertSame(320, $result->taxCents);
+        self::assertSame(3820, $result->totalCents);
+
+        // Breakdown ordered by ascending rate: 8% then 10%.
+        self::assertCount(2, $result->breakdown);
+        self::assertSame(800, $result->breakdown[0]->taxRateBps);
+        self::assertSame(1500, $result->breakdown[0]->taxableAmountCents);
+        self::assertSame(120, $result->breakdown[0]->taxCents);
+        self::assertSame(1000, $result->breakdown[1]->taxRateBps);
+        self::assertSame(2000, $result->breakdown[1]->taxableAmountCents);
+        self::assertSame(200, $result->breakdown[1]->taxCents);
+    }
+
+    public function test_half_up_rounding_at_boundary(): void
+    {
+        // ¥5 × 10% = ¥0.5 → half-up → ¥1
+        $result = $this->calculator->calculate([
+            new LineItemInput('Tiny', 1, 5, 1000),
+        ]);
+
+        self::assertSame(1, $result->taxCents);
+    }
+}


### PR DESCRIPTION
Closes #49

## 目的

見積・請求書の核となる消費税計算を、**純粋・単体テスト可能なドメインサービス**として実装。コンプライアンスの心臓部（ADR 0004 / accounting-compliance §3）。

## アルゴリズム

- 各 line: `line_subtotal = quantity × unit_price_cents`（**行では丸めない**）
- 税率ごとに合算 → 税率ごとに **1回だけ** half-up 丸め（整数演算 `intdiv(taxable×rate + 5000, 10000)`、float 不使用）
- `subtotal / tax / total` ＋ **税率ごとの内訳**（適格請求書の「税率ごとの対価の額・消費税額」）

## 検証

- **`composer check` green**: PHPUnit **72 tests / 216 assertions**・PHPStan level 8 **no errors**・cs clean
- 単体テスト: 空 / 単一10% / 10%・8%混在の内訳 / half-up 境界（¥5×10%→¥1）/ **「税率ごと1回」を行ごと丸め(8+8=16)との差(17)で証明**

## 非範囲（後続）

- `quotes` / `line_items` テーブル・採番・CRUD・状態機械（この結果を単一の真実として使用）

## セルフレビュー

Self-review: backend-api, docs-policy（compliance）

🤖 Generated with [Claude Code](https://claude.com/claude-code)