### PR TITLE
feat(invoice): 請求書の発行（INV 採番 + 適格請求書検証）を追加する (#69)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #67)
+Last updated: 2026-05-29 (Issue #69)
 
 ## Recently merged
 
@@ -34,13 +34,14 @@ Last updated: 2026-05-29 (Issue #67)
 - **Issue #61 / PR #62** — Quote 作成/一覧/取得（結線）✅ merged
 - **Issue #63 / PR #64** — Quote 状態遷移 ✅ merged
 - **Issue #65 / PR #66** — Invoice 永続化レイヤ ✅ merged
-- **Issue #67** — 見積→請求書変換 + 請求書一覧/取得 ⏳ this PR
+- **Issue #67 / PR #68** — 見積→請求書変換 + 請求書一覧/取得 ✅ merged
+- **Issue #69** — 請求書の発行（INV 採番 + 適格請求書検証）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #67 | `feat/67-invoice-convert-read` | 見積→請求書変換 + 請求書一覧/取得 | 🔄 PR pending |
+| #69 | `feat/69-invoice-issue` | 請求書の発行（INV 採番 + 適格請求書検証） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -169,12 +170,18 @@ Last updated: 2026-05-29 (Issue #67)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Invoice convert + list/get: 🔄 in progress** (Issue #67)
+**Phase 1 — Invoice issue (INV 採番 + 適格請求書検証): 🔄 in progress** (Issue #69)
+
+- `POST /admin/invoices/{id}/issue` {qualified?:bool=true, due_at?} — draft → issued
+- Compliance gates (accounting-compliance §2/§4): only a **draft** can be issued (issued docs immutable → 422 `validation-failed`); a **qualified** invoice requires the issuer registration number in company settings (→ 422 `qualified-invoice-incomplete`); no line items → 422
+- Allocates `INV-YYYY-NNN` (DocumentNumberGenerator) on issue; sets status/issued_at/due_at/is_qualified_invoice; `invoice.issued` audit (before/after)
+- Tested: qualified issue (number assigned, qualified true), non-qualified issue w/o registration, qualified-without-registration → reject, non-draft → reject, no-lines → reject, cross-org → 404; full DI boot verified (HealthEndpointTest)
+
+**Phase 1 — Invoice convert + list/get: ✅ complete** (Issue #67 / PR #68)
 
 - `POST /admin/quotes/{id}/convert` (accepted quote → draft invoice; copies client/totals/line_items, links quote_id, `invoice.created` audit; non-accepted → 422)
 - `GET /admin/invoices`, `GET /admin/invoices/{id}` (org-scoped, +line_items)
 - Verified live: convert-before-accept 422, accepted→draft invoice (total 2180, 2 lines, no number yet), list/get, audit trail
-- Next: issue (assign INV number + qualified-invoice validation)
 
 **Phase 1 — Invoice persistence: ✅ complete** (Issue #65 / PR #66)
 
@@ -239,6 +246,6 @@ Last updated: 2026-05-29 (Issue #67)
 
 ## Next steps
 
-1. Invoice issue — assign INV-YYYY-NNN + qualified-invoice field validation (issuer registration etc.) + status draft→issued
-2. Payments (record) → invoice paid/partially_paid; overdue computed
-3. Direct invoice create; audit read endpoint
+1. Payments (record) → invoice paid/partially_paid; overdue computed
+2. Direct invoice create; audit read endpoint (`GET /admin/audit-logs`)
+3. OpenAPI stub (Issue #5); Backend CI (Issue #6); ADR 0003 dual deployment (Issue #7)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -16,6 +16,8 @@ use NeneInvoice\Company\CompanySettingsNotFoundExceptionHandler;
 use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Invoice\InvoiceNotFoundExceptionHandler;
 use NeneInvoice\Invoice\InvoiceRouteRegistrar;
+use NeneInvoice\Invoice\InvoiceValidationExceptionHandler;
+use NeneInvoice\Invoice\QualifiedInvoiceIncompleteExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -104,6 +106,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $quoteValidation = $container->get(QuoteValidationExceptionHandler::class);
                     $quoteInvalidTransition = $container->get(InvalidStateTransitionExceptionHandler::class);
                     $invoiceNotFound = $container->get(InvoiceNotFoundExceptionHandler::class);
+                    $invoiceValidation = $container->get(InvoiceValidationExceptionHandler::class);
+                    $qualifiedIncomplete = $container->get(QualifiedInvoiceIncompleteExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -161,7 +165,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Invoice not-found exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound];
+                    if (!$invoiceValidation instanceof InvoiceValidationExceptionHandler) {
+                        throw new LogicException('Invoice validation exception handler service is invalid.');
+                    }
+
+                    if (!$qualifiedIncomplete instanceof QualifiedInvoiceIncompleteExceptionHandler) {
+                        throw new LogicException('Qualified invoice incomplete exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete];
                 },
             );
     }

--- a/src/Invoice/InvoiceRouteRegistrar.php
+++ b/src/Invoice/InvoiceRouteRegistrar.php
@@ -18,6 +18,7 @@ final readonly class InvoiceRouteRegistrar
         private ListInvoicesHandler $listHandler,
         private GetInvoiceByIdHandler $getHandler,
         private ConvertQuoteToInvoiceHandler $convertHandler,
+        private IssueInvoiceHandler $issueHandler,
     ) {
     }
 
@@ -26,9 +27,11 @@ final readonly class InvoiceRouteRegistrar
         $list = $this->listHandler;
         $get = $this->getHandler;
         $convert = $this->convertHandler;
+        $issue = $this->issueHandler;
 
         $router->get('/admin/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->get('/admin/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->post('/admin/invoices/{id}/issue', static fn (ServerRequestInterface $r) => $issue->handle($r));
         $router->post('/admin/quotes/{id}/convert', static fn (ServerRequestInterface $r) => $convert->handle($r));
     }
 }

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -11,6 +11,8 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Company\CompanySettingsRepositoryInterface;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\Quote\QuoteRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -42,6 +44,16 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, QuoteRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(
+                IssueInvoiceUseCase::class,
+                static fn (ContainerInterface $c): IssueInvoiceUseCase => new IssueInvoiceUseCase(
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, CompanySettingsRepositoryInterface::class),
+                    self::resolve($c, DocumentNumberGenerator::class),
                     self::resolve($c, AuditRecorderInterface::class),
                 ),
             )
@@ -78,8 +90,24 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                IssueInvoiceHandler::class,
+                static fn (ContainerInterface $c): IssueInvoiceHandler => new IssueInvoiceHandler(
+                    self::resolve($c, IssueInvoiceUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 InvoiceNotFoundExceptionHandler::class,
                 static fn (ContainerInterface $c): InvoiceNotFoundExceptionHandler => new InvoiceNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                InvoiceValidationExceptionHandler::class,
+                static fn (ContainerInterface $c): InvoiceValidationExceptionHandler => new InvoiceValidationExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                QualifiedInvoiceIncompleteExceptionHandler::class,
+                static fn (ContainerInterface $c): QualifiedInvoiceIncompleteExceptionHandler => new QualifiedInvoiceIncompleteExceptionHandler(self::problemDetails($c)),
             )
             ->set(
                 InvoiceRouteRegistrar::class,
@@ -87,12 +115,13 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     $list = $c->get(ListInvoicesHandler::class);
                     $get = $c->get(GetInvoiceByIdHandler::class);
                     $convert = $c->get(ConvertQuoteToInvoiceHandler::class);
+                    $issue = $c->get(IssueInvoiceHandler::class);
 
-                    if (!$list instanceof ListInvoicesHandler || !$get instanceof GetInvoiceByIdHandler || !$convert instanceof ConvertQuoteToInvoiceHandler) {
+                    if (!$list instanceof ListInvoicesHandler || !$get instanceof GetInvoiceByIdHandler || !$convert instanceof ConvertQuoteToInvoiceHandler || !$issue instanceof IssueInvoiceHandler) {
                         throw new LogicException('Invoice handler services are invalid.');
                     }
 
-                    return new InvoiceRouteRegistrar($list, $get, $convert);
+                    return new InvoiceRouteRegistrar($list, $get, $convert, $issue);
                 },
             );
     }

--- a/src/Invoice/InvoiceValidationException.php
+++ b/src/Invoice/InvoiceValidationException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use DomainException;
+
+/**
+ * Thrown for invoice operations that are not allowed in the current state
+ * (e.g. issuing a non-draft invoice, or one with no line items). Surfaces as 422.
+ */
+final class InvoiceValidationException extends DomainException
+{
+}

--- a/src/Invoice/InvoiceValidationExceptionHandler.php
+++ b/src/Invoice/InvoiceValidationExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvoiceValidationExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvoiceValidationException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $exception->getMessage());
+    }
+}

--- a/src/Invoice/IssueInvoiceHandler.php
+++ b/src/Invoice/IssueInvoiceHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/invoices/{id}/issue` — issues a draft invoice (assigns a number,
+ * validates qualified-invoice requirements, locks it).
+ */
+final readonly class IssueInvoiceHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private IssueInvoiceUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        $qualified = !array_key_exists('qualified', $decoded) || $decoded['qualified'] === true;
+        $dueAtValue = $decoded['due_at'] ?? null;
+        $dueAt = is_string($dueAtValue) && $dueAtValue !== '' ? $dueAtValue : null;
+
+        $result = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new IssueInvoiceInput($qualified, $dueAt));
+
+        return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines));
+    }
+}

--- a/src/Invoice/IssueInvoiceInput.php
+++ b/src/Invoice/IssueInvoiceInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+final readonly class IssueInvoiceInput
+{
+    public function __construct(
+        public bool $qualified = true,
+        public ?string $dueAt = null,
+    ) {
+    }
+}

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Company\CompanySettingsRepositoryInterface;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\DocumentSequence\DocumentType;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+/**
+ * Issues a draft invoice: validates qualified-invoice requirements, allocates an
+ * INV number, and locks it as issued. Compliance: a qualified invoice cannot be
+ * issued without an issuer registration number (accounting-compliance §2/§4),
+ * and only draft invoices can be issued (issued documents are immutable).
+ */
+final readonly class IssueInvoiceUseCase
+{
+    public function __construct(
+        private InvoiceRepositoryInterface $invoices,
+        private LineItemRepositoryInterface $lineItems,
+        private CompanySettingsRepositoryInterface $companySettings,
+        private DocumentNumberGenerator $numbers,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @throws InvoiceNotFoundException
+     * @throws InvoiceValidationException
+     * @throws QualifiedInvoiceIncompleteException
+     */
+    public function execute(int $organizationId, ?int $actorUserId, int $id, IssueInvoiceInput $input): InvoiceWithLines
+    {
+        $invoice = $this->invoices->findById($id);
+
+        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+            throw new InvoiceNotFoundException($id);
+        }
+
+        if ($invoice->status !== InvoiceStatus::Draft) {
+            throw new InvoiceValidationException('Only a draft invoice can be issued.');
+        }
+
+        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $id);
+
+        if ($lines === []) {
+            throw new InvoiceValidationException('An invoice cannot be issued without line items.');
+        }
+
+        if ($input->qualified) {
+            $settings = $this->companySettings->findByOrganization($organizationId);
+
+            if ($settings === null || $settings->registrationNumber === null) {
+                throw new QualifiedInvoiceIncompleteException('A qualified invoice requires the issuer registration number to be configured in company settings.');
+            }
+        }
+
+        $number = $this->numbers->next($organizationId, DocumentType::Invoice, (int) date('Y'));
+
+        $this->invoices->update(new Invoice(
+            organizationId: $invoice->organizationId,
+            clientId: $invoice->clientId,
+            status: InvoiceStatus::Issued,
+            subtotalCents: $invoice->subtotalCents,
+            taxCents: $invoice->taxCents,
+            totalCents: $invoice->totalCents,
+            isQualifiedInvoice: $input->qualified,
+            quoteId: $invoice->quoteId,
+            invoiceNumber: $number,
+            issuedAt: date('Y-m-d H:i:s'),
+            dueAt: $input->dueAt ?? $invoice->dueAt,
+            notes: $invoice->notes,
+            id: $invoice->id,
+            createdAt: $invoice->createdAt,
+            updatedAt: $invoice->updatedAt,
+        ));
+
+        $issued = $this->invoices->findById($id);
+
+        if ($issued === null) {
+            throw new LogicException('Invoice disappeared immediately after issue.');
+        }
+
+        $this->audit->record($actorUserId, $organizationId, 'invoice.issued', 'invoice', $id, InvoiceResponse::toArray($invoice, $lines), InvoiceResponse::toArray($issued, $lines));
+
+        return new InvoiceWithLines($issued, $lines);
+    }
+}

--- a/src/Invoice/QualifiedInvoiceIncompleteException.php
+++ b/src/Invoice/QualifiedInvoiceIncompleteException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use DomainException;
+
+/**
+ * Thrown when an invoice is being issued as a qualified invoice (適格請求書) but
+ * a statutorily required field is missing — e.g. the issuer registration number
+ * (accounting-compliance.md §2/§4).
+ */
+final class QualifiedInvoiceIncompleteException extends DomainException
+{
+}

--- a/src/Invoice/QualifiedInvoiceIncompleteExceptionHandler.php
+++ b/src/Invoice/QualifiedInvoiceIncompleteExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class QualifiedInvoiceIncompleteExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof QualifiedInvoiceIncompleteException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'qualified-invoice-incomplete', 'Unprocessable Entity', 422, $exception->getMessage());
+    }
+}

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\InvoiceValidationException;
+use NeneInvoice\Invoice\IssueInvoiceInput;
+use NeneInvoice\Invoice\IssueInvoiceUseCase;
+use NeneInvoice\Invoice\QualifiedInvoiceIncompleteException;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
+use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class IssueInvoiceUseCaseTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryCompanySettingsRepository $companySettings;
+    private RecordingAuditRecorder $audit;
+    private IssueInvoiceUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->companySettings = new InMemoryCompanySettingsRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->useCase = new IssueInvoiceUseCase(
+            $this->invoices,
+            $this->lineItems,
+            $this->companySettings,
+            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
+            $this->audit,
+        );
+    }
+
+    private function draftInvoice(bool $withLines = true): int
+    {
+        $id = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Draft,
+            subtotalCents: 2000,
+            taxCents: 200,
+            totalCents: 2200,
+        ));
+
+        if ($withLines) {
+            $this->lineItems->replaceForParent(LineItemParent::Invoice, $id, [
+                new LineItem(LineItemParent::Invoice, $id, 'Std', 1, 2000, 1000, sortOrder: 0),
+            ]);
+        }
+
+        return $id;
+    }
+
+    private function registerIssuer(): void
+    {
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'Example KK',
+            registrationNumber: 'T1234567890123',
+        ));
+    }
+
+    public function test_issues_qualified_invoice_allocating_number_and_auditing(): void
+    {
+        $this->registerIssuer();
+        $id = $this->draftInvoice();
+
+        $result = $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+
+        self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
+        self::assertTrue($result->invoice->isQualifiedInvoice);
+        self::assertSame('INV-' . date('Y') . '-001', $result->invoice->invoiceNumber);
+        self::assertNotNull($result->invoice->issuedAt);
+        self::assertSame('invoice.issued', $this->audit->records[0]['action']);
+    }
+
+    public function test_issues_non_qualified_invoice_without_registration_number(): void
+    {
+        $id = $this->draftInvoice();
+
+        $result = $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: false));
+
+        self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
+        self::assertFalse($result->invoice->isQualifiedInvoice);
+        self::assertSame('INV-' . date('Y') . '-001', $result->invoice->invoiceNumber);
+    }
+
+    public function test_qualified_invoice_without_registration_number_is_rejected(): void
+    {
+        $id = $this->draftInvoice();
+
+        $this->expectException(QualifiedInvoiceIncompleteException::class);
+        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+    }
+
+    public function test_only_draft_invoice_can_be_issued(): void
+    {
+        $this->registerIssuer();
+        $id = $this->draftInvoice();
+        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+    }
+
+    public function test_invoice_without_line_items_cannot_be_issued(): void
+    {
+        $this->registerIssuer();
+        $id = $this->draftInvoice(withLines: false);
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+    }
+
+    public function test_cross_organization_invoice_not_found(): void
+    {
+        $this->registerIssuer();
+        $id = $this->draftInvoice();
+
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->execute(2, 7, $id, new IssueInvoiceInput(qualified: true));
+    }
+}

--- a/tests/Support/InMemoryCompanySettingsRepository.php
+++ b/tests/Support/InMemoryCompanySettingsRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Company\CompanySettingsRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryCompanySettingsRepository implements CompanySettingsRepositoryInterface
+{
+    /** @var array<int, CompanySettings> */
+    private array $byOrganization = [];
+
+    public function findByOrganization(int $organizationId): ?CompanySettings
+    {
+        return $this->byOrganization[$organizationId] ?? null;
+    }
+
+    public function save(CompanySettings $settings): void
+    {
+        $this->byOrganization[$settings->organizationId] = $settings;
+    }
+}


### PR DESCRIPTION
## 概要

`POST /admin/invoices/{id}/issue` でドラフト請求書を **発行（issued）** する。発行時に `INV-YYYY-NNN` を採番し、適格請求書の要件を検証する。

Closes #69

## エンドポイント

`POST /admin/invoices/{id}/issue` — body `{ "qualified"?: bool = true, "due_at"?: string }`（`manage_billing`、org スコープ）

## コンプライアンス（accounting-compliance §2/§4・拘束）

- **ドラフトのみ発行可**。発行済み文書は不変 → 422 `validation-failed`
- **適格請求書**は発行者の登録番号（company settings `registration_number`）が必須 → 422 `qualified-invoice-incomplete`
- 明細が空の請求書は発行不可 → 422

## 振る舞い

- 発行時に `INV-YYYY-NNN` を採番（DocumentNumberGenerator）
- status `draft`→`issued`、`issued_at` / `due_at` / `is_qualified_invoice` を設定
- `invoice.issued` を before/after スナップショット付きで監査記録（ADR 0008）
- クロス org → 404

## テスト

- `IssueInvoiceUseCaseTest`: 適格発行（採番・qualified true）/ 非適格発行（登録番号なしでも可）/ 適格×登録番号なし→拒否 / 非ドラフト→拒否 / 明細なし→拒否 / クロス org→404
- DI ブート検証は `HealthEndpointTest`（フルコンテナ構築）でカバー
- `composer check` green（PHPUnit 108 / PHPStan lvl 8 / php-cs-fixer）

## セルフレビュー

- `docs/review/compliance.md`
- `docs/development/backend-standards.md` チェックリスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)