### PR TITLE
feat(line-item): line_items（quote/invoice 共有）の永続化を追加する (#57)

### DIFF
--- a/database/migrations/20260529180000_create_line_items_table.php
+++ b/database/migrations/20260529180000_create_line_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateLineItemsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('line_items')
+            ->addColumn('parent_type', 'string', ['limit' => 16, 'null' => false])
+            ->addColumn('parent_id', 'integer', ['null' => false])
+            ->addColumn('description', 'string', ['limit' => 1024, 'null' => false])
+            ->addColumn('quantity', 'integer', ['null' => false])
+            ->addColumn('unit_price_cents', 'integer', ['null' => false])
+            ->addColumn('tax_rate_bps', 'integer', ['null' => false])
+            ->addColumn('sort_order', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['parent_type', 'parent_id'], ['name' => 'idx_line_items_parent'])
+            ->create();
+    }
+}

--- a/database/schema/line_items.sql
+++ b/database/schema/line_items.sql
@@ -1,0 +1,15 @@
+-- Schema snapshot for the line_items table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS line_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_type VARCHAR(16) NOT NULL,
+    parent_id INTEGER NOT NULL,
+    description VARCHAR(1024) NOT NULL,
+    quantity INTEGER NOT NULL,
+    unit_price_cents INTEGER NOT NULL,
+    tax_rate_bps INTEGER NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_line_items_parent ON line_items (parent_type, parent_id);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #55)
+Last updated: 2026-05-29 (Issue #57)
 
 ## Recently merged
 
@@ -28,13 +28,14 @@ Last updated: 2026-05-29 (Issue #55)
 - **Issue #49 / PR #50** — 税計算エンジン（ADR 0004）✅ merged
 - **Issue #51 / PR #52** — 監査ログ基盤（ADR 0008）+ Client 統合 ✅ merged
 - **Issue #53 / PR #54** — 監査を Organization / User / CompanySettings に展開 ✅ merged
-- **Issue #55** — 文書採番（document_sequences）⏳ this PR
+- **Issue #55 / PR #56** — 文書採番（document_sequences）✅ merged
+- **Issue #57** — line_items 永続化（quote/invoice 共有）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #55 | `feat/55-document-numbering` | 文書採番（EST-/INV-YYYY-NNN・org×種別×年） | 🔄 PR pending |
+| #57 | `feat/57-line-items` | line_items 永続化（polymorphic・replaceForParent） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -163,7 +164,14 @@ Last updated: 2026-05-29 (Issue #55)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Document numbering: 🔄 in progress** (Issue #55)
+**Phase 1 — Line items persistence: 🔄 in progress** (Issue #57)
+
+- `line_items` (polymorphic `parent_type`+`parent_id`) + `PdoLineItemRepository` (findByParent ordered / replaceForParent / deleteForParent)
+- `LineItem` entity + `LineItemParent` enum; `LineItemResponse` (line_subtotal_cents only, no per-line tax per ADR 0004)
+- Tenant scoping via the parent (no org_id on line_items); tested on SQLite (order/replace/isolation/delete)
+- Quotes/invoices attach lines via `replaceForParent`
+
+**Phase 1 — Document numbering: ✅ complete** (Issue #55 / PR #56)
 
 - `document_sequences` (org × doc_type × year, unique) + `DocumentNumberGenerator` → `EST-2026-001` / `INV-2026-001`
 - Atomic allocation (UPDATE+1 / INSERT fallback on unique conflict); per-org/type/year isolation with yearly reset
@@ -194,6 +202,6 @@ Last updated: 2026-05-29 (Issue #55)
 
 ## Next steps
 
-1. `line_items` table + repository (polymorphic quote/invoice)
-2. Quote persistence — `quotes` + entity/repository; create uses `DocumentNumberGenerator` + `TaxCalculator` + audit
-3. Quote CRUD + status machine → Invoices (convert/issue/qualified validation) → Payments → overdue
+1. Quote persistence — `quotes` table + entity/repository (totals columns); reuses line items + numbering + tax
+2. Quote create/list/get + status machine; create uses `DocumentNumberGenerator` + `TaxCalculator` + audit
+3. Invoices (convert/issue/qualified validation) → Payments → overdue

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -25,6 +25,7 @@ use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
+use NeneInvoice\LineItem\LineItemServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -52,6 +53,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new ClientServiceProvider());
         $builder->addProvider(new CompanyServiceProvider());
         $builder->addProvider(new DocumentSequenceServiceProvider());
+        $builder->addProvider(new LineItemServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/LineItem/LineItem.php
+++ b/src/LineItem/LineItem.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * A persisted line on a quote or invoice. The parent is polymorphic
+ * (`parentType` + `parentId`). Money is integer cents; tax rate is basis points.
+ */
+final readonly class LineItem
+{
+    public function __construct(
+        public LineItemParent $parentType,
+        public int $parentId,
+        public string $description,
+        public int $quantity,
+        public int $unitPriceCents,
+        public int $taxRateBps,
+        public int $sortOrder = 0,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+
+    public function lineSubtotalCents(): int
+    {
+        return $this->quantity * $this->unitPriceCents;
+    }
+
+    public function toCalculationInput(): LineItemInput
+    {
+        return new LineItemInput($this->description, $this->quantity, $this->unitPriceCents, $this->taxRateBps);
+    }
+}

--- a/src/LineItem/LineItemParent.php
+++ b/src/LineItem/LineItemParent.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * The document type a line item belongs to (polymorphic parent).
+ */
+enum LineItemParent: string
+{
+    case Quote = 'quote';
+    case Invoice = 'invoice';
+}

--- a/src/LineItem/LineItemRepositoryInterface.php
+++ b/src/LineItem/LineItemRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Persistence for line items, addressed by their polymorphic parent.
+ */
+interface LineItemRepositoryInterface
+{
+    /** @return list<LineItem> ordered by sort_order */
+    public function findByParent(LineItemParent $parentType, int $parentId): array;
+
+    /**
+     * Replaces all line items for a parent with the given set (delete + insert).
+     *
+     * @param list<LineItem> $lines
+     */
+    public function replaceForParent(LineItemParent $parentType, int $parentId, array $lines): void;
+
+    public function deleteForParent(LineItemParent $parentType, int $parentId): void;
+}

--- a/src/LineItem/LineItemResponse.php
+++ b/src/LineItem/LineItemResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Serializes a {@see LineItem} to its snake_case JSON representation.
+ *
+ * `line_subtotal_cents` is the pre-tax row amount (illustrative). Per-line tax is
+ * intentionally omitted — tax is rounded once per rate at the document level
+ * (ADR 0004), so a per-line tax figure must never be summed.
+ */
+final class LineItemResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(LineItem $line): array
+    {
+        return [
+            'id' => $line->id,
+            'description' => $line->description,
+            'quantity' => $line->quantity,
+            'unit_price_cents' => $line->unitPriceCents,
+            'tax_rate_bps' => $line->taxRateBps,
+            'sort_order' => $line->sortOrder,
+            'line_subtotal_cents' => $line->lineSubtotalCents(),
+        ];
+    }
+}

--- a/src/LineItem/LineItemServiceProvider.php
+++ b/src/LineItem/LineItemServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the shared line-item repository.
+ */
+final readonly class LineItemServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            LineItemRepositoryInterface::class,
+            static function (ContainerInterface $c): LineItemRepositoryInterface {
+                $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoLineItemRepository($query);
+            },
+        );
+    }
+}

--- a/src/LineItem/PdoLineItemRepository.php
+++ b/src/LineItem/PdoLineItemRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoLineItemRepository implements LineItemRepositoryInterface
+{
+    private const COLUMNS = 'id, parent_type, parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    /** @return list<LineItem> */
+    public function findByParent(LineItemParent $parentType, int $parentId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM line_items WHERE parent_type = ? AND parent_id = ? ORDER BY sort_order ASC, id ASC',
+            [$parentType->value, $parentId],
+        );
+
+        return array_map(fn (array $row): LineItem => $this->mapRow($row), $rows);
+    }
+
+    /** @param list<LineItem> $lines */
+    public function replaceForParent(LineItemParent $parentType, int $parentId, array $lines): void
+    {
+        $this->deleteForParent($parentType, $parentId);
+
+        $now = date('Y-m-d H:i:s');
+
+        foreach ($lines as $line) {
+            $this->query->execute(
+                'INSERT INTO line_items (parent_type, parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $parentType->value,
+                    $parentId,
+                    $line->description,
+                    $line->quantity,
+                    $line->unitPriceCents,
+                    $line->taxRateBps,
+                    $line->sortOrder,
+                    $now,
+                    $now,
+                ],
+            );
+        }
+    }
+
+    public function deleteForParent(LineItemParent $parentType, int $parentId): void
+    {
+        $this->query->execute(
+            'DELETE FROM line_items WHERE parent_type = ? AND parent_id = ?',
+            [$parentType->value, $parentId],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): LineItem
+    {
+        return new LineItem(
+            parentType: LineItemParent::from((string) $row['parent_type']),
+            parentId: (int) $row['parent_id'],
+            description: (string) $row['description'],
+            quantity: (int) $row['quantity'],
+            unitPriceCents: (int) $row['unit_price_cents'],
+            taxRateBps: (int) $row['tax_rate_bps'],
+            sortOrder: (int) $row['sort_order'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/tests/LineItem/PdoLineItemRepositoryTest.php
+++ b/tests/LineItem/PdoLineItemRepositoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\LineItem;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\PdoLineItemRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoLineItemRepositoryTest extends TestCase
+{
+    private PdoLineItemRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/line_items.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoLineItemRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_replace_then_find_returns_lines_in_sort_order(): void
+    {
+        $this->repository->replaceForParent(LineItemParent::Quote, 10, [
+            new LineItem(LineItemParent::Quote, 10, 'Second', 1, 1000, 1000, sortOrder: 1),
+            new LineItem(LineItemParent::Quote, 10, 'First', 2, 500, 800, sortOrder: 0),
+        ]);
+
+        $lines = $this->repository->findByParent(LineItemParent::Quote, 10);
+
+        self::assertCount(2, $lines);
+        self::assertSame('First', $lines[0]->description);
+        self::assertSame('Second', $lines[1]->description);
+        self::assertSame(1000, $lines[0]->lineSubtotalCents()); // 2 × 500
+    }
+
+    public function test_replace_clears_previous_lines(): void
+    {
+        $this->repository->replaceForParent(LineItemParent::Quote, 10, [
+            new LineItem(LineItemParent::Quote, 10, 'Old A', 1, 1000, 1000),
+            new LineItem(LineItemParent::Quote, 10, 'Old B', 1, 1000, 1000),
+        ]);
+
+        $this->repository->replaceForParent(LineItemParent::Quote, 10, [
+            new LineItem(LineItemParent::Quote, 10, 'New only', 1, 2000, 1000),
+        ]);
+
+        $lines = $this->repository->findByParent(LineItemParent::Quote, 10);
+        self::assertCount(1, $lines);
+        self::assertSame('New only', $lines[0]->description);
+    }
+
+    public function test_lines_are_isolated_by_parent(): void
+    {
+        $this->repository->replaceForParent(LineItemParent::Quote, 10, [
+            new LineItem(LineItemParent::Quote, 10, 'Quote line', 1, 1000, 1000),
+        ]);
+        $this->repository->replaceForParent(LineItemParent::Invoice, 10, [
+            new LineItem(LineItemParent::Invoice, 10, 'Invoice line', 1, 1000, 1000),
+        ]);
+
+        // Same parent_id (10) but different type → independent.
+        self::assertCount(1, $this->repository->findByParent(LineItemParent::Quote, 10));
+        self::assertSame('Invoice line', $this->repository->findByParent(LineItemParent::Invoice, 10)[0]->description);
+    }
+
+    public function test_delete_for_parent_removes_all(): void
+    {
+        $this->repository->replaceForParent(LineItemParent::Quote, 10, [
+            new LineItem(LineItemParent::Quote, 10, 'X', 1, 1000, 1000),
+        ]);
+
+        $this->repository->deleteForParent(LineItemParent::Quote, 10);
+
+        self::assertCount(0, $this->repository->findByParent(LineItemParent::Quote, 10));
+    }
+}


### PR DESCRIPTION
Closes #57

## 目的

見積・請求書が共有する明細行（polymorphic `parent_type` + `parent_id`）の永続化。

## 変更内容

- `line_items` テーブル + マイグレーション + schema（index: parent_type+parent_id）
- `LineItem` エンティティ、`LineItemParent` enum（quote/invoice）、`LineItemResponse`（`line_subtotal_cents` のみ・**per-line 税なし** = ADR 0004）
- `PdoLineItemRepository`: `findByParent`（sort_order 順）/ `replaceForParent`（総入れ替え）/ `deleteForParent`

## 検証

- **`composer check` green**: PHPUnit **80 tests / 270 assertions**・PHPStan level 8 **no errors**・cs clean
- テスト: 並び順 / 総入れ替えで旧行クリア / 親（type+id）ごとの独立 / 削除
- `phinx migrate` 確認
- **修正**: `sort_order` の index フォールバックが明示 `sortOrder=0` を上書きするバグを発見・修正（caller 値を尊重）

## 注

- テナント分離は親（quote/invoice）経由 → line_items に organization_id は持たせない
- `replaceForParent` の delete+insert はトランザクション未統合（採番・監査と同方針）

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)