### PR TITLE
docs(adr): ADR 0003 デュアルデプロイ（Tier A / Tier B）を策定する (#7)

### DIFF
--- a/docs/adr/0003-dual-deployment-tiers.md
+++ b/docs/adr/0003-dual-deployment-tiers.md
@@ -1,0 +1,97 @@
+# ADR 0003: Dual Deployment — Tier A Shared Hosting and Tier B Docker
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Invoice is self-hosted OSS for Japan SMBs. Its primary audience already pays
+for **shared hosting** (Xserver, Sakura, Lolipop, etc.) and is often non-technical —
+general-affairs or accounting staff, not engineers (see `product-vision.md`). They
+will not run Docker, a CLI, or a long-running process, and they do not have root.
+A second audience — developers and VPS operators — wants a reproducible container
+setup for local development and production.
+
+Shared hosting imposes hard constraints:
+
+- PHP runs per-request (FPM/CGI); **no long-running daemons, queues, or workers**.
+- **No root, no shell access** assumed; no custom system packages or PHP extensions
+  beyond the common set (PDO, pdo_mysql, mbstring, json, openssl).
+- The application is served from a **document root** (e.g. `public_html/`); only that
+  directory is web-exposed.
+- **No Composer at runtime** — dependencies must be shipped, not installed on the host.
+- **MySQL** is the available database; migrations cannot rely on a CLI being present.
+
+Alternatives considered:
+
+1. **Docker-only** — rejected; excludes the majority (shared-hosting) audience, which
+   is the product's reason to exist.
+2. **Shared-hosting-only** — rejected; poor developer ergonomics and no reproducible
+   production story for Tier B operators.
+3. **Two divergent codebases** — rejected; doubles maintenance and invites compliance
+   drift between billing implementations.
+4. **One codebase, two deployment tiers** (chosen).
+
+## Decision
+
+Ship **one codebase and one runtime** (NENE2 consumer, single `public_html/index.php`
+entrypoint, one MySQL schema via Phinx migrations + SQLite schema snapshots) packaged
+two ways:
+
+**Tier A — Shared hosting (primary).**
+
+- Distributed as a **release ZIP** that includes `vendor/` and built admin assets
+  (no Composer or Node on the host).
+- A **web installer** collects MySQL credentials, the initial admin user, and company
+  information; writes `.env`; and applies the database schema **without a CLI** (the
+  installer runs the same migration set Phinx applies on Tier B).
+- **Same-origin admin**: PHP serves both the API and the prebuilt admin UI from the
+  document root, avoiding cross-origin setup the audience cannot perform.
+- Request/response only — no feature may require a daemon, queue, or cron to function
+  (scheduled work, if ever needed, degrades gracefully or is Tier B only).
+
+**Tier B — Docker / VPS (secondary).**
+
+- **Docker Compose** (app + MySQL) for local development and production.
+- Migrations via `composer migrations:migrate` (Phinx CLI); assets built from source.
+- **Identical API, admin UI, schema, and configuration surface** as Tier A.
+
+**Shared invariants (both tiers).**
+
+- MySQL in production on both tiers; SQLite is for tests only.
+- Configuration is environment-based (`.env`); no tier-specific code paths in domain logic.
+- The PHP floor is the project's required version (8.4); hosts below it are unsupported.
+
+## Consequences
+
+**Benefits.**
+
+- Reaches the shared-hosting majority *and* gives developers a reproducible setup.
+- One source of truth for billing/compliance logic — no divergence between tiers.
+
+**Costs / constraints.**
+
+- No feature may depend on root, background processes, cron, or uncommon PHP
+  extensions, or it breaks Tier A. Such features are Tier B-only and must be optional.
+- The release ZIP needs a build step that vendors dependencies and bundles admin assets.
+- The web installer must apply migrations safely and idempotently outside the CLI,
+  staying in lockstep with the Phinx migration set.
+- PHP 8.4 availability on target shared hosts is a real adoption risk; the operator
+  guide must state the supported PHP/MySQL versions explicitly.
+
+**Follow-up (Phase 3).**
+
+- Web installer + release-ZIP build tooling; Japanese operator guide.
+- Document supported PHP/MySQL versions and the shared invariants above.
+- A migration-parity check so the installer and Phinx never diverge.
+
+## Related
+
+- Issue: `#7`
+- PR: `#82`
+- Builds on: ADR 0001 (inherit NENE2 governance), ADR 0002 (separate from siblings)
+- See: `docs/explanation/product-vision.md` (audiences), `docs/roadmap.md` (Phase 3),
+  `docs/explanation/glossary.md` (Tier A / Tier B)
+- Supersedes: none
+- Superseded by: none

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,8 @@ Goal: engineering discipline and product design before runtime code.
 - Governance docs, ADR 0001/0002, inheritance map ✅
 - Product vision, requirements, domain model ✅ (Issue #3)
 - Multi-tenancy + role hierarchy adopted as foundational ✅ ADR 0006 (Issue #17)
-- NENE2 consumer scaffold (tenant resolution + JWT auth + RBAC + `GET /health`), OpenAPI, CI 🔲 Issues #4–#7
-- ADR 0003 dual deployment 🔲 Issue #7
+- NENE2 consumer scaffold (tenant resolution + JWT auth + RBAC + `GET /health`), OpenAPI, CI ✅ Issues #4–#6
+- ADR 0003 dual deployment ✅ Issue #7
 
 Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-29 (Issue #6)
+Last updated: 2026-05-29 (Issue #7)
 
 ## Recently merged
 
@@ -40,19 +40,21 @@ Last updated: 2026-05-29 (Issue #6)
 - **Issue #74 / PR #75** — 請求書の直接作成（POST /admin/invoices）✅ merged
 - **Issue #76 / PR #77** — 監査ログ参照 API（GET /admin/audit-logs）✅ merged
 - **Issue #5 / PR #78** — OpenAPI stub + MCP カタログ ✅ merged
-- **Issue #6** — Backend CI workflow（GitHub Actions）⏳ this PR
+- **Issue #6 / PR #79** — Backend CI workflow（GitHub Actions）✅ merged
+- **Issue #80 / PR #81** — CI Actions を Node 24 対応版（checkout/cache @v5）へ更新 ✅ merged
+- **Issue #7** — ADR 0003 dual deployment（Tier A / Tier B）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #6 | `feat/6-backend-ci` | Backend CI workflow（GitHub Actions） | 🔄 PR pending |
+| #7 | `docs/7-adr-dual-deployment` | ADR 0003 dual deployment（Tier A / Tier B） | 🔄 PR pending |
 
 ## Phase 0+ Backlog
 
 | Issue | Topic | Priority |
 | --- | --- | --- |
-| #7 | ADR 0003 dual deployment (Tier A / Tier B) | P1 |
+| — | Phase 3: Tier A web installer + release ZIP build + 運用ガイド（ADR 0003 フォロー） | P1 |
 | — | `public_html/openapi.php`（spec の HTTP 配信）/ ランタイム応答↔example 突合 | P2 |
 | — | overdue 表示 / 請求書 PDF・帳票 / 監査の transactional 記録 | P2 |
 
@@ -174,7 +176,17 @@ Last updated: 2026-05-29 (Issue #6)
 
 - `LineItem\TaxCalculator` (pure, integer-only): round **once per rate** half-up (ADR 0004); subtotal/tax/total + per-rate breakdown
 
-**Phase 0+ — Backend CI: 🔄 in progress** (Issue #6)
+**Phase 0+ — ADR 0003 dual deployment: 🔄 in progress** (Issue #7)
+
+- `docs/adr/0003-dual-deployment-tiers.md`（status: accepted）— Tier A 共有ホスティング（ZIP + web installer、MySQL、same-origin admin、CLI/daemon/root 不可）と Tier B Docker Compose を**単一コードベース**で両立する決定を正式化
+- 共有不変条件: 本番は MySQL（SQLite はテストのみ）、env ベース設定、ドメインロジックに tier 分岐なし、PHP 8.4 floor
+- 制約: root/常駐/cron/特殊拡張に依存する機能は Tier B 限定かつ任意; ZIP は vendor/ と admin アセットを同梱; installer は Phinx 移行と歩調を合わせる
+- roadmap Phase 0 の ADR 0003 マーカーを ✅ に更新
+
+**Phase 0+ — Backend CI: ✅ complete** (Issue #6 / PR #79, Node 24 対応 #80 / PR #81)
+
+- `.github/workflows/backend-ci.yml` — push/PR to `main` で `composer check`（test + analyse + cs + openapi + mcp）を実行。初回ラン green 確認済み
+- PHP 8.4（`shivammathur/setup-php@v2`）、`actions/checkout@v5` / `actions/cache@v5`（Node 24 対応）、Composer キャッシュ、NENE2 は Packagist 取得（clone 不要）
 
 - `.github/workflows/backend-ci.yml` — push/PR to `main` で `composer check`（test + analyse + cs + openapi + mcp）を実行
 - PHP 8.4（`shivammathur/setup-php`, ext pdo/pdo_sqlite）、Composer キャッシュ、`composer install`（NENE2 は Packagist から取得）
@@ -296,6 +308,6 @@ Last updated: 2026-05-29 (Issue #6)
 
 ## Next steps
 
-1. `public_html/openapi.php`（spec の HTTP 配信）; overdue 表示（issued/partially_paid past due_at）
-2. ADR 0003 dual deployment (Issue #7); 監査の transactional 記録
-3. 請求書 PDF / 帳票（後続フェーズ）; ランタイム応答↔OpenAPI example 突合テスト
+1. Phase 2 機能: overdue 表示（issued/partially_paid past due_at）、請求書 PDF（日本様式）
+2. Phase 3（ADR 0003 フォロー）: Tier A web installer + release ZIP build + 運用ガイド（ja）
+3. `public_html/openapi.php`（spec の HTTP 配信）; 監査の transactional 記録


### PR DESCRIPTION
## 概要

共有ホスティング（**Tier A**: ZIP + web installer + MySQL + same-origin admin）と Docker Compose（**Tier B**: dev / VPS）を**単一コードベース**で両立する方針を ADR として正式化する。

Closes #7

## 内容（`docs/adr/0003-dual-deployment-tiers.md`, status: accepted）

- **Context**: 主対象は非エンジニアの共有ホスティング利用者。root/CLI/Docker/常駐プロセス不可、document root 配信、Composer-at-runtime 不可、MySQL という制約を明示
- **Decision**: 単一ランタイム（NENE2 consumer / `public_html/index.php` / Phinx 移行 + SQLite snapshot）を 2 通りに packaging
  - Tier A: release ZIP（vendor/ + admin アセット同梱）+ web installer（DB 資格情報・管理者・会社情報を収集、CLI なしで schema 適用）、same-origin admin
  - Tier B: Docker Compose、Phinx CLI 移行、同一 API/UI/schema/設定
  - 共有不変条件: 本番 MySQL（SQLite はテストのみ）、env 設定、tier 分岐なし、PHP 8.4 floor
- **Consequences**: root/常駐/cron/特殊拡張依存機能は Tier B 限定かつ任意、ZIP ビルド手順、installer↔Phinx の移行パリティ、PHP 8.4 可用性リスク → Phase 3 フォロー
- roadmap の ADR 0003 マーカーを ✅ に更新

ドキュメントのみ。`composer check`（openapi/mcp 含む）は CI で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)