### PR TITLE
feat(audit): 監査ログ基盤（全操作の before/after 記録）+ ADR 0008 (#51)

### DIFF
--- a/database/migrations/20260529160000_create_audit_logs_table.php
+++ b/database/migrations/20260529160000_create_audit_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateAuditLogsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('audit_logs')
+            ->addColumn('actor_user_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('organization_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('action', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('entity_type', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('entity_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('before_json', 'text', ['null' => true, 'default' => null])
+            ->addColumn('after_json', 'text', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_audit_logs_organization_id'])
+            ->addIndex(['entity_type', 'entity_id'], ['name' => 'idx_audit_logs_entity'])
+            ->create();
+    }
+}

--- a/database/schema/audit_logs.sql
+++ b/database/schema/audit_logs.sql
@@ -1,0 +1,15 @@
+-- Schema snapshot for the audit_logs table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    actor_user_id INTEGER NULL DEFAULT NULL,
+    organization_id INTEGER NULL DEFAULT NULL,
+    action VARCHAR(64) NOT NULL,
+    entity_type VARCHAR(64) NOT NULL,
+    entity_id INTEGER NULL DEFAULT NULL,
+    before_json TEXT NULL DEFAULT NULL,
+    after_json TEXT NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL
+);
+CREATE INDEX idx_audit_logs_organization_id ON audit_logs (organization_id);
+CREATE INDEX idx_audit_logs_entity ON audit_logs (entity_type, entity_id);

--- a/docs/adr/0008-audit-logging.md
+++ b/docs/adr/0008-audit-logging.md
@@ -1,0 +1,78 @@
+# ADR 0008: Audit Logging of All Mutating Operations
+
+## Status
+
+accepted
+
+## Context
+
+`accounting-compliance.md` §8 requires an audit trail for billing-sensitive
+actions, and the maintainer wants **every** mutating operation to record who
+changed what, including the **before and after** state. A reviewer (or an
+auditor) must be able to reconstruct the history of any record.
+
+We need a consistent, cross-cutting mechanism that works for all current and
+future domains (organizations, users, clients, company settings, and the coming
+quotes / invoices / payments) without scattering ad-hoc logging.
+
+Alternatives considered:
+
+1. **Middleware-level logging** — rejected; middleware sees the HTTP request but
+   not the domain before/after state, and cannot cleanly name the entity changed.
+2. **Repository-level logging** — rejected; repositories know the row but not the
+   actor (that is request/auth context) nor the business action name.
+3. **UseCase-level recording via an `AuditRecorder`** (chosen) — the use case has
+   both the actor/tenant context and the before/after entity state, and names the
+   business action. This is where the change is meaningful.
+
+## Decision
+
+A dedicated `audit_logs` table records one row per mutating operation:
+
+| Column | Meaning |
+| --- | --- |
+| `actor_user_id` | The authenticated user who performed it (null for system) |
+| `organization_id` | Tenant the change belongs to |
+| `action` | `{entity}.{verb}` (e.g. `client.created`, `user.updated`, `client.deleted`) |
+| `entity_type` / `entity_id` | What was changed |
+| `before_json` | Sanitized snapshot before the change (null for create) |
+| `after_json` | Sanitized snapshot after the change (null for delete) |
+| `created_at` | When |
+
+- **Recording happens in the UseCase** via `Audit\AuditRecorder`. Use cases
+  already receive the tenant context and fetch the "before" state; handlers pass
+  the **actor user id** (from token claims via `AuthContext`).
+- **Before/after are sanitized snapshots** produced by the same `*Response`
+  presenters used for API output, so **secrets (e.g. `password_hash`) are never
+  written to the audit log**. The field-level diff is derivable from the two
+  snapshots.
+- **All create / update / delete operations** record an entry. Reads are not
+  audited. Soft deletes record a `*.deleted` action with the before snapshot.
+- New domains (quotes, invoices, payments, …) record audit from the start.
+
+## Consequences
+
+**Benefits**
+
+- Uniform, compliance-aligned trail of who changed what, with before/after.
+- Secrets excluded by reusing sanitized presenters.
+- Future-proof: new mutating use cases follow the same pattern.
+
+**Costs / limitations**
+
+- Use cases gain an `AuditRecorder` dependency and an `actorUserId` argument.
+- **Recording is synchronous and best-effort after the mutation, not yet in the
+  same DB transaction.** A crash between the mutation and the audit write could
+  drop an entry. Wrapping mutation + audit in one transaction is a planned
+  follow-up (the framework provides a transaction manager).
+
+**Follow-up**
+
+- Retrofit Organization / User / CompanySettings use cases.
+- Add a read endpoint (`GET /admin/audit-logs`) for admins/superadmin.
+- Make mutation + audit atomic via a transaction boundary.
+
+## Related
+
+- Compliance: `docs/explanation/accounting-compliance.md` §8
+- Issue: `#51`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #49)
+Last updated: 2026-05-29 (Issue #51)
 
 ## Recently merged
 
@@ -25,13 +25,14 @@ Last updated: 2026-05-29 (Issue #49)
 - **Issue #43 / PR #44** — Client（取引先）永続化 + 読み取り ✅ merged
 - **Issue #45 / PR #46** — Client write（create/update/delete）✅ merged
 - **Issue #47 / PR #48** — 発行者プロフィール（company settings）+ 登録番号検証共有化 ✅ merged
-- **Issue #49** — 税計算エンジン（ADR 0004）⏳ this PR
+- **Issue #49 / PR #50** — 税計算エンジン（ADR 0004）✅ merged
+- **Issue #51** — 監査ログ基盤（ADR 0008）+ Client 統合 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #49 | `feat/49-tax-calculator` | 税計算エンジン（ADR 0004: 税率ごと1回丸め）純粋ドメイン | 🔄 PR pending |
+| #51 | `feat/51-audit-log` | 監査ログ基盤（ADR 0008・before/after）+ Client 統合 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -156,12 +157,18 @@ Last updated: 2026-05-29 (Issue #49)
 
 - `GET/PUT /admin/company-settings` (upsert, one row per org); `Compliance\RegistrationNumber` single home of the T+13 rule
 
-**Phase 1 — Tax calculation engine: 🔄 in progress** (Issue #49)
+**Phase 1 — Tax calculation engine: ✅ complete** (Issue #49 / PR #50)
 
-- `LineItem\TaxCalculator` (pure, integer-only): groups line subtotals by `tax_rate_bps`, rounds **once per rate** half-up (ADR 0004)
-- Returns subtotal / tax / total + per-rate breakdown (税率ごとの対価の額・消費税額 for qualified invoices)
-- Unit-tested incl. the round-once-per-rate proof (8% × ¥105 + ¥105 → 17, not 8+8=16), mixed 10/8, half-up boundary
-- Single source of truth for document totals; quotes/invoices will use it
+- `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
+
+**Phase 1 — Audit logging foundation: 🔄 in progress** (Issue #51, ADR 0008)
+
+- `audit_logs` table + `Audit\AuditRecorder`: who (actor_user_id) / org / action / entity / **before & after sanitized snapshots**
+- Recorded in the UseCase; snapshots reuse `*Response` presenters so secrets (password_hash) are never logged
+- **Integrated into Client create/update/delete** (reference); actor plumbed from `AuthContext`
+- Verified live: create (before=null), update (before+after), delete (after=null) rows written; no password_hash leaked
+- Limitation (ADR 0008): recording is synchronous best-effort, not yet in the mutation's DB transaction
+- Next: retrofit Organization / User / CompanySettings; audit read endpoint
 
 ## Handoff Notes
 
@@ -179,6 +186,6 @@ Last updated: 2026-05-29 (Issue #49)
 
 ## Next steps
 
-1. Quote persistence — `quotes` + `line_items` tables, `document_sequences` numbering (EST-YYYY-NNN), repository
-2. Quote CRUD + status machine (draft→sent→accepted/rejected/expired), using `TaxCalculator` for totals
-3. Invoices (convert from quote, issue, qualified-invoice validation) → Payments → overdue
+1. Retrofit audit into Organization / User / CompanySettings mutating use cases (ADR 0008)
+2. Quote persistence — `quotes` + `line_items`, `document_sequences` numbering (EST-YYYY-NNN); built with audit + `TaxCalculator`
+3. Quote CRUD + status machine → Invoices (convert/issue/qualified validation) → Payments → overdue

--- a/src/Audit/AuditLog.php
+++ b/src/Audit/AuditLog.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * One recorded mutating operation (ADR 0008).
+ *
+ * `before` / `after` are sanitized snapshots (no secrets) of the affected entity.
+ * `before` is null for creates; `after` is null for deletes.
+ */
+final readonly class AuditLog
+{
+    /**
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>|null $after
+     */
+    public function __construct(
+        public string $action,
+        public string $entityType,
+        public ?int $actorUserId = null,
+        public ?int $organizationId = null,
+        public ?int $entityId = null,
+        public ?array $before = null,
+        public ?array $after = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+    ) {
+    }
+}

--- a/src/Audit/AuditLogRepositoryInterface.php
+++ b/src/Audit/AuditLogRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * Append-only persistence for the audit trail.
+ */
+interface AuditLogRepositoryInterface
+{
+    public function append(AuditLog $log): int;
+
+    /** @return list<AuditLog> */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+}

--- a/src/Audit/AuditRecorder.php
+++ b/src/Audit/AuditRecorder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+final readonly class AuditRecorder implements AuditRecorderInterface
+{
+    public function __construct(
+        private AuditLogRepositoryInterface $repository,
+    ) {
+    }
+
+    public function record(
+        ?int $actorUserId,
+        ?int $organizationId,
+        string $action,
+        string $entityType,
+        ?int $entityId,
+        ?array $before,
+        ?array $after,
+    ): void {
+        $this->repository->append(new AuditLog(
+            action: $action,
+            entityType: $entityType,
+            actorUserId: $actorUserId,
+            organizationId: $organizationId,
+            entityId: $entityId,
+            before: $before,
+            after: $after,
+        ));
+    }
+}

--- a/src/Audit/AuditRecorderInterface.php
+++ b/src/Audit/AuditRecorderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * Records a mutating operation in the audit trail (ADR 0008). Use cases call
+ * this after a successful create / update / delete.
+ */
+interface AuditRecorderInterface
+{
+    /**
+     * @param array<string, mixed>|null $before sanitized snapshot before the change (null for create)
+     * @param array<string, mixed>|null $after  sanitized snapshot after the change (null for delete)
+     */
+    public function record(
+        ?int $actorUserId,
+        ?int $organizationId,
+        string $action,
+        string $entityType,
+        ?int $entityId,
+        ?array $before,
+        ?array $after,
+    ): void;
+}

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the audit trail: repository and recorder (ADR 0008).
+ */
+final readonly class AuditServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AuditLogRepositoryInterface::class,
+                static function (ContainerInterface $c): AuditLogRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoAuditLogRepository($query);
+                },
+            )
+            ->set(
+                AuditRecorderInterface::class,
+                static function (ContainerInterface $c): AuditRecorderInterface {
+                    $repo = $c->get(AuditLogRepositoryInterface::class);
+
+                    if (!$repo instanceof AuditLogRepositoryInterface) {
+                        throw new LogicException('Audit log repository service is invalid.');
+                    }
+
+                    return new AuditRecorder($repo);
+                },
+            );
+    }
+}

--- a/src/Audit/PdoAuditLogRepository.php
+++ b/src/Audit/PdoAuditLogRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterface
+{
+    private const COLUMNS = 'id, actor_user_id, organization_id, action, entity_type, entity_id, before_json, after_json, created_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function append(AuditLog $log): int
+    {
+        $this->query->execute(
+            'INSERT INTO audit_logs (actor_user_id, organization_id, action, entity_type, entity_id, before_json, after_json, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $log->actorUserId,
+                $log->organizationId,
+                $log->action,
+                $log->entityType,
+                $log->entityId,
+                self::encode($log->before),
+                self::encode($log->after),
+                date('Y-m-d H:i:s'),
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /** @return list<AuditLog> */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM audit_logs WHERE organization_id = ? ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): AuditLog => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM audit_logs WHERE organization_id = ?', [$organizationId]);
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    /** @param array<string, mixed>|null $value */
+    private static function encode(?array $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * @param string|null $json
+     * @return array<string, mixed>|null
+     */
+    private static function decode(?string $json): ?array
+    {
+        if ($json === null || $json === '') {
+            return null;
+        }
+
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): AuditLog
+    {
+        return new AuditLog(
+            action: (string) $row['action'],
+            entityType: (string) $row['entity_type'],
+            actorUserId: isset($row['actor_user_id']) ? (int) $row['actor_user_id'] : null,
+            organizationId: isset($row['organization_id']) ? (int) $row['organization_id'] : null,
+            entityId: isset($row['entity_id']) ? (int) $row['entity_id'] : null,
+            before: self::decode(isset($row['before_json']) ? (string) $row['before_json'] : null),
+            after: self::decode(isset($row['after_json']) ? (string) $row['after_json'] : null),
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+        );
+    }
+}

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -35,9 +36,9 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
             )
             ->set(ListClientsUseCase::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
             ->set(GetClientByIdUseCase::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
-            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c)))
-            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c)))
-            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c)))
+            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c)))
+            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c)))
+            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c)))
             ->set(
                 ListClientsHandler::class,
                 static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
@@ -151,6 +152,17 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
         }
 
         return $repo;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $recorder = $c->get(AuditRecorderInterface::class);
+
+        if (!$recorder instanceof AuditRecorderInterface) {
+            throw new LogicException('Audit recorder service is invalid.');
+        }
+
+        return $recorder;
     }
 
     private static function listUseCase(ContainerInterface $c): ListClientsUseCase

--- a/src/Client/CreateClientHandler.php
+++ b/src/Client/CreateClientHandler.php
@@ -43,7 +43,7 @@ final readonly class CreateClientHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
         }
 
-        $client = $this->useCase->execute($organizationId, new CreateClientInput(
+        $client = $this->useCase->execute($organizationId, AuthContext::userId($request), new CreateClientInput(
             name: $name,
             contactName: ClientField::optionalString($decoded, 'contact_name'),
             email: ClientField::optionalString($decoded, 'email'),

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class CreateClientUseCase
 {
     public function __construct(
         private ClientRepositoryInterface $clients,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -20,7 +22,7 @@ final readonly class CreateClientUseCase
      *
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, CreateClientInput $input): Client
+    public function execute(int $organizationId, ?int $actorUserId, CreateClientInput $input): Client
     {
         if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
@@ -40,6 +42,8 @@ final readonly class CreateClientUseCase
         if ($created === null) {
             throw new LogicException('Client disappeared immediately after creation.');
         }
+
+        $this->audit->record($actorUserId, $organizationId, 'client.created', 'client', $id, null, ClientResponse::toArray($created));
 
         return $created;
     }

--- a/src/Client/DeleteClientHandler.php
+++ b/src/Client/DeleteClientHandler.php
@@ -35,7 +35,7 @@ final readonly class DeleteClientHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $this->useCase->execute($organizationId, $id);
+        $this->useCase->execute($organizationId, AuthContext::userId($request), $id);
 
         return $this->json->createEmpty(204);
     }

--- a/src/Client/DeleteClientUseCase.php
+++ b/src/Client/DeleteClientUseCase.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use NeneInvoice\Audit\AuditRecorderInterface;
+
 final readonly class DeleteClientUseCase
 {
     public function __construct(
         private ClientRepositoryInterface $clients,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -17,7 +20,7 @@ final readonly class DeleteClientUseCase
      *
      * @throws ClientNotFoundException
      */
-    public function execute(int $organizationId, int $id): void
+    public function execute(int $organizationId, ?int $actorUserId, int $id): void
     {
         $existing = $this->clients->findById($id);
 
@@ -26,5 +29,7 @@ final readonly class DeleteClientUseCase
         }
 
         $this->clients->delete($id);
+
+        $this->audit->record($actorUserId, $organizationId, 'client.deleted', 'client', $id, ClientResponse::toArray($existing), null);
     }
 }

--- a/src/Client/UpdateClientHandler.php
+++ b/src/Client/UpdateClientHandler.php
@@ -47,7 +47,7 @@ final readonly class UpdateClientHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
         }
 
-        $client = $this->useCase->execute($organizationId, $id, new UpdateClientInput(
+        $client = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new UpdateClientInput(
             name: $name,
             contactName: ClientField::optionalString($decoded, 'contact_name'),
             email: ClientField::optionalString($decoded, 'email'),

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class UpdateClientUseCase
 {
     public function __construct(
         private ClientRepositoryInterface $clients,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -21,7 +23,7 @@ final readonly class UpdateClientUseCase
      * @throws ClientNotFoundException
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, int $id, UpdateClientInput $input): Client
+    public function execute(int $organizationId, ?int $actorUserId, int $id, UpdateClientInput $input): Client
     {
         $existing = $this->clients->findById($id);
 
@@ -51,6 +53,8 @@ final readonly class UpdateClientUseCase
         if ($updated === null) {
             throw new LogicException('Client disappeared immediately after update.');
         }
+
+        $this->audit->record($actorUserId, $organizationId, 'client.updated', 'client', $id, ClientResponse::toArray($existing), ClientResponse::toArray($updated));
 
         return $updated;
     }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -19,6 +19,7 @@ use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
@@ -43,6 +44,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder->addProvider(new ApplicationServiceProvider());
+        $builder->addProvider(new AuditServiceProvider());
         $builder->addProvider(new AuthServiceProvider());
         $builder->addProvider(new OrganizationServiceProvider());
         $builder->addProvider(new UserServiceProvider());

--- a/tests/Audit/AuditLogTest.php
+++ b/tests/Audit/AuditLogTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Audit;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Audit\AuditRecorder;
+use NeneInvoice\Audit\PdoAuditLogRepository;
+use PHPUnit\Framework\TestCase;
+
+final class AuditLogTest extends TestCase
+{
+    private PdoAuditLogRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/audit_logs.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoAuditLogRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_recorder_persists_before_and_after_snapshots(): void
+    {
+        $recorder = new AuditRecorder($this->repository);
+
+        $recorder->record(7, 1, 'client.updated', 'client', 42, ['name' => '前'], ['name' => '後']);
+
+        $logs = $this->repository->findByOrganization(1, 10, 0);
+        self::assertCount(1, $logs);
+        self::assertSame('client.updated', $logs[0]->action);
+        self::assertSame(7, $logs[0]->actorUserId);
+        self::assertSame(42, $logs[0]->entityId);
+        self::assertSame(['name' => '前'], $logs[0]->before);
+        self::assertSame(['name' => '後'], $logs[0]->after);
+    }
+
+    public function test_logs_are_scoped_and_counted_per_organization(): void
+    {
+        $recorder = new AuditRecorder($this->repository);
+        $recorder->record(1, 1, 'client.created', 'client', 1, null, ['name' => 'A']);
+        $recorder->record(1, 1, 'client.deleted', 'client', 1, ['name' => 'A'], null);
+        $recorder->record(1, 2, 'client.created', 'client', 9, null, ['name' => 'B']);
+
+        self::assertSame(2, $this->repository->countByOrganization(1));
+        self::assertSame(1, $this->repository->countByOrganization(2));
+
+        // Most recent first.
+        $logs = $this->repository->findByOrganization(1, 10, 0);
+        self::assertSame('client.deleted', $logs[0]->action);
+    }
+}

--- a/tests/Client/ClientWriteUseCasesTest.php
+++ b/tests/Client/ClientWriteUseCasesTest.php
@@ -13,36 +13,53 @@ use NeneInvoice\Client\InvalidRegistrationNumberException;
 use NeneInvoice\Client\UpdateClientInput;
 use NeneInvoice\Client\UpdateClientUseCase;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
 
 final class ClientWriteUseCasesTest extends TestCase
 {
     private InMemoryClientRepository $repo;
+    private RecordingAuditRecorder $audit;
 
     protected function setUp(): void
     {
         $this->repo = new InMemoryClientRepository();
+        $this->audit = new RecordingAuditRecorder();
     }
 
-    public function test_create_forces_caller_organization(): void
+    public function test_create_forces_caller_organization_and_audits(): void
     {
-        $client = (new CreateClientUseCase($this->repo))->execute(7, new CreateClientInput(name: 'Acme'));
+        $client = (new CreateClientUseCase($this->repo, $this->audit))->execute(7, 42, new CreateClientInput(name: 'Acme'));
 
         self::assertSame(7, $client->organizationId);
-        self::assertSame('Acme', $client->name);
-    }
 
-    public function test_create_accepts_valid_registration_number(): void
-    {
-        $client = (new CreateClientUseCase($this->repo))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: 'T1234567890123'));
-
-        self::assertSame('T1234567890123', $client->registrationNumber);
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame('client.created', $record['action']);
+        self::assertSame(42, $record['actor_user_id']);
+        self::assertSame(7, $record['organization_id']);
+        self::assertNull($record['before']);
+        self::assertIsArray($record['after']);
+        self::assertSame('Acme', $record['after']['name']);
     }
 
     public function test_create_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new CreateClientUseCase($this->repo))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
+        (new CreateClientUseCase($this->repo, $this->audit))->execute(1, 1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
+    }
+
+    public function test_update_records_before_and_after(): void
+    {
+        $id = $this->repo->save(new Client(organizationId: 1, name: 'Before'));
+
+        (new UpdateClientUseCase($this->repo, $this->audit))->execute(1, 9, $id, new UpdateClientInput(name: 'After'));
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame('client.updated', $record['action']);
+        self::assertSame('Before', $record['before']['name'] ?? null);
+        self::assertSame('After', $record['after']['name'] ?? null);
     }
 
     public function test_update_blocks_cross_organization_target(): void
@@ -50,26 +67,21 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new UpdateClientUseCase($this->repo))->execute(1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
+        (new UpdateClientUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
     }
 
-    public function test_update_changes_fields_in_same_organization(): void
-    {
-        $id = $this->repo->save(new Client(organizationId: 1, name: 'Before'));
-
-        $updated = (new UpdateClientUseCase($this->repo))->execute(1, $id, new UpdateClientInput(name: 'After', email: 'a@x'));
-
-        self::assertSame('After', $updated->name);
-        self::assertSame('a@x', $updated->email);
-    }
-
-    public function test_delete_soft_deletes_in_same_organization(): void
+    public function test_delete_soft_deletes_and_records_before_only(): void
     {
         $id = $this->repo->save(new Client(organizationId: 1, name: 'Temp'));
 
-        (new DeleteClientUseCase($this->repo))->execute(1, $id);
+        (new DeleteClientUseCase($this->repo, $this->audit))->execute(1, 5, $id);
 
         self::assertNull($this->repo->findById($id));
+
+        $record = $this->audit->records[0];
+        self::assertSame('client.deleted', $record['action']);
+        self::assertSame('Temp', $record['before']['name'] ?? null);
+        self::assertNull($record['after']);
     }
 
     public function test_delete_blocks_cross_organization_target(): void
@@ -77,6 +89,6 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new DeleteClientUseCase($this->repo))->execute(1, $otherOrg);
+        (new DeleteClientUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrg);
     }
 }

--- a/tests/Support/RecordingAuditRecorder.php
+++ b/tests/Support/RecordingAuditRecorder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+/**
+ * Test spy that captures audit recordings instead of persisting them.
+ */
+final class RecordingAuditRecorder implements AuditRecorderInterface
+{
+    /** @var list<array<string, mixed>> */
+    public array $records = [];
+
+    public function record(
+        ?int $actorUserId,
+        ?int $organizationId,
+        string $action,
+        string $entityType,
+        ?int $entityId,
+        ?array $before,
+        ?array $after,
+    ): void {
+        $this->records[] = [
+            'actor_user_id' => $actorUserId,
+            'organization_id' => $organizationId,
+            'action' => $action,
+            'entity_type' => $entityType,
+            'entity_id' => $entityId,
+            'before' => $before,
+            'after' => $after,
+        ];
+    }
+}


### PR DESCRIPTION
Closes #51

## 目的

会計コンプライアンス（accounting-compliance §8）の監査要件。**全 mutating 操作で「誰が・何を・どう変えたか（前後）」を記録**する基盤を作り、Client に参照統合する。

## 設計（ADR 0008）

- **UseCase 層**で `Audit\AuditRecorder` により記録（actor/org 文脈と before/after を保持）
- before/after は `*Response` presenter 由来の**サニタイズ済みスナップショット** → `password_hash` 等の機密は**記録しない**
- 同期記録（成功後）。トランザクション統合は将来拡張（ADR に明記）

## 変更内容

- `audit_logs`（actor_user_id, organization_id, action, entity_type, entity_id, before_json, after_json, created_at）+ マイグレーション + schema
- `Audit\` モジュール（AuditLog / Repository / AuditRecorder / ServiceProvider）
- **Client create/update/delete に統合**（actor を `AuthContext` から plumbing）

## 検証

- **`composer check` green**: PHPUnit **73 tests / 237 assertions**・PHPStan level 8 **no errors**・cs clean
- リポジトリ/recorder テスト（before/after・org スコープ）、Client 統合（spy recorder）
- ライブ: `client.created`(before=null) / `client.updated`(before+after) / `client.deleted`(after=null) の監査行を確認、`password_hash` **非記録**を確認

## 非範囲（次 PR）

- Organization / User / CompanySettings の retrofit、監査閲覧エンドポイント、監査のトランザクション統合

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)