### PR TITLE
feat(service-api): GET /api/invoices に read フィルタを追加する (#105)

### DIFF
--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -36,6 +36,38 @@ paths:
           in: query
           required: false
           schema: { type: integer, minimum: 0, default: 0 }
+        - name: status
+          in: query
+          required: false
+          description: Comma-separated subset of status values (e.g. `issued,partially_paid`).
+          schema: { type: string }
+        - name: client_id
+          in: query
+          required: false
+          schema: { type: integer }
+        - name: due_before
+          in: query
+          required: false
+          description: Only invoices with due_at strictly before this date.
+          schema: { type: string }
+        - name: due_after
+          in: query
+          required: false
+          description: Only invoices with due_at strictly after this date.
+          schema: { type: string }
+        - name: overdue
+          in: query
+          required: false
+          description: When `true`, only issued/partially_paid invoices past their due date.
+          schema: { type: boolean }
+        - name: outstanding_gt
+          in: query
+          required: false
+          description: >
+            Only invoices with a positive outstanding balance (open receivables).
+            The contract example is `0`; any numeric value selects outstanding > 0.
+            Arbitrary thresholds (> N) are a follow-up.
+          schema: { type: integer, minimum: 0 }
       responses:
         '200':
           description: Invoice page

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #103)
+Last updated: 2026-05-30 (Issue #105)
 
 ## Recently merged
 
@@ -53,13 +53,14 @@ Last updated: 2026-05-30 (Issue #103)
 - **Issue #97 / PR #98** — NeNe Clear 上流契約の受諾＋ガバナンス整備（ADR 0009 / sibling / 用語）✅ merged
 - **Issue #99 / PR #100** — 売掛金残高 `outstanding_cents` を read モデルに公開 ✅ merged
 - **Issue #101 / PR #102** — `/api/*` サービス面 + サービストークン認証 + 請求書 read（Clear 向け）✅ merged
-- **Issue #103** — フロント: 請求書の残高 `outstanding_cents` を一覧・詳細に表示 ⏳ this PR
+- **Issue #103 / PR #104** — フロント: 請求書の残高 `outstanding_cents` を一覧・詳細に表示 ✅ merged
+- **Issue #105** — `GET /api/invoices` に read フィルタ（status/overdue/client/due/outstanding）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #103 | `feat/103-frontend-outstanding` | フロント: 残高 outstanding_cents を一覧・詳細に表示 | 🔄 PR pending |
+| #105 | `feat/105-service-invoice-filters` | `GET /api/invoices` の read フィルタ（Clear ②前半） | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 
@@ -69,7 +70,8 @@ Last updated: 2026-05-30 (Issue #103)
 - 後続（段階実装・別 Issue）: ①読み取りAPI（filters + `outstanding_cents` + payments 履歴）②書き込みAPI（idempotent payment create + `external_reference`、過入金→`payment-exceeds-outstanding`、void-with-audit）③サービストークン認証 ④`/api/*` OpenAPI + 契約テスト。
   - ①-a **済(#99)**: `outstanding_cents` を `/admin` の list/get read モデルに公開（PaymentRepo batch sum、純 read 派生・gate なし）。
   - ①-b **済(#101)**: `/api/*` サービス面 + サービストークン認証（`ServiceScope`/`ServiceAuthContext`/`ServiceScopeMiddleware`、BearerToken の保護 prefix に `/api/`）+ `GET /api/invoices` / `/api/invoices/{id}`（既存 UseCase 再利用、契約 read モデル + payments 履歴）。独立 OpenAPI `service-api.yaml`、`tools/issue-service-token.php`。ライブ確認: 401/403 分離・サービストークンで取得可。
-  - 次（②, 別 Issue）: read フィルタ（status/overdue/outstanding_gt/due/client）→ 書き込みAPI（payment create + `external_reference` + void、idempotency）← **税理士確認後**。複数 org スコープ・トークン発行/失効の運用。
+  - ②-前半 **済(#105)**: `GET /api/invoices` の read フィルタ（status 複数 / client_id / due_before・due_after / overdue / outstanding_gt=0＝未回収）。すべて invoices 表のみで完結（payment JOIN なし、ページング整合）。任意閾値 outstanding_gt=N は follow-up。
+  - 次（②後半・別 Issue）: 書き込みAPI（payment create + `external_reference` + void、idempotency）← **税理士確認後**。複数 org スコープ・トークン発行/失効の運用。
 - **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）

--- a/src/Invoice/InvoiceListFilter.php
+++ b/src/Invoice/InvoiceListFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+/**
+ * Read filters for listing invoices (service API §2.1). All predicates resolve
+ * against the invoices table alone — `overdueOnly` / `outstandingOnly` are
+ * expressed via status (outstanding > 0 ⟺ status issued/partially_paid in our
+ * model), so no payment join is needed and pagination stays correct.
+ */
+final readonly class InvoiceListFilter
+{
+    /**
+     * @param list<string> $statuses subset of status values; empty = any
+     */
+    public function __construct(
+        public array $statuses = [],
+        public ?int $clientId = null,
+        public ?string $dueBefore = null,
+        public ?string $dueAfter = null,
+        public bool $overdueOnly = false,
+        public bool $outstandingOnly = false,
+        /** Reference date for `overdueOnly` (YYYY-MM-DD); defaults to today. */
+        public ?string $today = null,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->statuses === []
+            && $this->clientId === null
+            && $this->dueBefore === null
+            && $this->dueAfter === null
+            && !$this->overdueOnly
+            && !$this->outstandingOnly;
+    }
+
+    public function todayOrNow(): string
+    {
+        return $this->today ?? date('Y-m-d');
+    }
+}

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -16,6 +16,16 @@ interface InvoiceRepositoryInterface
 
     public function countByOrganization(int $organizationId): int;
 
+    /** @return list<Invoice> */
+    public function findByOrganizationFiltered(
+        int $organizationId,
+        InvoiceListFilter $filter,
+        int $limit,
+        int $offset,
+    ): array;
+
+    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int;
+
     public function save(Invoice $invoice): int;
 
     /** @throws InvoiceNotFoundException */

--- a/src/Invoice/ListInvoicesUseCase.php
+++ b/src/Invoice/ListInvoicesUseCase.php
@@ -14,9 +14,19 @@ final readonly class ListInvoicesUseCase
     ) {
     }
 
-    public function execute(int $organizationId, int $limit, int $offset): ListInvoicesResult
-    {
-        $items = $this->invoices->findAllByOrganization($organizationId, $limit, $offset);
+    public function execute(
+        int $organizationId,
+        int $limit,
+        int $offset,
+        ?InvoiceListFilter $filter = null,
+    ): ListInvoicesResult {
+        if ($filter !== null && !$filter->isEmpty()) {
+            $items = $this->invoices->findByOrganizationFiltered($organizationId, $filter, $limit, $offset);
+            $total = $this->invoices->countByOrganizationFiltered($organizationId, $filter);
+        } else {
+            $items = $this->invoices->findAllByOrganization($organizationId, $limit, $offset);
+            $total = $this->invoices->countByOrganization($organizationId);
+        }
 
         $ids = [];
         foreach ($items as $invoice) {
@@ -34,10 +44,6 @@ final readonly class ListInvoicesUseCase
             }
         }
 
-        return new ListInvoicesResult(
-            $items,
-            $this->invoices->countByOrganization($organizationId),
-            $outstanding,
-        );
+        return new ListInvoicesResult($items, $total, $outstanding);
     }
 }

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -46,6 +46,77 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         return $row !== null ? (int) $row['cnt'] : 0;
     }
 
+    /** @return list<Invoice> */
+    public function findByOrganizationFiltered(
+        int $organizationId,
+        InvoiceListFilter $filter,
+        int $limit,
+        int $offset,
+    ): array {
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE ' . $where . ' ORDER BY id DESC LIMIT ? OFFSET ?',
+            [...$params, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): Invoice => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int
+    {
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
+
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM invoices WHERE ' . $where, $params);
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    /**
+     * @return array{0: string, 1: list<int|string>}
+     */
+    private function buildWhere(int $organizationId, InvoiceListFilter $filter): array
+    {
+        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        /** @var list<int|string> $params */
+        $params = [$organizationId];
+
+        if ($filter->statuses !== []) {
+            $placeholders = implode(', ', array_fill(0, count($filter->statuses), '?'));
+            $clauses[] = 'status IN (' . $placeholders . ')';
+            foreach ($filter->statuses as $status) {
+                $params[] = $status;
+            }
+        }
+
+        if ($filter->clientId !== null) {
+            $clauses[] = 'client_id = ?';
+            $params[] = $filter->clientId;
+        }
+
+        if ($filter->dueBefore !== null) {
+            $clauses[] = 'due_at IS NOT NULL AND due_at < ?';
+            $params[] = $filter->dueBefore;
+        }
+
+        if ($filter->dueAfter !== null) {
+            $clauses[] = 'due_at IS NOT NULL AND due_at > ?';
+            $params[] = $filter->dueAfter;
+        }
+
+        // Outstanding > 0 ⟺ the invoice is issued or partially paid (our model).
+        if ($filter->outstandingOnly || $filter->overdueOnly) {
+            $clauses[] = "status IN ('issued', 'partially_paid')";
+        }
+
+        if ($filter->overdueOnly) {
+            $clauses[] = 'due_at IS NOT NULL AND due_at < ?';
+            $params[] = $filter->todayOrNow();
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
     public function save(Invoice $invoice): int
     {
         $now = date('Y-m-d H:i:s');

--- a/src/ServiceApi/ListServiceInvoicesHandler.php
+++ b/src/ServiceApi/ListServiceInvoicesHandler.php
@@ -7,6 +7,8 @@ namespace NeneInvoice\ServiceApi;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceListFilter;
+use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -44,7 +46,7 @@ final readonly class ListServiceInvoicesHandler implements RequestHandlerInterfa
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($organizationId, $limit, $offset, $this->filterFrom($query));
         $outstanding = $result->outstandingByInvoiceId;
 
         return $this->json->create([
@@ -59,5 +61,49 @@ final readonly class ListServiceInvoicesHandler implements RequestHandlerInterfa
             'limit' => $limit,
             'offset' => $offset,
         ]);
+    }
+
+    /**
+     * Builds the read filter from query params (contract §2.1).
+     *
+     * @param array<string, mixed> $query
+     */
+    private function filterFrom(array $query): InvoiceListFilter
+    {
+        $statuses = [];
+        if (isset($query['status']) && is_string($query['status'])) {
+            $allowed = array_map(static fn (InvoiceStatus $s): string => $s->value, InvoiceStatus::cases());
+            foreach (explode(',', $query['status']) as $candidate) {
+                $candidate = trim($candidate);
+                if (in_array($candidate, $allowed, true)) {
+                    $statuses[] = $candidate;
+                }
+            }
+        }
+
+        $clientId = isset($query['client_id']) && is_numeric($query['client_id'])
+            ? (int) $query['client_id']
+            : null;
+
+        $dueBefore = isset($query['due_before']) && is_string($query['due_before']) && $query['due_before'] !== ''
+            ? $query['due_before']
+            : null;
+        $dueAfter = isset($query['due_after']) && is_string($query['due_after']) && $query['due_after'] !== ''
+            ? $query['due_after']
+            : null;
+
+        $overdue = isset($query['overdue']) && $query['overdue'] === 'true';
+        // Contract example is outstanding_gt=0 ("open receivables"); any provided
+        // numeric value selects invoices with a positive outstanding balance.
+        $outstandingOnly = isset($query['outstanding_gt']) && is_numeric($query['outstanding_gt']);
+
+        return new InvoiceListFilter(
+            statuses: $statuses,
+            clientId: $clientId,
+            dueBefore: $dueBefore,
+            dueAfter: $dueAfter,
+            overdueOnly: $overdue,
+            outstandingOnly: $outstandingOnly,
+        );
     }
 }

--- a/tests/Invoice/PdoInvoiceRepositoryTest.php
+++ b/tests/Invoice/PdoInvoiceRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Invoice\PdoInvoiceRepository;
@@ -110,5 +111,35 @@ final class PdoInvoiceRepositoryTest extends TestCase
 
         $this->expectException(InvoiceNotFoundException::class);
         $this->repository->delete(999);
+    }
+
+    public function test_filter_by_status_client_due_and_outstanding(): void
+    {
+        // org 1: a paid one (client 5), an issued one past due (client 5), an issued one future (client 9)
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Paid, subtotalCents: 1000, taxCents: 0, totalCents: 1000, invoiceNumber: 'INV-1', issuedAt: '2026-01-01 00:00:00', dueAt: '2026-01-31'));
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Issued, subtotalCents: 2000, taxCents: 0, totalCents: 2000, invoiceNumber: 'INV-2', issuedAt: '2026-02-01 00:00:00', dueAt: '2026-02-28'));
+        $this->repository->save(new Invoice(organizationId: 1, clientId: 9, status: InvoiceStatus::Issued, subtotalCents: 3000, taxCents: 0, totalCents: 3000, invoiceNumber: 'INV-3', issuedAt: '2026-02-01 00:00:00', dueAt: '2026-12-31'));
+
+        // status filter
+        $issued = new InvoiceListFilter(statuses: ['issued']);
+        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $issued));
+
+        // client filter
+        $client5 = new InvoiceListFilter(clientId: 5);
+        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $client5));
+
+        // outstanding only (open = issued/partially_paid) excludes the paid one
+        $open = new InvoiceListFilter(outstandingOnly: true);
+        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $open));
+
+        // overdue as of 2026-06-01: INV-2 (due 02-28) is overdue, INV-3 (due 12-31) is not
+        $overdue = new InvoiceListFilter(overdueOnly: true, today: '2026-06-01');
+        $rows = $this->repository->findByOrganizationFiltered(1, $overdue, 10, 0);
+        self::assertCount(1, $rows);
+        self::assertSame('INV-2', $rows[0]->invoiceNumber);
+
+        // due_before
+        $dueBeforeMarch = new InvoiceListFilter(dueBefore: '2026-03-01');
+        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $dueBeforeMarch)); // 01-31 and 02-28
     }
 }

