### PR TITLE
feat(audit): 監査ログ参照 API（GET /admin/audit-logs）を追加する (#76)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -137,6 +137,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | --- | --- |
 | `getHealth` | System |
 | `login`, `getCurrentUser` | Auth |
+| `listAuditLogs` | Audit (admin oversight) |
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `getCompanySettings`, `updateCompanySettings` | Company (issuer profile, per org) |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #74)
+Last updated: 2026-05-29 (Issue #76)
 
 ## Recently merged
 
@@ -37,13 +37,14 @@ Last updated: 2026-05-29 (Issue #74)
 - **Issue #67 / PR #68** — 見積→請求書変換 + 請求書一覧/取得 ✅ merged
 - **Issue #69 / PR #71** — 請求書の発行（INV 採番 + 適格請求書検証）✅ merged
 - **Issue #72 / PR #73** — 入金記録（payments）— paid/partially_paid 遷移 ✅ merged
-- **Issue #74** — 請求書の直接作成（POST /admin/invoices）⏳ this PR
+- **Issue #74 / PR #75** — 請求書の直接作成（POST /admin/invoices）✅ merged
+- **Issue #76** — 監査ログ参照 API（GET /admin/audit-logs）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #74 | `feat/74-invoice-create` | 請求書の直接作成（見積を介さない） | 🔄 PR pending |
+| #76 | `feat/76-audit-read` | 監査ログ参照 API（GET /admin/audit-logs） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
@@ -172,7 +173,16 @@ Last updated: 2026-05-29 (Issue #74)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Invoice direct create (見積を介さない請求書作成): 🔄 in progress** (Issue #74)
+**Phase 1 — Audit read API (監査ログ参照): 🔄 in progress** (Issue #76)
+
+- `GET /admin/audit-logs?limit&offset` — org-scoped audit trail, newest first (id DESC)
+- Access: `Capability::ManageUsers`（**admin / superadmin only**）— 監査証跡は管理者オーバーサイトで、billing オペレーター（member/viewer）には非開示
+- Response: `items`（id, actor_user_id, organization_id, action, entity_type, entity_id, before, after, created_at）+ `total` / `limit` / `offset`
+- Reuses existing `AuditLogRepositoryInterface::findByOrganization` / `countByOrganization`（read-only; no new table）
+- operationId `listAuditLogs` registered; `/admin/audit-logs` → ManageUsers added to CapabilityResolver
+- Tested: org isolation + newest-first + pagination + empty; CapabilityResolver mapping; full DI boot (HealthEndpointTest)
+
+**Phase 1 — Invoice direct create (見積を介さない請求書作成): ✅ complete** (Issue #74 / PR #75)
 
 - `POST /admin/invoices` {client_id, line_items[], notes?} — creates a draft invoice directly (no quote)
 - Same orchestration as quote create: client in-org validation + per-line checks + `TaxCalculator` (round once per rate, ADR 0004)
@@ -248,8 +258,9 @@ Last updated: 2026-05-29 (Issue #74)
 - `audit_logs` + `Audit\AuditRecorder` (ADR 0008): actor / org / action / entity / before & after sanitized snapshots
 - **Integrated into every mutating operation**: Client, Organization (create/delete), User (create/update/delete), CompanySettings (upsert → created/updated)
 - Verified live: all write actions record rows with the correct actor; `password_hash` never logged
+- **Read API added** (Issue #76): `GET /admin/audit-logs` (admin oversight; see Audit read API above)
 - Limitation (ADR 0008): synchronous best-effort recording, not yet in the mutation's DB transaction (planned)
-- Follow-up: audit read endpoint (`GET /admin/audit-logs`); transactional recording
+- Follow-up: transactional recording; richer audit filters (by entity_type / actor / date range)
 
 ## Handoff Notes
 
@@ -267,6 +278,6 @@ Last updated: 2026-05-29 (Issue #74)
 
 ## Next steps
 
-1. Audit read endpoint (`GET /admin/audit-logs`)
-2. overdue 表示（issued/partially_paid past due_at）; 請求書 PDF / 帳票（後続フェーズ）
-3. OpenAPI stub (Issue #5); Backend CI (Issue #6); ADR 0003 dual deployment (Issue #7)
+1. OpenAPI stub + MCP catalog (Issue #5) — 主要エンドポイントが出揃ったので着手適期
+2. Backend CI workflow (Issue #6); overdue 表示（issued/partially_paid past due_at）
+3. ADR 0003 dual deployment (Issue #7); 監査の transactional 記録

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeneInvoice;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneInvoice\Audit\AuditRouteRegistrar;
 use NeneInvoice\Auth\AuthRouteRegistrar;
 use NeneInvoice\Client\ClientNotFoundExceptionHandler;
 use NeneInvoice\Client\ClientRouteRegistrar;
@@ -53,6 +54,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $authRoutes = $container->get(AuthRouteRegistrar::class);
+                    $auditRoutes = $container->get(AuditRouteRegistrar::class);
                     $organizationRoutes = $container->get(OrganizationRouteRegistrar::class);
                     $userRoutes = $container->get(UserRouteRegistrar::class);
                     $clientRoutes = $container->get(ClientRouteRegistrar::class);
@@ -63,6 +65,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
+                    }
+
+                    if (!$auditRoutes instanceof AuditRouteRegistrar) {
+                        throw new LogicException('Audit route registrar service is invalid.');
                     }
 
                     if (!$organizationRoutes instanceof OrganizationRouteRegistrar) {
@@ -93,7 +99,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Payment route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes];
+                    return [$authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes];
                 },
             )
             ->set(

--- a/src/Audit/AuditLogResponse.php
+++ b/src/Audit/AuditLogResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * Serializes an {@see AuditLog} to its snake_case JSON representation. `before`
+ * and `after` are the already-sanitized snapshots stored at record time.
+ */
+final class AuditLogResponse
+{
+    /** @return array<string, mixed> */
+    public static function toArray(AuditLog $log): array
+    {
+        return [
+            'id' => $log->id,
+            'actor_user_id' => $log->actorUserId,
+            'organization_id' => $log->organizationId,
+            'action' => $log->action,
+            'entity_type' => $log->entityType,
+            'entity_id' => $log->entityId,
+            'before' => $log->before,
+            'after' => $log->after,
+            'created_at' => $log->createdAt,
+        ];
+    }
+}

--- a/src/Audit/AuditRouteRegistrar.php
+++ b/src/Audit/AuditRouteRegistrar.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the audit-log read route. Requires `manage_users` (admin / superadmin)
+ * via CapabilityResolver; scoped to the caller's organization.
+ */
+final readonly class AuditRouteRegistrar
+{
+    public function __construct(
+        private ListAuditLogsHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+
+        $router->get('/admin/audit-logs', static fn (ServerRequestInterface $r) => $list->handle($r));
+    }
+}

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -8,10 +8,12 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the audit trail: repository and recorder (ADR 0008).
+ * Wires the audit trail: repository, recorder, and the read endpoint (ADR 0008).
  */
 final readonly class AuditServiceProvider implements ServiceProviderInterface
 {
@@ -41,6 +43,46 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
 
                     return new AuditRecorder($repo);
                 },
+            )
+            ->set(
+                ListAuditLogsUseCase::class,
+                static fn (ContainerInterface $c): ListAuditLogsUseCase => new ListAuditLogsUseCase(self::resolve($c, AuditLogRepositoryInterface::class)),
+            )
+            ->set(
+                ListAuditLogsHandler::class,
+                static fn (ContainerInterface $c): ListAuditLogsHandler => new ListAuditLogsHandler(
+                    self::resolve($c, ListAuditLogsUseCase::class),
+                    self::resolve($c, JsonResponseFactory::class),
+                    self::resolve($c, ProblemDetailsResponseFactory::class),
+                ),
+            )
+            ->set(
+                AuditRouteRegistrar::class,
+                static function (ContainerInterface $c): AuditRouteRegistrar {
+                    $list = $c->get(ListAuditLogsHandler::class);
+
+                    if (!$list instanceof ListAuditLogsHandler) {
+                        throw new LogicException('Audit log handler service is invalid.');
+                    }
+
+                    return new AuditRouteRegistrar($list);
+                },
             );
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
     }
 }

--- a/src/Audit/ListAuditLogsHandler.php
+++ b/src/Audit/ListAuditLogsHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/audit-logs` — lists the audit trail for the caller's organization
+ * (admin oversight; gated by `manage_users` in CapabilityResolver).
+ */
+final readonly class ListAuditLogsHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListAuditLogsUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
+        }
+
+        $query = $request->getQueryParams();
+
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+
+        return $this->json->create([
+            'items' => array_map(static fn (AuditLog $log): array => AuditLogResponse::toArray($log), $result->items),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/Audit/ListAuditLogsResult.php
+++ b/src/Audit/ListAuditLogsResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * A page of audit logs plus the total count for the organization.
+ */
+final readonly class ListAuditLogsResult
+{
+    /** @param list<AuditLog> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/Audit/ListAuditLogsUseCase.php
+++ b/src/Audit/ListAuditLogsUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+/**
+ * Lists the audit trail for an organization, most recent first.
+ */
+final readonly class ListAuditLogsUseCase
+{
+    public function __construct(
+        private AuditLogRepositoryInterface $logs,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $limit, int $offset): ListAuditLogsResult
+    {
+        return new ListAuditLogsResult(
+            $this->logs->findByOrganization($organizationId, $limit, $offset),
+            $this->logs->countByOrganization($organizationId),
+        );
+    }
+}

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -24,6 +24,12 @@ final class CapabilityResolver
             return Capability::ManageUsers;
         }
 
+        // Audit trail is admin oversight (read-only); gated at the admin level,
+        // not for billing operators (member / viewer).
+        if (str_starts_with($path, '/admin/audit-logs')) {
+            return Capability::ManageUsers;
+        }
+
         if (str_starts_with($path, '/admin/company-settings')) {
             return Capability::ManageCompanySettings;
         }

--- a/tests/Audit/ListAuditLogsUseCaseTest.php
+++ b/tests/Audit/ListAuditLogsUseCaseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Audit;
+
+use NeneInvoice\Audit\AuditLog;
+use NeneInvoice\Audit\ListAuditLogsUseCase;
+use NeneInvoice\Tests\Support\InMemoryAuditLogRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ListAuditLogsUseCaseTest extends TestCase
+{
+    private InMemoryAuditLogRepository $logs;
+    private ListAuditLogsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->logs = new InMemoryAuditLogRepository();
+        $this->useCase = new ListAuditLogsUseCase($this->logs);
+    }
+
+    public function test_lists_only_the_callers_organization_most_recent_first(): void
+    {
+        $this->logs->append(new AuditLog(action: 'invoice.created', entityType: 'invoice', organizationId: 1, entityId: 10));
+        $this->logs->append(new AuditLog(action: 'invoice.issued', entityType: 'invoice', organizationId: 1, entityId: 10));
+        $this->logs->append(new AuditLog(action: 'client.created', entityType: 'client', organizationId: 2, entityId: 99));
+
+        $result = $this->useCase->execute(1, 20, 0);
+
+        self::assertSame(2, $result->total);
+        self::assertCount(2, $result->items);
+        self::assertSame('invoice.issued', $result->items[0]->action); // newest first
+        self::assertSame('invoice.created', $result->items[1]->action);
+    }
+
+    public function test_pagination_applies_limit_and_offset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->logs->append(new AuditLog(action: 'invoice.created', entityType: 'invoice', organizationId: 1, entityId: $i));
+        }
+
+        $page = $this->useCase->execute(1, 2, 2);
+
+        self::assertSame(5, $page->total);
+        self::assertCount(2, $page->items);
+    }
+
+    public function test_empty_for_organization_with_no_logs(): void
+    {
+        $result = $this->useCase->execute(7, 20, 0);
+
+        self::assertSame(0, $result->total);
+        self::assertSame([], $result->items);
+    }
+}

--- a/tests/Auth/CapabilityResolverTest.php
+++ b/tests/Auth/CapabilityResolverTest.php
@@ -18,6 +18,11 @@ final class CapabilityResolverTest extends TestCase
         self::assertSame(Capability::ManageCompanySettings, CapabilityResolver::resolve('/admin/company-settings', 'PUT'));
     }
 
+    public function test_audit_logs_require_admin_oversight_capability(): void
+    {
+        self::assertSame(Capability::ManageUsers, CapabilityResolver::resolve('/admin/audit-logs', 'GET'));
+    }
+
     public function test_billing_paths_split_read_and_write(): void
     {
         self::assertSame(Capability::ViewBilling, CapabilityResolver::resolve('/admin/invoices', 'GET'));

--- a/tests/Support/InMemoryAuditLogRepository.php
+++ b/tests/Support/InMemoryAuditLogRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Audit\AuditLog;
+use NeneInvoice\Audit\AuditLogRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database). Returns logs most-recent-first
+ * (descending id), mirroring PdoAuditLogRepository.
+ */
+final class InMemoryAuditLogRepository implements AuditLogRepositoryInterface
+{
+    /** @var array<int, AuditLog> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    public function append(AuditLog $log): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = new AuditLog(
+            action: $log->action,
+            entityType: $log->entityType,
+            actorUserId: $log->actorUserId,
+            organizationId: $log->organizationId,
+            entityId: $log->entityId,
+            before: $log->before,
+            after: $log->after,
+            id: $id,
+            createdAt: '2026-05-29 00:00:00',
+        );
+
+        return $id;
+    }
+
+    /** @return list<AuditLog> */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (AuditLog $log): bool => $log->organizationId === $organizationId,
+        ));
+
+        usort($matches, static fn (AuditLog $a, AuditLog $b): int => ($b->id ?? 0) <=> ($a->id ?? 0));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (AuditLog $log): bool => $log->organizationId === $organizationId,
+        ));
+    }
+}


### PR DESCRIPTION
## 概要

記録済みの監査ログ（ADR 0008）を組織スコープで参照する **read 専用** API。誰がいつ何をどう変えたか（before/after）を運用者が確認できる。

Closes #76

## エンドポイント

`GET /admin/audit-logs?limit&offset` — 自組織の監査ログを新しい順（id DESC）で返す。

## アクセス制御

- `Capability::ManageUsers`（**admin / superadmin のみ**）にマッピング
- 監査証跡は管理者のオーバーサイト機能であり、billing オペレーター（member / viewer）には開示しない
- org スコープ（自組織のログのみ）

## レスポンス

- `items`（id, actor_user_id, organization_id, action, entity_type, entity_id, before, after, created_at）+ `total` / `limit` / `offset`
- before/after は記録時点でサニタイズ済みのスナップショット（`password_hash` 等は記録時に既に除外）

## 実装メモ

- 既存 `AuditLogRepositoryInterface::findByOrganization` / `countByOrganization` を利用（**新テーブルなし**、read-only）
- `CapabilityResolver` に `/admin/audit-logs` → `ManageUsers` を追加
- 用語レジストリに operationId `listAuditLogs` を登録

## テスト

- `ListAuditLogsUseCaseTest`: org 分離 / 新しい順 / ページング（limit・offset）/ 空
- `CapabilityResolverTest`: `/admin/audit-logs` → ManageUsers
- DI ブート検証は `HealthEndpointTest`（フルコンテナ構築）でカバー
- `composer check` green（PHPUnit 127 / PHPStan lvl 8 / php-cs-fixer）

🤖 Generated with [Claude Code](https://claude.com/claude-code)