### PR TITLE
feat(audit): 監査を Organization / User / CompanySettings に展開する (#53)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #51)
+Last updated: 2026-05-29 (Issue #53)
 
 ## Recently merged
 
@@ -26,13 +26,14 @@ Last updated: 2026-05-29 (Issue #51)
 - **Issue #45 / PR #46** — Client write（create/update/delete）✅ merged
 - **Issue #47 / PR #48** — 発行者プロフィール（company settings）+ 登録番号検証共有化 ✅ merged
 - **Issue #49 / PR #50** — 税計算エンジン（ADR 0004）✅ merged
-- **Issue #51** — 監査ログ基盤（ADR 0008）+ Client 統合 ⏳ this PR
+- **Issue #51 / PR #52** — 監査ログ基盤（ADR 0008）+ Client 統合 ✅ merged
+- **Issue #53** — 監査ログを Organization / User / CompanySettings に retrofit ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #51 | `feat/51-audit-log` | 監査ログ基盤（ADR 0008・before/after）+ Client 統合 | 🔄 PR pending |
+| #53 | `feat/53-audit-retrofit` | 監査を Organization / User / CompanySettings に展開 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -161,14 +162,13 @@ Last updated: 2026-05-29 (Issue #51)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Audit logging foundation: 🔄 in progress** (Issue #51, ADR 0008)
+**Phase 1 — Audit logging: ✅ foundation + full platform coverage** (Issue #51 / PR #52, Issue #53)
 
-- `audit_logs` table + `Audit\AuditRecorder`: who (actor_user_id) / org / action / entity / **before & after sanitized snapshots**
-- Recorded in the UseCase; snapshots reuse `*Response` presenters so secrets (password_hash) are never logged
-- **Integrated into Client create/update/delete** (reference); actor plumbed from `AuthContext`
-- Verified live: create (before=null), update (before+after), delete (after=null) rows written; no password_hash leaked
-- Limitation (ADR 0008): recording is synchronous best-effort, not yet in the mutation's DB transaction
-- Next: retrofit Organization / User / CompanySettings; audit read endpoint
+- `audit_logs` + `Audit\AuditRecorder` (ADR 0008): actor / org / action / entity / before & after sanitized snapshots
+- **Integrated into every mutating operation**: Client, Organization (create/delete), User (create/update/delete), CompanySettings (upsert → created/updated)
+- Verified live: all write actions record rows with the correct actor; `password_hash` never logged
+- Limitation (ADR 0008): synchronous best-effort recording, not yet in the mutation's DB transaction (planned)
+- Follow-up: audit read endpoint (`GET /admin/audit-logs`); transactional recording
 
 ## Handoff Notes
 
@@ -186,6 +186,6 @@ Last updated: 2026-05-29 (Issue #51)
 
 ## Next steps
 
-1. Retrofit audit into Organization / User / CompanySettings mutating use cases (ADR 0008)
-2. Quote persistence — `quotes` + `line_items`, `document_sequences` numbering (EST-YYYY-NNN); built with audit + `TaxCalculator`
-3. Quote CRUD + status machine → Invoices (convert/issue/qualified validation) → Payments → overdue
+1. Quote persistence — `quotes` + `line_items`, `document_sequences` numbering (EST-YYYY-NNN); built with audit + `TaxCalculator` from the start
+2. Quote CRUD + status machine (draft→sent→accepted/rejected/expired)
+3. Invoices (convert/issue/qualified validation) → Payments → overdue; then audit read endpoint

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -34,7 +35,7 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(GetCompanySettingsUseCase::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c)))
-            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c)))
+            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c)))
             ->set(
                 GetCompanySettingsHandler::class,
                 static fn (ContainerInterface $c): GetCompanySettingsHandler => new GetCompanySettingsHandler(
@@ -83,6 +84,17 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
         }
 
         return $repo;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $recorder = $c->get(AuditRecorderInterface::class);
+
+        if (!$recorder instanceof AuditRecorderInterface) {
+            throw new LogicException('Audit recorder service is invalid.');
+        }
+
+        return $recorder;
     }
 
     private static function getUseCase(ContainerInterface $c): GetCompanySettingsUseCase

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -44,7 +44,7 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"legal_name" is required.');
         }
 
