### PR TITLE
feat(payment): 入金記録（payments）と paid / partially_paid 遷移を追加する (#72)

### DIFF
--- a/database/migrations/20260529210000_create_payments_table.php
+++ b/database/migrations/20260529210000_create_payments_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreatePaymentsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('payments')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('invoice_id', 'integer', ['null' => false])
+            ->addColumn('amount_cents', 'integer', ['null' => false])
+            ->addColumn('paid_at', 'datetime', ['null' => false])
+            ->addColumn('method', 'string', ['limit' => 32, 'null' => true, 'default' => null])
+            ->addColumn('note', 'text', ['null' => true, 'default' => null])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_payments_organization_id'])
+            ->addIndex(['invoice_id'], ['name' => 'idx_payments_invoice_id'])
+            ->create();
+    }
+}

--- a/database/schema/payments.sql
+++ b/database/schema/payments.sql
@@ -1,0 +1,18 @@
+-- Schema snapshot for the payments table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- A payment records an amount received against an issued invoice (integer cents).
+CREATE TABLE IF NOT EXISTS payments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER NOT NULL,
+    invoice_id INTEGER NOT NULL,
+    amount_cents INTEGER NOT NULL,
+    paid_at DATETIME NOT NULL,
+    method VARCHAR(32) NULL DEFAULT NULL,
+    note TEXT NULL DEFAULT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL DEFAULT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_payments_organization_id ON payments (organization_id);
+CREATE INDEX idx_payments_invoice_id ON payments (invoice_id);

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -143,7 +143,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
 | `listQuotes`, `getQuoteById`, `createQuote`, `changeQuoteStatus`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
-| `listPayments`, `createPayment` | Payment |
+| `listPayments`, `recordPayment` | Payment |
 
 Extend this list (do not improvise) when adding operations.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #69)
