### PR TITLE
feat(quote): Quote（見積）永続化レイヤを追加する (#59)

### DIFF
--- a/database/migrations/20260529190000_create_quotes_table.php
+++ b/database/migrations/20260529190000_create_quotes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateQuotesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('quotes')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('client_id', 'integer', ['null' => false])
+            ->addColumn('quote_number', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false, 'default' => 'draft'])
+            ->addColumn('issued_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('valid_until', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('subtotal_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('tax_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('total_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('notes', 'text', ['null' => true, 'default' => null])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_quotes_organization_id'])
+            ->addIndex(['organization_id', 'quote_number'], ['unique' => true, 'name' => 'uniq_quotes_org_number'])
+            ->create();
+    }
+}

--- a/database/schema/quotes.sql
+++ b/database/schema/quotes.sql
@@ -1,0 +1,21 @@
+-- Schema snapshot for the quotes table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+CREATE TABLE IF NOT EXISTS quotes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    client_id INTEGER NOT NULL,
+    quote_number VARCHAR(32) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'draft',
+    issued_at DATETIME NULL DEFAULT NULL,
+    valid_until DATETIME NULL DEFAULT NULL,
+    subtotal_cents INTEGER NOT NULL DEFAULT 0,
+    tax_cents INTEGER NOT NULL DEFAULT 0,
+    total_cents INTEGER NOT NULL DEFAULT 0,
+    notes TEXT NULL DEFAULT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_quotes_organization_id ON quotes (organization_id);
+CREATE UNIQUE INDEX uniq_quotes_org_number ON quotes (organization_id, quote_number);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #57)
+Last updated: 2026-05-29 (Issue #59)
 
 ## Recently merged
 
@@ -29,13 +29,14 @@ Last updated: 2026-05-29 (Issue #57)
 - **Issue #51 / PR #52** — 監査ログ基盤（ADR 0008）+ Client 統合 ✅ merged
 - **Issue #53 / PR #54** — 監査を Organization / User / CompanySettings に展開 ✅ merged
 - **Issue #55 / PR #56** — 文書採番（document_sequences）✅ merged
-- **Issue #57** — line_items 永続化（quote/invoice 共有）⏳ this PR
+- **Issue #57 / PR #58** — line_items 永続化（quote/invoice 共有）✅ merged
+- **Issue #59** — Quote 永続化レイヤ ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #57 | `feat/57-line-items` | line_items 永続化（polymorphic・replaceForParent） | 🔄 PR pending |
+| #59 | `feat/59-quote-persistence` | Quote 永続化（quotes テーブル・totals・ソフト削除） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -164,7 +165,13 @@ Last updated: 2026-05-29 (Issue #57)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Line items persistence: 🔄 in progress** (Issue #57)
+**Phase 1 — Quote persistence: 🔄 in progress** (Issue #59)
+
+- `quotes` table (totals columns, soft delete, unique org+quote_number) + `Quote` entity + `QuoteStatus` enum + `PdoQuoteRepository`
+- Org-scoped reads exclude soft-deleted; tested on SQLite (save/list/count/update/soft-delete)
+- Line items stay separate (`line_items`); the create use case orchestrates header + lines + numbering + tax + audit (next PR)
+
+**Phase 1 — Line items persistence: ✅ complete** (Issue #57 / PR #58)
 
 - `line_items` (polymorphic `parent_type`+`parent_id`) + `PdoLineItemRepository` (findByParent ordered / replaceForParent / deleteForParent)
 - `LineItem` entity + `LineItemParent` enum; `LineItemResponse` (line_subtotal_cents only, no per-line tax per ADR 0004)
@@ -202,6 +209,6 @@ Last updated: 2026-05-29 (Issue #57)
 
 ## Next steps
 
-1. Quote persistence — `quotes` table + entity/repository (totals columns); reuses line items + numbering + tax
-2. Quote create/list/get + status machine; create uses `DocumentNumberGenerator` + `TaxCalculator` + audit
-3. Invoices (convert/issue/qualified validation) → Payments → overdue
+1. Quote create/list/get endpoints — create orchestrates `DocumentNumberGenerator` + `TaxCalculator` + `LineItemRepository` + audit
+2. Quote status transitions (draft→sent→accepted/rejected/expired) with rules
+3. Invoices (convert from quote / issue / qualified validation) → Payments → overdue

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -27,6 +27,7 @@ use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
 use NeneInvoice\LineItem\LineItemServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
+use NeneInvoice\Quote\QuoteServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -54,6 +55,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new CompanyServiceProvider());
         $builder->addProvider(new DocumentSequenceServiceProvider());
         $builder->addProvider(new LineItemServiceProvider());
+        $builder->addProvider(new QuoteServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/Quote/PdoQuoteRepository.php
+++ b/src/Quote/PdoQuoteRepository.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Quote
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<Quote> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): Quote => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM quotes WHERE organization_id = ? AND is_deleted = 0',
+            [$organizationId],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function save(Quote $quote): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO quotes (organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [
+                $quote->organizationId,
+                $quote->clientId,
+                $quote->quoteNumber,
+                $quote->status->value,
+                $quote->issuedAt,
+                $quote->validUntil,
+                $quote->subtotalCents,
+                $quote->taxCents,
+                $quote->totalCents,
+                $quote->notes,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Quote $quote): void
+    {
+        if ($quote->id === null) {
+            throw new QuoteNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE quotes SET client_id = ?, status = ?, issued_at = ?, valid_until = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [
+                $quote->clientId,
+                $quote->status->value,
+                $quote->issuedAt,
+                $quote->validUntil,
+                $quote->subtotalCents,
+                $quote->taxCents,
+                $quote->totalCents,
+                $quote->notes,
+                $now,
+                $quote->id,
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($quote->id) === null) {
+            throw new QuoteNotFoundException($quote->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new QuoteNotFoundException($id);
+        }
+
+        $this->query->execute(
+            'UPDATE quotes SET is_deleted = 1, deleted_at = ? WHERE id = ?',
+            [date('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Quote
+    {
+        return new Quote(
+            organizationId: (int) $row['organization_id'],
+            clientId: (int) $row['client_id'],
+            quoteNumber: (string) $row['quote_number'],
+            status: QuoteStatus::from((string) $row['status']),
+            subtotalCents: (int) $row['subtotal_cents'],
+            taxCents: (int) $row['tax_cents'],
+            totalCents: (int) $row['total_cents'],
+            issuedAt: isset($row['issued_at']) && $row['issued_at'] !== '' ? (string) $row['issued_at'] : null,
+            validUntil: isset($row['valid_until']) && $row['valid_until'] !== '' ? (string) $row['valid_until'] : null,
+            notes: isset($row['notes']) && $row['notes'] !== '' ? (string) $row['notes'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Quote/Quote.php
+++ b/src/Quote/Quote.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+/**
+ * A quote (見積書) header. Line items live in `line_items` (polymorphic) and are
+ * loaded separately. Totals are integer cents and are the single source of truth
+ * computed by the tax calculator (ADR 0004).
+ */
+final readonly class Quote
+{
+    public function __construct(
+        public int $organizationId,
+        public int $clientId,
+        public string $quoteNumber,
+        public QuoteStatus $status,
+        public int $subtotalCents,
+        public int $taxCents,
+        public int $totalCents,
+        public ?string $issuedAt = null,
+        public ?string $validUntil = null,
+        public ?string $notes = null,
+        public bool $isDeleted = false,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Quote/QuoteNotFoundException.php
+++ b/src/Quote/QuoteNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use RuntimeException;
+
+final class QuoteNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Quote {$id} not found.");
+    }
+}

--- a/src/Quote/QuoteRepositoryInterface.php
+++ b/src/Quote/QuoteRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+/**
+ * Persistence for quotes. Reads exclude soft-deleted rows; `delete` is soft.
+ */
+interface QuoteRepositoryInterface
+{
+    public function findById(int $id): ?Quote;
+
+    /** @return list<Quote> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+
+    public function save(Quote $quote): int;
+
+    /** @throws QuoteNotFoundException */
+    public function update(Quote $quote): void;
+
+    /** @throws QuoteNotFoundException */
+    public function delete(int $id): void;
+}

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Quote domain. Use cases, handlers, and the route registrar are added
+ * with the quote CRUD PR.
+ */
+final readonly class QuoteServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            QuoteRepositoryInterface::class,
+            static function (ContainerInterface $c): QuoteRepositoryInterface {
+                $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoQuoteRepository($query);
+            },
+        );
+    }
+}

--- a/src/Quote/QuoteStatus.php
+++ b/src/Quote/QuoteStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+/**
+ * Quote lifecycle states (domain-model.md). Transition rules are enforced by the
+ * quote use cases (see the status-transition PR), not here.
+ */
+enum QuoteStatus: string
+{
+    case Draft = 'draft';
+    case Sent = 'sent';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Expired = 'expired';
+}

--- a/tests/Quote/PdoQuoteRepositoryTest.php
+++ b/tests/Quote/PdoQuoteRepositoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Quote\PdoQuoteRepository;
+use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteStatus;
+use PHPUnit\Framework\TestCase;
+
+final class PdoQuoteRepositoryTest extends TestCase
+{
+    private PdoQuoteRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/quotes.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoQuoteRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    private function draft(int $org, int $client, string $number): Quote
+    {
+        return new Quote(
+            organizationId: $org,
+            clientId: $client,
+            quoteNumber: $number,
+            status: QuoteStatus::Draft,
+            subtotalCents: 3000,
+            taxCents: 300,
+            totalCents: 3300,
+        );
+    }
+
+    public function test_saves_and_reads_back_with_totals(): void
+    {
+        $id = $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
+
+        $quote = $this->repository->findById($id);
+        self::assertNotNull($quote);
+        self::assertSame('EST-2026-001', $quote->quoteNumber);
+        self::assertSame(QuoteStatus::Draft, $quote->status);
+        self::assertSame(3300, $quote->totalCents);
+        self::assertSame(5, $quote->clientId);
+    }
+
+    public function test_list_and_count_scoped_to_organization(): void
+    {
+        $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
+        $this->repository->save($this->draft(1, 5, 'EST-2026-002'));
+        $this->repository->save($this->draft(2, 9, 'EST-2026-001'));
+
+        self::assertSame(2, $this->repository->countByOrganization(1));
+        self::assertCount(2, $this->repository->findAllByOrganization(1, 10, 0));
+        self::assertSame(1, $this->repository->countByOrganization(2));
+    }
+
+    public function test_update_changes_status_and_totals(): void
+    {
+        $id = $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
+        $quote = $this->repository->findById($id);
+        self::assertNotNull($quote);
+
+        $this->repository->update(new Quote(
+            organizationId: 1,
+            clientId: 5,
+            quoteNumber: 'EST-2026-001',
+            status: QuoteStatus::Sent,
+            subtotalCents: 5000,
+            taxCents: 500,
+            totalCents: 5500,
+            id: $id,
+        ));
+
+        $updated = $this->repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame(QuoteStatus::Sent, $updated->status);
+        self::assertSame(5500, $updated->totalCents);
+    }
+
+    public function test_soft_delete_hides_quote(): void
+    {
+        $id = $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
+
+        $this->repository->delete($id);
+
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->countByOrganization(1));
+    }
+
+    public function test_delete_throws_for_unknown_quote(): void
+    {
+        $this->expectException(QuoteNotFoundException::class);
+        $this->repository->delete(999);
+    }
+}


### PR DESCRIPTION
Closes #59

## 目的

見積（quote）ヘッダの永続化。組織スコープ・ソフト削除・totals 列。明細は `line_items`（別テーブル）。

## 変更内容

- `quotes` テーブル（unique `organization_id`+`quote_number`、index `organization_id`、totals / issued_at / valid_until / notes / soft delete）
- `Quote\QuoteStatus` enum（draft/sent/accepted/rejected/expired）
- `Quote` エンティティ、`QuoteNotFoundException`
- `QuoteRepositoryInterface` + `PdoQuoteRepository`（ソフト削除対応）、`QuoteServiceProvider`

## 検証

- **`composer check` green**: PHPUnit **85 tests / 290 assertions**・PHPStan level 8 **no errors**・cs clean
- リポジトリテスト: 保存/取得・一覧/件数（org スコープ）・更新（status/totals）・ソフト削除・未知 delete 404
- `phinx migrate` 確認

## 非範囲（次 PR）

- Quote create/list/get エンドポイント（採番＋税計算＋明細＋監査の結線）、状態遷移ロジック

## セルフレビュー

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)