### PR TITLE
feat(invoice): 売掛金残高 outstanding_cents を read モデルに公開する (#99)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1202,6 +1202,11 @@ components:
           type: integer
         total_cents:
           type: integer
+        outstanding_cents:
+          type: integer
+          description: >
+            total_cents − Σ valid payments. Present on read endpoints (list / get);
+            authoritative balance owned by Invoice. Integer cents.
         notes:
           type: [string, 'null']
         created_at:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #97)
+Last updated: 2026-05-30 (Issue #99)
 
 ## Recently merged
 
@@ -50,13 +50,14 @@ Last updated: 2026-05-30 (Issue #97)
 - **Issue #91 / PR #92** — 請求書作成フォーム（client 選択 + 明細）✅ merged
 - **Issue #93 / PR #94** — 請求書の発行アクション（下書き詳細から issue）✅ merged
 - **Issue #95 / PR #96** — 入金記録（発行済み詳細で入金フォーム＋入金一覧）✅ merged
-- **Issue #97** — NeNe Clear 上流契約の受諾＋ガバナンス整備（ADR 0009 / sibling / 用語）⏳ this PR
+- **Issue #97 / PR #98** — NeNe Clear 上流契約の受諾＋ガバナンス整備（ADR 0009 / sibling / 用語）✅ merged
+- **Issue #99** — 売掛金残高 `outstanding_cents` を read モデルに公開 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #97 | `docs/97-clear-upstream-contract` | NeNe Clear 上流契約 受諾（ADR 0009 + sibling + 用語） | 🔄 PR pending |
+| #99 | `feat/99-outstanding-cents` | `outstanding_cents` を read モデルに公開（ADR 0009 ①の土台） | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 
@@ -64,6 +65,8 @@ Last updated: 2026-05-30 (Issue #97)
 - 方針: Invoice が請求・入金の SoR。Clear は HTTP の read + scoped write のみ。service スコープ **`/api/*`** 名前空間（独立 OpenAPI）+ **サービストークン principal**（`read:invoices` / `write:payments`、組織スコープ）。
 - このPRはドキュメントのみ（ADR / sibling-products / terminology）。
 - 後続（段階実装・別 Issue）: ①読み取りAPI（filters + `outstanding_cents` + payments 履歴）②書き込みAPI（idempotent payment create + `external_reference`、過入金→`payment-exceeds-outstanding`、void-with-audit）③サービストークン認証 ④`/api/*` OpenAPI + 契約テスト。
+  - ①-a **済(#99)**: `outstanding_cents` を `/admin` の list/get read モデルに公開（PaymentRepo batch sum、純 read 派生・gate なし）。サービス read API がこの算出を再利用する。
+  - 次: `/api/*` サービス面 + サービストークン認証 + サービス read（filters / payments 履歴）。
 - **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）

--- a/src/Invoice/GetInvoiceByIdHandler.php
+++ b/src/Invoice/GetInvoiceByIdHandler.php
@@ -37,6 +37,8 @@ final readonly class GetInvoiceByIdHandler implements RequestHandlerInterface
 
         $result = $this->useCase->execute($organizationId, $id);
 
-        return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines));
+        return $this->json->create(
+            InvoiceResponse::toArray($result->invoice, $result->lines, $result->outstandingCents),
+        );
     }
 }

--- a/src/Invoice/GetInvoiceByIdUseCase.php
+++ b/src/Invoice/GetInvoiceByIdUseCase.php
@@ -6,12 +6,14 @@ namespace NeneInvoice\Invoice;
 
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
 
 final readonly class GetInvoiceByIdUseCase
 {
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private LineItemRepositoryInterface $lineItems,
+        private PaymentRepositoryInterface $payments,
     ) {
     }
 
@@ -24,6 +26,9 @@ final readonly class GetInvoiceByIdUseCase
             throw new InvoiceNotFoundException($id);
         }
 
-        return new InvoiceWithLines($invoice, $this->lineItems->findByParent(LineItemParent::Invoice, $id));
+        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $id);
+        $outstanding = max(0, $invoice->totalCents - $this->payments->totalPaidForInvoice($id));
+
+        return new InvoiceWithLines($invoice, $lines, $outstanding);
     }
 }

