### PR TITLE
fix(frontend): Vite dev では絶対 base を使う (#87)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,15 +9,16 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 // The PHP API runs same-origin in production (Tier A). In dev, Vite serves the
 // SPA and proxies API paths to the running PHP app. Override the target with
 // VITE_API_TARGET when the app listens elsewhere (e.g. the php -S dev port).
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, dirname, 'VITE_')
   const target = env['VITE_API_TARGET'] ?? 'http://127.0.0.1:8080'
 
   return {
     plugins: [react(), tailwindcss()],
-    // Relative asset paths so the bundle can be served from a sub-path
-    // (production same-origin wiring under public_html/ is a Tier A follow-up).
-    base: './',
+    // Relative asset paths for the production bundle so it can be served from a
+    // sub-path (Tier A). The dev server needs an absolute base ('/') — a relative
+    // base breaks dev import-URL normalization.
+    base: command === 'build' ? './' : '/',
     resolve: {
       alias: {
         '@': path.resolve(dirname, './src'),


### PR DESCRIPTION
## 概要

`vite.config.ts` の `base: './'`（相対）が **dev サーバの import URL 正規化を壊し**、ブラウザアクセス時に `Failed to resolve import "@/app/providers"`（normalizeUrl 失敗）を起こしていた。

Closes #87

## 修正

`command` で出し分け:
- **build**: `base: './'`（相対アセット — Tier A サブパス配信、従来どおり `public_html/admin/`）
- **serve(dev)**: `base: '/'`（絶対 — import 解決が正常化）

## 確認

- dev: `/src/main.tsx` が正常 transform、`@/app/providers` → `/src/app/providers.tsx` 200、実 API ログイン可
- build: `index.html` のアセットは相対 `./assets/...` のまま（Tier A 維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)