### PR TITLE
feat(frontend): 請求書の発行アクション（下書き詳細から issue）を追加する (#93)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #91)
+Last updated: 2026-05-30 (Issue #93)
 
 ## Recently merged
 
@@ -47,19 +47,22 @@ Last updated: 2026-05-30 (Issue #91)
 - **Issue #85 / PR #86** — admin UI スキャフォールド + ログイン〜請求書一覧 ✅ merged
 - **Issue #87 / PR #88** — Vite dev の base 修正（import 解決）✅ merged
 - **Issue #89 / PR #90** — 請求書詳細画面（/invoices/:id・明細表示）✅ merged
-- **Issue #91** — 請求書作成フォーム（client 選択 + 明細）⏳ this PR
+- **Issue #91 / PR #92** — 請求書作成フォーム（client 選択 + 明細）✅ merged
+- **Issue #93** — 請求書の発行アクション（下書き詳細から issue）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #91 | `feat/91-invoice-create` | 請求書作成フォーム（client 選択 + 明細） | 🔄 PR pending |
+| #93 | `feat/93-invoice-issue` | 請求書の発行アクション（下書き詳細から issue） | 🔄 PR pending |
 
 ### Frontend 画面の進め方（縦スライス）
 
-請求書 詳細(#89) ✅ → **作成(#91)** → 発行 → 入金 の順。各 PR で `entities/{r}` スライス + `features/*` を同パターンで追加。
-- entities: invoice（list/detail/create）、client（list）、auth。次は invoice の issue / payment mutation、client write。
-- 共有 UI primitives: Button/Input/Select/Text/Stack/Spinner + Field/EmptyState/ErrorState（Storybook 必須）。
+請求書 詳細(#89) ✅ → 作成(#91) ✅ → **発行(#93)** → 入金 の順。各 PR で `entities/{r}` + `features/*` を同パターンで追加。
+- entities/invoice: list/detail/create/issue。次は payment（記録）。
+- feature 同士は import せず**ページで合成**（詳細ページが ViewInvoice + IssueInvoice を並置、useInvoice 共有でクエリは重複しない）。
+- 共有 UI: Button/Input/Select/Text/Stack/Spinner + Field/EmptyState/ErrorState（Storybook 必須）。
+- フォロー: 発行の確認ダイアログ（ConfirmDialog primitive）、due_at 入力。
 
 ## Phase 0+ Backlog
 

--- a/frontend/src/entities/invoice/index.ts
+++ b/frontend/src/entities/invoice/index.ts
@@ -6,8 +6,9 @@ export type {
   LineItem,
   LineItemInput,
   CreateInvoiceInput,
+  IssueInvoiceInput,
 } from './model'
 export { INVOICE_STATUSES, type InvoiceStatus } from './enum'
 export { invoiceKeys, type InvoiceListParams } from './query-keys'
 export { useInvoiceList, useInvoice } from './queries'
-export { useCreateInvoice } from './mutations'
+export { useCreateInvoice, useIssueInvoice } from './mutations'

--- a/frontend/src/entities/invoice/model.ts
+++ b/frontend/src/entities/invoice/model.ts
@@ -51,3 +51,9 @@ export interface CreateInvoiceInput {
   line_items: LineItemInput[]
   notes: string | null
 }
+
+export interface IssueInvoiceInput {
+  id: InvoiceId
+  qualified: boolean
+  due_at: string | null
+}

--- a/frontend/src/entities/invoice/mutations.test.ts
+++ b/frontend/src/entities/invoice/mutations.test.ts
@@ -3,7 +3,8 @@ import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { server } from '@tests/msw/server'
 import { renderHookWithProviders } from '@tests/render/render-with-providers'
-import { useCreateInvoice } from './mutations'
+import { toInvoiceId } from './ids'
+import { useCreateInvoice, useIssueInvoice } from './mutations'
 
 describe('useCreateInvoice', () => {
   it('posts and returns the mapped invoice on success', async () => {
@@ -45,5 +46,44 @@ describe('useCreateInvoice', () => {
       expect(result.current.isError).toBe(true)
     })
     expect(result.current.error?.slug).toBe('validation-failed')
+  })
+})
+
+describe('useIssueInvoice', () => {
+  it('issues a draft and returns the issued invoice', async () => {
+    const { result } = renderHookWithProviders(() => useIssueInvoice())
+
+    result.current.mutate({ id: toInvoiceId(1), qualified: true, due_at: null })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.status).toBe('issued')
+    expect(result.current.data?.invoice_number).toBe('INV-2026-001')
+  })
+
+  it('surfaces a 422 when qualified-invoice requirements are missing', async () => {
+    server.use(
+      http.post(
+        '/admin/invoices/:id/issue',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/qualified-invoice-incomplete',
+              title: 'Validation Failed',
+              status: 422,
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice())
+    result.current.mutate({ id: toInvoiceId(1), qualified: true, due_at: null })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.slug).toBe('qualified-invoice-incomplete')
   })
 })

--- a/frontend/src/entities/invoice/mutations.ts
+++ b/frontend/src/entities/invoice/mutations.ts
@@ -3,7 +3,7 @@ import { apiClient } from '@/shared/api/client'
 import type { AppError } from '@/shared/api/errors'
 import type { InvoiceWithLinesDto } from './api-types'
 import { toInvoiceWithLines } from './mapper'
-import type { CreateInvoiceInput, InvoiceWithLines } from './model'
+import type { CreateInvoiceInput, InvoiceWithLines, IssueInvoiceInput } from './model'
 import { invoiceKeys } from './query-keys'
 
 /**
@@ -32,6 +32,32 @@ export function useCreateInvoice(): UseMutationResult<
       return toInvoiceWithLines(dto)
     },
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: invoiceKeys.lists() })
+    },
+  })
+}
+
+/**
+ * POST /admin/invoices/{id}/issue — issues a draft invoice (allocates the INV
+ * number, locks it). Invalidates the detail and lists so the new state shows.
+ */
+export function useIssueInvoice(): UseMutationResult<
+  InvoiceWithLines,
+  AppError,
+  IssueInvoiceInput
+> {
+  const queryClient = useQueryClient()
+
+  return useMutation<InvoiceWithLines, AppError, IssueInvoiceInput>({
+    mutationFn: async (input) => {
+      const dto = await apiClient.post<InvoiceWithLinesDto>(
+        `/admin/invoices/${String(input.id)}/issue`,
+        { qualified: input.qualified, due_at: input.due_at },
+      )
+      return toInvoiceWithLines(dto)
+    },
+    onSuccess: (invoice) => {
+      void queryClient.invalidateQueries({ queryKey: invoiceKeys.detail(invoice.id) })
       void queryClient.invalidateQueries({ queryKey: invoiceKeys.lists() })
     },
   })

--- a/frontend/src/features/issue-invoice/hooks/use-issue-invoice.test.ts
+++ b/frontend/src/features/issue-invoice/hooks/use-issue-invoice.test.ts
@@ -1,0 +1,32 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { toInvoiceId } from '@/entities/invoice'
+import { server } from '@tests/msw/server'
+import { buildInvoiceWithLinesDto } from '@tests/factories/invoice'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useIssueInvoice } from './use-issue-invoice'
+
+describe('useIssueInvoice (feature)', () => {
+  it('allows issuing a draft invoice', async () => {
+    server.use(
+      http.get('/admin/invoices/:id', () =>
+        HttpResponse.json(buildInvoiceWithLinesDto({ status: 'draft', invoice_number: null })),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.canIssue).toBe(true)
+    })
+  })
+
+  it('hides the action for an already-issued invoice', async () => {
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.canIssue).toBe(false)
+    })
+  })
+})