--- a/src/Invoice/InvoiceResponse.php
+++ b/src/Invoice/InvoiceResponse.php
@@ -17,8 +17,11 @@ final class InvoiceResponse
      * @param list<LineItem>|null $lines
      * @return array<string, mixed>
      */
-    public static function toArray(Invoice $invoice, ?array $lines = null): array
-    {
+    public static function toArray(
+        Invoice $invoice,
+        ?array $lines = null,
+        ?int $outstandingCents = null,
+    ): array {
         $data = [
             'id' => $invoice->id,
             'organization_id' => $invoice->organizationId,
@@ -36,6 +39,10 @@ final class InvoiceResponse
             'created_at' => $invoice->createdAt,
             'updated_at' => $invoice->updatedAt,
         ];
+
+        if ($outstandingCents !== null) {
+            $data['outstanding_cents'] = $outstandingCents;
+        }
 
         if ($lines !== null) {
             $data['line_items'] = array_map(static fn (LineItem $l): array => LineItemResponse::toArray($l), $lines);

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -16,6 +16,7 @@ use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
 use NeneInvoice\Quote\QuoteRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
@@ -69,12 +70,19 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, AuditRecorderInterface::class),
                 ),
             )
-            ->set(ListInvoicesUseCase::class, static fn (ContainerInterface $c): ListInvoicesUseCase => new ListInvoicesUseCase(self::resolve($c, InvoiceRepositoryInterface::class)))
+            ->set(
+                ListInvoicesUseCase::class,
+                static fn (ContainerInterface $c): ListInvoicesUseCase => new ListInvoicesUseCase(
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                ),
+            )
             ->set(
                 GetInvoiceByIdUseCase::class,
                 static fn (ContainerInterface $c): GetInvoiceByIdUseCase => new GetInvoiceByIdUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, PaymentRepositoryInterface::class),
                 ),
             )
             ->set(

--- a/src/Invoice/InvoiceWithLines.php
+++ b/src/Invoice/InvoiceWithLines.php
@@ -12,6 +12,8 @@ final readonly class InvoiceWithLines
     public function __construct(
         public Invoice $invoice,
         public array $lines,
+        /** total_cents − Σ valid payments; 0 unless the read path computes it. */
+        public int $outstandingCents = 0,
     ) {
     }
 }

--- a/src/Invoice/ListInvoicesHandler.php
+++ b/src/Invoice/ListInvoicesHandler.php
@@ -43,9 +43,17 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
         $offset = max(0, $offset);
 
         $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $outstanding = $result->outstandingByInvoiceId;
 
         return $this->json->create([
-            'items' => array_map(static fn (Invoice $i): array => InvoiceResponse::toArray($i), $result->items),
+            'items' => array_map(
+                static fn (Invoice $i): array => InvoiceResponse::toArray(
+                    $i,
+                    null,
+                    $i->id !== null ? ($outstanding[$i->id] ?? null) : null,
+                ),
+                $result->items,
+            ),
             'total' => $result->total,
             'limit' => $limit,
             'offset' => $offset,

--- a/src/Invoice/ListInvoicesResult.php
+++ b/src/Invoice/ListInvoicesResult.php
@@ -6,10 +6,14 @@ namespace NeneInvoice\Invoice;
 
 final readonly class ListInvoicesResult
 {
-    /** @param list<Invoice> $items */
+    /**
+     * @param list<Invoice> $items
+     * @param array<int, int> $outstandingByInvoiceId invoice id => outstanding cents
+     */
     public function __construct(
         public array $items,
         public int $total,
+        public array $outstandingByInvoiceId = [],
     ) {
     }
 }

--- a/src/Invoice/ListInvoicesUseCase.php
+++ b/src/Invoice/ListInvoicesUseCase.php
@@ -4,18 +4,40 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use NeneInvoice\Payment\PaymentRepositoryInterface;
+
 final readonly class ListInvoicesUseCase
 {
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
+        private PaymentRepositoryInterface $payments,
     ) {
     }
 
     public function execute(int $organizationId, int $limit, int $offset): ListInvoicesResult
     {
+        $items = $this->invoices->findAllByOrganization($organizationId, $limit, $offset);
+
+        $ids = [];
+        foreach ($items as $invoice) {
+            if ($invoice->id !== null) {
+                $ids[] = $invoice->id;
+            }
+        }
+
+        $paid = $this->payments->sumPaidForInvoices($ids);
+
+        $outstanding = [];
+        foreach ($items as $invoice) {
+            if ($invoice->id !== null) {
+                $outstanding[$invoice->id] = max(0, $invoice->totalCents - ($paid[$invoice->id] ?? 0));
+            }
+        }
+
         return new ListInvoicesResult(
-            $this->invoices->findAllByOrganization($organizationId, $limit, $offset),
+            $items,
             $this->invoices->countByOrganization($organizationId),
+            $outstanding,
         );
     }
 }

--- a/src/Payment/PaymentRepositoryInterface.php
+++ b/src/Payment/PaymentRepositoryInterface.php
@@ -19,4 +19,13 @@ interface PaymentRepositoryInterface
      * Sum of all (non-deleted) payment amounts recorded against the invoice, in cents.
      */
     public function totalPaidForInvoice(int $invoiceId): int;
+
+    /**
+     * Batch sum of (non-deleted) payments per invoice, in cents. Avoids N+1 when
+     * computing outstanding balances over a list.
+     *
+     * @param list<int> $invoiceIds
+     * @return array<int, int> invoice_id => paid cents (invoices with no payments are omitted)
+     */
+    public function sumPaidForInvoices(array $invoiceIds): array;
 }

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -58,6 +58,32 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         return $row !== null ? (int) $row['total'] : 0;
     }
 
