### PR TITLE
feat(invoice): 見積→請求書変換 + 請求書一覧/取得を追加する (#67)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #65)
+Last updated: 2026-05-29 (Issue #67)
 
 ## Recently merged
 
@@ -33,13 +33,14 @@ Last updated: 2026-05-29 (Issue #65)
 - **Issue #59 / PR #60** — Quote 永続化レイヤ ✅ merged
 - **Issue #61 / PR #62** — Quote 作成/一覧/取得（結線）✅ merged
 - **Issue #63 / PR #64** — Quote 状態遷移 ✅ merged
-- **Issue #65** — Invoice 永続化レイヤ ⏳ this PR
+- **Issue #65 / PR #66** — Invoice 永続化レイヤ ✅ merged
+- **Issue #67** — 見積→請求書変換 + 請求書一覧/取得 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #65 | `feat/65-invoice-persistence` | Invoice 永続化（invoices テーブル・適格請求書フラグ・totals） | 🔄 PR pending |
+| #67 | `feat/67-invoice-convert-read` | 見積→請求書変換 + 請求書一覧/取得 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -168,7 +169,14 @@ Last updated: 2026-05-29 (Issue #65)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Invoice persistence: 🔄 in progress** (Issue #65)
+**Phase 1 — Invoice convert + list/get: 🔄 in progress** (Issue #67)
+
+- `POST /admin/quotes/{id}/convert` (accepted quote → draft invoice; copies client/totals/line_items, links quote_id, `invoice.created` audit; non-accepted → 422)
+- `GET /admin/invoices`, `GET /admin/invoices/{id}` (org-scoped, +line_items)
+- Verified live: convert-before-accept 422, accepted→draft invoice (total 2180, 2 lines, no number yet), list/get, audit trail
+- Next: issue (assign INV number + qualified-invoice validation)
+
+**Phase 1 — Invoice persistence: ✅ complete** (Issue #65 / PR #66)
 
 - `invoices` table (qualified flag, totals, soft delete, nullable invoice_number until issued, unique org+number) + `Invoice` entity + `InvoiceStatus` enum (draft/issued/partially_paid/paid) + `PdoInvoiceRepository`
 - Drafts have no number (multiple NULLs allowed); issue assigns number + qualified flag; org-scoped reads
@@ -231,6 +239,6 @@ Last updated: 2026-05-29 (Issue #65)
 
 ## Next steps
 
-1. Invoice convert-from-quote (accepted quote → draft invoice, copy lines/totals) + list/get
-2. Invoice issue — assign INV number + qualified-invoice field validation (issuer registration etc.)
-3. Payments → overdue (paid/partially_paid); audit read endpoint
+1. Invoice issue — assign INV-YYYY-NNN + qualified-invoice field validation (issuer registration etc.) + status draft→issued
+2. Payments (record) → invoice paid/partially_paid; overdue computed
+3. Direct invoice create; audit read endpoint

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -14,6 +14,8 @@ use NeneInvoice\Client\InvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Company\CompanyRouteRegistrar;
 use NeneInvoice\Company\CompanySettingsNotFoundExceptionHandler;
 use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInvalidRegistrationNumberExceptionHandler;
+use NeneInvoice\Invoice\InvoiceNotFoundExceptionHandler;
+use NeneInvoice\Invoice\InvoiceRouteRegistrar;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -52,6 +54,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $clientRoutes = $container->get(ClientRouteRegistrar::class);
                     $companyRoutes = $container->get(CompanyRouteRegistrar::class);
                     $quoteRoutes = $container->get(QuoteRouteRegistrar::class);
+                    $invoiceRoutes = $container->get(InvoiceRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -77,7 +80,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Quote route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes];
+                    if (!$invoiceRoutes instanceof InvoiceRouteRegistrar) {
+                        throw new LogicException('Invoice route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes];
                 },
             )
             ->set(
@@ -96,6 +103,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $quoteNotFound = $container->get(QuoteNotFoundExceptionHandler::class);
                     $quoteValidation = $container->get(QuoteValidationExceptionHandler::class);
                     $quoteInvalidTransition = $container->get(InvalidStateTransitionExceptionHandler::class);
+                    $invoiceNotFound = $container->get(InvoiceNotFoundExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -149,7 +157,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Quote invalid state transition exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition];
+                    if (!$invoiceNotFound instanceof InvoiceNotFoundExceptionHandler) {
+                        throw new LogicException('Invoice not-found exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound];
                 },
             );
     }

--- a/src/Invoice/ConvertQuoteToInvoiceHandler.php
+++ b/src/Invoice/ConvertQuoteToInvoiceHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/quotes/{id}/convert` — creates a draft invoice from an accepted quote.
+ */
+final readonly class ConvertQuoteToInvoiceHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ConvertQuoteToInvoiceUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $quoteId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $result = $this->useCase->execute($organizationId, AuthContext::userId($request), $quoteId);
+
+        return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines), 201);
+    }
+}

--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteRepositoryInterface;
+use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Quote\QuoteValidationException;
+
+/**
+ * Converts an accepted quote into a new draft invoice, copying the client,
+ * totals, and line items. The invoice is numbered and validated later, at issue.
+ */
+final readonly class ConvertQuoteToInvoiceUseCase
+{
+    public function __construct(
+        private QuoteRepositoryInterface $quotes,
+        private InvoiceRepositoryInterface $invoices,
+        private LineItemRepositoryInterface $lineItems,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @throws QuoteNotFoundException
+     * @throws QuoteValidationException
+     */
+    public function execute(int $organizationId, ?int $actorUserId, int $quoteId): InvoiceWithLines
+    {
+        $quote = $this->quotes->findById($quoteId);
+
+        if ($quote === null || $quote->organizationId !== $organizationId) {
+            throw new QuoteNotFoundException($quoteId);
+        }
+
+        if ($quote->status !== QuoteStatus::Accepted) {
+            throw new QuoteValidationException('Only an accepted quote can be converted to an invoice.');
+        }
+
+        $invoiceId = $this->invoices->save(new Invoice(
+            organizationId: $organizationId,
+            clientId: $quote->clientId,
+            status: InvoiceStatus::Draft,
+            subtotalCents: $quote->subtotalCents,
+            taxCents: $quote->taxCents,
+            totalCents: $quote->totalCents,
+            quoteId: $quote->id,
+            notes: $quote->notes,
+        ));
+
+        $quoteLines = $this->lineItems->findByParent(LineItemParent::Quote, $quoteId);
+        $invoiceLines = [];
+        foreach ($quoteLines as $line) {
+            $invoiceLines[] = new LineItem(
+                parentType: LineItemParent::Invoice,
+                parentId: $invoiceId,
+                description: $line->description,
+                quantity: $line->quantity,
+                unitPriceCents: $line->unitPriceCents,
+                taxRateBps: $line->taxRateBps,
+                sortOrder: $line->sortOrder,
+            );
+        }
+
+        $this->lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $invoiceLines);
+
+        $saved = $this->invoices->findById($invoiceId);
+
+        if ($saved === null) {
+            throw new LogicException('Invoice disappeared immediately after conversion.');
+        }
+
+        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
+
+        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $invoiceId, null, InvoiceResponse::toArray($saved, $lines));
+
+        return new InvoiceWithLines($saved, $lines);
+    }
+}

--- a/src/Invoice/GetInvoiceByIdHandler.php
+++ b/src/Invoice/GetInvoiceByIdHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/invoices/{id}` — returns an invoice and its line items.
+ */
+final readonly class GetInvoiceByIdHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetInvoiceByIdUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $result = $this->useCase->execute($organizationId, $id);
+
+        return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines));
+    }
+}

--- a/src/Invoice/GetInvoiceByIdUseCase.php
+++ b/src/Invoice/GetInvoiceByIdUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+final readonly class GetInvoiceByIdUseCase
+{
+    public function __construct(
+        private InvoiceRepositoryInterface $invoices,
+        private LineItemRepositoryInterface $lineItems,
+    ) {
+    }
+
+    /** @throws InvoiceNotFoundException */
+    public function execute(int $organizationId, int $id): InvoiceWithLines
+    {
+        $invoice = $this->invoices->findById($id);
+
+        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+            throw new InvoiceNotFoundException($id);
+        }
+
+        return new InvoiceWithLines($invoice, $this->lineItems->findByParent(LineItemParent::Invoice, $id));
+    }
+}

--- a/src/Invoice/InvoiceNotFoundExceptionHandler.php
+++ b/src/Invoice/InvoiceNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvoiceNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvoiceNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'The requested invoice was not found.');
+    }
+}

