### PR TITLE
feat(invoice): 請求書の直接作成（POST /admin/invoices）を追加する (#74)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #72)
+Last updated: 2026-05-29 (Issue #74)
 
 ## Recently merged
 
@@ -36,13 +36,14 @@ Last updated: 2026-05-29 (Issue #72)
 - **Issue #65 / PR #66** — Invoice 永続化レイヤ ✅ merged
 - **Issue #67 / PR #68** — 見積→請求書変換 + 請求書一覧/取得 ✅ merged
 - **Issue #69 / PR #71** — 請求書の発行（INV 採番 + 適格請求書検証）✅ merged
-- **Issue #72** — 入金記録（payments）— paid/partially_paid 遷移 ⏳ this PR
+- **Issue #72 / PR #73** — 入金記録（payments）— paid/partially_paid 遷移 ✅ merged
+- **Issue #74** — 請求書の直接作成（POST /admin/invoices）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #72 | `feat/72-payments` | 入金記録（payments）— paid/partially_paid 遷移 | 🔄 PR pending |
+| #74 | `feat/74-invoice-create` | 請求書の直接作成（見積を介さない） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -171,7 +172,16 @@ Last updated: 2026-05-29 (Issue #72)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Payments (入金記録): 🔄 in progress** (Issue #72)
+**Phase 1 — Invoice direct create (見積を介さない請求書作成): 🔄 in progress** (Issue #74)
+
+- `POST /admin/invoices` {client_id, line_items[], notes?} — creates a draft invoice directly (no quote)
+- Same orchestration as quote create: client in-org validation + per-line checks + `TaxCalculator` (round once per rate, ADR 0004)
+- 税率は 10%/8% のみ（§3）; cross-org client / empty lines / bad rate → 422 `validation-failed`
+- status `draft`, `invoice_number` null（採番は発行時）, `quote_id` null; lines via `replaceForParent`; `invoice.created` audit
+- operationId `createInvoice`（既登録）; reuses `InvoiceValidationException`
+- Tested: create (subtotal 2000 / tax 200 / total 2200, 2 lines, no number) / cross-org client→422 / empty→422 / bad rate→422; full DI boot (HealthEndpointTest)
+
+**Phase 1 — Payments (入金記録): ✅ complete** (Issue #72 / PR #73)
 
 - `POST /admin/invoices/{id}/payments` {amount_cents, paid_at?, method?, note?} — records a payment, advances the invoice: partial → `partially_paid`, full → `paid`
 - `GET /admin/invoices/{id}/payments` — payment list + running `total_paid_cents`（org スコープ）
@@ -257,6 +267,6 @@ Last updated: 2026-05-29 (Issue #72)
 
 ## Next steps
 
-1. Direct invoice create（見積を介さない請求書作成）
-2. Audit read endpoint (`GET /admin/audit-logs`); overdue 表示（issued/partially_paid past due_at）
+1. Audit read endpoint (`GET /admin/audit-logs`)
+2. overdue 表示（issued/partially_paid past due_at）; 請求書 PDF / 帳票（後続フェーズ）
 3. OpenAPI stub (Issue #5); Backend CI (Issue #6); ADR 0003 dual deployment (Issue #7)

--- a/src/Invoice/CreateInvoiceHandler.php
+++ b/src/Invoice/CreateInvoiceHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\LineItem\LineItemInput;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/invoices` — creates a draft invoice directly in the caller's
+ * organization (no originating quote).
+ */
+final readonly class CreateInvoiceHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private CreateInvoiceUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        }
+
+        $clientId = $decoded['client_id'] ?? null;
+
+        if (!is_int($clientId) && !(is_string($clientId) && ctype_digit($clientId))) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"client_id" is required.');
+        }
+
+        $rawLines = $decoded['line_items'] ?? null;
+
+        if (!is_array($rawLines) || $rawLines === []) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"line_items" must be a non-empty array.');
+        }
+
+        $lines = [];
+        foreach ($rawLines as $raw) {
+            if (!is_array($raw)) {
+                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item must be an object.');
+            }
+
+            $description = $raw['description'] ?? null;
+            $quantity = $raw['quantity'] ?? null;
+            $unitPrice = $raw['unit_price_cents'] ?? null;
+            $taxRate = $raw['tax_rate_bps'] ?? null;
+
+            if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
+                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).');
+            }
+
+            $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
+        }
+
+        $result = $this->useCase->execute(
+            $organizationId,
+            AuthContext::userId($request),
+            new CreateInvoiceInput(
+                clientId: (int) $clientId,
+                lines: $lines,
+                notes: $this->optional($decoded, 'notes'),
+            ),
+        );
+
+        return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines), 201);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function optional(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Invoice/CreateInvoiceInput.php
+++ b/src/Invoice/CreateInvoiceInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\LineItem\LineItemInput;
+
+final readonly class CreateInvoiceInput
+{
+    /** @param list<LineItemInput> $lines */
+    public function __construct(
+        public int $clientId,
+        public array $lines,
+        public ?string $notes = null,
+    ) {
+    }
+}

--- a/src/Invoice/CreateInvoiceUseCase.php
+++ b/src/Invoice/CreateInvoiceUseCase.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use LogicException;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
+
+/**
+ * Creates a draft invoice directly (without an originating quote): validates the
+ * client and lines, computes totals (TaxCalculator, ADR 0004), persists the
+ * header and line items, and records an audit entry.
+ *
+ * No number is allocated here — drafts have no `invoice_number`; numbering happens
+ * at issue time ({@see IssueInvoiceUseCase}), so a draft can be edited freely.
+ */
+final readonly class CreateInvoiceUseCase
+{
+    /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
+    private const ALLOWED_TAX_RATES_BPS = [800, 1000];
+
+    public function __construct(
+        private InvoiceRepositoryInterface $invoices,
+        private LineItemRepositoryInterface $lineItems,
+        private ClientRepositoryInterface $clients,
+        private TaxCalculator $taxCalculator,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /** @throws InvoiceValidationException */
+    public function execute(int $organizationId, ?int $actorUserId, CreateInvoiceInput $input): InvoiceWithLines
+    {
+        $client = $this->clients->findById($input->clientId);
+
+        if ($client === null || $client->organizationId !== $organizationId) {
+            throw new InvoiceValidationException('The selected client does not exist in your organization.');
+        }
+
+        if ($input->lines === []) {
+            throw new InvoiceValidationException('An invoice requires at least one line item.');
+        }
+
+        foreach ($input->lines as $line) {
+            if (!in_array($line->taxRateBps, self::ALLOWED_TAX_RATES_BPS, true)) {
+                throw new InvoiceValidationException(sprintf('Tax rate %d bps is not allowed (use 1000 or 800).', $line->taxRateBps));
+            }
+
+            if ($line->quantity <= 0) {
+                throw new InvoiceValidationException('Line item quantity must be greater than zero.');
+            }
+
+            if ($line->unitPriceCents < 0) {
+                throw new InvoiceValidationException('Line item unit price must not be negative.');
+            }
+        }
+
+        $totals = $this->taxCalculator->calculate($input->lines);
+
+        $invoiceId = $this->invoices->save(new Invoice(
+            organizationId: $organizationId,
+            clientId: $input->clientId,
+            status: InvoiceStatus::Draft,
+            subtotalCents: $totals->subtotalCents,
+            taxCents: $totals->taxCents,
+            totalCents: $totals->totalCents,
+            notes: $input->notes,
+        ));
+
+        $lineEntities = [];
+        foreach ($input->lines as $index => $line) {
+            $lineEntities[] = new LineItem(
+                parentType: LineItemParent::Invoice,
+                parentId: $invoiceId,
+                description: $line->description,
+                quantity: $line->quantity,
+                unitPriceCents: $line->unitPriceCents,
+                taxRateBps: $line->taxRateBps,
+                sortOrder: $index,
+            );
+        }
+
+        $this->lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $lineEntities);
+
+        $saved = $this->invoices->findById($invoiceId);
+
+        if ($saved === null) {
+            throw new LogicException('Invoice disappeared immediately after creation.');
+        }
+
+        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
+
+        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $invoiceId, null, InvoiceResponse::toArray($saved, $lines));
+
+        return new InvoiceWithLines($saved, $lines);
+    }
+}

--- a/src/Invoice/InvoiceRouteRegistrar.php
+++ b/src/Invoice/InvoiceRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class InvoiceRouteRegistrar
     public function __construct(
         private ListInvoicesHandler $listHandler,
         private GetInvoiceByIdHandler $getHandler,
+        private CreateInvoiceHandler $createHandler,
         private ConvertQuoteToInvoiceHandler $convertHandler,
         private IssueInvoiceHandler $issueHandler,
     ) {
@@ -26,10 +27,12 @@ final readonly class InvoiceRouteRegistrar
     {
         $list = $this->listHandler;
         $get = $this->getHandler;
+        $create = $this->createHandler;
         $convert = $this->convertHandler;
         $issue = $this->issueHandler;
 
         $router->get('/admin/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/invoices', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->get('/admin/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
         $router->post('/admin/invoices/{id}/issue', static fn (ServerRequestInterface $r) => $issue->handle($r));
         $router->post('/admin/quotes/{id}/convert', static fn (ServerRequestInterface $r) => $convert->handle($r));

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -11,9 +11,11 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Quote\QuoteRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
@@ -44,6 +46,16 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, QuoteRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(
+                CreateInvoiceUseCase::class,
+                static fn (ContainerInterface $c): CreateInvoiceUseCase => new CreateInvoiceUseCase(
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, ClientRepositoryInterface::class),
+                    self::resolve($c, TaxCalculator::class),
                     self::resolve($c, AuditRecorderInterface::class),
                 ),
             )
@@ -90,6 +102,14 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                CreateInvoiceHandler::class,
+                static fn (ContainerInterface $c): CreateInvoiceHandler => new CreateInvoiceHandler(
+                    self::resolve($c, CreateInvoiceUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 IssueInvoiceHandler::class,
                 static fn (ContainerInterface $c): IssueInvoiceHandler => new IssueInvoiceHandler(
                     self::resolve($c, IssueInvoiceUseCase::class),
@@ -114,14 +134,15 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $c): InvoiceRouteRegistrar {
                     $list = $c->get(ListInvoicesHandler::class);
                     $get = $c->get(GetInvoiceByIdHandler::class);
+                    $create = $c->get(CreateInvoiceHandler::class);
                     $convert = $c->get(ConvertQuoteToInvoiceHandler::class);
                     $issue = $c->get(IssueInvoiceHandler::class);
 
-                    if (!$list instanceof ListInvoicesHandler || !$get instanceof GetInvoiceByIdHandler || !$convert instanceof ConvertQuoteToInvoiceHandler || !$issue instanceof IssueInvoiceHandler) {
+                    if (!$list instanceof ListInvoicesHandler || !$get instanceof GetInvoiceByIdHandler || !$create instanceof CreateInvoiceHandler || !$convert instanceof ConvertQuoteToInvoiceHandler || !$issue instanceof IssueInvoiceHandler) {
                         throw new LogicException('Invoice handler services are invalid.');
                     }
 
-                    return new InvoiceRouteRegistrar($list, $get, $convert, $issue);
+                    return new InvoiceRouteRegistrar($list, $get, $create, $convert, $issue);
                 },
             );
     }

--- a/tests/Invoice/CreateInvoiceUseCaseTest.php
+++ b/tests/Invoice/CreateInvoiceUseCaseTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Invoice\CreateInvoiceInput;
+use NeneInvoice\Invoice\CreateInvoiceUseCase;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\InvoiceValidationException;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class CreateInvoiceUseCaseTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private RecordingAuditRecorder $audit;
+    private CreateInvoiceUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->clients = new InMemoryClientRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->useCase = new CreateInvoiceUseCase(
+            $this->invoices,
+            $this->lineItems,
+            $this->clients,
+            new TaxCalculator(),
+            $this->audit,
+        );
+    }
+
+    private function client(int $organizationId = 1): int
+    {
+        return $this->clients->save(new Client(organizationId: $organizationId, name: 'Buyer KK'));
+    }
+
+    public function test_creates_draft_invoice_with_totals_lines_and_audit(): void
+    {
+        $clientId = $this->client();
+
+        $result = $this->useCase->execute(1, 7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [
+                new LineItemInput('Std', 1, 1000, 1000),
+                new LineItemInput('Std2', 1, 1000, 1000),
+            ],
+        ));
+
+        self::assertSame(InvoiceStatus::Draft, $result->invoice->status);
+        self::assertNull($result->invoice->invoiceNumber); // numbered at issue
+        self::assertNull($result->invoice->quoteId);
+        self::assertSame(2000, $result->invoice->subtotalCents);
+        self::assertSame(200, $result->invoice->taxCents);
+        self::assertSame(2200, $result->invoice->totalCents);
+        self::assertCount(2, $result->lines);
+        self::assertSame(LineItemParent::Invoice, $result->lines[0]->parentType);
+        self::assertSame('invoice.created', $this->audit->records[0]['action']);
+    }
+
+    public function test_cross_organization_client_is_rejected(): void
+    {
+        $clientId = $this->client(2);
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(1, 7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('Std', 1, 1000, 1000)],
+        ));
+    }
+
+    public function test_empty_line_items_rejected(): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(1, 7, new CreateInvoiceInput(clientId: $clientId, lines: []));
+    }
+
+    public function test_disallowed_tax_rate_rejected(): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(1, 7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('Std', 1, 1000, 500)],
+        ));
+    }
+}


### PR DESCRIPTION
## 概要

見積（quote）を介さずに、ドラフト請求書を直接作成する。Quote 作成と対称のオーケストレーション。

Closes #74

## エンドポイント

`POST /admin/invoices` — body `{ "client_id": int, "line_items": [{ "description", "quantity", "unit_price_cents", "tax_rate_bps" }], "notes"?: string }`（`manage_billing`、org スコープ）

## 振る舞い / コンプライアンス（拘束）

- 取引先（client）は同一 org に属すること。クロス org / 不在 → 422 `validation-failed`
- `line_items` は非空。各明細は description + quantity / unit_price_cents / tax_rate_bps（integer）
- 税率は **10% / 8% のみ**（accounting-compliance §3）。それ以外 → 422
- `TaxCalculator` で subtotal / tax / total を算出（税率ごとに一度だけ丸め・ADR 0004）
- status `draft`、`invoice_number` は **null**（採番は発行時 = IssueInvoice）、`quote_id` は null
- 明細を `line_items` に保存（`replaceForParent`）
- `invoice.created` を監査記録（ADR 0008）

## テスト

- `CreateInvoiceUseCaseTest`: 作成（subtotal 2000 / tax 200 / total 2200・2 明細・採番なし・監査）/ クロス org client→422 / 空明細→422 / 不正税率→422
- DI ブート検証は `HealthEndpointTest`（フルコンテナ構築、5 引数 RouteRegistrar）でカバー
- `composer check` green（PHPUnit 123 / PHPStan lvl 8 / php-cs-fixer）

## 備考

- operationId `createInvoice` は用語レジストリに既登録（変更なし）
- `InvoiceValidationException`（422 `validation-failed`）を再利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)