-        $settings = $this->useCase->execute($organizationId, new UpdateCompanySettingsInput(
+        $settings = $this->useCase->execute($organizationId, AuthContext::userId($request), new UpdateCompanySettingsInput(
             legalName: $legalName,
             address: $this->optional($decoded, 'address'),
             phone: $this->optional($decoded, 'phone'),

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeneInvoice\Company;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class UpdateCompanySettingsUseCase
 {
     public function __construct(
         private CompanySettingsRepositoryInterface $repository,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -19,11 +21,13 @@ final readonly class UpdateCompanySettingsUseCase
      *
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, UpdateCompanySettingsInput $input): CompanySettings
+    public function execute(int $organizationId, ?int $actorUserId, UpdateCompanySettingsInput $input): CompanySettings
     {
         if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
+
+        $existing = $this->repository->findByOrganization($organizationId);
 
         $this->repository->save(new CompanySettings(
             organizationId: $organizationId,
@@ -44,6 +48,16 @@ final readonly class UpdateCompanySettingsUseCase
         if ($saved === null) {
             throw new LogicException('Company settings disappeared immediately after save.');
         }
+
+        $this->audit->record(
+            $actorUserId,
+            $organizationId,
+            $existing === null ? 'company_settings.created' : 'company_settings.updated',
+            'company_settings',
+            $organizationId,
+            $existing !== null ? CompanySettingsResponse::toArray($existing) : null,
+            CompanySettingsResponse::toArray($saved),
+        );
 
         return $saved;
     }

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Organization;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -40,7 +41,7 @@ final readonly class CreateOrganizationHandler implements RequestHandlerInterfac
         $plan = $decoded['plan'] ?? 'free';
         $plan = is_string($plan) && $plan !== '' ? $plan : 'free';
 
-        $organization = $this->useCase->execute(new CreateOrganizationInput($name, $slug, $plan));
+        $organization = $this->useCase->execute(AuthContext::userId($request), new CreateOrganizationInput($name, $slug, $plan));
 
         return $this->json->create(OrganizationResponse::toArray($organization), 201);
     }

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\Organization;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class CreateOrganizationUseCase
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
     /** @throws OrganizationSlugConflictException */
-    public function execute(CreateOrganizationInput $input): Organization
+    public function execute(?int $actorUserId, CreateOrganizationInput $input): Organization
     {
         $id = $this->organizations->save(new Organization(
             name: $input->name,
@@ -28,6 +30,8 @@ final readonly class CreateOrganizationUseCase
         if ($created === null) {
             throw new LogicException('Organization disappeared immediately after creation.');
         }
+
+        $this->audit->record($actorUserId, $id, 'organization.created', 'organization', $id, null, OrganizationResponse::toArray($created));
 
         return $created;
     }

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Organization;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -27,7 +28,7 @@ final readonly class DeleteOrganizationHandler implements RequestHandlerInterfac
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $this->useCase->execute($id);
+        $this->useCase->execute(AuthContext::userId($request), $id);
 
         return $this->json->createEmpty(204);
     }

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -4,16 +4,27 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
+use NeneInvoice\Audit\AuditRecorderInterface;
+
 final readonly class DeleteOrganizationUseCase
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
     /** @throws OrganizationNotFoundException */
-    public function execute(int $id): void
+    public function execute(?int $actorUserId, int $id): void
     {
+        $existing = $this->organizations->findById($id);
+
+        if ($existing === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
         $this->organizations->delete($id);
+
+        $this->audit->record($actorUserId, $id, 'organization.deleted', 'organization', $id, OrganizationResponse::toArray($existing), null);
     }
 }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -35,8 +36,8 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
             )
             ->set(ListOrganizationsUseCase::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
             ->set(GetOrganizationByIdUseCase::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
-            ->set(CreateOrganizationUseCase::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c)))
-            ->set(DeleteOrganizationUseCase::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c)))
+            ->set(CreateOrganizationUseCase::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c), self::audit($c)))
+            ->set(DeleteOrganizationUseCase::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::audit($c)))
             ->set(
                 ListOrganizationsHandler::class,
                 static fn (ContainerInterface $c): ListOrganizationsHandler => new ListOrganizationsHandler(
@@ -104,6 +105,17 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
         }
 
         return $repo;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $recorder = $c->get(AuditRecorderInterface::class);
+
+        if (!$recorder instanceof AuditRecorderInterface) {
+            throw new LogicException('Audit recorder service is invalid.');
+        }
+
+        return $recorder;
     }
 
     private static function listUseCase(ContainerInterface $c): ListOrganizationsUseCase

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -52,7 +52,7 @@ final readonly class CreateUserHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
         }
 