--- a/frontend/src/features/issue-invoice/hooks/use-issue-invoice.ts
+++ b/frontend/src/features/issue-invoice/hooks/use-issue-invoice.ts
@@ -1,0 +1,33 @@
+import {
+  useInvoice,
+  useIssueInvoice as useIssueInvoiceMutation,
+  type InvoiceId,
+} from '@/entities/invoice'
+import { useTranslation } from '@/shared/i18n'
+
+export interface UseIssueInvoice {
+  /** Only draft invoices can be issued; the action hides otherwise. */
+  canIssue: boolean
+  issue: () => void
+  isPending: boolean
+  errorMessage: string | null
+}
+
+/**
+ * Issues the invoice as a qualified invoice. Reads the (cached) invoice to gate
+ * the action on draft status — shares the detail query, so no extra fetch.
+ */
+export function useIssueInvoice(invoiceId: InvoiceId): UseIssueInvoice {
+  const { t } = useTranslation()
+  const invoice = useInvoice(invoiceId)
+  const mutation = useIssueInvoiceMutation()
+
+  return {
+    canIssue: invoice.data?.status === 'draft',
+    issue: () => {
+      mutation.mutate({ id: invoiceId, qualified: true, due_at: null })
+    },
+    isPending: mutation.isPending,
+    errorMessage: mutation.isError ? t('admin.invoices.issue.error') : null,
+  }
+}

--- a/frontend/src/features/issue-invoice/index.ts
+++ b/frontend/src/features/issue-invoice/index.ts
@@ -1,0 +1,1 @@
+export { IssueInvoice } from './ui/IssueInvoice'

