### PR TITLE
feat(service-api): /api/* サービス面 + サービストークン認証 + 請求書 read を追加する (#101)

### DIFF
--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -35,9 +35,12 @@ architecture: **ADR 0009**.
   the operator's `organization_id`(s) and to `read:invoices` + `write:payments`.
 - **Writes:** idempotent payment create (with `external_reference`) and
   void-with-audit; over-allocation rejected (`payment-exceeds-outstanding`).
-- **Status:** contract accepted (ADR 0009); endpoints delivered in sequenced
-  follow-up Issues (tracking: #97). Until shipped, Clear runs against a fake
-  upstream in its contract tests.
+- **Status:** contract accepted (ADR 0009). **Read API shipped** (#101):
+  `GET /api/invoices` and `GET /api/invoices/{id}` (with `outstanding_cents` +
+  payment history) behind service-token auth; OpenAPI `docs/openapi/service-api.yaml`;
+  mint tokens with `php tools/issue-service-token.php --org=N --scopes=read:invoices`.
+  Write API (payment create / void) and read filters are sequenced follow-ups
+  (write API gated on 税理士 sign-off).
 
 ## Environment variables (planned)
 

--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -1,0 +1,158 @@
+openapi: 3.1.0
+info:
+  title: NeNe Invoice — Service API (NeNe Clear)
+  version: 0.1.0
+  description: >
+    Machine-to-machine surface for the NeNe Clear reconciliation product
+    (ADR 0009). Authenticated with a service token (scope `read:invoices` /
+    `write:payments`), org-scoped. NeNe Invoice is the system of record for
+    billing figures and the authoritative outstanding balance; Clear never
+    recomputes them. This document is separate from the operator OpenAPI
+    (`openapi.yaml`); read-only operations land first, the write API follows.
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+tags:
+  - name: ServiceInvoices
+    description: Invoice reads for reconciliation (service scope).
+security:
+  - serviceToken: []
+paths:
+  /api/invoices:
+    get:
+      tags: [ServiceInvoices]
+      summary: List invoices (service)
+      description: >
+        Lists invoices in the token's organization with the authoritative
+        outstanding balance. Filters (status / overdue / outstanding_gt / due /
+        client) are an additive follow-up.
+      operationId: listInvoices
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+        - name: offset
+          in: query
+          required: false
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        '200':
+          description: Invoice page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceInvoiceList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientScope'
+  /api/invoices/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    get:
+      tags: [ServiceInvoices]
+      summary: Get invoice (service)
+      description: One invoice with authoritative outstanding balance and payment history.
+      operationId: getInvoiceById
+      responses:
+        '200':
+          description: Invoice with payments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceInvoiceDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientScope'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  securitySchemes:
+    serviceToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Service token issued by NeNe Invoice (scopes read:invoices / write:payments).
+  responses:
+    Unauthorized:
+      description: Missing or invalid service token.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    InsufficientScope:
+      description: Token lacks the required scope or organization.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    NotFound:
+      description: Invoice not found (or not in the token's organization).
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+  schemas:
+    ProblemDetails:
+      type: object
+      description: RFC 9457 problem details.
+      properties:
+        type: { type: string }
+        title: { type: string }
+        status: { type: integer }
+        detail: { type: string }
+      required: [type, title, status]
+    ServiceInvoice:
+      type: object
+      properties:
+        invoice_id: { type: integer }
+        invoice_number: { type: [string, 'null'] }
+        client_id: { type: integer }
+        issued_at: { type: [string, 'null'] }
+        due_at: { type: [string, 'null'] }
+        total_cents: { type: integer, description: Integer cents (smallest unit). }
+        outstanding_cents:
+          type: integer
+          description: total_cents − Σ valid payments; authoritative, owned by Invoice.
+        status:
+          type: string
+          enum: [draft, issued, partially_paid, paid]
+        currency: { type: string, description: ISO 4217; JPY for Phase 1–3. }
+      required: [invoice_id, client_id, total_cents, outstanding_cents, status, currency]
+    ServiceInvoiceList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceInvoice'
+        total: { type: integer }
+        limit: { type: integer }
+        offset: { type: integer }
+      required: [items, total, limit, offset]
+    ServicePayment:
+      type: object
+      properties:
+        payment_id: { type: [integer, 'null'] }
+        amount_cents: { type: integer }
+        paid_at: { type: string, description: Bank value date (入金日). }
+        method: { type: [string, 'null'] }
+        external_reference:
+          type: [string, 'null']
+          description: Clear reconciliation id; null until the write API stores it.
+      required: [amount_cents, paid_at]
+    ServiceInvoiceDetail:
+      allOf:
+        - $ref: '#/components/schemas/ServiceInvoice'
+        - type: object
+          properties:
+            payments:
+              type: array
+              items:
+                $ref: '#/components/schemas/ServicePayment'
+          required: [payments]

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #99)
+Last updated: 2026-05-30 (Issue #101)
 
 ## Recently merged
 
@@ -51,13 +51,14 @@ Last updated: 2026-05-30 (Issue #99)
 - **Issue #93 / PR #94** — 請求書の発行アクション（下書き詳細から issue）✅ merged
 - **Issue #95 / PR #96** — 入金記録（発行済み詳細で入金フォーム＋入金一覧）✅ merged
 - **Issue #97 / PR #98** — NeNe Clear 上流契約の受諾＋ガバナンス整備（ADR 0009 / sibling / 用語）✅ merged
-- **Issue #99** — 売掛金残高 `outstanding_cents` を read モデルに公開 ⏳ this PR
+- **Issue #99 / PR #100** — 売掛金残高 `outstanding_cents` を read モデルに公開 ✅ merged
+- **Issue #101** — `/api/*` サービス面 + サービストークン認証 + 請求書 read（Clear 向け）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #99 | `feat/99-outstanding-cents` | `outstanding_cents` を read モデルに公開（ADR 0009 ①の土台） | 🔄 PR pending |
+| #101 | `feat/101-service-api-read` | `/api/*` サービス面 + サービストークン + 請求書 read | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 
@@ -65,8 +66,9 @@ Last updated: 2026-05-30 (Issue #99)
 - 方針: Invoice が請求・入金の SoR。Clear は HTTP の read + scoped write のみ。service スコープ **`/api/*`** 名前空間（独立 OpenAPI）+ **サービストークン principal**（`read:invoices` / `write:payments`、組織スコープ）。
 - このPRはドキュメントのみ（ADR / sibling-products / terminology）。
 - 後続（段階実装・別 Issue）: ①読み取りAPI（filters + `outstanding_cents` + payments 履歴）②書き込みAPI（idempotent payment create + `external_reference`、過入金→`payment-exceeds-outstanding`、void-with-audit）③サービストークン認証 ④`/api/*` OpenAPI + 契約テスト。
-  - ①-a **済(#99)**: `outstanding_cents` を `/admin` の list/get read モデルに公開（PaymentRepo batch sum、純 read 派生・gate なし）。サービス read API がこの算出を再利用する。
-  - 次: `/api/*` サービス面 + サービストークン認証 + サービス read（filters / payments 履歴）。
+  - ①-a **済(#99)**: `outstanding_cents` を `/admin` の list/get read モデルに公開（PaymentRepo batch sum、純 read 派生・gate なし）。
+  - ①-b **済(#101)**: `/api/*` サービス面 + サービストークン認証（`ServiceScope`/`ServiceAuthContext`/`ServiceScopeMiddleware`、BearerToken の保護 prefix に `/api/`）+ `GET /api/invoices` / `/api/invoices/{id}`（既存 UseCase 再利用、契約 read モデル + payments 履歴）。独立 OpenAPI `service-api.yaml`、`tools/issue-service-token.php`。ライブ確認: 401/403 分離・サービストークンで取得可。
+  - 次（②, 別 Issue）: read フィルタ（status/overdue/outstanding_gt/due/client）→ 書き込みAPI（payment create + `external_reference` + void、idempotency）← **税理士確認後**。複数 org スコープ・トークン発行/失効の運用。
 - **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -28,6 +28,7 @@ use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
 use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
 use NeneInvoice\Quote\QuoteRouteRegistrar;
 use NeneInvoice\Quote\QuoteValidationExceptionHandler;
+use NeneInvoice\ServiceApi\ServiceApiRouteRegistrar;
 use NeneInvoice\User\CannotDeleteSelfExceptionHandler;
 use NeneInvoice\User\RoleNotAssignableExceptionHandler;
 use NeneInvoice\User\UserEmailConflictExceptionHandler;
@@ -62,6 +63,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $quoteRoutes = $container->get(QuoteRouteRegistrar::class);
                     $invoiceRoutes = $container->get(InvoiceRouteRegistrar::class);
                     $paymentRoutes = $container->get(PaymentRouteRegistrar::class);
+                    $serviceApiRoutes = $container->get(ServiceApiRouteRegistrar::class);
 
                     if (!$authRoutes instanceof AuthRouteRegistrar) {
                         throw new LogicException('Auth route registrar service is invalid.');
@@ -99,7 +101,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Payment route registrar service is invalid.');
                     }
 
-                    return [$authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes];
+                    if (!$serviceApiRoutes instanceof ServiceApiRouteRegistrar) {
+                        throw new LogicException('Service API route registrar service is invalid.');
+                    }
+
+                    return [$authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes];
                 },
             )
             ->set(

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -122,12 +122,13 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Token verifier service is invalid.');
                     }
 
-                    // Protect everything under /admin/. Public routes (/, /health,
-                    // /auth/login) are not matched by the prefix and pass through.
+                    // Protect everything under /admin/ (operator) and /api/ (service
+                    // tokens — ADR 0009). Public routes (/, /health, /auth/login) are
+                    // not matched by the prefix and pass through.
                     return new BearerTokenMiddleware(
                         $problemDetails,
                         $verifier,
-                        protectedPathPrefixes: ['/admin/'],
+                        protectedPathPrefixes: ['/admin/', '/api/'],
                     );
                 },
             )

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -30,6 +30,8 @@ use NeneInvoice\LineItem\LineItemServiceProvider;
 use NeneInvoice\Organization\OrganizationServiceProvider;
 use NeneInvoice\Payment\PaymentServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
+use NeneInvoice\ServiceApi\ServiceApiServiceProvider;
+use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -60,6 +62,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new QuoteServiceProvider());
         $builder->addProvider(new InvoiceServiceProvider());
         $builder->addProvider(new PaymentServiceProvider());
+        $builder->addProvider(new ServiceApiServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())
@@ -156,6 +159,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Capability middleware service is invalid.');
                     }
 
+                    $serviceScopeMiddleware = $container->get(ServiceScopeMiddleware::class);
+
+                    if (!$serviceScopeMiddleware instanceof ServiceScopeMiddleware) {
+                        throw new LogicException('Service scope middleware service is invalid.');
+                    }
+
                     $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
 
                     if (!is_array($routeRegistrars) || !array_is_list($routeRegistrars)) {
@@ -177,7 +186,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         streamFactory: $psr17,
                         domainExceptionHandlers: $exceptionHandlers,
                         routeRegistrars: $routeRegistrars,
-                        authMiddleware: [$bearerTokenMiddleware, $capabilityMiddleware],
+                        authMiddleware: [$bearerTokenMiddleware, $capabilityMiddleware, $serviceScopeMiddleware],
                         healthChecks: [$databaseHealthCheck],
                         debug: $config->debug,
                     );

--- a/src/ServiceApi/GetServiceInvoiceHandler.php
+++ b/src/ServiceApi/GetServiceInvoiceHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
+use NeneInvoice\Payment\ListPaymentsUseCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /api/invoices/{id}` — service read with authoritative `outstanding_cents`
+ * and payment history (contract §2.2). Org-scoped to the service token; reuses
+ * the operator use cases. Cross-tenant access surfaces as not-found.
+ */
+final readonly class GetServiceInvoiceHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GetInvoiceByIdUseCase $getInvoice,
+        private ListPaymentsUseCase $listPayments,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $invoice = $this->getInvoice->execute($organizationId, $id);
+        $payments = $this->listPayments->execute($organizationId, $id);
+
+        return $this->json->create(
+            ServiceInvoiceResponse::detail($invoice->invoice, $invoice->outstandingCents, $payments),
+        );
+    }
+}

