### PR TITLE
feat(quote): Quote 状態遷移（draft→sent→accepted/rejected/expired）を追加する (#63)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -141,7 +141,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `getCompanySettings`, `updateCompanySettings` | Company (issuer profile, per org) |
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
-| `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
+| `listQuotes`, `getQuoteById`, `createQuote`, `changeQuoteStatus`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
 | `listPayments`, `createPayment` | Payment |
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #61)
+Last updated: 2026-05-29 (Issue #63)
 
 ## Recently merged
 
@@ -31,13 +31,14 @@ Last updated: 2026-05-29 (Issue #61)
 - **Issue #55 / PR #56** — 文書採番（document_sequences）✅ merged
 - **Issue #57 / PR #58** — line_items 永続化（quote/invoice 共有）✅ merged
 - **Issue #59 / PR #60** — Quote 永続化レイヤ ✅ merged
-- **Issue #61** — Quote 作成/一覧/取得（結線）⏳ this PR
+- **Issue #61 / PR #62** — Quote 作成/一覧/取得（結線）✅ merged
+- **Issue #63** — Quote 状態遷移 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #61 | `feat/61-quote-create-read` | Quote 作成/一覧/取得（採番+税+明細+監査の結線） | 🔄 PR pending |
+| #63 | `feat/63-quote-status` | Quote 状態遷移（draft→sent→accepted/rejected/expired） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -166,7 +167,13 @@ Last updated: 2026-05-29 (Issue #61)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Quote create/list/get: 🔄 in progress** (Issue #61)
+**Phase 1 — Quote status transitions: 🔄 in progress** (Issue #63)
+
+- `QuoteStatus::canTransitionTo` (draft→sent→accepted/rejected/expired; terminal states blocked)
+- `PATCH /admin/quotes/{id}` {status} → 422 `invalid-state-transition` on illegal moves; draft→sent sets issued_at; `quote.status_changed` audit
+- Verified live: sent/accepted ok, accepted→rejected 422, garbage 422, audit trail
+
+**Phase 1 — Quote create/list/get: ✅ complete** (Issue #61 / PR #62)
 
 - `POST/GET /admin/quotes`, `GET /admin/quotes/{id}` — create orchestrates client validation + `TaxCalculator` + `DocumentNumberGenerator` (EST-YYYY-NNN) + line items + `quote.created` audit
 - Allowed tax rates 10%/8% (accounting-compliance §3); cross-org client / empty lines / bad rate → 422
@@ -217,6 +224,6 @@ Last updated: 2026-05-29 (Issue #61)
 
 ## Next steps
 
-1. Quote status transitions (draft→sent→accepted/rejected/expired) with rules + audit
-2. Invoices — convert from accepted quote, issue (number/qualified validation), line items
-3. Payments → overdue; audit read endpoint
+1. Invoice persistence — `invoices` table + entity/repository (qualified fields, totals, soft delete)
+2. Invoice convert-from-quote / issue (qualified validation) / list / get
+3. Payments → overdue (paid/partially_paid); audit read endpoint

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -17,6 +17,7 @@ use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInva
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
 use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
 use NeneInvoice\Quote\QuoteRouteRegistrar;
 use NeneInvoice\Quote\QuoteValidationExceptionHandler;
@@ -94,6 +95,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $companyInvalidRegNumber = $container->get(CompanyInvalidRegistrationNumberExceptionHandler::class);
                     $quoteNotFound = $container->get(QuoteNotFoundExceptionHandler::class);
                     $quoteValidation = $container->get(QuoteValidationExceptionHandler::class);
+                    $quoteInvalidTransition = $container->get(InvalidStateTransitionExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -143,7 +145,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Quote validation exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation];
+                    if (!$quoteInvalidTransition instanceof InvalidStateTransitionExceptionHandler) {
+                        throw new LogicException('Quote invalid state transition exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition];
                 },
             );
     }

--- a/src/Quote/ChangeQuoteStatusHandler.php
+++ b/src/Quote/ChangeQuoteStatusHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `PATCH /admin/quotes/{id}` — changes a quote's status (e.g. send, accept).
+ */
+final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ChangeQuoteStatusUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        $statusValue = is_array($decoded) ? ($decoded['status'] ?? null) : null;
+        $target = is_string($statusValue) ? QuoteStatus::tryFrom($statusValue) : null;
+
+        if ($target === null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"status" must be one of: draft, sent, accepted, rejected, expired.');
+        }
+
+        $quote = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, $target);
+
+        return $this->json->create(QuoteResponse::toArray($quote));
+    }
+}

--- a/src/Quote/ChangeQuoteStatusUseCase.php
+++ b/src/Quote/ChangeQuoteStatusUseCase.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+final readonly class ChangeQuoteStatusUseCase
+{
+    public function __construct(
+        private QuoteRepositoryInterface $quotes,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @throws QuoteNotFoundException
+     * @throws InvalidStateTransitionException
+     */
+    public function execute(int $organizationId, ?int $actorUserId, int $id, QuoteStatus $target): Quote
+    {
+        $quote = $this->quotes->findById($id);
+
+        if ($quote === null || $quote->organizationId !== $organizationId) {
+            throw new QuoteNotFoundException($id);
+        }
+
+        if (!$quote->status->canTransitionTo($target)) {
+            throw new InvalidStateTransitionException($quote->status, $target);
+        }
+
+        // A quote is considered issued when first sent.
+        $issuedAt = $target === QuoteStatus::Sent && $quote->issuedAt === null
+            ? date('Y-m-d H:i:s')
+            : $quote->issuedAt;
+
+        $this->quotes->update(new Quote(
+            organizationId: $quote->organizationId,
+            clientId: $quote->clientId,
+            quoteNumber: $quote->quoteNumber,
+            status: $target,
+            subtotalCents: $quote->subtotalCents,
+            taxCents: $quote->taxCents,
+            totalCents: $quote->totalCents,
+            issuedAt: $issuedAt,
+            validUntil: $quote->validUntil,
+            notes: $quote->notes,
+            id: $quote->id,
+            createdAt: $quote->createdAt,
+            updatedAt: $quote->updatedAt,
+        ));
+
+        $updated = $this->quotes->findById($id);
+
+        if ($updated === null) {
+            throw new LogicException('Quote disappeared immediately after status change.');
+        }
+
+        $this->audit->record(
+            $actorUserId,
+            $organizationId,
+            'quote.status_changed',
+            'quote',
+            $id,
+            QuoteResponse::toArray($quote),
+            QuoteResponse::toArray($updated),
+        );
+
+        return $updated;
+    }
+}

--- a/src/Quote/InvalidStateTransitionException.php
+++ b/src/Quote/InvalidStateTransitionException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use DomainException;
+
+final class InvalidStateTransitionException extends DomainException
+{
+    public function __construct(QuoteStatus $from, QuoteStatus $to)
+    {
+        parent::__construct(sprintf('A quote cannot transition from "%s" to "%s".', $from->value, $to->value));
+    }
+}

--- a/src/Quote/InvalidStateTransitionExceptionHandler.php
+++ b/src/Quote/InvalidStateTransitionExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidStateTransitionExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidStateTransitionException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invalid-state-transition', 'Unprocessable Entity', 422, $exception->getMessage());
+    }
+}

--- a/src/Quote/QuoteRouteRegistrar.php
+++ b/src/Quote/QuoteRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class QuoteRouteRegistrar
         private ListQuotesHandler $listHandler,
         private GetQuoteByIdHandler $getHandler,
         private CreateQuoteHandler $createHandler,
+        private ChangeQuoteStatusHandler $changeStatusHandler,
     ) {
     }
 
@@ -25,9 +26,11 @@ final readonly class QuoteRouteRegistrar
         $list = $this->listHandler;
         $get = $this->getHandler;
         $create = $this->createHandler;
+        $changeStatus = $this->changeStatusHandler;
 
         $router->get('/admin/quotes', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->post('/admin/quotes', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->get('/admin/quotes/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->patch('/admin/quotes/{id}', static fn (ServerRequestInterface $r) => $changeStatus->handle($r));
     }
 }

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -50,6 +50,13 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                     self::resolve($c, AuditRecorderInterface::class),
                 ),
             )
+            ->set(
+                ChangeQuoteStatusUseCase::class,
+                static fn (ContainerInterface $c): ChangeQuoteStatusUseCase => new ChangeQuoteStatusUseCase(
+                    self::quotes($c),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
             ->set(ListQuotesUseCase::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
             ->set(
                 GetQuoteByIdUseCase::class,
@@ -83,6 +90,14 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                ChangeQuoteStatusHandler::class,
+                static fn (ContainerInterface $c): ChangeQuoteStatusHandler => new ChangeQuoteStatusHandler(
+                    self::resolve($c, ChangeQuoteStatusUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 QuoteNotFoundExceptionHandler::class,
                 static fn (ContainerInterface $c): QuoteNotFoundExceptionHandler => new QuoteNotFoundExceptionHandler(self::problemDetails($c)),
             )
@@ -91,17 +106,22 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): QuoteValidationExceptionHandler => new QuoteValidationExceptionHandler(self::problemDetails($c)),
             )
             ->set(
+                InvalidStateTransitionExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidStateTransitionExceptionHandler => new InvalidStateTransitionExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
                 QuoteRouteRegistrar::class,
                 static function (ContainerInterface $c): QuoteRouteRegistrar {
                     $list = $c->get(ListQuotesHandler::class);
                     $get = $c->get(GetQuoteByIdHandler::class);
                     $create = $c->get(CreateQuoteHandler::class);
+                    $changeStatus = $c->get(ChangeQuoteStatusHandler::class);
 
-                    if (!$list instanceof ListQuotesHandler || !$get instanceof GetQuoteByIdHandler || !$create instanceof CreateQuoteHandler) {
+                    if (!$list instanceof ListQuotesHandler || !$get instanceof GetQuoteByIdHandler || !$create instanceof CreateQuoteHandler || !$changeStatus instanceof ChangeQuoteStatusHandler) {
                         throw new LogicException('Quote handler services are invalid.');
                     }
 
-                    return new QuoteRouteRegistrar($list, $get, $create);
+                    return new QuoteRouteRegistrar($list, $get, $create, $changeStatus);
                 },
             );
     }

--- a/src/Quote/QuoteStatus.php
+++ b/src/Quote/QuoteStatus.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 /**
- * Quote lifecycle states (domain-model.md). Transition rules are enforced by the
- * quote use cases (see the status-transition PR), not here.
+ * Quote lifecycle states and allowed transitions (domain-model.md):
+ * draft → sent → accepted / rejected / expired. Accepted/rejected/expired are
+ * terminal here (acceptance leads to invoice conversion in the Invoice domain).
  */
 enum QuoteStatus: string
 {
@@ -15,4 +16,13 @@ enum QuoteStatus: string
     case Accepted = 'accepted';
     case Rejected = 'rejected';
     case Expired = 'expired';
+
+    public function canTransitionTo(self $target): bool
+    {
+        return match ($this) {
+            self::Draft => $target === self::Sent,
+            self::Sent => in_array($target, [self::Accepted, self::Rejected, self::Expired], true),
+            self::Accepted, self::Rejected, self::Expired => false,
+        };
+    }
 }

--- a/tests/Quote/ChangeQuoteStatusUseCaseTest.php
+++ b/tests/Quote/ChangeQuoteStatusUseCaseTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote;
+
+use NeneInvoice\Quote\ChangeQuoteStatusUseCase;
+use NeneInvoice\Quote\InvalidStateTransitionException;
+use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeQuoteStatusUseCaseTest extends TestCase
+{
+    private InMemoryQuoteRepository $quotes;
+    private RecordingAuditRecorder $audit;
+    private ChangeQuoteStatusUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->quotes = new InMemoryQuoteRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit);
+    }
+
+    private function draft(): int
+    {
+        return $this->quotes->save(new Quote(
+            organizationId: 1,
+            clientId: 5,
+            quoteNumber: 'EST-2026-001',
+            status: QuoteStatus::Draft,
+            subtotalCents: 1000,
+            taxCents: 100,
+            totalCents: 1100,
+        ));
+    }
+
+    public function test_draft_to_sent_sets_issued_at_and_audits(): void
+    {
+        $id = $this->draft();
+
+        $quote = $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
+
+        self::assertSame(QuoteStatus::Sent, $quote->status);
+        self::assertNotNull($quote->issuedAt);
+        self::assertSame('quote.status_changed', $this->audit->records[0]['action']);
+        self::assertSame('draft', $this->audit->records[0]['before']['status'] ?? null);
+        self::assertSame('sent', $this->audit->records[0]['after']['status'] ?? null);
+    }
+
+    public function test_sent_to_accepted_is_allowed(): void
+    {
+        $id = $this->draft();
+        $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
+
+        $quote = $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+        self::assertSame(QuoteStatus::Accepted, $quote->status);
+    }
+
+    public function test_draft_to_accepted_is_rejected(): void
+    {
+        $id = $this->draft();
+
+        $this->expectException(InvalidStateTransitionException::class);
+        $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+    }
+
+    public function test_accepted_is_terminal(): void
+    {
+        $id = $this->draft();
+        $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
+        $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+
+        $this->expectException(InvalidStateTransitionException::class);
+        $this->useCase->execute(1, 7, $id, QuoteStatus::Rejected);
+    }
+
+    public function test_cross_organization_quote_not_found(): void
+    {
+        $id = $this->draft();
+
+        $this->expectException(QuoteNotFoundException::class);
+        $this->useCase->execute(2, 7, $id, QuoteStatus::Sent);
+    }
+}


### PR DESCRIPTION
Closes #63

## 変更
- `QuoteStatus::canTransitionTo`（draft→sent→accepted/rejected/expired、終端は不可）
- `PATCH /admin/quotes/{id}` {status}：不正遷移は **422 invalid-state-transition**、draft→sent で issued_at 設定、`quote.status_changed` 監査
- terminology に `changeQuoteStatus` 追加

## 検証
- composer check green（**94 tests / 313 assertions**・PHPStan no errors・cs clean）
- UseCase テスト（有効/無効遷移・終端・越境404・監査）
- ライブ: draft→sent→accepted ok、accepted→rejected **422**、不正status **422**、監査トレイル

Self-review: backend-api, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)