--- a/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
+++ b/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
@@ -73,4 +73,29 @@ final class ListServiceInvoicesHandlerTest extends TestCase
 
         self::assertSame(403, $handler->handle($request)->getStatusCode());
     }
+
+    public function test_status_query_filter_narrows_results(): void
+    {
+        $invoices = new InMemoryInvoiceRepository();
+        $invoices->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Paid, subtotalCents: 1000, taxCents: 0, totalCents: 1000, invoiceNumber: 'INV-PAID', issuedAt: '2026-01-01 00:00:00'));
+        $invoices->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Issued, subtotalCents: 2000, taxCents: 0, totalCents: 2000, invoiceNumber: 'INV-OPEN', issuedAt: '2026-02-01 00:00:00'));
+
+        $psr17 = new Psr17Factory();
+        $handler = new ListServiceInvoicesHandler(
+            new ListInvoicesUseCase($invoices, new InMemoryPaymentRepository()),
+            new JsonResponseFactory($psr17, $psr17),
+            new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        $request = $psr17->createServerRequest('GET', '/api/invoices', ['status' => 'issued'])
+            ->withQueryParams(['status' => 'issued'])
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']]);
+
+        $body = json_decode((string) $handler->handle($request)->getBody(), true);
+        self::assertIsArray($body);
+        self::assertSame(1, $body['total']);
+        self::assertIsArray($body['items']);
+        self::assertCount(1, $body['items']);
+        self::assertSame('INV-OPEN', $body['items'][0]['invoice_number']);
+    }
 }

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\Support;
 
 use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceStatus;
 
 /**
  * In-memory fake for use-case tests (no database).
@@ -41,6 +43,53 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
             $this->byId,
             static fn (Invoice $i): bool => $i->organizationId === $organizationId && !$i->isDeleted,
         ));
+    }
+
+    /** @return list<Invoice> */
+    public function findByOrganizationFiltered(
+        int $organizationId,
+        InvoiceListFilter $filter,
+        int $limit,
+        int $offset,
+    ): array {
+        return array_slice($this->filtered($organizationId, $filter), $offset, $limit);
+    }
+
+    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int
+    {
+        return count($this->filtered($organizationId, $filter));
+    }
+
+    /** @return list<Invoice> */
+    private function filtered(int $organizationId, InvoiceListFilter $filter): array
+    {
+        $open = [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid];
+
+        return array_values(array_filter($this->byId, function (Invoice $i) use ($organizationId, $filter, $open): bool {
+            if ($i->organizationId !== $organizationId || $i->isDeleted) {
+                return false;
+            }
+            if ($filter->statuses !== [] && !in_array($i->status->value, $filter->statuses, true)) {
+                return false;
+            }
+            if ($filter->clientId !== null && $i->clientId !== $filter->clientId) {
+                return false;
+            }
+            if ($filter->dueBefore !== null && ($i->dueAt === null || $i->dueAt >= $filter->dueBefore)) {
+                return false;
+            }
+            if ($filter->dueAfter !== null && ($i->dueAt === null || $i->dueAt <= $filter->dueAfter)) {
+                return false;
+            }
+            if (($filter->outstandingOnly || $filter->overdueOnly) && !in_array($i->status, $open, true)) {
+                return false;
+            }
+            if ($filter->overdueOnly && ($i->dueAt === null || $i->dueAt >= $filter->todayOrNow())) {
+                return false;
+            }
+
+            return true;
+        }));
     }
 
     public function save(Invoice $invoice): int