-        $user = $this->useCase->execute($organizationId, new CreateUserInput($email, $password, $role));
+        $user = $this->useCase->execute($organizationId, AuthContext::userId($request), new CreateUserInput($email, $password, $role));
 
         return $this->json->create(UserResponse::toArray($user), 201);
     }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeneInvoice\User;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
 final readonly class CreateUserUseCase
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -22,7 +24,7 @@ final readonly class CreateUserUseCase
      * @throws RoleNotAssignableException   when attempting to assign superadmin
      * @throws UserEmailConflictException   when the email is already in use
      */
-    public function execute(int $organizationId, CreateUserInput $input): User
+    public function execute(int $organizationId, ?int $actorUserId, CreateUserInput $input): User
     {
         if ($input->role === Role::Superadmin) {
             throw new RoleNotAssignableException($input->role);
@@ -41,6 +43,8 @@ final readonly class CreateUserUseCase
         if ($created === null) {
             throw new LogicException('User disappeared immediately after creation.');
         }
+
+        $this->audit->record($actorUserId, $organizationId, 'user.created', 'user', $id, null, UserResponse::toArray($created));
 
         return $created;
     }

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use NeneInvoice\Audit\AuditRecorderInterface;
+
 final readonly class DeleteUserUseCase
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -31,5 +34,7 @@ final readonly class DeleteUserUseCase
         }
 
         $this->users->delete($userId);
+
+        $this->audit->record($callerUserId, $organizationId, 'user.deleted', 'user', $userId, UserResponse::toArray($existing), null);
     }
 }

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -61,7 +61,7 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
         $passwordValue = $decoded['password'] ?? null;
         $password = is_string($passwordValue) && $passwordValue !== '' ? $passwordValue : null;
 
-        $user = $this->useCase->execute($organizationId, $id, new UpdateUserInput($role, $status, $password));
+        $user = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new UpdateUserInput($role, $status, $password));
 
         return $this->json->create(UserResponse::toArray($user));
     }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace NeneInvoice\User;
 
 use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
 final readonly class UpdateUserUseCase
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditRecorderInterface $audit,
     ) {
     }
 
@@ -22,7 +24,7 @@ final readonly class UpdateUserUseCase
      * @throws UserNotFoundException        when the user is missing or in another org
      * @throws RoleNotAssignableException   when attempting to assign superadmin
      */
-    public function execute(int $organizationId, int $userId, UpdateUserInput $input): User
+    public function execute(int $organizationId, ?int $actorUserId, int $userId, UpdateUserInput $input): User
     {
         $existing = $this->users->findById($userId);
 
@@ -50,6 +52,8 @@ final readonly class UpdateUserUseCase
         if ($updated === null) {
             throw new LogicException('User disappeared immediately after update.');
         }
+
+        $this->audit->record($actorUserId, $organizationId, 'user.updated', 'user', $userId, UserResponse::toArray($existing), UserResponse::toArray($updated));
 
         return $updated;
     }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -23,9 +24,9 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         $builder
             ->set(ListUsersUseCase::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
             ->set(GetUserByIdUseCase::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
-            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c)))
-            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c)))
-            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c)))
+            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c)))
+            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c)))
+            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c)))
             ->set(
                 ListUsersHandler::class,
                 static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
@@ -114,6 +115,17 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         }
 
         return $repo;
+    }
+
+    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    {
+        $recorder = $c->get(AuditRecorderInterface::class);
+
+        if (!$recorder instanceof AuditRecorderInterface) {
+            throw new LogicException('Audit recorder service is invalid.');
+        }
+
+        return $recorder;
     }
 
     private static function listUseCase(ContainerInterface $c): ListUsersUseCase

