### PR TITLE
docs(integration): NeNe Clear 上流契約を受諾しガバナンス整備する (#97)

### DIFF
--- a/docs/adr/0009-accept-nene-clear-upstream-contract.md
+++ b/docs/adr/0009-accept-nene-clear-upstream-contract.md
@@ -1,0 +1,121 @@
+# ADR 0009: Accept the NeNe Clear Upstream Integration Contract
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear (`nene-clear`, private) owns **payment reconciliation and dunning**
+(入金消込・督促): it imports bank deposit lines, matches them to invoices, tracks
+client credit from over-payment, and sends dunning notices. Its ADR 0009
+("Separate Domain from nene-invoice") establishes that Clear and NeNe Invoice are
+**separate deployable units** integrated over **HTTP only** — never a shared
+database — and that **NeNe Invoice is the system of record for billing figures**
+(quotes, invoices, payments, outstanding balances, qualified-invoice copies).
+
+Clear has published a binding request to us:
+`nene-clear/docs/integrations/invoice-upstream-contract.md`. It is a hand-off
+specifying what NeNe Invoice must expose so Clear can reconcile deposits while we
+keep ownership of the numbers. This ADR records our acceptance of that contract
+and the architectural decisions it forces; it does **not** implement the
+endpoints (sequenced follow-up Issues do).
+
+This aligns with our existing **ADR 0002** (separate from sibling products; HTTP
+only) — Clear is simply the first *downstream* consumer that also performs
+**scoped writes** (creating/voiding payments), where prior siblings were read-only
+or inbound webhooks.
+
+## Decision
+
+We **accept** the contract and commit to the following, to be delivered in
+sequenced follow-up PRs (Issue #97 and successors):
+
+### 1. Boundary (restated, binding)
+
+NeNe Invoice remains the **system of record** for invoice figures, the payment
+record, and the authoritative **outstanding balance**
+(`outstanding_cents = total_cents − Σ valid payments`). Clear holds the bank
+evidence (証憑) and the reconciliation link; it never recomputes our figures.
+Over-payment is **not** posted to an invoice (no negative outstanding) — the
+excess is Clear's `client_credit`. (Clear ADR 0009; contract §1, §3.1.5.)
+
+### 2. A dedicated service API surface — `/api/*`
+
+Clear is a **machine consumer**, not an operator. We expose its operations under a
+**separate `/api/*` namespace**, distinct from the operator `/admin/*` surface,
+published as its **own OpenAPI document** (so `operationId`s like `listInvoices`
+may coexist across the two surfaces without collision). Domain logic (UseCases,
+repositories, tax, numbering) is shared; only Handlers/routes/auth differ.
+
+### 3. Service-token authentication (machine principal)
+
+NeNe Invoice **issues a bearer service token** for Clear, representing a
+**service principal** scoped to one or more `organization_id`s and to the scopes
+**`read:invoices`** and **`write:payments`**. It is independent of human
+`Role`/`Capability` (ADR 0006); cross-tenant access is rejected. Clear stores it
+only in its own `.env` (`NENE_INVOICE_API_BASE_URL`, `NENE_INVOICE_BEARER_TOKEN`).
+
+### 4. Invariants we guarantee (contract §4)
+
+- Issued invoice figures immutable (already ADR-bound; `accounting-compliance.md`).
+- `outstanding_cents` computed and owned by Invoice; exposed on read models.
+- `paid_at` is the **bank value date** supplied by Clear — stored as given, never
+  overwritten with a posting timestamp.
+- **No hard delete** of payments — **void-with-audit** only (already our policy;
+  `accounting-compliance.md` §"No hard delete of billing records").
+- **Idempotency** on every write via `idempotency_key`; `external_reference`
+  (Clear's reconciliation id) is stored and round-trips.
+- Integer minimum currency units (`*_cents`), JPY; no float/DECIMAL for money.
+- **Audit** on payment create/void with actor = the Clear service principal.
+- Over-allocation rejected with `422 payment-exceeds-outstanding`, returning the
+  current `outstanding_cents`.
+
+### 5. Stability
+
+`operationId`s and JSON field names on `/api/*` are stable once shipped —
+deprecate, never rename (mirrors Clear). New identifiers are registered in
+`terminology.md` in the same PR that introduces them.
+
+## Consequences
+
+**Benefits.** A clean books-↔-evidence split an auditor can rely on; the boundary
+is enforced by separate surfaces and a least-privilege machine principal; reuse of
+all existing billing domain logic.
+
+**Costs / new surface.** A second OpenAPI document + contract tests; a
+service-principal auth path beyond the human RBAC model; idempotency storage;
+`outstanding_cents` computation exposed on read models; a payment **void** endpoint
+(the data model already soft-deletes, but no use case/route exists yet).
+
+**Compliance (binding — `accounting-compliance.md`).** The mechanics align with
+existing policy (void-not-delete, auditable payments, integer cents). The points
+that touch tax/record-keeping law — treating `paid_at` as the value date, accepting
+externally-sourced payments, and keeping over-payment as Clear-side `client_credit`
+rather than invoice revenue — must be **confirmed with a licensed 税理士 /
+公認会計士** before the write API ships, per the contract's own caveat and our
+non-negotiable compliance rule. This ADR records the *engineering* acceptance; the
+tax sign-off is a gate on the §3 write-API PR, not on this documentation PR.
+
+**Follow-up (sequenced Issues).**
+
+1. Read API: `GET /api/invoices` (filters + `outstanding_cents` + `currency`),
+   `GET /api/invoices/{id}` (outstanding + line items + payment history),
+   optional `GET /api/clients`.
+2. Write API: idempotent `POST /api/invoices/{id}/payments` (+ `external_reference`,
+   over-allocation → `payment-exceeds-outstanding`); `POST …/payments/{id}/void`
+   (void-with-audit, idempotent).
+3. Service-token auth (org-scoped principal) + Problem Details slugs.
+4. `/api/*` OpenAPI document + contract tests; add Clear to `sibling-products.md`.
+
+## Related
+
+- Issue: `#97`
+- PR: `#98`
+- Upstream contract (source): `nene-clear/docs/integrations/invoice-upstream-contract.md`
+- Builds on: ADR 0002 (separate from siblings), ADR 0006 (multi-tenancy/roles),
+  ADR 0008 (audit logging)
+- Binding compliance: `docs/explanation/accounting-compliance.md`
+- See: `docs/integrations/sibling-products.md`, `docs/explanation/terminology.md`
+- Supersedes: none
+- Superseded by: none

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -82,6 +82,10 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Total | `total_cents` | `amount_cents` (on documents), `grand_total` |
 | Unit price | `unit_price_cents` | `price_cents`, `unitprice_cents` |
 | Payment amount | `amount_cents` | `paid_cents`, `payment_cents` |
+| Outstanding balance | `outstanding_cents` | `balance`, `remaining`, `unpaid_cents` |
+| External (Clear) reconciliation id | `external_reference` | `ext_ref`, `clear_id`, `reconciliation_id` |
+| Idempotency key | `idempotency_key` | `idempotencyKey`, `dedupe_key` |
+| Currency | `currency` (ISO 4217, `JPY`) | `ccy`, `currency_code` |
 | Tax rate | `tax_rate_bps` | `tax_rate`, `rate`, `tax_rate_percent` |
 | Foreign keys | `client_id`, `quote_id`, `invoice_id` | `clientId`, `client` |
 | Polymorphic parent | `parent_type`, `parent_id` | `parentType`, `owner_id` |
@@ -121,6 +125,9 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `invalid-state-transition` | Disallowed status change |
 | `company-settings-not-found` | Issuer profile not configured for the organization (404) |
 | `qualified-invoice-incomplete` | Missing required qualified-invoice field |
+| `payment-exceeds-outstanding` | Payment would exceed the invoice outstanding balance (422; service API) |
+| `payment-not-found` | Payment id / external_reference not found (404; service API) |
+| `insufficient-scope` | Service token lacks the required scope (403; service API) |
 
 Add new slugs here before using them. Validation `errors[].field` uses
 snake_case paths (e.g. `body.registration_number`); `errors[].code` is
@@ -144,7 +151,20 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
 | `listQuotes`, `getQuoteById`, `createQuote`, `changeQuoteStatus`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
-| `listPayments`, `recordPayment` | Payment |
+| `listPayments`, `recordPayment` | Payment (operator `/admin/*`) |
+
+### Service API (`/api/*`, NeNe Clear — ADR 0009)
+
+A **separate** OpenAPI document for the machine consumer; `operationId`s may
+reuse operator-surface names within their own doc. New / service-scope stems:
+
+| operationId | Resource |
+| --- | --- |
+| `listInvoices`, `getInvoiceById` | Invoice (service read; outstanding + payments) |
+| `createPayment`, `voidPayment` | Payment (service write; idempotent, `external_reference`) |
+| `listClients` | Client (service read; optional) |
+
+Service-token scopes (not human `Capability`): `read:invoices`, `write:payments`.
 
 Extend this list (do not improvise) when adding operations.
 

--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -5,7 +5,8 @@ NeNe Invoice integrates with other NeNe ecosystem products **via HTTP only**. Se
 ## Dependency direction
 
 ```
-NeNe Invoice  →  HTTP  →  NeNe Records / NeNe Concierge / NeNe Corpus (optional)
+NeNe Invoice  →  HTTP  →  NeNe Records / NeNe Concierge / NeNe Corpus (optional)   (outbound, Invoice consumes)
+NeNe Clear    →  HTTP  →  NeNe Invoice API                                          (inbound, Invoice is upstream SoR)
 ```
 
 Never embed NeNe Invoice code in sibling repositories. Never share databases.
@@ -17,6 +18,26 @@ Never embed NeNe Invoice code in sibling repositories. Never share databases.
 | **NeNe Records** | Invoice → Records (read) | Import product names and prices for line items | Phase 4+ |
 | **NeNe Concierge** | Concierge → Invoice (write via webhook/API) | Create draft client or quote from scenario lead capture | Phase 4+ |
 | **NeNe Corpus** | None required | No default integration | — |
+| **NeNe Clear** | **Clear → Invoice** (read + scoped write) | Bank-deposit reconciliation: read invoices/outstanding, create/void payments. Invoice stays system of record. | See ADR 0009 |
+
+## Downstream consumer: NeNe Clear (入金消込・督促)
+
+NeNe Clear is the first **downstream** consumer that performs **scoped writes**.
+NeNe Invoice is the **system of record** for billing figures and the
+authoritative outstanding balance; Clear holds the bank evidence and the
+reconciliation link only. Contract (binding once both repos accept):
+`nene-clear/docs/integrations/invoice-upstream-contract.md`; our acceptance and
+architecture: **ADR 0009**.
+
+- **Surface:** a dedicated service namespace **`/api/*`** (separate OpenAPI doc),
+  distinct from the operator `/admin/*` surface.
+- **Auth:** NeNe Invoice issues a **service token** (machine principal) scoped to
+  the operator's `organization_id`(s) and to `read:invoices` + `write:payments`.
+- **Writes:** idempotent payment create (with `external_reference`) and
+  void-with-audit; over-allocation rejected (`payment-exceeds-outstanding`).
+- **Status:** contract accepted (ADR 0009); endpoints delivered in sequenced
+  follow-up Issues (tracking: #97). Until shipped, Clear runs against a fake
+  upstream in its contract tests.
 
 ## Environment variables (planned)
 
@@ -27,6 +48,11 @@ Document in `.env.example` when clients land:
 | `NENE_RECORDS_API_BASE_URL` | Optional product catalog upstream |
 | `NENE_RECORDS_BEARER_TOKEN` | Read-only token for Records API |
 | `NENE_CONCIERGE_WEBHOOK_SECRET` | Verify inbound lead webhooks |
+
+For NeNe Clear, the direction is reversed: **NeNe Invoice issues** the service
+token; Clear stores `NENE_INVOICE_API_BASE_URL` / `NENE_INVOICE_BEARER_TOKEN` in
+*its* env. On our side, service-token signing/verification config is defined with
+the `/api/*` auth work (ADR 0009 follow-up), not here.
 
 ## Implementation rules
 
@@ -41,4 +67,5 @@ Document in `.env.example` when clients land:
 | --- | --- |
 | Missing Records catalog API | nene-records |
 | Concierge action node needs Invoice endpoint | nene-concierge (or here if Invoice API is the deliverable) |
+| Clear cannot read invoices / write payments (`/api/*`) | nene-invoice (this repo — ADR 0009 follow-up) |
 | NENE2 middleware / Problem Details | NENE2 |

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #95)
+Last updated: 2026-05-30 (Issue #97)
 
 ## Recently merged
 
@@ -49,18 +49,26 @@ Last updated: 2026-05-30 (Issue #95)
 - **Issue #89 / PR #90** — 請求書詳細画面（/invoices/:id・明細表示）✅ merged
 - **Issue #91 / PR #92** — 請求書作成フォーム（client 選択 + 明細）✅ merged
 - **Issue #93 / PR #94** — 請求書の発行アクション（下書き詳細から issue）✅ merged
-- **Issue #95** — 入金記録（発行済み詳細で入金フォーム＋入金一覧）⏳ this PR
-- **Issue #93** — 請求書の発行アクション（下書き詳細から issue）⏳ this PR
+- **Issue #95 / PR #96** — 入金記録（発行済み詳細で入金フォーム＋入金一覧）✅ merged
+- **Issue #97** — NeNe Clear 上流契約の受諾＋ガバナンス整備（ADR 0009 / sibling / 用語）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #95 | `feat/95-payments` | 入金記録（発行済み詳細で入金フォーム＋一覧） | 🔄 PR pending |
+| #97 | `docs/97-clear-upstream-contract` | NeNe Clear 上流契約 受諾（ADR 0009 + sibling + 用語） | 🔄 PR pending |
+
+### NeNe Clear 連携（入金消込・督促、downstream consumer）
+
+契約原本: `nene-clear/docs/integrations/invoice-upstream-contract.md`。受諾 = **ADR 0009**。
+- 方針: Invoice が請求・入金の SoR。Clear は HTTP の read + scoped write のみ。service スコープ **`/api/*`** 名前空間（独立 OpenAPI）+ **サービストークン principal**（`read:invoices` / `write:payments`、組織スコープ）。
+- このPRはドキュメントのみ（ADR / sibling-products / terminology）。
+- 後続（段階実装・別 Issue）: ①読み取りAPI（filters + `outstanding_cents` + payments 履歴）②書き込みAPI（idempotent payment create + `external_reference`、過入金→`payment-exceeds-outstanding`、void-with-audit）③サービストークン認証 ④`/api/*` OpenAPI + 契約テスト。
+- **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）
 
-請求書 詳細(#89) ✅ → 作成(#91) ✅ → 発行(#93) ✅ → **入金(#95)** ＝ quote-to-cash UI 一巡。
+請求書 詳細(#89) ✅ → 作成(#91) ✅ → 発行(#93) ✅ → 入金(#95) ✅ ＝ quote-to-cash UI 一巡。
 - entities: invoice（list/detail/create/issue）、client（list）、payment（list/record）、auth。
 - 詳細ページが ViewInvoice + IssueInvoice + ManagePayments をページ合成（feature 間 import なし、useInvoice 共有）。payment mutation は invoice 無効化をフィーチャ側で実施（sibling entity 直接 import 回避）。
 - 共有 UI: Button/Input/Select/Text/Stack/Spinner + Field/EmptyState/ErrorState（Storybook 必須）。


### PR DESCRIPTION
## 概要

NeNe Clear（入金消込・督促、private）からの**上流契約ハンドオフを受諾**し、ガバナンス基盤を整える。コードなし（ドキュメントのみ）。契約原本: `nene-clear/docs/integrations/invoice-upstream-contract.md`。

Closes #97

## 決定（ADR 0009）

- **境界**: NeNe Invoice が請求・入金の **system of record**。Clear は HTTP 経由の read + scoped write のみ（ADR 0002 準拠、Clear ADR 0009 の対）。過入金は Invoice に載せず Clear 側 `client_credit`。
- **API 面**: Clear 向けに **service スコープ `/api/*`** 名前空間を新設（独立 OpenAPI ドキュメント、operationId 衝突回避）。operator `/admin/*` と分離。
- **認証**: Invoice が **サービストークン**（machine principal、`read:invoices` / `write:payments`、組織スコープ）を発行。人間の Role/Capability とは独立。
- **invariants**: `outstanding_cents` を算出・公開／`paid_at`=入金日（銀行 value date）／payment は no hard delete = void-with-audit／idempotency + `external_reference` round-trip／integer cents／監査（actor=Clear サービス principal）／過入金は `422 payment-exceeds-outstanding`。

## 変更ファイル

- `docs/adr/0009-accept-nene-clear-upstream-contract.md`（accepted）
- `docs/integrations/sibling-products.md` — Clear を downstream consumer として追記（依存方向 Clear→Invoice）
- `docs/explanation/terminology.md` — 新 field / slug / service operationId / scope を登録
- `docs/todo/current.md`

## コンプライアンス gate

`accounting-compliance.md`（拘束）と整合（payment の no hard delete / void / 監査は既存方針）。`paid_at`=入金日扱い・外部起票・過入金の client_credit 各点は、**書き込みAPI PR の前に 税理士確認**を要する旨を ADR に明記。

## 後続（段階実装・別 Issue）

①読み取りAPI（filters + `outstanding_cents` + payments 履歴）②書き込みAPI（idempotent + `external_reference` + void-with-audit）③サービストークン認証 ④`/api/*` OpenAPI + 契約テスト。

🤖 Generated with [Claude Code](https://claude.com/claude-code)