### PR DESCRIPTION
## 概要

ADR 0009 ② 前半（read フィルタ、**gate なし**）。Clear のマッチング/督促対象抽出のため `GET /api/invoices` にフィルタを追加。

Closes #105 ・ ADR 0009 follow-up ②-前半

## フィルタ（すべて invoices 表のみで完結 — payment JOIN なし・ページング整合）

| param | 効果 |
|---|---|
| `status=issued,partially_paid` | status の部分集合（カンマ区切り）|
| `client_id` | 取引先 |
| `due_before` / `due_after` | due_at の前後 |
| `overdue=true` | status ∈ (issued, partially_paid) かつ due_at < 今日 |
| `outstanding_gt=0` | 未回収のみ（outstanding>0 ＝ status ∈ (issued, partially_paid)）。契約の例 `=0` を採用。任意閾値 N>0 は follow-up |

## 実装

- `InvoiceListFilter` VO + `InvoiceRepositoryInterface::findByOrganizationFiltered` / `countByOrganizationFiltered`（Pdo 動的 WHERE / InMemory 述語）
- `ListInvoicesUseCase` に任意 `?InvoiceListFilter`（operator 経路は従来どおり null＝挙動不変）
- `ListServiceInvoicesHandler` が query から filter 構築。`service-api.yaml` にパラメータ記載

## テスト / 検証

- `PdoInvoiceRepositoryTest`（status/client/overdue/outstanding/due_before）/ `ListServiceInvoicesHandlerTest`（status 絞り込み）
- `composer check` green（**149 tests** / PHPStan L8 / cs / openapi×2 / mcp）
- live: `?status=` `?outstanding_gt=0` `?client_id=` が正しく絞り込み

## 次

C（フロント拡充: 取引先 CRUD / 一覧ページング）へ。Clear ②後半（書き込みAPI）は **税理士確認後**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)