--- a/src/Invoice/InvoiceResponse.php
+++ b/src/Invoice/InvoiceResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemResponse;
+
+/**
+ * Serializes an {@see Invoice} to its snake_case JSON representation. Line items
+ * are nested under `line_items` when supplied.
+ */
+final class InvoiceResponse
+{
+    /**
+     * @param list<LineItem>|null $lines
+     * @return array<string, mixed>
+     */
+    public static function toArray(Invoice $invoice, ?array $lines = null): array
+    {
+        $data = [
+            'id' => $invoice->id,
+            'organization_id' => $invoice->organizationId,
+            'client_id' => $invoice->clientId,
+            'quote_id' => $invoice->quoteId,
+            'invoice_number' => $invoice->invoiceNumber,
+            'status' => $invoice->status->value,
+            'is_qualified_invoice' => $invoice->isQualifiedInvoice,
+            'issued_at' => $invoice->issuedAt,
+            'due_at' => $invoice->dueAt,
+            'subtotal_cents' => $invoice->subtotalCents,
+            'tax_cents' => $invoice->taxCents,
+            'total_cents' => $invoice->totalCents,
+            'notes' => $invoice->notes,
+            'created_at' => $invoice->createdAt,
+            'updated_at' => $invoice->updatedAt,
+        ];
+
+        if ($lines !== null) {
+            $data['line_items'] = array_map(static fn (LineItem $l): array => LineItemResponse::toArray($l), $lines);
+        }
+
+        return $data;
+    }
+}