+Last updated: 2026-05-29 (Issue #72)
 
 ## Recently merged
 
@@ -35,13 +35,14 @@ Last updated: 2026-05-29 (Issue #69)
 - **Issue #63 / PR #64** — Quote 状態遷移 ✅ merged
 - **Issue #65 / PR #66** — Invoice 永続化レイヤ ✅ merged
 - **Issue #67 / PR #68** — 見積→請求書変換 + 請求書一覧/取得 ✅ merged
-- **Issue #69** — 請求書の発行（INV 採番 + 適格請求書検証）⏳ this PR
+- **Issue #69 / PR #71** — 請求書の発行（INV 採番 + 適格請求書検証）✅ merged
+- **Issue #72** — 入金記録（payments）— paid/partially_paid 遷移 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #69 | `feat/69-invoice-issue` | 請求書の発行（INV 採番 + 適格請求書検証） | 🔄 PR pending |
+| #72 | `feat/72-payments` | 入金記録（payments）— paid/partially_paid 遷移 | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -170,7 +171,17 @@ Last updated: 2026-05-29 (Issue #69)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Invoice issue (INV 採番 + 適格請求書検証): 🔄 in progress** (Issue #69)
+**Phase 1 — Payments (入金記録): 🔄 in progress** (Issue #72)
+
+- `POST /admin/invoices/{id}/payments` {amount_cents, paid_at?, method?, note?} — records a payment, advances the invoice: partial → `partially_paid`, full → `paid`
+- `GET /admin/invoices/{id}/payments` — payment list + running `total_paid_cents`（org スコープ）
+- Compliance gates: integer cents only (ADR 0004); only **issued / partially_paid** invoices accept payments (draft / paid → 422 `validation-failed`); non-positive amount → 422; over-payment (recorded total > invoice total) → 422
+- `payment.recorded` audit with before/after invoice status (ADR 0008); cross-org → 404
+- `payments` table (Phinx + SQLite snapshot) + `Payment` entity + `PdoPaymentRepository`
+- Terminology: operationId `recordPayment` registered (was speculative `createPayment`)
+- Tested: partial→partially_paid / full→paid / cumulative→paid / over-payment→422 / non-positive→422 / draft→422 / paid→422 / cross-org→404; Pdo repo (sum/order); full DI boot (HealthEndpointTest)
+
+**Phase 1 — Invoice issue (INV 採番 + 適格請求書検証): ✅ complete** (Issue #69 / PR #71)
 
 - `POST /admin/invoices/{id}/issue` {qualified?:bool=true, due_at?} — draft → issued
 - Compliance gates (accounting-compliance §2/§4): only a **draft** can be issued (issued docs immutable → 422 `validation-failed`); a **qualified** invoice requires the issuer registration number in company settings (→ 422 `qualified-invoice-incomplete`); no line items → 422
@@ -246,6 +257,6 @@ Last updated: 2026-05-29 (Issue #69)
 
 ## Next steps
 
-1. Payments (record) → invoice paid/partially_paid; overdue computed
-2. Direct invoice create; audit read endpoint (`GET /admin/audit-logs`)
+1. Direct invoice create（見積を介さない請求書作成）
+2. Audit read endpoint (`GET /admin/audit-logs`); overdue 表示（issued/partially_paid past due_at）
 3. OpenAPI stub (Issue #5); Backend CI (Issue #6); ADR 0003 dual deployment (Issue #7)

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -21,6 +21,8 @@ use NeneInvoice\Invoice\QualifiedInvoiceIncompleteExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\Payment\PaymentRouteRegistrar;
+use NeneInvoice\Payment\PaymentValidationExceptionHandler;
 use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
 use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
 use NeneInvoice\Quote\QuoteRouteRegistrar;
@@ -57,6 +59,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $companyRoutes = $container->get(CompanyRouteRegistrar::class);
                     $quoteRoutes = $container->get(QuoteRouteRegistrar::class);
                     $invoiceRoutes = $container->get(InvoiceRouteRegistrar::class);
+                    $paymentRoutes = $container->get(PaymentRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -86,7 +89,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Invoice route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes];
+                    if (!$paymentRoutes instanceof PaymentRouteRegistrar) {
+                        throw new LogicException('Payment route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes];
                 },
             )
             ->set(
@@ -108,6 +115,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $invoiceNotFound = $container->get(InvoiceNotFoundExceptionHandler::class);
                     $invoiceValidation = $container->get(InvoiceValidationExceptionHandler::class);
                     $qualifiedIncomplete = $container->get(QualifiedInvoiceIncompleteExceptionHandler::class);
+                    $paymentValidation = $container->get(PaymentValidationExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -173,7 +181,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Qualified invoice incomplete exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete];
+                    if (!$paymentValidation instanceof PaymentValidationExceptionHandler) {
+                        throw new LogicException('Payment validation exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $paymentValidation];
                 },
             );
     }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -28,6 +28,7 @@ use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
 use NeneInvoice\Invoice\InvoiceServiceProvider;
 use NeneInvoice\LineItem\LineItemServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
+use NeneInvoice\Payment\PaymentServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -58,6 +59,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new LineItemServiceProvider());
         $builder->addProvider(new QuoteServiceProvider());
         $builder->addProvider(new InvoiceServiceProvider());
+        $builder->addProvider(new PaymentServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/Payment/ListPaymentsHandler.php
+++ b/src/Payment/ListPaymentsHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/invoices/{id}/payments` — lists the payments recorded against an
+ * invoice in the caller's organization.
+ */
+final readonly class ListPaymentsHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ListPaymentsUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $payments = $this->useCase->execute($organizationId, $invoiceId);
+
+        return $this->json->create([
+            'items' => array_map(static fn (Payment $p): array => PaymentResponse::toArray($p), $payments),
+            'total_paid_cents' => array_sum(array_map(static fn (Payment $p): int => $p->amountCents, $payments)),
+        ]);
+    }
+}

--- a/src/Payment/ListPaymentsUseCase.php
+++ b/src/Payment/ListPaymentsUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+
+/**
+ * Lists the payments recorded against an invoice, scoped to the caller's
+ * organization (cross-org access surfaces as not-found, never a leak).
+ */
+final readonly class ListPaymentsUseCase
+{
+    public function __construct(
+        private PaymentRepositoryInterface $payments,
+        private InvoiceRepositoryInterface $invoices,
+    ) {
+    }
+
+    /**
+     * @return list<Payment>
+     *
+     * @throws InvoiceNotFoundException
+     */
+    public function execute(int $organizationId, int $invoiceId): array
+    {
+        $invoice = $this->invoices->findById($invoiceId);
+
+        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+            throw new InvoiceNotFoundException($invoiceId);
+        }
+
+        return $this->payments->findByInvoice($invoiceId);
+    }
+}

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+/**
+ * A payment (入金) received against an issued invoice. `amountCents` is integer
+ * cents (smallest currency unit; ADR 0004 — no floats). One invoice may have many
+ * payments; their sum drives the invoice's paid / partially_paid status.
+ */
+final readonly class Payment
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public int $amountCents,
+        public string $paidAt,
+        public ?string $method = null,
+        public ?string $note = null,
+        public bool $isDeleted = false,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Payment/PaymentRepositoryInterface.php
+++ b/src/Payment/PaymentRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+/**
+ * Persistence for payments. Payments are immaterial of their own lifecycle — a
+ * correction is a separate (future) refund operation, not an in-place edit.
+ */
+interface PaymentRepositoryInterface
+{
+    public function save(Payment $payment): int;
+
+    /** @return list<Payment> */
+    public function findByInvoice(int $invoiceId): array;
+
+    /**
+     * Sum of all (non-deleted) payment amounts recorded against the invoice, in cents.
+     */
+    public function totalPaidForInvoice(int $invoiceId): int;
+}

--- a/src/Payment/PaymentResponse.php
+++ b/src/Payment/PaymentResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+/**
+ * Serializes a {@see Payment} to its snake_case JSON representation.
+ */
+final class PaymentResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(Payment $payment): array
+    {
+        return [
+            'id' => $payment->id,
+            'organization_id' => $payment->organizationId,
+            'invoice_id' => $payment->invoiceId,
+            'amount_cents' => $payment->amountCents,
+            'paid_at' => $payment->paidAt,
+            'method' => $payment->method,
+            'note' => $payment->note,
+            'created_at' => $payment->createdAt,
+            'updated_at' => $payment->updatedAt,
+        ];
+    }
+}

--- a/src/Payment/PaymentRouteRegistrar.php
+++ b/src/Payment/PaymentRouteRegistrar.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers payment routes, nested under an invoice. Reads require `view_billing`,
+ * recording a payment requires `manage_billing` (both resolved by the
+ * `/admin/invoices` prefix in CapabilityResolver); all scoped to the caller's org.
+ */
+final readonly class PaymentRouteRegistrar
+{
+    public function __construct(
+        private RecordPaymentHandler $recordHandler,
+        private ListPaymentsHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $record = $this->recordHandler;
+        $list = $this->listHandler;
+
+        $router->get('/admin/invoices/{id}/payments', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/invoices/{id}/payments', static fn (ServerRequestInterface $r) => $record->handle($r));
+    }
+}

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Payment domain: repository, use cases (record / list), handlers, the
+ * validation exception handler, and the route registrar.
+ */
+final readonly class PaymentServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                PaymentRepositoryInterface::class,
+                static function (ContainerInterface $c): PaymentRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoPaymentRepository($query);
+                },
+            )
+            ->set(
+                RecordPaymentUseCase::class,
+                static fn (ContainerInterface $c): RecordPaymentUseCase => new RecordPaymentUseCase(
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(
+                ListPaymentsUseCase::class,
+                static fn (ContainerInterface $c): ListPaymentsUseCase => new ListPaymentsUseCase(
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                RecordPaymentHandler::class,
+                static fn (ContainerInterface $c): RecordPaymentHandler => new RecordPaymentHandler(
+                    self::resolve($c, RecordPaymentUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                ListPaymentsHandler::class,
+                static fn (ContainerInterface $c): ListPaymentsHandler => new ListPaymentsHandler(
+                    self::resolve($c, ListPaymentsUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                PaymentValidationExceptionHandler::class,
+                static fn (ContainerInterface $c): PaymentValidationExceptionHandler => new PaymentValidationExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                PaymentRouteRegistrar::class,
+                static function (ContainerInterface $c): PaymentRouteRegistrar {
+                    $record = $c->get(RecordPaymentHandler::class);
+                    $list = $c->get(ListPaymentsHandler::class);
+
+                    if (!$record instanceof RecordPaymentHandler || !$list instanceof ListPaymentsHandler) {
+                        throw new LogicException('Payment handler services are invalid.');
+                    }
+
+                    return new PaymentRouteRegistrar($record, $list);
+                },
+            );
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        return self::resolve($c, JsonResponseFactory::class);
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+}

--- a/src/Payment/PaymentValidationException.php
+++ b/src/Payment/PaymentValidationException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use DomainException;
+
+/**
+ * Thrown for payment operations that are not allowed: a non-positive amount, a
+ * payment against a draft / fully-paid invoice, or one that would exceed the
+ * outstanding balance (over-payment). Surfaces as 422.
+ */
+final class PaymentValidationException extends DomainException
+{
+}

--- a/src/Payment/PaymentValidationExceptionHandler.php
+++ b/src/Payment/PaymentValidationExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class PaymentValidationExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof PaymentValidationException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $exception->getMessage());
+    }
+}

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(Payment $payment): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [
+                $payment->organizationId,
+                $payment->invoiceId,
+                $payment->amountCents,
+                $payment->paidAt,
+                $payment->method,
+                $payment->note,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /** @return list<Payment> */
+    public function findByInvoice(int $invoiceId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE invoice_id = ? AND is_deleted = 0 ORDER BY paid_at ASC, id ASC',
+            [$invoiceId],
+        );
+
+        return array_map(fn (array $row): Payment => $this->mapRow($row), $rows);
+    }
+
+    public function totalPaidForInvoice(int $invoiceId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COALESCE(SUM(amount_cents), 0) AS total FROM payments WHERE invoice_id = ? AND is_deleted = 0',
+            [$invoiceId],
+        );
+
+        return $row !== null ? (int) $row['total'] : 0;
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Payment
+    {
+        return new Payment(
+            organizationId: (int) $row['organization_id'],
+            invoiceId: (int) $row['invoice_id'],
+            amountCents: (int) $row['amount_cents'],
+            paidAt: (string) $row['paid_at'],
+            method: isset($row['method']) && $row['method'] !== '' ? (string) $row['method'] : null,
+            note: isset($row['note']) && $row['note'] !== '' ? (string) $row['note'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Payment/RecordPaymentHandler.php
+++ b/src/Payment/RecordPaymentHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\Invoice\InvoiceResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/invoices/{id}/payments` — records a payment against an issued
+ * invoice and returns the payment plus the invoice in its resulting state.
+ */
+final readonly class RecordPaymentHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private RecordPaymentUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        $amountValue = $decoded['amount_cents'] ?? null;
+        $amountCents = is_int($amountValue) ? $amountValue : (is_numeric($amountValue) ? (int) $amountValue : 0);
+
+        $paidAtValue = $decoded['paid_at'] ?? null;
+        $paidAt = is_string($paidAtValue) && $paidAtValue !== '' ? $paidAtValue : null;
+
+        $methodValue = $decoded['method'] ?? null;
+        $method = is_string($methodValue) && $methodValue !== '' ? $methodValue : null;
+
+        $noteValue = $decoded['note'] ?? null;
+        $note = is_string($noteValue) && $noteValue !== '' ? $noteValue : null;
+
+        $result = $this->useCase->execute(
+            $organizationId,
+            AuthContext::userId($request),
+            $invoiceId,
+            new RecordPaymentInput($amountCents, $paidAt, $method, $note),
+        );
+
+        return $this->json->create([
+            'payment' => PaymentResponse::toArray($result->payment),
+            'invoice' => InvoiceResponse::toArray($result->invoice),
+            'total_paid_cents' => $result->totalPaidCents,
+        ], 201);
+    }
+}

--- a/src/Payment/RecordPaymentInput.php
+++ b/src/Payment/RecordPaymentInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+final readonly class RecordPaymentInput
+{
+    public function __construct(
+        public int $amountCents,
+        public ?string $paidAt = null,
+        public ?string $method = null,
+        public ?string $note = null,
+    ) {
+    }
+}

--- a/src/Payment/RecordPaymentResult.php
+++ b/src/Payment/RecordPaymentResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use NeneInvoice\Invoice\Invoice;
+
+/**
+ * The outcome of recording a payment: the stored payment plus the invoice in its
+ * resulting state (status may have transitioned to partially_paid / paid) and the
+ * running total paid so far.
+ */
+final readonly class RecordPaymentResult
+{
+    public function __construct(
+        public Payment $payment,
+        public Invoice $invoice,
+        public int $totalPaidCents,
+    ) {
+    }
+}

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceResponse;
+use NeneInvoice\Invoice\InvoiceStatus;
+
+/**
+ * Records a payment against an issued invoice and advances the invoice status:
+ * partial payment → partially_paid, full payment → paid.
+ *
+ * Compliance: amounts are integer cents (ADR 0004). Only issued invoices accept
+ * payments — a draft has no liability yet and a paid invoice has none left.
+ * Over-payment is rejected: the recorded total may not exceed the invoice total
+ * (refunds / over-receipts are a separate operation, deliberately not handled here).
+ */
+final readonly class RecordPaymentUseCase
+{
+    public function __construct(
+        private PaymentRepositoryInterface $payments,
+        private InvoiceRepositoryInterface $invoices,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @throws InvoiceNotFoundException
+     * @throws PaymentValidationException
+     */
+    public function execute(int $organizationId, ?int $actorUserId, int $invoiceId, RecordPaymentInput $input): RecordPaymentResult
+    {
+        $invoice = $this->invoices->findById($invoiceId);
+
+        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+            throw new InvoiceNotFoundException($invoiceId);
+        }
+
+        if ($input->amountCents <= 0) {
+            throw new PaymentValidationException('A payment amount must be a positive number of cents.');
+        }
+
+        if (!in_array($invoice->status, [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid], true)) {
+            throw new PaymentValidationException('Payments can only be recorded against an issued invoice.');
+        }
+
+        $alreadyPaid = $this->payments->totalPaidForInvoice($invoiceId);
+
+        if ($alreadyPaid + $input->amountCents > $invoice->totalCents) {
+            throw new PaymentValidationException('The payment would exceed the invoice total (over-payment is not allowed).');
+        }
+
+        $before = InvoiceResponse::toArray($invoice);
+
+        $paidAt = $input->paidAt ?? date('Y-m-d H:i:s');
+
+        $paymentId = $this->payments->save(new Payment(
+            organizationId: $organizationId,
+            invoiceId: $invoiceId,
+            amountCents: $input->amountCents,
+            paidAt: $paidAt,
+            method: $input->method,
+            note: $input->note,
+        ));
+
+        $totalPaid = $alreadyPaid + $input->amountCents;
+        $newStatus = $totalPaid >= $invoice->totalCents ? InvoiceStatus::Paid : InvoiceStatus::PartiallyPaid;
+
+        $updatedInvoice = new Invoice(
+            organizationId: $invoice->organizationId,
+            clientId: $invoice->clientId,
+            status: $newStatus,
+            subtotalCents: $invoice->subtotalCents,
+            taxCents: $invoice->taxCents,
+            totalCents: $invoice->totalCents,
+            isQualifiedInvoice: $invoice->isQualifiedInvoice,
+            quoteId: $invoice->quoteId,
+            invoiceNumber: $invoice->invoiceNumber,
+            issuedAt: $invoice->issuedAt,
+            dueAt: $invoice->dueAt,
+            notes: $invoice->notes,
+            id: $invoice->id,
+            createdAt: $invoice->createdAt,
+            updatedAt: $invoice->updatedAt,
+        );
+
+        $this->invoices->update($updatedInvoice);
+
+        $stored = $this->payments->findByInvoice($invoiceId);
+        $payment = null;
+
+        foreach ($stored as $candidate) {
+            if ($candidate->id === $paymentId) {
+                $payment = $candidate;
+
+                break;
+            }
+        }
+
+        if ($payment === null) {
+            throw new LogicException('Payment disappeared immediately after recording.');
+        }
+
+        $this->audit->record(
+            $actorUserId,
+            $organizationId,
+            'payment.recorded',
+            'invoice',
+            $invoiceId,
+            $before,
+            InvoiceResponse::toArray($updatedInvoice),
+        );
+
+        return new RecordPaymentResult($payment, $updatedInvoice, $totalPaid);
+    }
+}

--- a/tests/Payment/PdoPaymentRepositoryTest.php
+++ b/tests/Payment/PdoPaymentRepositoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Payment;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Payment\PdoPaymentRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoPaymentRepositoryTest extends TestCase
+{
+    private PdoPaymentRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/payments.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repository = new PdoPaymentRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_saves_and_reads_back_payments_for_invoice(): void
+    {
+        $id = $this->repository->save(new Payment(
+            organizationId: 1,
+            invoiceId: 42,
+            amountCents: 1000,
+            paidAt: '2026-05-29 10:00:00',
+            method: 'bank_transfer',
+            note: 'first',
+        ));
+
+        $payments = $this->repository->findByInvoice(42);
+        self::assertCount(1, $payments);
+        self::assertSame($id, $payments[0]->id);
+        self::assertSame(1000, $payments[0]->amountCents);
+        self::assertSame('bank_transfer', $payments[0]->method);
+        self::assertSame('first', $payments[0]->note);
+    }
+
+    public function test_total_paid_sums_only_matching_invoice(): void
+    {
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1000, paidAt: '2026-05-29 10:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1200, paidAt: '2026-05-29 11:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 99, amountCents: 500, paidAt: '2026-05-29 12:00:00'));
+
+        self::assertSame(2200, $this->repository->totalPaidForInvoice(42));
+        self::assertSame(500, $this->repository->totalPaidForInvoice(99));
+        self::assertSame(0, $this->repository->totalPaidForInvoice(7));
+    }
+
+    public function test_payments_ordered_by_paid_at(): void
+    {
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1200, paidAt: '2026-05-29 11:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1000, paidAt: '2026-05-29 10:00:00'));
+
+        $payments = $this->repository->findByInvoice(42);
+        self::assertSame('2026-05-29 10:00:00', $payments[0]->paidAt);
+        self::assertSame('2026-05-29 11:00:00', $payments[1]->paidAt);
+    }
+}

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Payment;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentValidationException;
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class RecordPaymentUseCaseTest extends TestCase
+{
+    private InMemoryPaymentRepository $payments;
+    private InMemoryInvoiceRepository $invoices;
+    private RecordingAuditRecorder $audit;
+    private RecordPaymentUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->payments = new InMemoryPaymentRepository();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit);
+    }
+
+    private function issuedInvoice(int $totalCents = 2200): int
+    {
+        return $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Issued,
+            subtotalCents: $totalCents,
+            taxCents: 0,
+            totalCents: $totalCents,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-29 00:00:00',
+        ));
+    }
+
+    public function test_partial_payment_moves_invoice_to_partially_paid(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+
+        self::assertSame(InvoiceStatus::PartiallyPaid, $result->invoice->status);
+        self::assertSame(1000, $result->totalPaidCents);
+        self::assertSame(1000, $result->payment->amountCents);
+        self::assertSame('payment.recorded', $this->audit->records[0]['action']);
+    }
+
+    public function test_full_payment_moves_invoice_to_paid(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2200));
+
+        self::assertSame(InvoiceStatus::Paid, $result->invoice->status);
+        self::assertSame(2200, $result->totalPaidCents);
+    }
+
+    public function test_cumulative_payments_reach_paid(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1200));
+        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+
+        self::assertSame(InvoiceStatus::Paid, $result->invoice->status);
+        self::assertSame(2200, $result->totalPaidCents);
+    }
+
+    public function test_over_payment_is_rejected(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2201));
+    }
+
+    public function test_non_positive_amount_is_rejected(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 0));
+    }
+
+    public function test_payment_against_draft_is_rejected(): void
+    {
+        $id = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Draft,
+            subtotalCents: 2200,
+            taxCents: 0,
+            totalCents: 2200,
+        ));
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+    }
+
+    public function test_payment_against_fully_paid_invoice_is_rejected(): void
+    {
+        $id = $this->issuedInvoice(2200);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2200));
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1));
+    }
+
+    public function test_cross_organization_invoice_not_found(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->execute(2, 7, $id, new RecordPaymentInput(amountCents: 1000));
+    }
+}