--- a/src/ServiceApi/ListServiceInvoicesHandler.php
+++ b/src/ServiceApi/ListServiceInvoicesHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\ListInvoicesUseCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /api/invoices` — service read for NeNe Clear. Org-scoped to the service
+ * token. Reuses the operator list use case (which computes outstanding) and
+ * serializes the contract read model. Filters (status/overdue/outstanding_gt/…)
+ * are an additive follow-up.
+ */
+final readonly class ListServiceInvoicesHandler implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ListInvoicesUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
+        }
+
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
+        $offset = max(0, $offset);
+
+        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $outstanding = $result->outstandingByInvoiceId;
+
+        return $this->json->create([
+            'items' => array_map(
+                static fn (Invoice $i): array => ServiceInvoiceResponse::listItem(
+                    $i,
+                    $i->id !== null ? ($outstanding[$i->id] ?? $i->totalCents) : $i->totalCents,
+                ),
+                $result->items,
+            ),
+            'total' => $result->total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+    }
+}

--- a/src/ServiceApi/ServiceApiRouteRegistrar.php
+++ b/src/ServiceApi/ServiceApiRouteRegistrar.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the NeNe Clear service surface under `/api/*` (ADR 0009). Auth is the
+ * service token (`read:invoices` scope) enforced by ServiceScopeMiddleware;
+ * org scoping comes from the token. Read-only for now (write API is a follow-up).
+ */
+final readonly class ServiceApiRouteRegistrar
+{
+    public function __construct(
+        private ListServiceInvoicesHandler $listHandler,
+        private GetServiceInvoiceHandler $getHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $get = $this->getHandler;
+
+        $router->get('/api/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->get('/api/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+    }
+}

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
+use NeneInvoice\Invoice\ListInvoicesUseCase;
+use NeneInvoice\Payment\ListPaymentsUseCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the NeNe Clear service surface (`/api/*`): scope middleware, read
+ * handlers (reusing operator use cases), and the route registrar (ADR 0009).
+ */
+final readonly class ServiceApiServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ServiceScopeMiddleware::class,
+                static fn (ContainerInterface $c): ServiceScopeMiddleware => new ServiceScopeMiddleware(self::problemDetails($c)),
+            )
+            ->set(
+                ListServiceInvoicesHandler::class,
+                static fn (ContainerInterface $c): ListServiceInvoicesHandler => new ListServiceInvoicesHandler(
+                    self::resolve($c, ListInvoicesUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                GetServiceInvoiceHandler::class,
+                static fn (ContainerInterface $c): GetServiceInvoiceHandler => new GetServiceInvoiceHandler(
+                    self::resolve($c, GetInvoiceByIdUseCase::class),
+                    self::resolve($c, ListPaymentsUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
+                ServiceApiRouteRegistrar::class,
+                static function (ContainerInterface $c): ServiceApiRouteRegistrar {
+                    $list = $c->get(ListServiceInvoicesHandler::class);
+                    $get = $c->get(GetServiceInvoiceHandler::class);
+
+                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler) {
+                        throw new LogicException('Service API handler services are invalid.');
+                    }
+
+                    return new ServiceApiRouteRegistrar($list, $get);
+                },
+            );
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        return self::resolve($c, JsonResponseFactory::class);
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+}

--- a/src/ServiceApi/ServiceAuthContext.php
+++ b/src/ServiceApi/ServiceAuthContext.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Reads the **service principal** from the verified token claims set by the
+ * framework `BearerTokenMiddleware` (`nene2.auth.claims`).
+ *
+ * A service token (issued for a sibling like NeNe Clear — ADR 0009) carries:
+ *   `sub` (e.g. `service:clear`), `org` (organization scope), and
+ *   `scopes` (list of {@see ServiceScope} values).
+ */
+final class ServiceAuthContext
+{
+    private const CLAIMS_ATTRIBUTE = 'nene2.auth.claims';
+
+    public static function organizationId(ServerRequestInterface $request): ?int
+    {
+        $value = self::claim($request, 'org');
+
+        return is_int($value) ? $value : null;
+    }
+
+    /** @return list<string> */
+    public static function scopes(ServerRequestInterface $request): array
+    {
+        $value = self::claim($request, 'scopes');
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $s): bool => is_string($s)));
+    }
+
+    public static function hasScope(ServerRequestInterface $request, ServiceScope $scope): bool
+    {
+        return in_array($scope->value, self::scopes($request), true);
+    }
+
+    /** A service principal is any token carrying a `scopes` claim. */
+    public static function isServicePrincipal(ServerRequestInterface $request): bool
+    {
+        return is_array(self::claim($request, 'scopes'));
+    }
+
+    private static function claim(ServerRequestInterface $request, string $key): mixed
+    {
+        $claims = $request->getAttribute(self::CLAIMS_ATTRIBUTE);
+
+        return is_array($claims) ? ($claims[$key] ?? null) : null;
+    }
+}