+    /**
+     * @param list<int> $invoiceIds
+     * @return array<int, int>
+     */
+    public function sumPaidForInvoices(array $invoiceIds): array
+    {
+        if ($invoiceIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($invoiceIds), '?'));
+        $rows = $this->query->fetchAll(
+            'SELECT invoice_id, COALESCE(SUM(amount_cents), 0) AS total
+             FROM payments WHERE is_deleted = 0 AND invoice_id IN (' . $placeholders . ')
+             GROUP BY invoice_id',
+            $invoiceIds,
+        );
+
+        $totals = [];
+        foreach ($rows as $row) {
+            $totals[(int) $row['invoice_id']] = (int) $row['total'];
+        }
+
+        return $totals;
+    }
+
     /** @param array<string, mixed> $row */
     private function mapRow(array $row): Payment
     {

--- a/tests/Invoice/InvoiceOutstandingTest.php
+++ b/tests/Invoice/InvoiceOutstandingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\ListInvoicesUseCase;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use PHPUnit\Framework\TestCase;
+
+final class InvoiceOutstandingTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryPaymentRepository $payments;
+
+    protected function setUp(): void
+    {
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->payments = new InMemoryPaymentRepository();
+    }
+
+    private function issuedInvoice(int $totalCents): int
+    {
+        return $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Issued,
+            subtotalCents: $totalCents,
+            taxCents: 0,
+            totalCents: $totalCents,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-30 00:00:00',
+        ));
+    }
+
+    public function test_get_computes_outstanding_as_total_minus_paid(): void
+    {
+        $id = $this->issuedInvoice(2200);
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $id, amountCents: 800, paidAt: '2026-05-30 10:00:00'));
+
+        $useCase = new GetInvoiceByIdUseCase($this->invoices, $this->lineItems, $this->payments);
+        $result = $useCase->execute(1, $id);
+
+        self::assertSame(1400, $result->outstandingCents);
+    }
+
+    public function test_get_outstanding_never_negative(): void
+    {
+        $id = $this->issuedInvoice(1000);
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $id, amountCents: 1000, paidAt: '2026-05-30 10:00:00'));
+
+        $useCase = new GetInvoiceByIdUseCase($this->invoices, $this->lineItems, $this->payments);
+        self::assertSame(0, $useCase->execute(1, $id)->outstandingCents);
+    }
+
+    public function test_list_returns_outstanding_per_invoice(): void
+    {
+        $paidId = $this->issuedInvoice(2200);
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $paidId, amountCents: 2200, paidAt: '2026-05-30 10:00:00'));
+        $unpaidId = $this->issuedInvoice(5000);
+
+        $useCase = new ListInvoicesUseCase($this->invoices, $this->payments);
+        $result = $useCase->execute(1, 20, 0);
+
+        self::assertSame(0, $result->outstandingByInvoiceId[$paidId] ?? null);
+        self::assertSame(5000, $result->outstandingByInvoiceId[$unpaidId] ?? null);
+    }
+}

