### PR TITLE
feat(quote): Quote 作成/一覧/取得 — 採番・税計算・明細・監査を結線する (#61)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #59)
+Last updated: 2026-05-29 (Issue #61)
 
 ## Recently merged
 
@@ -30,13 +30,14 @@ Last updated: 2026-05-29 (Issue #59)
 - **Issue #53 / PR #54** — 監査を Organization / User / CompanySettings に展開 ✅ merged
 - **Issue #55 / PR #56** — 文書採番（document_sequences）✅ merged
 - **Issue #57 / PR #58** — line_items 永続化（quote/invoice 共有）✅ merged
-- **Issue #59** — Quote 永続化レイヤ ⏳ this PR
+- **Issue #59 / PR #60** — Quote 永続化レイヤ ✅ merged
+- **Issue #61** — Quote 作成/一覧/取得（結線）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #59 | `feat/59-quote-persistence` | Quote 永続化（quotes テーブル・totals・ソフト削除） | 🔄 PR pending |
+| #61 | `feat/61-quote-create-read` | Quote 作成/一覧/取得（採番+税+明細+監査の結線） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -165,7 +166,14 @@ Last updated: 2026-05-29 (Issue #59)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Quote persistence: 🔄 in progress** (Issue #59)
+**Phase 1 — Quote create/list/get: 🔄 in progress** (Issue #61)
+
+- `POST/GET /admin/quotes`, `GET /admin/quotes/{id}` — create orchestrates client validation + `TaxCalculator` + `DocumentNumberGenerator` (EST-YYYY-NNN) + line items + `quote.created` audit
+- Allowed tax rates 10%/8% (accounting-compliance §3); cross-org client / empty lines / bad rate → 422
+- Verified live: create 201 (subtotal 2000 / tax 180 / total 2180, EST-2026-001, 2 lines), get/list, audit row
+- Next: status transitions (draft→sent→accepted/rejected/expired)
+
+**Phase 1 — Quote persistence: ✅ complete** (Issue #59 / PR #60)
 
 - `quotes` table (totals columns, soft delete, unique org+quote_number) + `Quote` entity + `QuoteStatus` enum + `PdoQuoteRepository`
 - Org-scoped reads exclude soft-deleted; tested on SQLite (save/list/count/update/soft-delete)
@@ -209,6 +217,6 @@ Last updated: 2026-05-29 (Issue #59)
 
 ## Next steps
 
-1. Quote create/list/get endpoints — create orchestrates `DocumentNumberGenerator` + `TaxCalculator` + `LineItemRepository` + audit
-2. Quote status transitions (draft→sent→accepted/rejected/expired) with rules
-3. Invoices (convert from quote / issue / qualified validation) → Payments → overdue
+1. Quote status transitions (draft→sent→accepted/rejected/expired) with rules + audit
+2. Invoices — convert from accepted quote, issue (number/qualified validation), line items
+3. Payments → overdue; audit read endpoint

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -17,6 +17,9 @@ use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInva
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
+use NeneInvoice\Quote\QuoteRouteRegistrar;
+use NeneInvoice\Quote\QuoteValidationExceptionHandler;
 use NeneInvoice\User\CannotDeleteSelfExceptionHandler;
 use NeneInvoice\User\RoleNotAssignableExceptionHandler;
 use NeneInvoice\User\UserEmailConflictExceptionHandler;
@@ -47,6 +50,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $userRoutes = $container->get(UserRouteRegistrar::class);
                     $clientRoutes = $container->get(ClientRouteRegistrar::class);
                     $companyRoutes = $container->get(CompanyRouteRegistrar::class);
+                    $quoteRoutes = $container->get(QuoteRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -68,7 +72,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Company route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes];
+                    if (!$quoteRoutes instanceof QuoteRouteRegistrar) {
+                        throw new LogicException('Quote route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes];
                 },
             )
             ->set(
@@ -84,6 +92,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $invalidRegNumber = $container->get(InvalidRegistrationNumberExceptionHandler::class);
                     $companySettingsNotFound = $container->get(CompanySettingsNotFoundExceptionHandler::class);
                     $companyInvalidRegNumber = $container->get(CompanyInvalidRegistrationNumberExceptionHandler::class);
+                    $quoteNotFound = $container->get(QuoteNotFoundExceptionHandler::class);
+                    $quoteValidation = $container->get(QuoteValidationExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -125,7 +135,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Company invalid registration number exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber];
+                    if (!$quoteNotFound instanceof QuoteNotFoundExceptionHandler) {
+                        throw new LogicException('Quote not-found exception handler service is invalid.');
+                    }
+
+                    if (!$quoteValidation instanceof QuoteValidationExceptionHandler) {
+                        throw new LogicException('Quote validation exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation];
                 },
             );
     }

--- a/src/Quote/CreateQuoteHandler.php
+++ b/src/Quote/CreateQuoteHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\LineItem\LineItemInput;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/quotes` — creates a draft quote in the caller's organization.
+ */
+final readonly class CreateQuoteHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private CreateQuoteUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $clientId = $decoded['client_id'] ?? null;
+
+        if (!is_int($clientId) && !(is_string($clientId) && ctype_digit($clientId))) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"client_id" is required.');
+        }
+
+        $rawLines = $decoded['line_items'] ?? null;
+
+        if (!is_array($rawLines) || $rawLines === []) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"line_items" must be a non-empty array.');
+        }
+
+        $lines = [];
+        foreach ($rawLines as $raw) {
+            if (!is_array($raw)) {
+                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item must be an object.');
+            }
+
+            $description = $raw['description'] ?? null;
+            $quantity = $raw['quantity'] ?? null;
+            $unitPrice = $raw['unit_price_cents'] ?? null;
+            $taxRate = $raw['tax_rate_bps'] ?? null;
+
+            if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
+                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).');
+            }
+
+            $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
+        }
+
+        $result = $this->useCase->execute(
+            $organizationId,
+            AuthContext::userId($request),
+            new CreateQuoteInput(
+                clientId: (int) $clientId,
+                lines: $lines,
+                validUntil: $this->optional($decoded, 'valid_until'),
+                notes: $this->optional($decoded, 'notes'),
+            ),
+        );
+
+        return $this->json->create(QuoteResponse::toArray($result->quote, $result->lines), 201);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function optional(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Quote/CreateQuoteInput.php
+++ b/src/Quote/CreateQuoteInput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use NeneInvoice\LineItem\LineItemInput;
+
+final readonly class CreateQuoteInput
+{
+    /** @param list<LineItemInput> $lines */
+    public function __construct(
+        public int $clientId,
+        public array $lines,
+        public ?string $validUntil = null,
+        public ?string $notes = null,
+    ) {
+    }
+}

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\DocumentSequence\DocumentType;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
+
+/**
+ * Creates a draft quote: validates the client and lines, computes totals
+ * (TaxCalculator, ADR 0004), allocates a quote number, persists the header and
+ * line items, and records an audit entry.
+ */
+final readonly class CreateQuoteUseCase
+{
+    /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
+    private const ALLOWED_TAX_RATES_BPS = [800, 1000];
+
+    public function __construct(
+        private QuoteRepositoryInterface $quotes,
+        private LineItemRepositoryInterface $lineItems,
+        private ClientRepositoryInterface $clients,
+        private DocumentNumberGenerator $numbers,
+        private TaxCalculator $taxCalculator,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /** @throws QuoteValidationException */
+    public function execute(int $organizationId, ?int $actorUserId, CreateQuoteInput $input): QuoteWithLines
+    {
+        $client = $this->clients->findById($input->clientId);
+
+        if ($client === null || $client->organizationId !== $organizationId) {
+            throw new QuoteValidationException('The selected client does not exist in your organization.');
+        }
+
+        if ($input->lines === []) {
+            throw new QuoteValidationException('A quote requires at least one line item.');
+        }
+
+        foreach ($input->lines as $line) {
+            if (!in_array($line->taxRateBps, self::ALLOWED_TAX_RATES_BPS, true)) {
+                throw new QuoteValidationException(sprintf('Tax rate %d bps is not allowed (use 1000 or 800).', $line->taxRateBps));
+            }
+
+            if ($line->quantity <= 0) {
+                throw new QuoteValidationException('Line item quantity must be greater than zero.');
+            }
+
+            if ($line->unitPriceCents < 0) {
+                throw new QuoteValidationException('Line item unit price must not be negative.');
+            }
+        }
+
+        $totals = $this->taxCalculator->calculate($input->lines);
+        $number = $this->numbers->next($organizationId, DocumentType::Quote, (int) date('Y'));
+
+        $quoteId = $this->quotes->save(new Quote(
+            organizationId: $organizationId,
+            clientId: $input->clientId,
+            quoteNumber: $number,
+            status: QuoteStatus::Draft,
+            subtotalCents: $totals->subtotalCents,
+            taxCents: $totals->taxCents,
+            totalCents: $totals->totalCents,
+            validUntil: $input->validUntil,
+            notes: $input->notes,
+        ));
+
+        $lineEntities = [];
+        foreach ($input->lines as $index => $line) {
+            $lineEntities[] = new LineItem(
+                parentType: LineItemParent::Quote,
+                parentId: $quoteId,
+                description: $line->description,
+                quantity: $line->quantity,
+                unitPriceCents: $line->unitPriceCents,
+                taxRateBps: $line->taxRateBps,
+                sortOrder: $index,
+            );
+        }
+
+        $this->lineItems->replaceForParent(LineItemParent::Quote, $quoteId, $lineEntities);
+
+        $saved = $this->quotes->findById($quoteId);
+
+        if ($saved === null) {
+            throw new LogicException('Quote disappeared immediately after creation.');
+        }
+
+        $lines = $this->lineItems->findByParent(LineItemParent::Quote, $quoteId);
+
+        $this->audit->record($actorUserId, $organizationId, 'quote.created', 'quote', $quoteId, null, QuoteResponse::toArray($saved, $lines));
+
+        return new QuoteWithLines($saved, $lines);
+    }
+}

--- a/src/Quote/GetQuoteByIdHandler.php
+++ b/src/Quote/GetQuoteByIdHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/quotes/{id}` — returns a quote and its line items.
+ */
+final readonly class GetQuoteByIdHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetQuoteByIdUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $result = $this->useCase->execute($organizationId, $id);
+
+        return $this->json->create(QuoteResponse::toArray($result->quote, $result->lines));
+    }
+}

--- a/src/Quote/GetQuoteByIdUseCase.php
+++ b/src/Quote/GetQuoteByIdUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+final readonly class GetQuoteByIdUseCase
+{
+    public function __construct(
+        private QuoteRepositoryInterface $quotes,
+        private LineItemRepositoryInterface $lineItems,
+    ) {
+    }
+
+    /**
+     * Fetches a quote (with its line items) belonging to the organization. A
+     * quote from another organization (or missing/soft-deleted) is not found.
+     *
+     * @throws QuoteNotFoundException
+     */
+    public function execute(int $organizationId, int $id): QuoteWithLines
+    {
+        $quote = $this->quotes->findById($id);
+
+        if ($quote === null || $quote->organizationId !== $organizationId) {
+            throw new QuoteNotFoundException($id);
+        }
+
+        return new QuoteWithLines($quote, $this->lineItems->findByParent(LineItemParent::Quote, $id));
+    }
+}

--- a/src/Quote/ListQuotesHandler.php
+++ b/src/Quote/ListQuotesHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/quotes` — lists quote headers in the caller's organization.
+ */
+final readonly class ListQuotesHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListQuotesUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (Quote $q): array => QuoteResponse::toArray($q), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/Quote/ListQuotesResult.php
+++ b/src/Quote/ListQuotesResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+final readonly class ListQuotesResult
+{
+    /** @param list<Quote> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/Quote/ListQuotesUseCase.php
+++ b/src/Quote/ListQuotesUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+final readonly class ListQuotesUseCase
+{
+    public function __construct(
+        private QuoteRepositoryInterface $quotes,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $limit, int $offset): ListQuotesResult
+    {
+        return new ListQuotesResult(
+            $this->quotes->findAllByOrganization($organizationId, $limit, $offset),
+            $this->quotes->countByOrganization($organizationId),
+        );
+    }
+}

--- a/src/Quote/QuoteNotFoundExceptionHandler.php
+++ b/src/Quote/QuoteNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class QuoteNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof QuoteNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'quote-not-found', 'Not Found', 404, 'The requested quote was not found.');
+    }
+}

--- a/src/Quote/QuoteResponse.php
+++ b/src/Quote/QuoteResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemResponse;
+
+/**
+ * Serializes a {@see Quote} to its snake_case JSON representation. When line
+ * items are supplied they are nested under `line_items`.
+ */
+final class QuoteResponse
+{
+    /**
+     * @param list<LineItem>|null $lines
+     * @return array<string, mixed>
+     */
+    public static function toArray(Quote $quote, ?array $lines = null): array
+    {
+        $data = [
+            'id' => $quote->id,
+            'organization_id' => $quote->organizationId,
+            'client_id' => $quote->clientId,
+            'quote_number' => $quote->quoteNumber,
+            'status' => $quote->status->value,
+            'issued_at' => $quote->issuedAt,
+            'valid_until' => $quote->validUntil,
+            'subtotal_cents' => $quote->subtotalCents,
+            'tax_cents' => $quote->taxCents,
+            'total_cents' => $quote->totalCents,
+            'notes' => $quote->notes,
+            'created_at' => $quote->createdAt,
+            'updated_at' => $quote->updatedAt,
+        ];
+
+        if ($lines !== null) {
+            $data['line_items'] = array_map(static fn (LineItem $l): array => LineItemResponse::toArray($l), $lines);
+        }
+
+        return $data;
+    }
+}

--- a/src/Quote/QuoteRouteRegistrar.php
+++ b/src/Quote/QuoteRouteRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers quote routes. Reads require `view_billing`, mutations require
+ * `manage_billing` (CapabilityMiddleware); all scoped to the caller's organization.
+ */
+final readonly class QuoteRouteRegistrar
+{
+    public function __construct(
+        private ListQuotesHandler $listHandler,
+        private GetQuoteByIdHandler $getHandler,
+        private CreateQuoteHandler $createHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+        $create = $this->createHandler;
+
+        $router->get('/admin/quotes', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/quotes', static fn (ServerRequestInterface $r) => $create->handle($r));
+        $router->get('/admin/quotes/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+    }
+}

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -8,27 +8,138 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the Quote domain. Use cases, handlers, and the route registrar are added
- * with the quote CRUD PR.
+ * Wires the Quote domain: repository, use cases, handlers, domain exception
+ * handlers, and the route registrar.
  */
 final readonly class QuoteServiceProvider implements ServiceProviderInterface
 {
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            QuoteRepositoryInterface::class,
-            static function (ContainerInterface $c): QuoteRepositoryInterface {
-                $query = $c->get(DatabaseQueryExecutorInterface::class);
+        $builder
+            ->set(
+                QuoteRepositoryInterface::class,
+                static function (ContainerInterface $c): QuoteRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
 
-                if (!$query instanceof DatabaseQueryExecutorInterface) {
-                    throw new LogicException('Database query executor service is invalid.');
-                }
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
 
-                return new PdoQuoteRepository($query);
-            },
-        );
+                    return new PdoQuoteRepository($query);
+                },
+            )
+            ->set(TaxCalculator::class, static fn (ContainerInterface $c): TaxCalculator => new TaxCalculator())
+            ->set(
+                CreateQuoteUseCase::class,
+                static fn (ContainerInterface $c): CreateQuoteUseCase => new CreateQuoteUseCase(
+                    self::quotes($c),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, ClientRepositoryInterface::class),
+                    self::resolve($c, DocumentNumberGenerator::class),
+                    self::resolve($c, TaxCalculator::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(ListQuotesUseCase::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
+            ->set(
+                GetQuoteByIdUseCase::class,
+                static fn (ContainerInterface $c): GetQuoteByIdUseCase => new GetQuoteByIdUseCase(
+                    self::quotes($c),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                CreateQuoteHandler::class,
+                static fn (ContainerInterface $c): CreateQuoteHandler => new CreateQuoteHandler(
+                    self::resolve($c, CreateQuoteUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                ListQuotesHandler::class,
+                static fn (ContainerInterface $c): ListQuotesHandler => new ListQuotesHandler(
+                    self::resolve($c, ListQuotesUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                GetQuoteByIdHandler::class,
+                static fn (ContainerInterface $c): GetQuoteByIdHandler => new GetQuoteByIdHandler(
+                    self::resolve($c, GetQuoteByIdUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                QuoteNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): QuoteNotFoundExceptionHandler => new QuoteNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                QuoteValidationExceptionHandler::class,
+                static fn (ContainerInterface $c): QuoteValidationExceptionHandler => new QuoteValidationExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                QuoteRouteRegistrar::class,
+                static function (ContainerInterface $c): QuoteRouteRegistrar {
+                    $list = $c->get(ListQuotesHandler::class);
+                    $get = $c->get(GetQuoteByIdHandler::class);
+                    $create = $c->get(CreateQuoteHandler::class);
+
+                    if (!$list instanceof ListQuotesHandler || !$get instanceof GetQuoteByIdHandler || !$create instanceof CreateQuoteHandler) {
+                        throw new LogicException('Quote handler services are invalid.');
+                    }
+
+                    return new QuoteRouteRegistrar($list, $get, $create);
+                },
+            );
+    }
+
+    private static function quotes(ContainerInterface $c): QuoteRepositoryInterface
+    {
+        $repo = $c->get(QuoteRepositoryInterface::class);
+
+        if (!$repo instanceof QuoteRepositoryInterface) {
+            throw new LogicException('Quote repository service is invalid.');
+        }
+
+        return $repo;
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        return self::resolve($c, JsonResponseFactory::class);
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        return self::resolve($c, ProblemDetailsResponseFactory::class);
     }
 }

--- a/src/Quote/QuoteValidationException.php
+++ b/src/Quote/QuoteValidationException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use DomainException;
+
+/**
+ * Thrown when quote input is invalid (unknown client, empty lines, disallowed
+ * tax rate, etc.). Surfaces as 422 Validation Failed.
+ */
+final class QuoteValidationException extends DomainException
+{
+}

--- a/src/Quote/QuoteValidationExceptionHandler.php
+++ b/src/Quote/QuoteValidationExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class QuoteValidationExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof QuoteValidationException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $exception->getMessage());
+    }
+}

--- a/src/Quote/QuoteWithLines.php
+++ b/src/Quote/QuoteWithLines.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use NeneInvoice\LineItem\LineItem;
+
+final readonly class QuoteWithLines
+{
+    /** @param list<LineItem> $lines */
+    public function __construct(
+        public Quote $quote,
+        public array $lines,
+    ) {
+    }
+}

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Quote\CreateQuoteInput;
+use NeneInvoice\Quote\CreateQuoteUseCase;
+use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Quote\QuoteValidationException;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class CreateQuoteUseCaseTest extends TestCase
+{
+    private InMemoryQuoteRepository $quotes;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private RecordingAuditRecorder $audit;
+    private CreateQuoteUseCase $useCase;
+    private int $clientId;
+
+    protected function setUp(): void
+    {
+        $this->quotes = new InMemoryQuoteRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->clients = new InMemoryClientRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->clientId = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
+
+        $this->useCase = new CreateQuoteUseCase(
+            $this->quotes,
+            $this->lineItems,
+            $this->clients,
+            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
+            new TaxCalculator(),
+            $this->audit,
+        );
+    }
+
+    public function test_creates_quote_with_computed_totals_number_lines_and_audit(): void
+    {
+        $result = $this->useCase->execute(1, 42, new CreateQuoteInput(
+            clientId: $this->clientId,
+            lines: [
+                new LineItemInput('Standard', 1, 1000, 1000), // ¥1000 @10% → 100
+                new LineItemInput('Reduced', 1, 1000, 800),   // ¥1000 @8%  → 80
+            ],
+        ));
+
+        self::assertSame(QuoteStatus::Draft, $result->quote->status);
+        self::assertSame(2000, $result->quote->subtotalCents);
+        self::assertSame(180, $result->quote->taxCents);
+        self::assertSame(2180, $result->quote->totalCents);
+        self::assertStringStartsWith('EST-', $result->quote->quoteNumber);
+        self::assertStringEndsWith('-001', $result->quote->quoteNumber);
+
+        self::assertCount(2, $result->lines);
+        self::assertSame(LineItemParent::Quote, $result->lines[0]->parentType);
+
+        self::assertCount(1, $this->audit->records);
+        self::assertSame('quote.created', $this->audit->records[0]['action']);
+        self::assertSame(42, $this->audit->records[0]['actor_user_id']);
+    }
+
+    public function test_rejects_client_from_another_organization(): void
+    {
+        $otherClient = $this->clients->save(new Client(organizationId: 2, name: 'Other'));
+
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, 1, new CreateQuoteInput($otherClient, [new LineItemInput('X', 1, 1000, 1000)]));
+    }
+
+    public function test_rejects_empty_lines(): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, 1, new CreateQuoteInput($this->clientId, []));
+    }
+
+    public function test_rejects_disallowed_tax_rate(): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, 1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, 500)]));
+    }
+}

--- a/tests/Support/InMemoryDocumentSequenceRepository.php
+++ b/tests/Support/InMemoryDocumentSequenceRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\DocumentSequence\DocumentSequenceRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryDocumentSequenceRepository implements DocumentSequenceRepositoryInterface
+{
+    /** @var array<string, int> */
+    private array $counters = [];
+
+    public function nextNumber(int $organizationId, string $docType, int $year): int
+    {
+        $key = $organizationId . ':' . $docType . ':' . $year;
+        $next = ($this->counters[$key] ?? 0) + 1;
+        $this->counters[$key] = $next;
+
+        return $next;
+    }
+}

--- a/tests/Support/InMemoryLineItemRepository.php
+++ b/tests/Support/InMemoryLineItemRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryLineItemRepository implements LineItemRepositoryInterface
+{
+    /** @var array<string, list<LineItem>> */
+    private array $byParent = [];
+    private int $nextId = 1;
+
+    /** @return list<LineItem> */
+    public function findByParent(LineItemParent $parentType, int $parentId): array
+    {
+        $lines = $this->byParent[$this->key($parentType, $parentId)] ?? [];
+
+        usort($lines, static fn (LineItem $a, LineItem $b): int => $a->sortOrder <=> $b->sortOrder);
+
+        return $lines;
+    }
+
+    /** @param list<LineItem> $lines */
+    public function replaceForParent(LineItemParent $parentType, int $parentId, array $lines): void
+    {
+        $stored = [];
+
+        foreach ($lines as $line) {
+            $stored[] = new LineItem(
+                parentType: $parentType,
+                parentId: $parentId,
+                description: $line->description,
+                quantity: $line->quantity,
+                unitPriceCents: $line->unitPriceCents,
+                taxRateBps: $line->taxRateBps,
+                sortOrder: $line->sortOrder,
+                id: $this->nextId++,
+                createdAt: '2026-05-29 00:00:00',
+                updatedAt: '2026-05-29 00:00:00',
+            );
+        }
+
+        $this->byParent[$this->key($parentType, $parentId)] = $stored;
+    }
+
+    public function deleteForParent(LineItemParent $parentType, int $parentId): void
+    {
+        unset($this->byParent[$this->key($parentType, $parentId)]);
+    }
+
+    private function key(LineItemParent $parentType, int $parentId): string
+    {
+        return $parentType->value . ':' . $parentId;
+    }
+}

--- a/tests/Support/InMemoryQuoteRepository.php
+++ b/tests/Support/InMemoryQuoteRepository.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryQuoteRepository implements QuoteRepositoryInterface
+{
+    /** @var array<int, Quote> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?Quote
+    {
+        $quote = $this->byId[$id] ?? null;
+
+        return $quote !== null && !$quote->isDeleted ? $quote : null;
+    }
+
+    /** @return list<Quote> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (Quote $q): bool => $q->organizationId === $organizationId && !$q->isDeleted,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (Quote $q): bool => $q->organizationId === $organizationId && !$q->isDeleted,
+        ));
+    }
+
+    public function save(Quote $quote): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = $this->withId($quote, $id);
+
+        return $id;
+    }
+
+    public function update(Quote $quote): void
+    {
+        if ($quote->id === null || $this->findById($quote->id) === null) {
+            throw new QuoteNotFoundException($quote->id ?? 0);
+        }
+
+        $this->byId[$quote->id] = $quote;
+    }
+
+    public function delete(int $id): void
+    {
+        $existing = $this->findById($id);
+
+        if ($existing === null) {
+            throw new QuoteNotFoundException($id);
+        }
+
+        $this->byId[$id] = $this->withId($existing, $id, isDeleted: true);
+    }
+
+    private function withId(Quote $quote, int $id, bool $isDeleted = false): Quote
+    {
+        return new Quote(
+            organizationId: $quote->organizationId,
+            clientId: $quote->clientId,
+            quoteNumber: $quote->quoteNumber,
+            status: $quote->status,
+            subtotalCents: $quote->subtotalCents,
+            taxCents: $quote->taxCents,
+            totalCents: $quote->totalCents,
+            issuedAt: $quote->issuedAt,
+            validUntil: $quote->validUntil,
+            notes: $quote->notes,
+            isDeleted: $isDeleted,
+            id: $id,
+            createdAt: $quote->createdAt ?? '2026-05-29 00:00:00',
+            updatedAt: '2026-05-29 00:00:00',
+        );
+    }
+}


### PR DESCRIPTION
Closes #61

## 目的
見積の作成・一覧・取得。**create で全ドメイン部品（client検証 → TaxCalculator → DocumentNumberGenerator → line_items → 監査）を1ユースケースに結線**。

## エンドポイント（org スコープ）
- POST /admin/quotes（manage_billing）: 税率 10%/8% のみ、cross-org client/空行/不正税率 → 422
- GET /admin/quotes（view_billing）/ GET /admin/quotes/{id}（+line_items）

## 検証
- composer check green（**89 tests / 304 assertions**・PHPStan no errors・cs clean）
- UseCase テスト（totals/採番/明細/監査、越境 client・空行・不正税率を拒否）
- ライブ: create 201（subtotal 2000 / tax **180** / total 2180、**EST-2026-001**、2 lines）、bad-rate 422、get/list、quote.created 監査

## 非範囲（次 PR）
状態遷移（draft→sent→accepted/rejected/expired）

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)