### PR TITLE
feat(invoice): Invoice（請求書）永続化レイヤを追加する (#65)

### DIFF
--- a/database/migrations/20260529200000_create_invoices_table.php
+++ b/database/migrations/20260529200000_create_invoices_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateInvoicesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('invoices')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('client_id', 'integer', ['null' => false])
+            ->addColumn('quote_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('invoice_number', 'string', ['limit' => 32, 'null' => true, 'default' => null])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false, 'default' => 'draft'])
+            ->addColumn('is_qualified_invoice', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('issued_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('due_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('subtotal_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('tax_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('total_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('notes', 'text', ['null' => true, 'default' => null])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_invoices_organization_id'])
+            ->addIndex(['organization_id', 'invoice_number'], ['unique' => true, 'name' => 'uniq_invoices_org_number'])
+            ->create();
+    }
+}

--- a/database/schema/invoices.sql
+++ b/database/schema/invoices.sql
@@ -1,0 +1,24 @@
+-- Schema snapshot for the invoices table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- invoice_number is NULL for drafts; the UNIQUE index permits multiple NULLs.
+CREATE TABLE IF NOT EXISTS invoices (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    client_id INTEGER NOT NULL,
+    quote_id INTEGER NULL DEFAULT NULL,
+    invoice_number VARCHAR(32) NULL DEFAULT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'draft',
+    is_qualified_invoice BOOLEAN NOT NULL DEFAULT 0,
+    issued_at DATETIME NULL DEFAULT NULL,
+    due_at DATETIME NULL DEFAULT NULL,
+    subtotal_cents INTEGER NOT NULL DEFAULT 0,
+    tax_cents INTEGER NOT NULL DEFAULT 0,
+    total_cents INTEGER NOT NULL DEFAULT 0,
+    notes TEXT NULL DEFAULT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_invoices_organization_id ON invoices (organization_id);
+CREATE UNIQUE INDEX uniq_invoices_org_number ON invoices (organization_id, invoice_number);

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #63)
+Last updated: 2026-05-29 (Issue #65)
 
 ## Recently merged
 
@@ -32,13 +32,14 @@ Last updated: 2026-05-29 (Issue #63)
 - **Issue #57 / PR #58** — line_items 永続化（quote/invoice 共有）✅ merged
 - **Issue #59 / PR #60** — Quote 永続化レイヤ ✅ merged
 - **Issue #61 / PR #62** — Quote 作成/一覧/取得（結線）✅ merged
-- **Issue #63** — Quote 状態遷移 ⏳ this PR
+- **Issue #63 / PR #64** — Quote 状態遷移 ✅ merged
+- **Issue #65** — Invoice 永続化レイヤ ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #63 | `feat/63-quote-status` | Quote 状態遷移（draft→sent→accepted/rejected/expired） | 🔄 PR pending |
+| #65 | `feat/65-invoice-persistence` | Invoice 永続化（invoices テーブル・適格請求書フラグ・totals） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -167,7 +168,13 @@ Last updated: 2026-05-29 (Issue #63)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Quote status transitions: 🔄 in progress** (Issue #63)
+**Phase 1 — Invoice persistence: 🔄 in progress** (Issue #65)
+
+- `invoices` table (qualified flag, totals, soft delete, nullable invoice_number until issued, unique org+number) + `Invoice` entity + `InvoiceStatus` enum (draft/issued/partially_paid/paid) + `PdoInvoiceRepository`
+- Drafts have no number (multiple NULLs allowed); issue assigns number + qualified flag; org-scoped reads
+- Tested on SQLite (draft save, multi-null, issue, list/count, soft delete)
+
+**Phase 1 — Quote status transitions: ✅ complete** (Issue #63 / PR #64)
 
 - `QuoteStatus::canTransitionTo` (draft→sent→accepted/rejected/expired; terminal states blocked)
 - `PATCH /admin/quotes/{id}` {status} → 422 `invalid-state-transition` on illegal moves; draft→sent sets issued_at; `quote.status_changed` audit
@@ -224,6 +231,6 @@ Last updated: 2026-05-29 (Issue #63)
 
 ## Next steps
 
-1. Invoice persistence — `invoices` table + entity/repository (qualified fields, totals, soft delete)
-2. Invoice convert-from-quote / issue (qualified validation) / list / get
+1. Invoice convert-from-quote (accepted quote → draft invoice, copy lines/totals) + list/get
+2. Invoice issue — assign INV number + qualified-invoice field validation (issuer registration etc.)
 3. Payments → overdue (paid/partially_paid); audit read endpoint

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -25,6 +25,7 @@ use NeneInvoice\Auth\CapabilityMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
+use NeneInvoice\Invoice\InvoiceServiceProvider;
 use NeneInvoice\LineItem\LineItemServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
@@ -56,6 +57,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new DocumentSequenceServiceProvider());
         $builder->addProvider(new LineItemServiceProvider());
         $builder->addProvider(new QuoteServiceProvider());
+        $builder->addProvider(new InvoiceServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/Invoice/Invoice.php
+++ b/src/Invoice/Invoice.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+/**
+ * An invoice (請求書) header. `invoiceNumber` is null until the invoice is issued
+ * (drafts have no number). `quoteId` links back to the originating quote when
+ * converted. Totals are integer cents (single source of truth — ADR 0004).
+ */
+final readonly class Invoice
+{
+    public function __construct(
+        public int $organizationId,
+        public int $clientId,
+        public InvoiceStatus $status,
+        public int $subtotalCents,
+        public int $taxCents,
+        public int $totalCents,
+        public bool $isQualifiedInvoice = false,
+        public ?int $quoteId = null,
+        public ?string $invoiceNumber = null,
+        public ?string $issuedAt = null,
+        public ?string $dueAt = null,
+        public ?string $notes = null,
+        public bool $isDeleted = false,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Invoice/InvoiceNotFoundException.php
+++ b/src/Invoice/InvoiceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use RuntimeException;
+
+final class InvoiceNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Invoice {$id} not found.");
+    }
+}

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+/**
+ * Persistence for invoices. Reads exclude soft-deleted rows; `delete` is soft.
+ */
+interface InvoiceRepositoryInterface
+{
+    public function findById(int $id): ?Invoice;
+
+    /** @return list<Invoice> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+
+    public function save(Invoice $invoice): int;
+
+    /** @throws InvoiceNotFoundException */
+    public function update(Invoice $invoice): void;
+
+    /** @throws InvoiceNotFoundException */
+    public function delete(int $id): void;
+}

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Invoice domain. Use cases, handlers, and the route registrar are
+ * added with the invoice conversion/issue/CRUD PR.
+ */
+final readonly class InvoiceServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            InvoiceRepositoryInterface::class,
+            static function (ContainerInterface $c): InvoiceRepositoryInterface {
+                $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoInvoiceRepository($query);
+            },
+        );
+    }
+}

--- a/src/Invoice/InvoiceStatus.php
+++ b/src/Invoice/InvoiceStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+/**
+ * Invoice lifecycle states (domain-model.md). `overdue` is a computed flag
+ * (status is `issued`/`partially_paid` past `due_at`), not a stored status.
+ */
+enum InvoiceStatus: string
+{
+    case Draft = 'draft';
+    case Issued = 'issued';
+    case PartiallyPaid = 'partially_paid';
+    case Paid = 'paid';
+}

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Invoice
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<Invoice> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): Invoice => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM invoices WHERE organization_id = ? AND is_deleted = 0',
+            [$organizationId],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function save(Invoice $invoice): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO invoices (organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [
+                $invoice->organizationId,
+                $invoice->clientId,
+                $invoice->quoteId,
+                $invoice->invoiceNumber,
+                $invoice->status->value,
+                $invoice->isQualifiedInvoice ? 1 : 0,
+                $invoice->issuedAt,
+                $invoice->dueAt,
+                $invoice->subtotalCents,
+                $invoice->taxCents,
+                $invoice->totalCents,
+                $invoice->notes,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Invoice $invoice): void
+    {
+        if ($invoice->id === null) {
+            throw new InvoiceNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE invoices SET client_id = ?, quote_id = ?, invoice_number = ?, status = ?, is_qualified_invoice = ?, issued_at = ?, due_at = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [
+                $invoice->clientId,
+                $invoice->quoteId,
+                $invoice->invoiceNumber,
+                $invoice->status->value,
+                $invoice->isQualifiedInvoice ? 1 : 0,
+                $invoice->issuedAt,
+                $invoice->dueAt,
+                $invoice->subtotalCents,
+                $invoice->taxCents,
+                $invoice->totalCents,
+                $invoice->notes,
+                $now,
+                $invoice->id,
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($invoice->id) === null) {
+            throw new InvoiceNotFoundException($invoice->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new InvoiceNotFoundException($id);
+        }
+
+        $this->query->execute(
+            'UPDATE invoices SET is_deleted = 1, deleted_at = ? WHERE id = ?',
+            [date('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Invoice
+    {
+        return new Invoice(
+            organizationId: (int) $row['organization_id'],
+            clientId: (int) $row['client_id'],
+            status: InvoiceStatus::from((string) $row['status']),
+            subtotalCents: (int) $row['subtotal_cents'],
+            taxCents: (int) $row['tax_cents'],
+            totalCents: (int) $row['total_cents'],
+            isQualifiedInvoice: (bool) $row['is_qualified_invoice'],
+            quoteId: isset($row['quote_id']) ? (int) $row['quote_id'] : null,
+            invoiceNumber: isset($row['invoice_number']) && $row['invoice_number'] !== '' ? (string) $row['invoice_number'] : null,
+            issuedAt: isset($row['issued_at']) && $row['issued_at'] !== '' ? (string) $row['issued_at'] : null,
+            dueAt: isset($row['due_at']) && $row['due_at'] !== '' ? (string) $row['due_at'] : null,
+            notes: isset($row['notes']) && $row['notes'] !== '' ? (string) $row['notes'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/tests/Invoice/PdoInvoiceRepositoryTest.php
+++ b/tests/Invoice/PdoInvoiceRepositoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\PdoInvoiceRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoInvoiceRepositoryTest extends TestCase
+{
+    private PdoInvoiceRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/invoices.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoInvoiceRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_saves_draft_without_number_then_reads_back(): void
+    {
+        $id = $this->repository->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Draft,
+            subtotalCents: 2000,
+            taxCents: 180,
+            totalCents: 2180,
+            quoteId: 9,
+        ));
+
+        $invoice = $this->repository->findById($id);
+        self::assertNotNull($invoice);
+        self::assertNull($invoice->invoiceNumber);
+        self::assertSame(InvoiceStatus::Draft, $invoice->status);
+        self::assertSame(9, $invoice->quoteId);
+        self::assertFalse($invoice->isQualifiedInvoice);
+        self::assertSame(2180, $invoice->totalCents);
+    }
+
+    public function test_multiple_drafts_with_null_number_allowed(): void
+    {
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+
+        self::assertSame(2, $this->repository->countByOrganization(1));
+    }
+
+    public function test_issue_assigns_number_and_qualified_flag(): void
+    {
+        $id = $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 1000, taxCents: 100, totalCents: 1100));
+
+        $this->repository->update(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 1000,
+            taxCents: 100,
+            totalCents: 1100,
+            isQualifiedInvoice: true,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-29 00:00:00',
+            id: $id,
+        ));
+
+        $issued = $this->repository->findById($id);
+        self::assertNotNull($issued);
+        self::assertSame('INV-2026-001', $issued->invoiceNumber);
+        self::assertSame(InvoiceStatus::Issued, $issued->status);
+        self::assertTrue($issued->isQualifiedInvoice);
+    }
+
+    public function test_list_and_count_scoped_to_organization(): void
+    {
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+        $this->repository->save(new Invoice(organizationId: 2, clientId: 9, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+
+        self::assertSame(1, $this->repository->countByOrganization(1));
+        self::assertCount(1, $this->repository->findAllByOrganization(1, 10, 0));
+    }
+
+    public function test_soft_delete_and_unknown_delete_throws(): void
+    {
+        $id = $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+        $this->repository->delete($id);
+        self::assertNull($this->repository->findById($id));
+
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->repository->delete(999);
+    }
+}


### PR DESCRIPTION
Closes #65

## 変更
- `invoices` テーブル（nullable invoice_number＝発行時採番・unique org+number は複数NULL許容・is_qualified_invoice・quote_id・issued_at/due_at・ソフト削除）
- `InvoiceStatus` enum（draft/issued/partially_paid/paid、overdue は計算値で非保存）
- `Invoice` エンティティ・`PdoInvoiceRepository`・`InvoiceServiceProvider`

## 検証
- composer check green（**99 tests / 333 assertions**・PHPStan no errors・cs clean）
- リポジトリテスト：draft 無番号・複数NULL許容・発行で採番/適格フラグ・org スコープ・ソフト削除
- phinx migrate 確認

## 非範囲（次 PR）
見積→請求書変換 / 発行（採番・適格請求書検証） / Payments

Self-review: backend-api, database, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)