### PR TITLE
ci(backend): Actions を Node 24 対応版へ更新する (#80)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -28,7 +28,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}


### PR DESCRIPTION
## 概要

Backend CI（#6）の初回ランで出た Node 20 非推奨警告に対応。2026-06-02 の Node 24 強制切替前に更新する。

Closes #80

## 変更

- `actions/checkout@v4` → `@v5`
- `actions/cache@v4` → `@v5`
- `shivammathur/setup-php` は `@v2` のまま（最新メジャー）

この PR で CI が再実行され、警告が解消されることを確認してから merge する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)