--- a/tests/Support/InMemoryPaymentRepository.php
+++ b/tests/Support/InMemoryPaymentRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database).
+ */
+final class InMemoryPaymentRepository implements PaymentRepositoryInterface
+{
+    /** @var array<int, Payment> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function save(Payment $payment): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = new Payment(
+            organizationId: $payment->organizationId,
+            invoiceId: $payment->invoiceId,
+            amountCents: $payment->amountCents,
+            paidAt: $payment->paidAt,
+            method: $payment->method,
+            note: $payment->note,
+            isDeleted: $payment->isDeleted,
+            id: $id,
+            createdAt: '2026-05-29 00:00:00',
+            updatedAt: '2026-05-29 00:00:00',
+        );
+
+        return $id;
+    }
+
+    /** @return list<Payment> */
+    public function findByInvoice(int $invoiceId): array
+    {
+        return array_values(array_filter(
+            $this->byId,
+            static fn (Payment $p): bool => $p->invoiceId === $invoiceId && !$p->isDeleted,
+        ));
+    }
+
+    public function totalPaidForInvoice(int $invoiceId): int
+    {
+        $total = 0;
+
+        foreach ($this->findByInvoice($invoiceId) as $payment) {
+            $total += $payment->amountCents;
+        }
+
+        return $total;
+    }
+}