--- a/src/Invoice/InvoiceRouteRegistrar.php
+++ b/src/Invoice/InvoiceRouteRegistrar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers invoice routes. Reads require `view_billing`, mutations require
+ * `manage_billing`; all scoped to the caller's organization. The convert action
+ * lives under `/admin/quotes/{id}/convert` (acts on a quote, produces an invoice).
+ */
+final readonly class InvoiceRouteRegistrar
+{
+    public function __construct(
+        private ListInvoicesHandler $listHandler,
+        private GetInvoiceByIdHandler $getHandler,
+        private ConvertQuoteToInvoiceHandler $convertHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+        $convert = $this->convertHandler;
+
+        $router->get('/admin/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->get('/admin/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->post('/admin/quotes/{id}/convert', static fn (ServerRequestInterface $r) => $convert->handle($r));
+    }
+}

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -8,27 +8,118 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\Quote\QuoteRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the Invoice domain. Use cases, handlers, and the route registrar are
- * added with the invoice conversion/issue/CRUD PR.
+ * Wires the Invoice domain: repository, use cases (convert / list / get),
+ * handlers, the not-found exception handler, and the route registrar.
  */
 final readonly class InvoiceServiceProvider implements ServiceProviderInterface
 {
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            InvoiceRepositoryInterface::class,
-            static function (ContainerInterface $c): InvoiceRepositoryInterface {
-                $query = $c->get(DatabaseQueryExecutorInterface::class);
+        $builder
+            ->set(
+                InvoiceRepositoryInterface::class,
+                static function (ContainerInterface $c): InvoiceRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
 
-                if (!$query instanceof DatabaseQueryExecutorInterface) {
-                    throw new LogicException('Database query executor service is invalid.');
-                }
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
 
-                return new PdoInvoiceRepository($query);
-            },
-        );
+                    return new PdoInvoiceRepository($query);
+                },
+            )
+            ->set(
+                ConvertQuoteToInvoiceUseCase::class,
+                static fn (ContainerInterface $c): ConvertQuoteToInvoiceUseCase => new ConvertQuoteToInvoiceUseCase(
+                    self::resolve($c, QuoteRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(ListInvoicesUseCase::class, static fn (ContainerInterface $c): ListInvoicesUseCase => new ListInvoicesUseCase(self::resolve($c, InvoiceRepositoryInterface::class)))
+            ->set(
+                GetInvoiceByIdUseCase::class,
+                static fn (ContainerInterface $c): GetInvoiceByIdUseCase => new GetInvoiceByIdUseCase(
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                ConvertQuoteToInvoiceHandler::class,
+                static fn (ContainerInterface $c): ConvertQuoteToInvoiceHandler => new ConvertQuoteToInvoiceHandler(
+                    self::resolve($c, ConvertQuoteToInvoiceUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                ListInvoicesHandler::class,
+                static fn (ContainerInterface $c): ListInvoicesHandler => new ListInvoicesHandler(
+                    self::resolve($c, ListInvoicesUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                GetInvoiceByIdHandler::class,
+                static fn (ContainerInterface $c): GetInvoiceByIdHandler => new GetInvoiceByIdHandler(
+                    self::resolve($c, GetInvoiceByIdUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                InvoiceNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): InvoiceNotFoundExceptionHandler => new InvoiceNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                InvoiceRouteRegistrar::class,
+                static function (ContainerInterface $c): InvoiceRouteRegistrar {
+                    $list = $c->get(ListInvoicesHandler::class);
+                    $get = $c->get(GetInvoiceByIdHandler::class);
+                    $convert = $c->get(ConvertQuoteToInvoiceHandler::class);
+
+                    if (!$list instanceof ListInvoicesHandler || !$get instanceof GetInvoiceByIdHandler || !$convert instanceof ConvertQuoteToInvoiceHandler) {
+                        throw new LogicException('Invoice handler services are invalid.');
+                    }
+
+                    return new InvoiceRouteRegistrar($list, $get, $convert);
+                },
+            );
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        return self::resolve($c, JsonResponseFactory::class);
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        return self::resolve($c, ProblemDetailsResponseFactory::class);
     }
 }

--- a/src/Invoice/InvoiceWithLines.php
+++ b/src/Invoice/InvoiceWithLines.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\LineItem\LineItem;
+
+final readonly class InvoiceWithLines
+{
+    /** @param list<LineItem> $lines */
+    public function __construct(
+        public Invoice $invoice,
+        public array $lines,
+    ) {
+    }
+}

--- a/src/Invoice/ListInvoicesHandler.php
+++ b/src/Invoice/ListInvoicesHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/invoices` — lists invoice headers in the caller's organization.
+ */
+final readonly class ListInvoicesHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListInvoicesUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (Invoice $i): array => InvoiceResponse::toArray($i), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/Invoice/ListInvoicesResult.php
+++ b/src/Invoice/ListInvoicesResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+final readonly class ListInvoicesResult
+{
+    /** @param list<Invoice> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/Invoice/ListInvoicesUseCase.php
+++ b/src/Invoice/ListInvoicesUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+final readonly class ListInvoicesUseCase
+{
+    public function __construct(
+        private InvoiceRepositoryInterface $invoices,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $limit, int $offset): ListInvoicesResult
+    {
+        return new ListInvoicesResult(
+            $this->invoices->findAllByOrganization($organizationId, $limit, $offset),
+            $this->invoices->countByOrganization($organizationId),
+        );
+    }
+}

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use NeneInvoice\Invoice\ConvertQuoteToInvoiceUseCase;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Quote\QuoteValidationException;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
+{
+    private InMemoryQuoteRepository $quotes;
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryLineItemRepository $lineItems;
+    private RecordingAuditRecorder $audit;
+    private ConvertQuoteToInvoiceUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->quotes = new InMemoryQuoteRepository();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, $this->invoices, $this->lineItems, $this->audit);
+    }
+
+    private function quote(QuoteStatus $status): int
+    {
+        $id = $this->quotes->save(new Quote(
+            organizationId: 1,
+            clientId: 5,
+            quoteNumber: 'EST-2026-001',
+            status: $status,
+            subtotalCents: 2000,
+            taxCents: 180,
+            totalCents: 2180,
+        ));
+
+        $this->lineItems->replaceForParent(LineItemParent::Quote, $id, [
+            new LineItem(LineItemParent::Quote, $id, 'Std', 1, 1000, 1000, sortOrder: 0),
+            new LineItem(LineItemParent::Quote, $id, 'Red', 1, 1000, 800, sortOrder: 1),
+        ]);
+
+        return $id;
+    }
+
+    public function test_converts_accepted_quote_copying_totals_lines_and_audits(): void
+    {
+        $quoteId = $this->quote(QuoteStatus::Accepted);
+
+        $result = $this->useCase->execute(1, 7, $quoteId);
+
+        self::assertSame(InvoiceStatus::Draft, $result->invoice->status);
+        self::assertSame($quoteId, $result->invoice->quoteId);
+        self::assertNull($result->invoice->invoiceNumber); // numbered at issue
+        self::assertSame(2180, $result->invoice->totalCents);
+        self::assertCount(2, $result->lines);
+        self::assertSame(LineItemParent::Invoice, $result->lines[0]->parentType);
+
+        self::assertSame('invoice.created', $this->audit->records[0]['action']);
+    }
+
+    public function test_rejects_non_accepted_quote(): void
+    {
+        $quoteId = $this->quote(QuoteStatus::Sent);
+
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, 7, $quoteId);
+    }
+
+    public function test_cross_organization_quote_not_found(): void
+    {
+        $quoteId = $this->quote(QuoteStatus::Accepted);
+
+        $this->expectException(QuoteNotFoundException::class);
+        $this->useCase->execute(2, 7, $quoteId);
+    }
+}

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
+{
+    /** @var array<int, Invoice> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?Invoice
+    {
+        $invoice = $this->byId[$id] ?? null;
+
+        return $invoice !== null && !$invoice->isDeleted ? $invoice : null;
+    }
+
+    /** @return list<Invoice> */
+    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (Invoice $i): bool => $i->organizationId === $organizationId && !$i->isDeleted,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (Invoice $i): bool => $i->organizationId === $organizationId && !$i->isDeleted,
+        ));
+    }
+
+    public function save(Invoice $invoice): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = $this->withId($invoice, $id, $invoice->isDeleted);
+
+        return $id;
+    }
+
+    public function update(Invoice $invoice): void
+    {
+        if ($invoice->id === null || $this->findById($invoice->id) === null) {
+            throw new InvoiceNotFoundException($invoice->id ?? 0);
+        }
+
+        $this->byId[$invoice->id] = $invoice;
+    }
+
+    public function delete(int $id): void
+    {
+        $existing = $this->findById($id);
+
+        if ($existing === null) {
+            throw new InvoiceNotFoundException($id);
+        }
+
+        $this->byId[$id] = $this->withId($existing, $id, true);
+    }
+
+    private function withId(Invoice $invoice, int $id, bool $isDeleted): Invoice
+    {
+        return new Invoice(
+            organizationId: $invoice->organizationId,
+            clientId: $invoice->clientId,
+            status: $invoice->status,
+            subtotalCents: $invoice->subtotalCents,
+            taxCents: $invoice->taxCents,
+            totalCents: $invoice->totalCents,
+            isQualifiedInvoice: $invoice->isQualifiedInvoice,
+            quoteId: $invoice->quoteId,
+            invoiceNumber: $invoice->invoiceNumber,
+            issuedAt: $invoice->issuedAt,
+            dueAt: $invoice->dueAt,
+            notes: $invoice->notes,
+            isDeleted: $isDeleted,
+            id: $id,
+            createdAt: $invoice->createdAt ?? '2026-05-29 00:00:00',
+            updatedAt: '2026-05-29 00:00:00',
+        );
+    }
+}


### PR DESCRIPTION
Closes #67

## 変更
- `POST /admin/quotes/{id}/convert`：accepted 見積のみ→draft 請求書（client/totals/line_items コピー、quote_id 紐付け、invoice.created 監査）。非 accepted は **422**
- `GET /admin/invoices` / `GET /admin/invoices/{id}`（明細付き）

## 検証
- composer check green（**102 tests / 342 assertions**・PHPStan no errors・cs clean）
- UseCase テスト（変換コピー/監査・非accepted 422・越境404）
- ライブ: convert-before-accept **422**、accepted→draft（total 2180・2 lines・番号未付与）、list/get、監査トレイル

## 非範囲（次 PR）
請求書発行（INV採番・適格請求書検証）、Payments

Self-review: backend-api, database, middleware-security, docs-policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)