### PR TITLE
feat(numbering): 文書採番（document_sequences, EST-/INV-YYYY-NNN）を追加する (#55)

### DIFF
--- a/database/migrations/20260529170000_create_document_sequences_table.php
+++ b/database/migrations/20260529170000_create_document_sequences_table.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateDocumentSequencesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('document_sequences')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('doc_type', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('year', 'integer', ['null' => false])
+            ->addColumn('last_number', 'integer', ['null' => false, 'default' => 0])
+            ->addIndex(['organization_id', 'doc_type', 'year'], ['unique' => true, 'name' => 'uniq_document_sequences_scope'])
+            ->create();
+    }
+}

--- a/database/schema/document_sequences.sql
+++ b/database/schema/document_sequences.sql
@@ -1,0 +1,10 @@
+-- Schema snapshot for the document_sequences table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS document_sequences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    doc_type VARCHAR(32) NOT NULL,
+    year INTEGER NOT NULL,
+    last_number INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX uniq_document_sequences_scope ON document_sequences (organization_id, doc_type, year);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #53)
+Last updated: 2026-05-29 (Issue #55)
 
 ## Recently merged
 
@@ -27,13 +27,14 @@ Last updated: 2026-05-29 (Issue #53)
 - **Issue #47 / PR #48** — 発行者プロフィール（company settings）+ 登録番号検証共有化 ✅ merged
 - **Issue #49 / PR #50** — 税計算エンジン（ADR 0004）✅ merged
 - **Issue #51 / PR #52** — 監査ログ基盤（ADR 0008）+ Client 統合 ✅ merged
-- **Issue #53** — 監査ログを Organization / User / CompanySettings に retrofit ⏳ this PR
+- **Issue #53 / PR #54** — 監査を Organization / User / CompanySettings に展開 ✅ merged
+- **Issue #55** — 文書採番（document_sequences）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #53 | `feat/53-audit-retrofit` | 監査を Organization / User / CompanySettings に展開 | 🔄 PR pending |
+| #55 | `feat/55-document-numbering` | 文書採番（EST-/INV-YYYY-NNN・org×種別×年） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -162,7 +163,14 @@ Last updated: 2026-05-29 (Issue #53)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Audit logging: ✅ foundation + full platform coverage** (Issue #51 / PR #52, Issue #53)
+**Phase 1 — Document numbering: 🔄 in progress** (Issue #55)
+
+- `document_sequences` (org × doc_type × year, unique) + `DocumentNumberGenerator` → `EST-2026-001` / `INV-2026-001`
+- Atomic allocation (UPDATE+1 / INSERT fallback on unique conflict); per-org/type/year isolation with yearly reset
+- Tested on SQLite; concurrency-safe locking is a documented follow-up (like audit transactionality)
+- Quotes/invoices will use this for numbers
+
+**Phase 1 — Audit logging: ✅ foundation + full platform coverage** (Issue #51 / PR #52, Issue #53 / PR #54)
 
 - `audit_logs` + `Audit\AuditRecorder` (ADR 0008): actor / org / action / entity / before & after sanitized snapshots
 - **Integrated into every mutating operation**: Client, Organization (create/delete), User (create/update/delete), CompanySettings (upsert → created/updated)
@@ -186,6 +194,6 @@ Last updated: 2026-05-29 (Issue #53)
 
 ## Next steps
 
-1. Quote persistence — `quotes` + `line_items`, `document_sequences` numbering (EST-YYYY-NNN); built with audit + `TaxCalculator` from the start
-2. Quote CRUD + status machine (draft→sent→accepted/rejected/expired)
-3. Invoices (convert/issue/qualified validation) → Payments → overdue; then audit read endpoint
+1. `line_items` table + repository (polymorphic quote/invoice)
+2. Quote persistence — `quotes` + entity/repository; create uses `DocumentNumberGenerator` + `TaxCalculator` + audit
+3. Quote CRUD + status machine → Invoices (convert/issue/qualified validation) → Payments → overdue

--- a/src/DocumentSequence/DocumentNumberGenerator.php
+++ b/src/DocumentSequence/DocumentNumberGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\DocumentSequence;
+
+/**
+ * Generates a formatted document number such as `EST-2026-001`, allocating the
+ * next sequence per organization, document type, and year.
+ */
+final readonly class DocumentNumberGenerator
+{
+    public function __construct(
+        private DocumentSequenceRepositoryInterface $sequences,
+    ) {
+    }
+
+    public function next(int $organizationId, DocumentType $type, int $year): string
+    {
+        $sequence = $this->sequences->nextNumber($organizationId, $type->value, $year);
+
+        return sprintf('%s%d-%03d', $type->prefix(), $year, $sequence);
+    }
+}

--- a/src/DocumentSequence/DocumentSequenceRepositoryInterface.php
+++ b/src/DocumentSequence/DocumentSequenceRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\DocumentSequence;
+
+interface DocumentSequenceRepositoryInterface
+{
+    /**
+     * Atomically allocates and returns the next sequence number for the given
+     * organization, document type, and year (starting at 1 each year).
+     */
+    public function nextNumber(int $organizationId, string $docType, int $year): int;
+}

--- a/src/DocumentSequence/DocumentSequenceServiceProvider.php
+++ b/src/DocumentSequence/DocumentSequenceServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\DocumentSequence;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires document numbering: the sequence repository and number generator.
+ */
+final readonly class DocumentSequenceServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DocumentSequenceRepositoryInterface::class,
+                static function (ContainerInterface $c): DocumentSequenceRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoDocumentSequenceRepository($query);
+                },
+            )
+            ->set(
+                DocumentNumberGenerator::class,
+                static function (ContainerInterface $c): DocumentNumberGenerator {
+                    $repo = $c->get(DocumentSequenceRepositoryInterface::class);
+
+                    if (!$repo instanceof DocumentSequenceRepositoryInterface) {
+                        throw new LogicException('Document sequence repository service is invalid.');
+                    }
+
+                    return new DocumentNumberGenerator($repo);
+                },
+            );
+    }
+}

--- a/src/DocumentSequence/DocumentType.php
+++ b/src/DocumentSequence/DocumentType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\DocumentSequence;
+
+/**
+ * Numbered document types and their human-facing number prefixes.
+ * Quote → `EST-2026-001`, Invoice → `INV-2026-001`.
+ */
+enum DocumentType: string
+{
+    case Quote = 'quote';
+    case Invoice = 'invoice';
+
+    public function prefix(): string
+    {
+        return match ($this) {
+            self::Quote => 'EST-',
+            self::Invoice => 'INV-',
+        };
+    }
+}

--- a/src/DocumentSequence/PdoDocumentSequenceRepository.php
+++ b/src/DocumentSequence/PdoDocumentSequenceRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\DocumentSequence;
+
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use RuntimeException;
+
+final readonly class PdoDocumentSequenceRepository implements DocumentSequenceRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function nextNumber(int $organizationId, string $docType, int $year): int
+    {
+        // Increment the existing counter; if there is no row yet for this
+        // org/type/year, create it. A concurrent INSERT (unique conflict) means
+        // another caller created the row first, so we increment instead.
+        $affected = $this->increment($organizationId, $docType, $year);
+
+        if ($affected === 0) {
+            try {
+                $this->query->execute(
+                    'INSERT INTO document_sequences (organization_id, doc_type, year, last_number) VALUES (?, ?, ?, 1)',
+                    [$organizationId, $docType, $year],
+                );
+            } catch (DatabaseConstraintException) {
+                $this->increment($organizationId, $docType, $year);
+            }
+        }
+
+        $row = $this->query->fetchOne(
+            'SELECT last_number FROM document_sequences WHERE organization_id = ? AND doc_type = ? AND year = ?',
+            [$organizationId, $docType, $year],
+        );
+
+        if ($row === null) {
+            throw new RuntimeException('Document sequence row missing immediately after allocation.');
+        }
+
+        return (int) $row['last_number'];
+    }
+
+    private function increment(int $organizationId, string $docType, int $year): int
+    {
+        return $this->query->execute(
+            'UPDATE document_sequences SET last_number = last_number + 1 WHERE organization_id = ? AND doc_type = ? AND year = ?',
+            [$organizationId, $docType, $year],
+        );
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -24,6 +24,7 @@ use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Company\CompanyServiceProvider;
+use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -50,6 +51,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new UserServiceProvider());
         $builder->addProvider(new ClientServiceProvider());
         $builder->addProvider(new CompanyServiceProvider());
+        $builder->addProvider(new DocumentSequenceServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/tests/DocumentSequence/DocumentNumberGeneratorTest.php
+++ b/tests/DocumentSequence/DocumentNumberGeneratorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\DocumentSequence;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\DocumentSequence\DocumentType;
+use NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository;
+use PHPUnit\Framework\TestCase;
+
+final class DocumentNumberGeneratorTest extends TestCase
+{
+    private DocumentNumberGenerator $generator;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/document_sequences.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->generator = new DocumentNumberGenerator(
+            new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo)),
+        );
+    }
+
+    public function test_numbers_increment_sequentially_with_format(): void
+    {
+        self::assertSame('EST-2026-001', $this->generator->next(1, DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-002', $this->generator->next(1, DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-003', $this->generator->next(1, DocumentType::Quote, 2026));
+    }
+
+    public function test_sequences_are_isolated_by_org_type_and_year(): void
+    {
+        self::assertSame('EST-2026-001', $this->generator->next(1, DocumentType::Quote, 2026));
+        // Different document type → its own counter.
+        self::assertSame('INV-2026-001', $this->generator->next(1, DocumentType::Invoice, 2026));
+        // Different organization → its own counter.
+        self::assertSame('EST-2026-001', $this->generator->next(2, DocumentType::Quote, 2026));
+        // Different year → resets.
+        self::assertSame('EST-2027-001', $this->generator->next(1, DocumentType::Quote, 2027));
+        // Original counter continues.
+        self::assertSame('EST-2026-002', $this->generator->next(1, DocumentType::Quote, 2026));
+    }
+}


### PR DESCRIPTION
Closes #55

## 目的

見積・請求書の連番採番を、組織 × 文書種別 × 年でスコープした採番器として実装。連番はコンプライアンス上重要（重複・欠番なし）。

## 変更内容

- `document_sequences`（unique: org+doc_type+year）+ マイグレーション + schema
- `DocumentType` enum（Quote→`EST-` / Invoice→`INV-`）
- `PdoDocumentSequenceRepository`（アトミック +1：UPDATE→0件なら INSERT、unique 競合は UPDATE 再試行）
- `DocumentNumberGenerator`: `next(orgId, type, year)` → `EST-2026-001`

## 検証

- **`composer check` green**: PHPUnit **76 tests / 257 assertions**・PHPStan level 8 **no errors**・cs clean
- テスト: 連番（001→002→003）、org/種別/年の独立、**年次リセット**、フォーマット
- `phinx migrate` で作成確認

## 限界（明記）

採番はトランザクション/行ロック未統合。逐次実行では正しいが、高並行下の厳密性はトランザクション統合を将来拡張（監査と同様の方針）。

## 非範囲（後続）

- `line_items` テーブル、`quotes` 永続化・CRUD・状態機械

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)