--- a/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
+++ b/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
@@ -1,0 +1,33 @@
+import type { InvoiceId } from '@/entities/invoice'
+import { useTranslation } from '@/shared/i18n'
+import { Button, Stack, Text } from '@/shared/ui'
+import { useIssueInvoice } from '../hooks/use-issue-invoice'
+
+export interface IssueInvoiceProps {
+  invoiceId: InvoiceId
+}
+
+/** Issue action — renders only for a draft invoice. */
+export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
+  const { t } = useTranslation()
+  const { canIssue, issue, isPending, errorMessage } = useIssueInvoice(invoiceId)
+
+  if (!canIssue) {
+    return null
+  }
+
+  return (
+    <Stack gap="sm">
+      <div>
+        <Button onClick={issue} disabled={isPending}>
+          {isPending ? t('admin.invoices.issue.submitting') : t('admin.invoices.issue.action')}
+        </Button>
+      </div>
+      {errorMessage !== null && (
+        <Text variant="muted" role="alert">
+          {errorMessage}
+        </Text>
+      )}
+    </Stack>
+  )
+}

--- a/frontend/src/pages/invoice-detail/InvoiceDetailPage.tsx
+++ b/frontend/src/pages/invoice-detail/InvoiceDetailPage.tsx
@@ -1,6 +1,8 @@
 import { Navigate, useParams } from 'react-router-dom'
 import { toInvoiceId } from '@/entities/invoice'
+import { IssueInvoice } from '@/features/issue-invoice'
 import { ViewInvoice } from '@/features/view-invoice'
+import { Stack } from '@/shared/ui'
 
 export function InvoiceDetailPage() {
   const { id } = useParams()
@@ -10,5 +12,12 @@ export function InvoiceDetailPage() {
     return <Navigate to="/invoices" replace />
   }
 
-  return <ViewInvoice invoiceId={toInvoiceId(numericId)} />
+  const invoiceId = toInvoiceId(numericId)
+
+  return (
+    <Stack gap="lg">
+      <ViewInvoice invoiceId={invoiceId} />
+      <IssueInvoice invoiceId={invoiceId} />
+    </Stack>
+  )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -56,5 +56,9 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.create.submitting': 'Creating…',
   'admin.invoices.create.error': 'Could not create the invoice. Check your input.',
   'admin.invoices.create.invalid': 'Please fix the highlighted fields.',
+  'admin.invoices.issue.action': 'Issue (qualified invoice)',
+  'admin.invoices.issue.submitting': 'Issuing…',
+  'admin.invoices.issue.error':
+    'Could not issue. Check the registration number in company settings.',
   'admin.forbidden.title': 'You do not have access.',
 }

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -57,5 +57,8 @@ export const jaMessages = {
   'admin.invoices.create.submitting': '作成中…',
   'admin.invoices.create.error': '請求書を作成できませんでした。入力内容を確認してください。',
   'admin.invoices.create.invalid': '入力内容に誤りがあります。',
+  'admin.invoices.issue.action': '発行する（適格請求書）',
+  'admin.invoices.issue.submitting': '発行中…',
+  'admin.invoices.issue.error': '発行できませんでした。会社情報の登録番号を確認してください。',
   'admin.forbidden.title': 'アクセス権限がありません。',
 } as const

--- a/frontend/tests/msw/handlers.ts
+++ b/frontend/tests/msw/handlers.ts
@@ -23,4 +23,6 @@ export const handlers = [
   ),
 
   http.get('/admin/invoices/:id', () => HttpResponse.json(buildInvoiceWithLinesDto())),
+
+  http.post('/admin/invoices/:id/issue', () => HttpResponse.json(buildInvoiceWithLinesDto())),
 ]


### PR DESCRIPTION
## 概要

下書き請求書の詳細に発行ボタンを置き、`POST /admin/invoices/:id/issue` で発行（INV 採番・status draft→issued）。縦スライス第4弾。

Closes #93

## 内容

- **entities/invoice**: `useIssueInvoice` mutation（成功で `detail(id)` と `lists` を invalidate → 状態更新）、`IssueInvoiceInput`
- **features/issue-invoice**: hook（`useInvoice` で draft 判定 → `canIssue`、`useIssueInvoice` で発行、適格=true 固定）+ ui（draft のときだけボタン表示、422 はエラー表示）
- **pages/invoice-detail** が `ViewInvoice` + `IssueInvoice` を**ページ合成**（feature 同士の import なし。両者が同じ `useInvoice(id)` を使うため TanStack でクエリ共有・重複フェッチなし）

## テスト（23 件 green）

- `useIssueInvoice`（issued 成功 / 422 `qualified-invoice-incomplete`）
- `use-issue-invoice`（draft→可 / issued→不可）
- `npm run check` green

## フォローアップ

発行の確認ダイアログ（`ConfirmDialog` primitive）、`due_at` 入力。次の縦スライスは **入金記録**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)