### PR DESCRIPTION
## 概要

発行済み請求書に対して **入金（payment）** を記録し、入金合計に応じて請求書ステータスを `partially_paid` / `paid` に遷移させる。

Closes #72

## エンドポイント

- `POST /admin/invoices/{id}/payments` — body `{ "amount_cents": int, "paid_at"?: string, "method"?: string, "note"?: string }`（`manage_billing`）
- `GET /admin/invoices/{id}/payments` — 入金一覧 + `total_paid_cents`（`view_billing`）

> いずれも `/admin/invoices` プレフィックスで CapabilityResolver が解決（変更なし）。org スコープ。

## コンプライアンス / 振る舞い（拘束）

- 金額は **integer cents**（float 禁止・ADR 0004）
- **issued / partially_paid** の請求書のみ入金可。draft / paid → 422 `validation-failed`
- 非正値の金額 → 422
- 過入金（記録合計 > 請求書 total）→ 422（返金・過入金は別操作として今回は扱わない）
- 入金合計 < total → `partially_paid`、== total → `paid`
- `payment.recorded` を before/after（請求書ステータス）付きで監査記録（ADR 0008）
- クロス org → 404

## 永続化

- `payments` テーブル（Phinx migration + SQLite schema snapshot）
- `Payment` エンティティ + `PdoPaymentRepository`（save / findByInvoice / totalPaidForInvoice）

## 用語

- operationId を `recordPayment` に登録（暫定 `createPayment` を会計的に正確な「記録」へ更新・同一 PR でレジストリ更新）

## テスト

- `RecordPaymentUseCaseTest`: 部分→partially_paid / 完納→paid / 累積→paid / 過入金→422 / 非正値→422 / draft→422 / 完納後→422 / クロス org→404
- `PdoPaymentRepositoryTest`: 保存・読み戻し / 請求書別合計 / paid_at 昇順
- DI ブート検証は `HealthEndpointTest`（フルコンテナ構築）でカバー
- `composer check` green（PHPUnit 119 / PHPStan lvl 8 / php-cs-fixer）

## セルフレビュー

- `docs/review/compliance.md`
- `docs/development/backend-standards.md` チェックリスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)