--- a/src/ServiceApi/ServiceInvoiceResponse.php
+++ b/src/ServiceApi/ServiceInvoiceResponse.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Payment\Payment;
+
+/**
+ * Serializes invoices for the NeNe Clear service surface (ADR 0009 / upstream
+ * contract §2). Field names follow the contract read model (`invoice_id`,
+ * `outstanding_cents`, `currency`), which differs from the operator
+ * `InvoiceResponse`. Money is integer cents; figures are owned by Invoice.
+ */
+final class ServiceInvoiceResponse
+{
+    private const CURRENCY = 'JPY';
+
+    /** @return array<string, mixed> */
+    public static function listItem(Invoice $invoice, int $outstandingCents): array
+    {
+        return [
+            'invoice_id' => $invoice->id,
+            'invoice_number' => $invoice->invoiceNumber,
+            'client_id' => $invoice->clientId,
+            'issued_at' => $invoice->issuedAt,
+            'due_at' => $invoice->dueAt,
+            'total_cents' => $invoice->totalCents,
+            'outstanding_cents' => $outstandingCents,
+            'status' => $invoice->status->value,
+            'currency' => self::CURRENCY,
+        ];
+    }
+
+    /**
+     * @param list<Payment> $payments
+     * @return array<string, mixed>
+     */
+    public static function detail(Invoice $invoice, int $outstandingCents, array $payments): array
+    {
+        $data = self::listItem($invoice, $outstandingCents);
+        $data['payments'] = array_map(static fn (Payment $p): array => [
+            'payment_id' => $p->id,
+            'amount_cents' => $p->amountCents,
+            'paid_at' => $p->paidAt,
+            'method' => $p->method,
+            // external_reference lands with the write API (ADR 0009 §3); null until then.
+            'external_reference' => null,
+        ], $payments);
+
+        return $data;
+    }
+}