--- a/tests/Company/CompanySettingsTest.php
+++ b/tests/Company/CompanySettingsTest.php
@@ -13,14 +13,18 @@ use NeneInvoice\Company\InvalidRegistrationNumberException;
 use NeneInvoice\Company\PdoCompanySettingsRepository;
 use NeneInvoice\Company\UpdateCompanySettingsInput;
 use NeneInvoice\Company\UpdateCompanySettingsUseCase;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
 
 final class CompanySettingsTest extends TestCase
 {
     private PdoCompanySettingsRepository $repository;
+    private RecordingAuditRecorder $audit;
 
     protected function setUp(): void
     {
+        $this->audit = new RecordingAuditRecorder();
+
         $config = new DatabaseConfig(
             url: null,
             environment: 'test',
@@ -50,9 +54,9 @@ final class CompanySettingsTest extends TestCase
 
     public function test_update_upserts_and_get_returns_settings(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository);
+        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit);
 
-        $created = $update->execute(1, new UpdateCompanySettingsInput(
+        $created = $update->execute(1, 5, new UpdateCompanySettingsInput(
             legalName: '株式会社あやね',
             registrationNumber: 'T1234567890123',
             bankName: 'みずほ',
@@ -61,7 +65,7 @@ final class CompanySettingsTest extends TestCase
         self::assertSame('T1234567890123', $created->registrationNumber);
 
         // Upsert: a second update replaces, not duplicates.
-        $update->execute(1, new UpdateCompanySettingsInput(legalName: '株式会社あやね（改）'));
+        $update->execute(1, 5, new UpdateCompanySettingsInput(legalName: '株式会社あやね（改）'));
 
         $fetched = (new GetCompanySettingsUseCase($this->repository))->execute(1);
         self::assertSame('株式会社あやね（改）', $fetched->legalName);
@@ -71,7 +75,7 @@ final class CompanySettingsTest extends TestCase
     public function test_update_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new UpdateCompanySettingsUseCase($this->repository))->execute(1, new UpdateCompanySettingsInput(
+        (new UpdateCompanySettingsUseCase($this->repository, $this->audit))->execute(1, 5, new UpdateCompanySettingsInput(
             legalName: 'X',
             registrationNumber: 'bad',
         ));
@@ -79,9 +83,9 @@ final class CompanySettingsTest extends TestCase
 
     public function test_settings_are_scoped_per_organization(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository);
-        $update->execute(1, new UpdateCompanySettingsInput(legalName: 'Org One'));
-        $update->execute(2, new UpdateCompanySettingsInput(legalName: 'Org Two'));
+        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit);
+        $update->execute(1, 5, new UpdateCompanySettingsInput(legalName: 'Org One'));
+        $update->execute(2, 5, new UpdateCompanySettingsInput(legalName: 'Org Two'));
 
         self::assertSame('Org One', (new GetCompanySettingsUseCase($this->repository))->execute(1)->legalName);
         self::assertSame('Org Two', (new GetCompanySettingsUseCase($this->repository))->execute(2)->legalName);

--- a/tests/Organization/OrganizationUseCasesTest.php
+++ b/tests/Organization/OrganizationUseCasesTest.php
@@ -12,45 +12,50 @@ use NeneInvoice\Organization\ListOrganizationsUseCase;
 use NeneInvoice\Organization\OrganizationNotFoundException;
 use NeneInvoice\Organization\OrganizationSlugConflictException;
 use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
 
 final class OrganizationUseCasesTest extends TestCase
 {
     private InMemoryOrganizationRepository $repo;
+    private RecordingAuditRecorder $audit;
 
     protected function setUp(): void
     {
         $this->repo = new InMemoryOrganizationRepository();
+        $this->audit = new RecordingAuditRecorder();
     }
 
-    public function test_create_persists_and_returns_organization_with_id(): void
+    public function test_create_persists_returns_with_id_and_audits(): void
     {
-        $useCase = new CreateOrganizationUseCase($this->repo);
+        $useCase = new CreateOrganizationUseCase($this->repo, $this->audit);
 
-        $org = $useCase->execute(new CreateOrganizationInput('Acme', 'acme'));
+        $org = $useCase->execute(1, new CreateOrganizationInput('Acme', 'acme'));
 
         self::assertNotNull($org->id);
         self::assertSame('Acme', $org->name);
-        self::assertSame('acme', $org->slug);
-        self::assertSame('free', $org->plan);
         self::assertTrue($org->isActive);
-        self::assertNotNull($org->createdAt);
+
+        self::assertCount(1, $this->audit->records);
+        self::assertSame('organization.created', $this->audit->records[0]['action']);
+        self::assertSame(1, $this->audit->records[0]['actor_user_id']);
+        self::assertNull($this->audit->records[0]['before']);
     }
 
     public function test_create_rejects_duplicate_slug(): void
     {
-        $useCase = new CreateOrganizationUseCase($this->repo);
-        $useCase->execute(new CreateOrganizationInput('First', 'dup'));
+        $useCase = new CreateOrganizationUseCase($this->repo, $this->audit);
+        $useCase->execute(1, new CreateOrganizationInput('First', 'dup'));
 
         $this->expectException(OrganizationSlugConflictException::class);
-        $useCase->execute(new CreateOrganizationInput('Second', 'dup'));
+        $useCase->execute(1, new CreateOrganizationInput('Second', 'dup'));
     }
 
     public function test_list_returns_items_and_total(): void
     {
-        $create = new CreateOrganizationUseCase($this->repo);
-        $create->execute(new CreateOrganizationInput('A', 'a'));
-        $create->execute(new CreateOrganizationInput('B', 'b'));
+        $create = new CreateOrganizationUseCase($this->repo, $this->audit);
+        $create->execute(1, new CreateOrganizationInput('A', 'a'));
+        $create->execute(1, new CreateOrganizationInput('B', 'b'));
 
         $result = (new ListOrganizationsUseCase($this->repo))->execute(10, 0);
 
@@ -60,7 +65,7 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_get_returns_organization_or_throws(): void
     {
-        $id = (new CreateOrganizationUseCase($this->repo))->execute(new CreateOrganizationInput('A', 'a'))->id;
+        $id = (new CreateOrganizationUseCase($this->repo, $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
         self::assertNotNull($id);
 
         $get = new GetOrganizationByIdUseCase($this->repo);
@@ -70,16 +75,18 @@ final class OrganizationUseCasesTest extends TestCase
         $get->execute(999);
     }
 
-    public function test_delete_removes_or_throws_when_missing(): void
+    public function test_delete_removes_audits_and_throws_when_missing(): void
     {
-        $id = (new CreateOrganizationUseCase($this->repo))->execute(new CreateOrganizationInput('A', 'a'))->id;
+        $id = (new CreateOrganizationUseCase($this->repo, $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
         self::assertNotNull($id);
 
-        $delete = new DeleteOrganizationUseCase($this->repo);
-        $delete->execute($id);
+        $delete = new DeleteOrganizationUseCase($this->repo, $this->audit);
+        $delete->execute(1, $id);
         self::assertSame(0, $this->repo->count());
+        self::assertSame('organization.deleted', $this->audit->records[1]['action']);
+        self::assertNull($this->audit->records[1]['after']);
 
         $this->expectException(OrganizationNotFoundException::class);
-        $delete->execute($id);
+        $delete->execute(1, $id);
     }
 }

--- a/tests/User/UserWriteUseCasesTest.php
+++ b/tests/User/UserWriteUseCasesTest.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Tests\User;
 
 use NeneInvoice\Auth\Role;
 use NeneInvoice\Tests\Support\InMemoryUserRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use NeneInvoice\User\CannotDeleteSelfException;
 use NeneInvoice\User\CreateUserInput;
 use NeneInvoice\User\CreateUserUseCase;
@@ -21,35 +22,52 @@ use PHPUnit\Framework\TestCase;
 final class UserWriteUseCasesTest extends TestCase
 {
     private InMemoryUserRepository $repo;
+    private RecordingAuditRecorder $audit;
 
     protected function setUp(): void
     {
         $this->repo = new InMemoryUserRepository();
+        $this->audit = new RecordingAuditRecorder();
     }
 
-    public function test_create_hashes_password_and_forces_caller_organization(): void
+    public function test_create_hashes_password_forces_org_and_audits(): void
     {
-        $user = (new CreateUserUseCase($this->repo))->execute(1, new CreateUserInput('m@org1', 'secret', Role::Member));
+        $user = (new CreateUserUseCase($this->repo, $this->audit))->execute(1, 99, new CreateUserInput('m@org1', 'secret', Role::Member));
 
         self::assertSame(1, $user->organizationId);
         self::assertSame(Role::Member, $user->role);
-        self::assertNotSame('secret', $user->passwordHash);
         self::assertTrue(password_verify('secret', $user->passwordHash));
+
+        self::assertSame('user.created', $this->audit->records[0]['action']);
+        self::assertSame(99, $this->audit->records[0]['actor_user_id']);
+        // The audit snapshot must not leak the password hash.
+        self::assertArrayNotHasKey('password_hash', $this->audit->records[0]['after']);
     }
 
     public function test_create_blocks_superadmin_role(): void
     {
         $this->expectException(RoleNotAssignableException::class);
-        (new CreateUserUseCase($this->repo))->execute(1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
+        (new CreateUserUseCase($this->repo, $this->audit))->execute(1, 1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
     }
 
     public function test_create_rejects_duplicate_email(): void
     {
-        $create = new CreateUserUseCase($this->repo);
-        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Member));
+        $create = new CreateUserUseCase($this->repo, $this->audit);
+        $create->execute(1, 1, new CreateUserInput('dup@org1', 'secret', Role::Member));
 
         $this->expectException(UserEmailConflictException::class);
-        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Admin));
+        $create->execute(1, 1, new CreateUserInput('dup@org1', 'secret', Role::Admin));
+    }
+
+    public function test_update_records_before_and_after(): void
+    {
+        $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
+
+        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 7, $id, new UpdateUserInput(Role::Admin, 'active'));
+
+        self::assertSame('user.updated', $this->audit->records[0]['action']);
+        self::assertSame('member', $this->audit->records[0]['before']['role'] ?? null);
+        self::assertSame('admin', $this->audit->records[0]['after']['role'] ?? null);
     }
 
     public function test_update_blocks_cross_organization_target(): void
@@ -57,7 +75,7 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new UpdateUserUseCase($this->repo))->execute(1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
+        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
     }
 
     public function test_update_blocks_superadmin_escalation(): void
@@ -65,7 +83,7 @@ final class UserWriteUseCasesTest extends TestCase
         $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
 
         $this->expectException(RoleNotAssignableException::class);
-        (new UpdateUserUseCase($this->repo))->execute(1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
+        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
     }
 
     public function test_delete_blocks_self(): void
@@ -73,7 +91,7 @@ final class UserWriteUseCasesTest extends TestCase
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
 
         $this->expectException(CannotDeleteSelfException::class);
-        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $caller);
+        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $caller);
     }
 
     public function test_delete_blocks_cross_organization_target(): void
@@ -82,16 +100,18 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $otherOrgUser);
+        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $otherOrgUser);
     }
 
-    public function test_delete_removes_user_in_same_organization(): void
+    public function test_delete_removes_user_and_audits(): void
     {
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
         $target = $this->repo->save(new User('t@org1', 'h', Role::Member, 1));
 
-        (new DeleteUserUseCase($this->repo))->execute(1, $caller, $target);
+        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $target);
 
         self::assertNull($this->repo->findById($target));
+        self::assertSame('user.deleted', $this->audit->records[0]['action']);
+        self::assertSame($caller, $this->audit->records[0]['actor_user_id']);
     }
 }


### PR DESCRIPTION
Closes #53

## 目的

ADR 0008 の監査記録を Client 以外の全 mutating 操作へ適用し、**「全操作」を網羅**する。

## 変更内容

- **Organization**: create → `organization.created`、delete → `organization.deleted`
- **User**: create/update/delete → `user.*`（before/after は `UserResponse`、**password_hash 非記録**）
- **CompanySettings**: upsert → 既存有無で `company_settings.created` / `updated` を出し分け
- 各 UseCase に `AuditRecorder` と `actorUserId` を追加、Handler から `AuthContext::userId` を plumbing

## 検証

- **`composer check` green**: PHPUnit **74 tests / 247 assertions**・PHPStan level 8 **no errors**・cs clean
- 既存 UseCase テストを `RecordingAuditRecorder` で更新（before/after・actor 検証）
- ライブ: `organization.created` / `user.created` / `user.updated` / `company_settings.created` を正しい actor で記録、`password_hash` 非記録を確認

これで Client + Organization + User + CompanySettings の**全 mutating 操作が監査対象**。

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)