### PR TITLE
feat(openapi): OpenAPI 3.1 契約と MCP カタログを追加する (#5)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,15 @@
         "migrations:status": "phinx status -c phinx.php",
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
+        "openapi": "php tools/validate-openapi.php",
+        "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
+        "mcp:generate": "php tools/generate-mcp-tools.php",
         "check": [
             "@test",
             "@analyse",
-            "@cs"
+            "@cs",
+            "@openapi",
+            "@mcp"
         ]
     },
     "config": {
@@ -38,6 +43,7 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^13.1",
-        "robmorgan/phinx": "^0.16.11"
+        "robmorgan/phinx": "^0.16.11",
+        "symfony/yaml": "^8.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b14c605343b8b3a5db561b3c2de8457c",
+    "content-hash": "bda781369c1ba8450ccae28d69b55347",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -6025,6 +6025,82 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/string/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
             },
             "funding": [
                 {

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,0 +1,396 @@
+{
+    "version": 1,
+    "source": "docs/openapi/openapi.yaml",
+    "tools": [
+        {
+            "name": "getHealth",
+            "title": "Health",
+            "description": "Operational health check for the NeNe Invoice API runtime.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getHealth",
+                "method": "GET",
+                "path": "/health"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/HealthStatus"
+        },
+        {
+            "name": "getCurrentUser",
+            "title": "Current user",
+            "description": "Returns the authenticated user resolved from the bearer token.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getCurrentUser",
+                "method": "GET",
+                "path": "/admin/me"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/CurrentUser"
+        },
+        {
+            "name": "listAuditLogs",
+            "title": "List audit logs",
+            "description": "Lists the organization audit trail, newest first (admin oversight).",
+            "safety": "admin",
+            "source": {
+                "type": "openapi",
+                "operationId": "listAuditLogs",
+                "method": "GET",
+                "path": "/admin/audit-logs"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/AuditLogList"
+        },
+        {
+            "name": "listOrganizations",
+            "title": "List organizations",
+            "description": "Lists tenant organizations (superadmin).",
+            "safety": "admin",
+            "source": {
+                "type": "openapi",
+                "operationId": "listOrganizations",
+                "method": "GET",
+                "path": "/admin/organizations"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/OrganizationList"
+        },
+        {
+            "name": "getOrganizationById",
+            "title": "Get organization",
+            "description": "Returns one organization by id (superadmin).",
+            "safety": "admin",
+            "source": {
+                "type": "openapi",
+                "operationId": "getOrganizationById",
+                "method": "GET",
+                "path": "/admin/organizations/{id}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/Organization"
+        },
+        {
+            "name": "listUsers",
+            "title": "List users",
+            "description": "Lists users in the caller organization (admin).",
+            "safety": "admin",
+            "source": {
+                "type": "openapi",
+                "operationId": "listUsers",
+                "method": "GET",
+                "path": "/admin/users"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/UserList"
+        },
+        {
+            "name": "getUserById",
+            "title": "Get user",
+            "description": "Returns one user by id (admin).",
+            "safety": "admin",
+            "source": {
+                "type": "openapi",
+                "operationId": "getUserById",
+                "method": "GET",
+                "path": "/admin/users/{id}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/User"
+        },
+        {
+            "name": "getCompanySettings",
+            "title": "Get company settings",
+            "description": "Returns the issuer profile for the caller organization.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getCompanySettings",
+                "method": "GET",
+                "path": "/admin/company-settings"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/CompanySettings"
+        },
+        {
+            "name": "listClients",
+            "title": "List clients",
+            "description": "Lists clients (trading partners) in the caller organization.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listClients",
+                "method": "GET",
+                "path": "/admin/clients"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/ClientList"
+        },
+        {
+            "name": "getClientById",
+            "title": "Get client",
+            "description": "Returns one client by id.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getClientById",
+                "method": "GET",
+                "path": "/admin/clients/{id}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/Client"
+        },
+        {
+            "name": "listQuotes",
+            "title": "List quotes",
+            "description": "Lists quotes (estimates) in the caller organization.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listQuotes",
+                "method": "GET",
+                "path": "/admin/quotes"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/QuoteList"
+        },
+        {
+            "name": "getQuoteById",
+            "title": "Get quote",
+            "description": "Returns one quote with its line items.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getQuoteById",
+                "method": "GET",
+                "path": "/admin/quotes/{id}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/QuoteWithLines"
+        },
+        {
+            "name": "listInvoices",
+            "title": "List invoices",
+            "description": "Lists invoices in the caller organization.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listInvoices",
+                "method": "GET",
+                "path": "/admin/invoices"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0
+                    }
+                },
+                "additionalProperties": false
+            },
+            "responseSchemaRef": "#/components/schemas/InvoiceList"
+        },
+        {
+            "name": "getInvoiceById",
+            "title": "Get invoice",
+            "description": "Returns one invoice with its line items.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "getInvoiceById",
+                "method": "GET",
+                "path": "/admin/invoices/{id}"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/InvoiceWithLines"
+        },
+        {
+            "name": "listPayments",
+            "title": "List payments",
+            "description": "Lists the payments recorded against an invoice.",
+            "safety": "read",
+            "source": {
+                "type": "openapi",
+                "operationId": "listPayments",
+                "method": "GET",
+                "path": "/admin/invoices/{id}/payments"
+            },
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "id"
+                ]
+            },
+            "responseSchemaRef": "#/components/schemas/PaymentList"
+        }
+    ]
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,0 +1,1348 @@
+openapi: 3.1.0
+info:
+  title: NeNe Invoice API
+  version: 0.1.0
+  description: >
+    NeNe Invoice API contract — self-hosted estimate / invoice / payment
+    management for Japanese SMBs (qualified-invoice / 適格請求書 compliant).
+    Multi-tenant (organization-scoped); money is always integer cents and tax
+    rates are basis points (1000 = 10%). All mutating operations are audited.
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+tags:
+  - name: System
+    description: Runtime health endpoint.
+  - name: Auth
+    description: Authentication and current-user self-service.
+  - name: Audit
+    description: Audit trail read access (admin oversight).
+  - name: Organizations
+    description: Tenant organizations (superadmin only).
+  - name: Users
+    description: User accounts within an organization (admin).
+  - name: CompanySettings
+    description: Issuer (自社) profile per organization.
+  - name: Clients
+    description: Buyers / trading partners (取引先).
+  - name: Quotes
+    description: Estimates / quotes (見積).
+  - name: Invoices
+    description: Invoices (請求書), including issue and quote conversion.
+  - name: Payments
+    description: Payments (入金) recorded against invoices.
+paths:
+  /health:
+    get:
+      tags: [System]
+      summary: Health check
+      description: Reports runtime and database health.
+      operationId: getHealth
+      security: []
+      responses:
+        '200':
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+              example:
+                status: ok
+                service: nene-invoice
+                checks:
+                  database: ok
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Admin login
+      description: Authenticates with email and password and returns a bearer token.
+      operationId: login
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              email: admin@example.com
+              password: secret
+      responses:
+        '200':
+          description: Token issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              example:
+                token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/me:
+    get:
+      tags: [Auth]
+      summary: Current user
+      description: Returns the authenticated user resolved from the bearer token.
+      operationId: getCurrentUser
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CurrentUser'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /admin/audit-logs:
+    get:
+      tags: [Audit]
+      summary: List audit logs
+      description: >
+        Lists the organization's audit trail, newest first. Admin oversight —
+        requires the manage_users capability (admin / superadmin).
+      operationId: listAuditLogs
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Audit log page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+  /admin/organizations:
+    get:
+      tags: [Organizations]
+      summary: List organizations
+      operationId: listOrganizations
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Organization page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [Organizations]
+      summary: Create organization
+      operationId: createOrganization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationRequest'
+            example:
+              name: Acme KK
+              slug: acme
+      responses:
+        '201':
+          description: Organization created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '409':
+          $ref: '#/components/responses/SlugConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/organizations/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Organizations]
+      summary: Get organization by id
+      operationId: getOrganizationById
+      responses:
+        '200':
+          description: Organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags: [Organizations]
+      summary: Delete organization
+      operationId: deleteOrganization
+      responses:
+        '204':
+          description: Organization deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /admin/users:
+    get:
+      tags: [Users]
+      summary: List users
+      operationId: listUsers
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: User page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [Users]
+      summary: Create user
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+            example:
+              email: member@example.com
+              password: secret
+              role: member
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '409':
+          $ref: '#/components/responses/EmailConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Users]
+      summary: Get user by id
+      operationId: getUserById
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Users]
+      summary: Update user
+      operationId: updateUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: User updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/EmailConflict'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+    delete:
+      tags: [Users]
+      summary: Delete user
+      operationId: deleteUser
+      responses:
+        '204':
+          description: User deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /admin/company-settings:
+    get:
+      tags: [CompanySettings]
+      summary: Get company settings
+      description: Returns the issuer profile for the caller's organization.
+      operationId: getCompanySettings
+      responses:
+        '200':
+          description: Company settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanySettings'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags: [CompanySettings]
+      summary: Update company settings
+      description: Upserts the issuer profile (one record per organization).
+      operationId: updateCompanySettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCompanySettingsRequest'
+            example:
+              legal_name: Acme KK
+              registration_number: T1234567890123
+      responses:
+        '200':
+          description: Company settings updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompanySettings'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '422':
+          $ref: '#/components/responses/InvalidRegistrationNumber'
+  /admin/clients:
+    get:
+      tags: [Clients]
+      summary: List clients
+      operationId: listClients
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Client page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [Clients]
+      summary: Create client
+      operationId: createClient
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateClientRequest'
+            example:
+              name: Buyer KK
+              registration_number: T9876543210123
+      responses:
+        '201':
+          description: Client created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '422':
+          $ref: '#/components/responses/InvalidRegistrationNumber'
+  /admin/clients/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Clients]
+      summary: Get client by id
+      operationId: getClientById
+      responses:
+        '200':
+          description: Client
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Clients]
+      summary: Update client
+      operationId: updateClient
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateClientRequest'
+      responses:
+        '200':
+          description: Client updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/InvalidRegistrationNumber'
+    delete:
+      tags: [Clients]
+      summary: Delete client
+      operationId: deleteClient
+      responses:
+        '204':
+          description: Client deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /admin/quotes:
+    get:
+      tags: [Quotes]
+      summary: List quotes
+      operationId: listQuotes
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Quote page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [Quotes]
+      summary: Create quote
+      description: Creates a draft quote; computes totals (round once per tax rate).
+      operationId: createQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateQuoteRequest'
+            example:
+              client_id: 1
+              line_items:
+                - description: Consulting
+                  quantity: 1
+                  unit_price_cents: 100000
+                  tax_rate_bps: 1000
+      responses:
+        '201':
+          description: Quote created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/quotes/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Quotes]
+      summary: Get quote by id
+      operationId: getQuoteById
+      responses:
+        '200':
+          description: Quote with line items
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Quotes]
+      summary: Change quote status
+      description: Transitions the quote status (draft→sent→accepted/rejected/expired).
+      operationId: changeQuoteStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeQuoteStatusRequest'
+            example:
+              status: sent
+      responses:
+        '200':
+          description: Quote updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/InvalidStateTransition'
+  /admin/quotes/{id}/convert:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Invoices]
+      summary: Convert quote to invoice
+      description: Converts an accepted quote into a draft invoice (copies lines/totals).
+      operationId: convertQuoteToInvoice
+      responses:
+        '201':
+          description: Invoice created from quote
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/invoices:
+    get:
+      tags: [Invoices]
+      summary: List invoices
+      operationId: listInvoices
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Invoice page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [Invoices]
+      summary: Create invoice
+      description: Creates a draft invoice directly (no originating quote).
+      operationId: createInvoice
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInvoiceRequest'
+            example:
+              client_id: 1
+              line_items:
+                - description: License
+                  quantity: 2
+                  unit_price_cents: 50000
+                  tax_rate_bps: 1000
+      responses:
+        '201':
+          description: Invoice created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/invoices/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Invoices]
+      summary: Get invoice by id
+      operationId: getInvoiceById
+      responses:
+        '200':
+          description: Invoice with line items
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /admin/invoices/{id}/issue:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Invoices]
+      summary: Issue invoice
+      description: >
+        Issues a draft invoice: allocates an INV number and locks it. A qualified
+        invoice requires the issuer registration number in company settings.
+      operationId: issueInvoice
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueInvoiceRequest'
+            example:
+              qualified: true
+      responses:
+        '200':
+          description: Invoice issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceWithLines'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/QualifiedInvoiceIncomplete'
+  /admin/invoices/{id}/payments:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Payments]
+      summary: List payments
+      description: Lists the payments recorded against an invoice.
+      operationId: listPayments
+      responses:
+        '200':
+          description: Payments for the invoice
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    post:
+      tags: [Payments]
+      summary: Record payment
+      description: >
+        Records a payment against an issued invoice and advances its status to
+        partially_paid or paid. Amounts are integer cents; over-payment is rejected.
+      operationId: recordPayment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordPaymentRequest'
+            example:
+              amount_cents: 110000
+              method: bank_transfer
+      responses:
+        '201':
+          description: Payment recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordPaymentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      description: Maximum number of items to return (1–100, default 20).
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    OffsetParam:
+      name: offset
+      in: query
+      required: false
+      description: Number of items to skip (default 0).
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    IdPathParam:
+      name: id
+      in: path
+      required: true
+      description: Resource identifier.
+      schema:
+        type: integer
+        minimum: 1
+  responses:
+    Unauthorized:
+      description: Missing or invalid bearer token, or bad credentials.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    InsufficientCapability:
+      description: Authenticated but lacking the required capability.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    NotFound:
+      description: Resource not found (or not in the caller's organization).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    Conflict:
+      description: Conflicting request (e.g. cannot delete self).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    SlugConflict:
+      description: Organization slug already in use.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    EmailConflict:
+      description: User email already in use.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    ValidationFailed:
+      description: Request body or field validation error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    InvalidRegistrationNumber:
+      description: Registration number is not `T` followed by 13 digits.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    InvalidStateTransition:
+      description: Disallowed status change.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    QualifiedInvoiceIncomplete:
+      description: A required qualified-invoice field is missing.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+  schemas:
+    ProblemDetails:
+      type: object
+      description: RFC 9457 problem details.
+      properties:
+        type:
+          type: string
+          description: Problem type URI (base https://nene-invoice.dev/problems/).
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+      required: [type, title, status]
+    HealthStatus:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        service:
+          type: string
+          example: nene-invoice
+        checks:
+          type: object
+          properties:
+            database:
+              type: string
+              example: ok
+      required: [status, service]
+    LoginRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+      required: [email, password]
+    LoginResponse:
+      type: object
+      properties:
+        token:
+          type: string
+          description: HMAC bearer token (HS256).
+      required: [token]
+    CurrentUser:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          $ref: '#/components/schemas/Role'
+        organization_id:
+          type: [integer, 'null']
+      required: [id, email, role]
+    Role:
+      type: string
+      enum: [superadmin, admin, member, viewer]
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          $ref: '#/components/schemas/Role'
+        organization_id:
+          type: [integer, 'null']
+        status:
+          type: string
+          enum: [active, invited]
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, email, role]
+    UserList:
+      $ref: '#/components/schemas/PageEnvelope'
+    CreateUserRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        role:
+          $ref: '#/components/schemas/Role'
+      required: [email, password, role]
+    UpdateUserRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        role:
+          $ref: '#/components/schemas/Role'
+    Organization:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        slug:
+          type: string
+        plan:
+          type: [string, 'null']
+        is_active:
+          type: boolean
+        external_id:
+          type: [string, 'null']
+        custom_domain:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, name, slug, is_active]
+    OrganizationList:
+      $ref: '#/components/schemas/PageEnvelope'
+    CreateOrganizationRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+      required: [name, slug]
+    CompanySettings:
+      type: object
+      description: Issuer (自社) profile. registration_number is `T` + 13 digits.
+      properties:
+        organization_id:
+          type: integer
+        legal_name:
+          type: string
+        address:
+          type: [string, 'null']
+        phone:
+          type: [string, 'null']
+        email:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+        bank_name:
+          type: [string, 'null']
+        bank_branch:
+          type: [string, 'null']
+        account_type:
+          type: [string, 'null']
+        account_number:
+          type: [string, 'null']
+        logo_url:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [organization_id, legal_name]
+    UpdateCompanySettingsRequest:
+      type: object
+      properties:
+        legal_name:
+          type: string
+        address:
+          type: [string, 'null']
+        phone:
+          type: [string, 'null']
+        email:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+        bank_name:
+          type: [string, 'null']
+        bank_branch:
+          type: [string, 'null']
+        account_type:
+          type: [string, 'null']
+        account_number:
+          type: [string, 'null']
+        logo_url:
+          type: [string, 'null']
+      required: [legal_name]
+    Client:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        name:
+          type: string
+        contact_name:
+          type: [string, 'null']
+        email:
+          type: [string, 'null']
+        billing_address:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, organization_id, name]
+    ClientList:
+      $ref: '#/components/schemas/PageEnvelope'
+    CreateClientRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        contact_name:
+          type: [string, 'null']
+        email:
+          type: [string, 'null']
+        billing_address:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+      required: [name]
+    UpdateClientRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        contact_name:
+          type: [string, 'null']
+        email:
+          type: [string, 'null']
+        billing_address:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+    LineItem:
+      type: object
+      description: A line on a quote or invoice. Money is integer cents.
+      properties:
+        id:
+          type: integer
+        description:
+          type: string
+        quantity:
+          type: integer
+        unit_price_cents:
+          type: integer
+          description: Unit price in integer cents (smallest currency unit).
+        tax_rate_bps:
+          type: integer
+          description: Tax rate in basis points (1000 = 10%, 800 = 8%).
+        sort_order:
+          type: integer
+        line_subtotal_cents:
+          type: integer
+          description: quantity × unit_price_cents (pre-tax, not rounded).
+      required: [description, quantity, unit_price_cents, tax_rate_bps]
+    LineItemInput:
+      type: object
+      properties:
+        description:
+          type: string
+        quantity:
+          type: integer
+          minimum: 1
+        unit_price_cents:
+          type: integer
+          minimum: 0
+        tax_rate_bps:
+          type: integer
+          enum: [800, 1000]
+      required: [description, quantity, unit_price_cents, tax_rate_bps]
+    Quote:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        client_id:
+          type: integer
+        quote_number:
+          type: string
+          description: Format EST-YYYY-NNN.
+        status:
+          type: string
+          enum: [draft, sent, accepted, rejected, expired]
+        issued_at:
+          type: [string, 'null']
+        valid_until:
+          type: [string, 'null']
+        subtotal_cents:
+          type: integer
+        tax_cents:
+          type: integer
+        total_cents:
+          type: integer
+        notes:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, organization_id, client_id, quote_number, status, subtotal_cents, tax_cents, total_cents]
+    QuoteWithLines:
+      allOf:
+        - $ref: '#/components/schemas/Quote'
+        - type: object
+          properties:
+            line_items:
+              type: array
+              items:
+                $ref: '#/components/schemas/LineItem'
+    QuoteList:
+      $ref: '#/components/schemas/PageEnvelope'
+    CreateQuoteRequest:
+      type: object
+      properties:
+        client_id:
+          type: integer
+        line_items:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/LineItemInput'
+        valid_until:
+          type: [string, 'null']
+        notes:
+          type: [string, 'null']
+      required: [client_id, line_items]
+    ChangeQuoteStatusRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [draft, sent, accepted, rejected, expired]
+      required: [status]
+    Invoice:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        client_id:
+          type: integer
+        quote_id:
+          type: [integer, 'null']
+        invoice_number:
+          type: [string, 'null']
+          description: Null until issued; format INV-YYYY-NNN.
+        status:
+          type: string
+          enum: [draft, issued, partially_paid, paid]
+        is_qualified_invoice:
+          type: boolean
+        issued_at:
+          type: [string, 'null']
+        due_at:
+          type: [string, 'null']
+        subtotal_cents:
+          type: integer
+        tax_cents:
+          type: integer
+        total_cents:
+          type: integer
+        notes:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, organization_id, client_id, status, is_qualified_invoice, subtotal_cents, tax_cents, total_cents]
+    InvoiceWithLines:
+      allOf:
+        - $ref: '#/components/schemas/Invoice'
+        - type: object
+          properties:
+            line_items:
+              type: array
+              items:
+                $ref: '#/components/schemas/LineItem'
+    InvoiceList:
+      $ref: '#/components/schemas/PageEnvelope'
+    CreateInvoiceRequest:
+      type: object
+      properties:
+        client_id:
+          type: integer
+        line_items:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/LineItemInput'
+        notes:
+          type: [string, 'null']
+      required: [client_id, line_items]
+    IssueInvoiceRequest:
+      type: object
+      properties:
+        qualified:
+          type: boolean
+          default: true
+          description: Whether to issue as a qualified invoice (適格請求書).
+        due_at:
+          type: [string, 'null']
+    Payment:
+      type: object
+      properties:
+        id:
+          type: integer
+        organization_id:
+          type: integer
+        invoice_id:
+          type: integer
+        amount_cents:
+          type: integer
+          description: Payment amount in integer cents.
+        paid_at:
+          type: string
+        method:
+          type: [string, 'null']
+          enum: [bank_transfer, cash, other, null]
+        note:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+        updated_at:
+          type: [string, 'null']
+      required: [id, organization_id, invoice_id, amount_cents, paid_at]
+    PaymentList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Payment'
+        total_paid_cents:
+          type: integer
+      required: [items, total_paid_cents]
+    RecordPaymentRequest:
+      type: object
+      properties:
+        amount_cents:
+          type: integer
+          minimum: 1
+          description: Payment amount in integer cents (positive).
+        paid_at:
+          type: [string, 'null']
+        method:
+          type: [string, 'null']
+          enum: [bank_transfer, cash, other, null]
+        note:
+          type: [string, 'null']
+      required: [amount_cents]
+    RecordPaymentResponse:
+      type: object
+      properties:
+        payment:
+          $ref: '#/components/schemas/Payment'
+        invoice:
+          $ref: '#/components/schemas/Invoice'
+        total_paid_cents:
+          type: integer
+      required: [payment, invoice, total_paid_cents]
+    AuditLog:
+      type: object
+      properties:
+        id:
+          type: integer
+        actor_user_id:
+          type: [integer, 'null']
+        organization_id:
+          type: [integer, 'null']
+        action:
+          type: string
+          description: e.g. invoice.created, invoice.issued, payment.recorded.
+        entity_type:
+          type: string
+        entity_id:
+          type: [integer, 'null']
+        before:
+          type: [object, 'null']
+          additionalProperties: true
+        after:
+          type: [object, 'null']
+          additionalProperties: true
+        created_at:
+          type: [string, 'null']
+      required: [id, action, entity_type]
+    AuditLogList:
+      $ref: '#/components/schemas/PageEnvelope'
+    PageEnvelope:
+      type: object
+      description: Standard list envelope (items vary by endpoint).
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+      required: [items, total, limit, offset]
+security:
+  - bearerAuth: []

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #76)
+Last updated: 2026-05-29 (Issue #5)
 
 ## Recently merged
 
@@ -38,22 +38,22 @@ Last updated: 2026-05-29 (Issue #76)
 - **Issue #69 / PR #71** — 請求書の発行（INV 採番 + 適格請求書検証）✅ merged
 - **Issue #72 / PR #73** — 入金記録（payments）— paid/partially_paid 遷移 ✅ merged
 - **Issue #74 / PR #75** — 請求書の直接作成（POST /admin/invoices）✅ merged
-- **Issue #76** — 監査ログ参照 API（GET /admin/audit-logs）⏳ this PR
+- **Issue #76 / PR #77** — 監査ログ参照 API（GET /admin/audit-logs）✅ merged
+- **Issue #5** — OpenAPI stub + MCP カタログ ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #76 | `feat/76-audit-read` | 監査ログ参照 API（GET /admin/audit-logs） | 🔄 PR pending |
+| #5 | `feat/5-openapi-mcp` | OpenAPI stub + MCP カタログ | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
 | Issue | Topic | Priority |
 | --- | --- | --- |
-| #4 | ランタイム基盤: テナント解決＋JWT認証＋RBAC＋`GET /health`（ADR 0006 で拡張） | P0 |
-| #5 | OpenAPI stub + MCP catalog | P0 |
-| #6 | Backend CI workflow | P0 |
+| #6 | Backend CI workflow（`composer check` を Actions で実行） | P0 |
 | #7 | ADR 0003 dual deployment (Tier A / Tier B) | P1 |
+| — | `public_html/openapi.php`（spec の HTTP 配信）/ ランタイム応答↔example 突合 | P2 |
 
 > マルチテナント前提のため、Issue #4 は単なる health から **テナント解決＋認証＋RBAC を含むランタイム基盤** に拡張。組織/ユーザー CRUD は後続 PR。
 
@@ -173,7 +173,17 @@ Last updated: 2026-05-29 (Issue #76)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 1 — Audit read API (監査ログ参照): 🔄 in progress** (Issue #76)
+**Phase 0+ — OpenAPI + MCP catalog: 🔄 in progress** (Issue #5)
+
+- `docs/openapi/openapi.yaml` (3.1.0) — 全 31 オペレーションを網羅（System/Auth/Audit/Organizations/Users/CompanySettings/Clients/Quotes/Invoices/Payments）、再利用 schema・parameters・Problem Details responses・examples
+- `docs/mcp/tools.json`（read 専用 15 tools; mutating は非公開）+ `tools/generate-mcp-tools.php`（再生成可能）
+- `tools/validate-openapi.php`（$ref 解決検証）; MCP は NENE2 `validate-mcp-tools.php` で検証（tool source↔OpenAPI operation, responseSchemaRef↔200 schema）
+- composer: `openapi` / `mcp` / `mcp:generate` を追加し、`check` に `@openapi` `@mcp` を組み込み（CI ゲート化）
+- `tests/OpenApi/OpenApiContractTest`: operationId 集合が実装エンドポイントと一致 / 一意 / well-formed / `{id}` パラメータ宣言 / MCP↔spec 整合
+- dev 依存に `symfony/yaml ^8.1` を追加（YAML パース）
+- フォロー: `public_html/openapi.php`（HTTP 配信）、ランタイム応答↔example 突合テスト
+
+**Phase 1 — Audit read API (監査ログ参照): ✅ complete** (Issue #76 / PR #77)
 
 - `GET /admin/audit-logs?limit&offset` — org-scoped audit trail, newest first (id DESC)
 - Access: `Capability::ManageUsers`（**admin / superadmin only**）— 監査証跡は管理者オーバーサイトで、billing オペレーター（member/viewer）には非開示
@@ -278,6 +288,6 @@ Last updated: 2026-05-29 (Issue #76)
 
 ## Next steps
 
-1. OpenAPI stub + MCP catalog (Issue #5) — 主要エンドポイントが出揃ったので着手適期
-2. Backend CI workflow (Issue #6); overdue 表示（issued/partially_paid past due_at）
+1. Backend CI workflow (Issue #6) — `composer check`（openapi/mcp 含む）を GitHub Actions で実行
+2. `public_html/openapi.php`（spec の HTTP 配信）; overdue 表示（issued/partially_paid past due_at）
 3. ADR 0003 dual deployment (Issue #7); 監査の transactional 記録

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\OpenApi;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Contract guards for docs/openapi/openapi.yaml. Complements
+ * tools/validate-openapi.php (which checks $ref resolution): asserts the
+ * documented operation set matches the implemented endpoints, that every
+ * operation is well-formed, and that the MCP catalog stays aligned.
+ */
+final class OpenApiContractTest extends TestCase
+{
+    /**
+     * The canonical set of operationIds the API implements. Adding or removing an
+     * endpoint must update this set, the OpenAPI spec, and terminology.md together.
+     *
+     * @var list<string>
+     */
+    private const EXPECTED_OPERATION_IDS = [
+        'getHealth',
+        'login',
+        'getCurrentUser',
+        'listAuditLogs',
+        'listOrganizations',
+        'getOrganizationById',
+        'createOrganization',
+        'deleteOrganization',
+        'listUsers',
+        'getUserById',
+        'createUser',
+        'updateUser',
+        'deleteUser',
+        'getCompanySettings',
+        'updateCompanySettings',
+        'listClients',
+        'getClientById',
+        'createClient',
+        'updateClient',
+        'deleteClient',
+        'listQuotes',
+        'getQuoteById',
+        'createQuote',
+        'changeQuoteStatus',
+        'convertQuoteToInvoice',
+        'listInvoices',
+        'getInvoiceById',
+        'createInvoice',
+        'issueInvoice',
+        'listPayments',
+        'recordPayment',
+    ];
+
+    /** @var array<string, mixed> */
+    private static array $document = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        $parsed = Yaml::parseFile(dirname(__DIR__, 2) . '/docs/openapi/openapi.yaml');
+        self::assertIsArray($parsed);
+        self::$document = $parsed;
+    }
+
+    public function test_documented_operations_match_the_implemented_set(): void
+    {
+        $documented = $this->operationIds();
+
+        sort($documented);
+        $expected = self::EXPECTED_OPERATION_IDS;
+        sort($expected);
+
+        self::assertSame($expected, $documented, 'OpenAPI operationIds drifted from the implemented endpoints.');
+    }
+
+    public function test_operation_ids_are_unique(): void
+    {
+        $ids = $this->operationIds();
+
+        self::assertSame(count($ids), count(array_unique($ids)), 'Duplicate operationId in the OpenAPI spec.');
+    }
+
+    public function test_every_operation_is_well_formed(): void
+    {
+        foreach ($this->operations() as $key => $operation) {
+            self::assertArrayHasKey('operationId', $operation, "Missing operationId at {$key}");
+            self::assertArrayHasKey('summary', $operation, "Missing summary at {$key}");
+            self::assertArrayHasKey('tags', $operation, "Missing tags at {$key}");
+            self::assertArrayHasKey('responses', $operation, "Missing responses at {$key}");
+            self::assertMatchesRegularExpression('/^[a-z][a-zA-Z]+$/', (string) $operation['operationId'], "operationId not camelCase at {$key}");
+        }
+    }
+
+    public function test_id_paths_declare_an_id_parameter(): void
+    {
+        $paths = self::$document['paths'];
+        self::assertIsArray($paths);
+
+        foreach ($paths as $path => $pathItem) {
+            if (!str_contains((string) $path, '{id}') || !is_array($pathItem)) {
+                continue;
+            }
+
+            $hasPathLevel = $this->declaresIdParam($pathItem['parameters'] ?? null);
+
+            foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
+                if (!isset($pathItem[$method]) || !is_array($pathItem[$method])) {
+                    continue;
+                }
+
+                $hasOpLevel = $this->declaresIdParam($pathItem[$method]['parameters'] ?? null);
+                self::assertTrue($hasPathLevel || $hasOpLevel, "Path {$path} {$method} does not declare an id parameter.");
+            }
+        }
+    }
+
+    public function test_mcp_catalog_tools_reference_documented_operations(): void
+    {
+        $raw = file_get_contents(dirname(__DIR__, 2) . '/docs/mcp/tools.json');
+        self::assertIsString($raw);
+        $catalog = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($catalog);
+        self::assertArrayHasKey('tools', $catalog);
+        self::assertIsArray($catalog['tools']);
+
+        $documented = $this->operationIds();
+
+        foreach ($catalog['tools'] as $tool) {
+            self::assertIsArray($tool);
+            $operationId = $tool['source']['operationId'] ?? null;
+            self::assertIsString($operationId);
+            self::assertContains($operationId, $documented, "MCP tool references unknown operationId {$operationId}");
+        }
+    }
+
+    /**
+     * @param mixed $parameters
+     */
+    private function declaresIdParam($parameters): bool
+    {
+        if (!is_array($parameters)) {
+            return false;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (is_array($parameter) && (($parameter['name'] ?? null) === 'id' || str_contains((string) ($parameter['$ref'] ?? ''), 'IdPathParam'))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return list<string> */
+    private function operationIds(): array
+    {
+        $ids = [];
+
+        foreach ($this->operations() as $operation) {
+            if (isset($operation['operationId']) && is_string($operation['operationId'])) {
+                $ids[] = $operation['operationId'];
+            }
+        }
+
+        return $ids;
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    private function operations(): array
+    {
+        $paths = self::$document['paths'] ?? [];
+        self::assertIsArray($paths);
+
+        $operations = [];
+
+        foreach ($paths as $path => $pathItem) {
+            if (!is_array($pathItem)) {
+                continue;
+            }
+
+            foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
+                if (isset($pathItem[$method]) && is_array($pathItem[$method])) {
+                    $operations[$method . ' ' . (string) $path] = $pathItem[$method];
+                }
+            }
+        }
+
+        return $operations;
+    }
+}

--- a/tools/generate-mcp-tools.php
+++ b/tools/generate-mcp-tools.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Regenerates docs/mcp/tools.json from declarative read-tool definitions aligned
+ * with docs/openapi/openapi.yaml. The MCP catalog exposes read-only operations
+ * (aggregated views) for ops / MCP clients; mutating operations are not exposed.
+ *
+ * Usage: php tools/generate-mcp-tools.php
+ *
+ * Validated by `composer mcp` (NENE2 validate-mcp-tools.php): each tool's source
+ * must match an OpenAPI operation and responseSchemaRef must equal that
+ * operation's 200 response schema $ref.
+ */
+
+$root = dirname(__DIR__);
+$outputPath = $root . '/docs/mcp/tools.json';
+
+/** @return array<string, mixed> */
+function limitOffsetProperties(): array
+{
+    return [
+        'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'default' => 20],
+        'offset' => ['type' => 'integer', 'minimum' => 0, 'default' => 0],
+    ];
+}
+
+/** @return array<string, mixed> */
+function idProperty(): array
+{
+    return ['id' => ['type' => 'integer', 'minimum' => 1]];
+}
+
+/**
+ * @param array<string, mixed> $properties
+ * @param list<string> $required
+ * @return array<string, mixed>
+ */
+function readTool(
+    string $name,
+    string $title,
+    string $description,
+    string $method,
+    string $path,
+    string $responseSchemaRef,
+    string $safety,
+    array $properties = [],
+    array $required = [],
+): array {
+    $inputSchema = [
+        'type' => 'object',
+        'properties' => $properties === [] ? (object) [] : $properties,
+        'additionalProperties' => false,
+    ];
+
+    if ($required !== []) {
+        $inputSchema['required'] = $required;
+    }
+
+    return [
+        'name' => $name,
+        'title' => $title,
+        'description' => $description,
+        'safety' => $safety,
+        'source' => [
+            'type' => 'openapi',
+            'operationId' => $name,
+            'method' => $method,
+            'path' => $path,
+        ],
+        'inputSchema' => $inputSchema,
+        'responseSchemaRef' => $responseSchemaRef,
+    ];
+}
+
+$tools = [
+    readTool('getHealth', 'Health', 'Operational health check for the NeNe Invoice API runtime.', 'GET', '/health', '#/components/schemas/HealthStatus', 'read'),
+    readTool('getCurrentUser', 'Current user', 'Returns the authenticated user resolved from the bearer token.', 'GET', '/admin/me', '#/components/schemas/CurrentUser', 'read'),
+    readTool('listAuditLogs', 'List audit logs', 'Lists the organization audit trail, newest first (admin oversight).', 'GET', '/admin/audit-logs', '#/components/schemas/AuditLogList', 'admin', limitOffsetProperties()),
+    readTool('listOrganizations', 'List organizations', 'Lists tenant organizations (superadmin).', 'GET', '/admin/organizations', '#/components/schemas/OrganizationList', 'admin', limitOffsetProperties()),
+    readTool('getOrganizationById', 'Get organization', 'Returns one organization by id (superadmin).', 'GET', '/admin/organizations/{id}', '#/components/schemas/Organization', 'admin', idProperty(), ['id']),
+    readTool('listUsers', 'List users', 'Lists users in the caller organization (admin).', 'GET', '/admin/users', '#/components/schemas/UserList', 'admin', limitOffsetProperties()),
+    readTool('getUserById', 'Get user', 'Returns one user by id (admin).', 'GET', '/admin/users/{id}', '#/components/schemas/User', 'admin', idProperty(), ['id']),
+    readTool('getCompanySettings', 'Get company settings', 'Returns the issuer profile for the caller organization.', 'GET', '/admin/company-settings', '#/components/schemas/CompanySettings', 'read'),
+    readTool('listClients', 'List clients', 'Lists clients (trading partners) in the caller organization.', 'GET', '/admin/clients', '#/components/schemas/ClientList', 'read', limitOffsetProperties()),
+    readTool('getClientById', 'Get client', 'Returns one client by id.', 'GET', '/admin/clients/{id}', '#/components/schemas/Client', 'read', idProperty(), ['id']),
+    readTool('listQuotes', 'List quotes', 'Lists quotes (estimates) in the caller organization.', 'GET', '/admin/quotes', '#/components/schemas/QuoteList', 'read', limitOffsetProperties()),
+    readTool('getQuoteById', 'Get quote', 'Returns one quote with its line items.', 'GET', '/admin/quotes/{id}', '#/components/schemas/QuoteWithLines', 'read', idProperty(), ['id']),
+    readTool('listInvoices', 'List invoices', 'Lists invoices in the caller organization.', 'GET', '/admin/invoices', '#/components/schemas/InvoiceList', 'read', limitOffsetProperties()),
+    readTool('getInvoiceById', 'Get invoice', 'Returns one invoice with its line items.', 'GET', '/admin/invoices/{id}', '#/components/schemas/InvoiceWithLines', 'read', idProperty(), ['id']),
+    readTool('listPayments', 'List payments', 'Lists the payments recorded against an invoice.', 'GET', '/admin/invoices/{id}/payments', '#/components/schemas/PaymentList', 'read', idProperty(), ['id']),
+];
+
+$catalog = [
+    'version' => 1,
+    'source' => 'docs/openapi/openapi.yaml',
+    'tools' => $tools,
+];
+
+file_put_contents(
+    $outputPath,
+    json_encode($catalog, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n",
+);
+
+echo sprintf("Wrote %d MCP tools to %s\n", count($tools), $outputPath);

--- a/tools/validate-openapi.php
+++ b/tools/validate-openapi.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$path = dirname(__DIR__) . '/docs/openapi/openapi.yaml';
+
+try {
+    $document = Yaml::parseFile($path);
+} catch (ParseException $exception) {
+    fwrite(STDERR, sprintf("OpenAPI YAML parse error: %s\n", $exception->getMessage()));
+    exit(1);
+}
+
+if (!is_array($document)) {
+    fwrite(STDERR, "OpenAPI document must parse to a mapping.\n");
+    exit(1);
+}
+
+$errors = [];
+
+foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
+    if (!array_key_exists($requiredKey, $document)) {
+        $errors[] = sprintf('Missing required top-level key: %s', $requiredKey);
+    }
+}
+
+if (($document['openapi'] ?? null) !== '3.1.0') {
+    $errors[] = 'OpenAPI version must be 3.1.0.';
+}
+
+validateInternalReferences($document, $document, '#', $errors);
+
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, sprintf("OpenAPI validation error: %s\n", $error));
+    }
+
+    exit(1);
+}
+
+echo "OpenAPI contract is valid.\n";
+
+/**
+ * @param array<mixed> $node
+ * @param array<mixed> $document
+ * @param list<string> $errors
+ */
+function validateInternalReferences(array $node, array $document, string $path, array &$errors): void
+{
+    foreach ($node as $key => $value) {
+        $childPath = $path . '/' . (string) $key;
+
+        if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/')) {
+            if (!hasJsonPointer($document, $value)) {
+                $errors[] = sprintf('Unresolved internal reference at %s: %s', $path, $value);
+            }
+
+            continue;
+        }
+
+        if (is_array($value)) {
+            validateInternalReferences($value, $document, $childPath, $errors);
+        }
+    }
+}
+
+/**
+ * @param array<mixed> $document
+ */
+function hasJsonPointer(array $document, string $reference): bool
+{
+    $current = $document;
+
+    foreach (explode('/', substr($reference, 2)) as $segment) {
+        $segment = str_replace(['~1', '~0'], ['/', '~'], $segment);
+
+        if (!is_array($current) || !array_key_exists($segment, $current)) {
+            return false;
+        }
+
+        $current = $current[$segment];
+    }
+
+    return true;
+}


### PR DESCRIPTION
## 概要

実装済み**全 31 オペレーション**の OpenAPI 3.1 契約と、read 専用 MCP ツールカタログを整備。検証を `composer check`（= CI ゲート）に組み込む。

Closes #5

## 成果物

- **`docs/openapi/openapi.yaml`**（3.1.0）— System / Auth / Audit / Organizations / Users / CompanySettings / Clients / Quotes / Invoices / Payments の全エンドポイント。再利用 schema・parameters（limit/offset/id）・Problem Details responses・examples
- **`docs/mcp/tools.json`** — read 専用 15 tools（list/get 系）。mutating 操作は MCP 非公開
- **`tools/generate-mcp-tools.php`** — カタログ再生成（`composer mcp:generate`）
- **`tools/validate-openapi.php`** — `$ref` 解決＋必須キー＋version 検証（`composer openapi`）
- MCP は NENE2 同梱 `validate-mcp-tools.php` で検証（`composer mcp`）— tool source ↔ OpenAPI operation、responseSchemaRef ↔ 200 schema を突合
- `composer check` に `@openapi` `@mcp` を追加（CI ゲート化）
- dev 依存に **`symfony/yaml ^8.1`**

## テスト

- `tests/OpenApi/OpenApiContractTest`: operationId 集合が実装エンドポイントと一致 / 一意 / well-formed / `{id}` パラメータ宣言 / MCP↔spec 整合
- `composer check` green（PHPUnit **132** / PHPStan lvl 8 / php-cs-fixer / openapi / mcp）

## 規約整合

- operationId は用語レジストリ（`terminology.md`）と一致。snake_case プロパティ、money は integer cents と明記（`docs/review/openapi-contract.md` 準拠）

## フォローアップ（別 Issue）

- `public_html/openapi.php`（spec の HTTP 配信）、ランタイム応答↔example 突合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)