--- a/tests/Payment/PdoPaymentRepositoryTest.php
+++ b/tests/Payment/PdoPaymentRepositoryTest.php
@@ -77,4 +77,22 @@ final class PdoPaymentRepositoryTest extends TestCase
         self::assertSame('2026-05-29 10:00:00', $payments[0]->paidAt);
         self::assertSame('2026-05-29 11:00:00', $payments[1]->paidAt);
     }
+
+    public function test_sum_paid_for_invoices_batches_and_omits_empties(): void
+    {
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1000, paidAt: '2026-05-29 10:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1200, paidAt: '2026-05-29 11:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 99, amountCents: 500, paidAt: '2026-05-29 12:00:00'));
+
+        $totals = $this->repository->sumPaidForInvoices([42, 99, 7]);
+
+        self::assertSame(2200, $totals[42] ?? null);
+        self::assertSame(500, $totals[99] ?? null);
+        self::assertArrayNotHasKey(7, $totals); // no payments → omitted
+    }
+
+    public function test_sum_paid_for_invoices_empty_input(): void
+    {
+        self::assertSame([], $this->repository->sumPaidForInvoices([]));
+    }
 }

--- a/tests/Support/InMemoryPaymentRepository.php
+++ b/tests/Support/InMemoryPaymentRepository.php
@@ -54,4 +54,22 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
 
         return $total;
     }
+
+    /**
+     * @param list<int> $invoiceIds
+     * @return array<int, int>
+     */
+    public function sumPaidForInvoices(array $invoiceIds): array
+    {
+        $totals = [];
+
+        foreach ($invoiceIds as $invoiceId) {
+            $paid = $this->totalPaidForInvoice($invoiceId);
+            if ($paid > 0) {
+                $totals[$invoiceId] = $paid;
+            }
+        }
+
+        return $totals;
+    }
 }


### PR DESCRIPTION
## 概要

ADR 0009 の読み取りAPI（①）の**土台**。`outstanding_cents = total_cents − Σ(有効な入金)` を算出し、`/admin` の list / get レスポンスに公開。**純粋な read 派生でコンプライアンス gate なし**、operator UI の残高表示にも使え、Clear 向け `/api/*` read がこの算出を再利用する。

Closes #99 ・ ADR 0009 follow-up ①-a

## 内容

- `PaymentRepositoryInterface::sumPaidForInvoices(int[]): array<int,int>`（batch 集計、一覧の N+1 回避。Pdo は `IN (...) GROUP BY`、InMemory も実装）
- `ListInvoicesUseCase` / `GetInvoiceByIdUseCase` が `PaymentRepository` で outstanding を算出（`max(0, total − paid)`）
- `ListInvoicesResult.outstandingByInvoiceId`、`InvoiceWithLines.outstandingCents`（既定 0、read 経路のみ設定）
- `InvoiceResponse::toArray(..., ?int $outstandingCents)`（指定時のみ `outstanding_cents` を出力）。list / get で公開、mutation 応答は対象外
- OpenAPI `Invoice` schema に `outstanding_cents` を追記（用語は #97 で登録済み）

## テスト / 検証

- `InvoiceOutstandingTest`（get の算出・非負クランプ・list の per-invoice マップ）、`PdoPaymentRepositoryTest`（batch sum・空入力）
- `composer check` green（**137 tests** / PHPStan L8 / cs / openapi / mcp）
- live: `GET /admin/invoices` と `/admin/invoices/{id}` が `outstanding_cents` を返す（#1 全額入金 → 0 を確認）

## 次

`/api/*` サービス面 + サービストークン認証 + サービス read（status/overdue/outstanding フィルタ + payments 履歴）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)