--- a/src/ServiceApi/ServiceScope.php
+++ b/src/ServiceApi/ServiceScope.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+/**
+ * Scopes a service token (machine principal) may carry (ADR 0009). These are the
+ * service-to-service equivalent of human capabilities — a Clear token is scoped to
+ * exactly the operations it needs.
+ */
+enum ServiceScope: string
+{
+    case ReadInvoices = 'read:invoices';
+    case WritePayments = 'write:payments';
+}

--- a/src/ServiceApi/ServiceScopeMiddleware.php
+++ b/src/ServiceApi/ServiceScopeMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Enforces service-token scopes on `/api/*` (ADR 0009). Runs after the framework
+ * `BearerTokenMiddleware` (which already 401s a missing/invalid token on the
+ * protected `/api/` prefix). Here we additionally require the token to be a
+ * **service principal** carrying the required scope — a human/operator token
+ * (no `scopes` claim) is rejected from the service surface.
+ */
+final readonly class ServiceScopeMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $required = ServiceScopeResolver::resolve($request->getUri()->getPath() ?: '/', $request->getMethod());
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        if (!ServiceAuthContext::isServicePrincipal($request) || !ServiceAuthContext::hasScope($request, $required)) {
+            return $this->problemDetails->create(
+                $request,
+                'insufficient-scope',
+                'Forbidden',
+                403,
+                'The service token lacks the required scope for this operation.',
+            );
+        }
+
+        if (ServiceAuthContext::organizationId($request) === null) {
+            return $this->problemDetails->create(
+                $request,
+                'insufficient-scope',
+                'Forbidden',
+                403,
+                'The service token is not scoped to an organization.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/ServiceApi/ServiceScopeResolver.php
+++ b/src/ServiceApi/ServiceScopeResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+/**
+ * Maps a service-API request (path + method) to the {@see ServiceScope} it
+ * requires. Returns null for non-`/api/` paths (the scope check does not apply).
+ */
+final class ServiceScopeResolver
+{
+    public static function resolve(string $path, string $method): ?ServiceScope
+    {
+        if (!str_starts_with($path, '/api/')) {
+            return null;
+        }
+
+        $method = strtoupper($method);
+        $isRead = in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
+
+        if (str_starts_with($path, '/api/invoices')) {
+            // Payments are written under /api/invoices/{id}/payments.
+            if (str_contains($path, '/payments') && !$isRead) {
+                return ServiceScope::WritePayments;
+            }
+
+            return $isRead ? ServiceScope::ReadInvoices : ServiceScope::WritePayments;
+        }
+
+        if (str_starts_with($path, '/api/clients')) {
+            return ServiceScope::ReadInvoices;
+        }
+
+        return null;
+    }
+}

--- a/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
+++ b/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\ListInvoicesUseCase;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\ServiceApi\ListServiceInvoicesHandler;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class ListServiceInvoicesHandlerTest extends TestCase
+{
+    public function test_returns_service_read_model_with_outstanding_and_currency(): void
+    {
+        $invoices = new InMemoryInvoiceRepository();
+        $payments = new InMemoryPaymentRepository();
+
+        $id = $invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::PartiallyPaid,
+            subtotalCents: 2200,
+            taxCents: 0,
+            totalCents: 2200,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-30 00:00:00',
+        ));
+        $payments->save(new Payment(organizationId: 1, invoiceId: $id, amountCents: 800, paidAt: '2026-05-30 10:00:00'));
+
+        $psr17 = new Psr17Factory();
+        $handler = new ListServiceInvoicesHandler(
+            new ListInvoicesUseCase($invoices, $payments),
+            new JsonResponseFactory($psr17, $psr17),
+            new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        $request = $psr17->createServerRequest('GET', '/api/invoices')
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']]);
+
+        $response = $handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertIsArray($body['items']);
+        $item = $body['items'][0];
+        self::assertIsArray($item);
+        self::assertSame($id, $item['invoice_id']);
+        self::assertSame(1400, $item['outstanding_cents']); // 2200 − 800
+        self::assertSame('JPY', $item['currency']);
+        self::assertSame('partially_paid', $item['status']);
+    }
+
+    public function test_rejects_token_without_organization(): void
+    {
+        $psr17 = new Psr17Factory();
+        $handler = new ListServiceInvoicesHandler(
+            new ListInvoicesUseCase(new InMemoryInvoiceRepository(), new InMemoryPaymentRepository()),
+            new JsonResponseFactory($psr17, $psr17),
+            new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        $request = $psr17->createServerRequest('GET', '/api/invoices')
+            ->withAttribute('nene2.auth.claims', ['scopes' => ['read:invoices']]);
+
+        self::assertSame(403, $handler->handle($request)->getStatusCode());
+    }
+}

--- a/tests/ServiceApi/ServiceScopeMiddlewareTest.php
+++ b/tests/ServiceApi/ServiceScopeMiddlewareTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ServiceScopeMiddlewareTest extends TestCase
+{
+    private const CLAIMS = 'nene2.auth.claims';
+
+    private Psr17Factory $psr17;
+    private ServiceScopeMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->middleware = new ServiceScopeMiddleware(
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    private function handler(): RequestHandlerInterface
+    {
+        $psr17 = $this->psr17;
+
+        return new class ($psr17) implements RequestHandlerInterface {
+            public function __construct(private readonly Psr17Factory $psr17)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->psr17->createResponse(200);
+            }
+        };
+    }
+
+    private function request(string $path, mixed $claims): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest('GET', $path);
+
+        return $claims === null ? $request : $request->withAttribute(self::CLAIMS, $claims);
+    }
+
+    public function test_service_token_with_scope_passes(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['org' => 1, 'scopes' => ['read:invoices']]),
+            $this->handler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_operator_token_without_scopes_is_rejected(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['sub' => 7, 'role' => 'admin', 'org' => 1]),
+            $this->handler(),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_service_token_missing_required_scope_is_rejected(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['org' => 1, 'scopes' => ['write:payments']]),
+            $this->handler(),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_service_token_without_organization_is_rejected(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['scopes' => ['read:invoices']]),
+            $this->handler(),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_non_api_paths_pass_through(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/admin/invoices', ['sub' => 7, 'role' => 'admin', 'org' => 1]),
+            $this->handler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/ServiceApi/ServiceScopeResolverTest.php
+++ b/tests/ServiceApi/ServiceScopeResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use NeneInvoice\ServiceApi\ServiceScope;
+use NeneInvoice\ServiceApi\ServiceScopeResolver;
+use PHPUnit\Framework\TestCase;
+
+final class ServiceScopeResolverTest extends TestCase
+{
+    public function test_invoice_reads_require_read_scope(): void
+    {
+        self::assertSame(ServiceScope::ReadInvoices, ServiceScopeResolver::resolve('/api/invoices', 'GET'));
+        self::assertSame(ServiceScope::ReadInvoices, ServiceScopeResolver::resolve('/api/invoices/5', 'GET'));
+    }
+
+    public function test_payment_writes_require_write_scope(): void
+    {
+        self::assertSame(
+            ServiceScope::WritePayments,
+            ServiceScopeResolver::resolve('/api/invoices/5/payments', 'POST'),
+        );
+    }
+
+    public function test_non_api_paths_need_no_service_scope(): void
+    {
+        self::assertNull(ServiceScopeResolver::resolve('/admin/invoices', 'GET'));
+        self::assertNull(ServiceScopeResolver::resolve('/health', 'GET'));
+    }
+}

--- a/tools/issue-service-token.php
+++ b/tools/issue-service-token.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issues a NeNe Clear service token (ADR 0009) for local/ops use.
+ *
+ * Usage:
+ *   php tools/issue-service-token.php --org=1 --scopes=read:invoices,write:payments \
+ *       [--sub=service:clear] [--ttl=2592000]
+ *
+ * Prints the bearer token to stdout. Clear stores it as NENE_INVOICE_BEARER_TOKEN.
+ * The token is signed with the same HMAC secret as login tokens; treat it as a
+ * secret. (Issuance/revocation via an operator UI is a follow-up.)
+ */
+
+use Nene2\Auth\TokenIssuerInterface;
+use NeneInvoice\Http\RuntimeContainerFactory;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/** @return array<string, string> */
+function parseArgs(): array
+{
+    $args = [];
+    foreach (array_slice($GLOBALS['argv'], 1) as $arg) {
+        if (preg_match('/^--([a-z-]+)=(.*)$/', $arg, $m) === 1) {
+            $args[$m[1]] = $m[2];
+        }
+    }
+
+    return $args;
+}
+
+$args = parseArgs();
+
+$org = isset($args['org']) && ctype_digit($args['org']) ? (int) $args['org'] : null;
+if ($org === null) {
+    fwrite(STDERR, "Error: --org=<organization_id> is required.\n");
+    exit(1);
+}
+
+$scopes = array_values(array_filter(
+    explode(',', $args['scopes'] ?? 'read:invoices'),
+    static fn (string $s): bool => $s !== '',
+));
+$sub = $args['sub'] ?? 'service:clear';
+$ttl = isset($args['ttl']) && ctype_digit($args['ttl']) ? (int) $args['ttl'] : 2592000; // 30 days
+
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+$issuer = $container->get(TokenIssuerInterface::class);
+
+if (!$issuer instanceof TokenIssuerInterface) {
+    fwrite(STDERR, "Error: token issuer service is unavailable.\n");
+    exit(1);
+}
+
+$now = time();
+$token = $issuer->issue([
+    'sub' => $sub,
+    'org' => $org,
+    'scopes' => $scopes,
+    'iat' => $now,
+    'exp' => $now + $ttl,
+]);
+
+echo $token . "\n";

--- a/tools/validate-openapi.php
+++ b/tools/validate-openapi.php
@@ -7,33 +7,43 @@ use Symfony\Component\Yaml\Yaml;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$path = dirname(__DIR__) . '/docs/openapi/openapi.yaml';
+// Validate every OpenAPI document under docs/openapi/ (operator + service surfaces).
+$paths = glob(dirname(__DIR__) . '/docs/openapi/*.yaml');
 
-try {
-    $document = Yaml::parseFile($path);
-} catch (ParseException $exception) {
-    fwrite(STDERR, sprintf("OpenAPI YAML parse error: %s\n", $exception->getMessage()));
-    exit(1);
-}
-
-if (!is_array($document)) {
-    fwrite(STDERR, "OpenAPI document must parse to a mapping.\n");
+if ($paths === false || $paths === []) {
+    fwrite(STDERR, "No OpenAPI documents found under docs/openapi/.\n");
     exit(1);
 }
 
 $errors = [];
 
-foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
-    if (!array_key_exists($requiredKey, $document)) {
-        $errors[] = sprintf('Missing required top-level key: %s', $requiredKey);
+foreach ($paths as $path) {
+    $name = basename($path);
+
+    try {
+        $document = Yaml::parseFile($path);
+    } catch (ParseException $exception) {
+        $errors[] = sprintf('%s: YAML parse error: %s', $name, $exception->getMessage());
+        continue;
     }
-}
 
-if (($document['openapi'] ?? null) !== '3.1.0') {
-    $errors[] = 'OpenAPI version must be 3.1.0.';
-}
+    if (!is_array($document)) {
+        $errors[] = sprintf('%s: document must parse to a mapping.', $name);
+        continue;
+    }
 
-validateInternalReferences($document, $document, '#', $errors);
+    foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
+        if (!array_key_exists($requiredKey, $document)) {
+            $errors[] = sprintf('%s: missing required top-level key: %s', $name, $requiredKey);
+        }
+    }
+
+    if (($document['openapi'] ?? null) !== '3.1.0') {
+        $errors[] = sprintf('%s: OpenAPI version must be 3.1.0.', $name);
+    }
+
+    validateInternalReferences($document, $document, '#', $errors);
+}
 
 if ($errors !== []) {
     foreach ($errors as $error) {
@@ -43,7 +53,7 @@ if ($errors !== []) {
     exit(1);
 }
 
-echo "OpenAPI contract is valid.\n";
+echo sprintf("OpenAPI contracts are valid (%d document(s)).\n", count($paths));
 
 /**
  * @param array<mixed> $node


### PR DESCRIPTION
## 概要

ADR 0009 ① の本体。NeNe Clear 向けの **machine 面**（read のみ、compliance gate なし）。Invoice が SoR、Clear はサービストークンで read。

Closes #101 ・ ADR 0009 follow-up ①-b

## 認証（サービストークン）

- HMAC トークン（claims `sub:"service:..."` / `org` / `scopes:[read:invoices,...]`）。`BearerTokenMiddleware` の保護 prefix に **`/api/`** を追加、`ServiceScopeMiddleware` で scope/org を強制
  - 未認証 → **401**、scope・org 不足 → **403 `insufficient-scope`**
  - **相互分離**: operator トークンは `/api` 不可（scopes なし→403）、サービストークンは `/admin` 不可（role なし→403）— ライブ確認済み
- `ServiceAuthContext`（org/scopes）、`ServiceScope`（enum）、`ServiceScopeResolver`

## サービス面 `src/ServiceApi/`（`/admin` と分離・既存 UseCase 再利用）

- `GET /api/invoices` … `ListInvoicesUseCase` + outstanding → 契約 read モデル（`invoice_id` / `outstanding_cents` / `currency`=JPY）
- `GET /api/invoices/{id}` … `GetInvoiceByIdUseCase` + `ListPaymentsUseCase`（payments 履歴）。クロス org は既存 `invoice-not-found` で 404
- フィルタ（status/overdue/outstanding_gt/…）は additive な後続

## OpenAPI / ツール

- 独立ドキュメント **`docs/openapi/service-api.yaml`**（operationId 衝突回避）。`tools/validate-openapi.php` を `docs/openapi/*.yaml` 全件検証へ一般化（2 docs valid）
- **`tools/issue-service-token.php`**（`--org` / `--scopes` でトークン発行、ops/テスト用）

## テスト / 検証

- `ServiceScopeResolverTest` / `ServiceScopeMiddlewareTest`（相互分離・org なし拒否）/ `ListServiceInvoicesHandlerTest`（read モデル + outstanding）
- `composer check` green（**147 tests** / PHPStan L8 / cs / openapi×2 / mcp）
- live（:8123）: 無トークン 401、サービストークンで一覧/詳細（payments 3件）取得、user トークン→403、サービストークン→/admin 403

## 次

read フィルタ → 書き込みAPI（payment create + `external_reference` + void、idempotency）← **税理士確認後**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)