### PR TITLE
feat(payment): external_reference / idempotency_key / void をデータ層に追加する (#109)

### DIFF
--- a/database/migrations/20260530100000_add_external_reference_and_idempotency_to_payments.php
+++ b/database/migrations/20260530100000_add_external_reference_and_idempotency_to_payments.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Adds external_reference (the originating system's reconciliation id, e.g. NeNe
+ * Clear) and idempotency_key (for safe retried writes) to payments — ADR 0009.
+ * idempotency_key is unique; it is null for manual operator payments (multiple
+ * NULLs are allowed by the unique index).
+ */
+final class AddExternalReferenceAndIdempotencyToPayments extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('payments')
+            ->addColumn('external_reference', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('idempotency_key', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addIndex(['idempotency_key'], ['unique' => true, 'name' => 'uniq_payments_idempotency_key'])
+            ->update();
+    }
+}

--- a/database/schema/payments.sql
+++ b/database/schema/payments.sql
@@ -1,6 +1,9 @@
 -- Schema snapshot for the payments table (SQLite dialect, used by repository tests).
 -- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
 -- A payment records an amount received against an issued invoice (integer cents).
+-- external_reference / idempotency_key support externally-sourced payments
+-- (e.g. NeNe Clear reconciliation — ADR 0009); idempotency_key is unique but
+-- nullable (manual operator payments leave it null; multiple NULLs are allowed).
 CREATE TABLE IF NOT EXISTS payments (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     organization_id INTEGER NOT NULL,
@@ -9,6 +12,8 @@ CREATE TABLE IF NOT EXISTS payments (
     paid_at DATETIME NOT NULL,
     method VARCHAR(32) NULL DEFAULT NULL,
     note TEXT NULL DEFAULT NULL,
+    external_reference VARCHAR(255) NULL DEFAULT NULL,
+    idempotency_key VARCHAR(255) NULL DEFAULT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
     deleted_at DATETIME NULL DEFAULT NULL,
     created_at DATETIME NOT NULL,
@@ -16,3 +21,4 @@ CREATE TABLE IF NOT EXISTS payments (
 );
 CREATE INDEX idx_payments_organization_id ON payments (organization_id);
 CREATE INDEX idx_payments_invoice_id ON payments (invoice_id);
+CREATE UNIQUE INDEX uniq_payments_idempotency_key ON payments (idempotency_key);

--- a/src/Payment/Payment.php
+++ b/src/Payment/Payment.php
@@ -18,6 +18,10 @@ final readonly class Payment
         public string $paidAt,
         public ?string $method = null,
         public ?string $note = null,
+        /** Originating system's reconciliation id (e.g. NeNe Clear) — ADR 0009. */
+        public ?string $externalReference = null,
+        /** Idempotency key for safe retried writes; null for manual payments. */
+        public ?string $idempotencyKey = null,
         public bool $isDeleted = false,
         public ?int $id = null,
         public ?string $createdAt = null,

--- a/src/Payment/PaymentRepositoryInterface.php
+++ b/src/Payment/PaymentRepositoryInterface.php
@@ -12,6 +12,14 @@ interface PaymentRepositoryInterface
 {
     public function save(Payment $payment): int;
 
+    public function findById(int $id): ?Payment;
+
+    /** Returns the payment previously recorded with this idempotency key, if any. */
+    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment;
+
+    /** Voids a payment (soft delete). Idempotent: voiding an already-voided one is a no-op. */
+    public function markVoided(int $id): void;
+
     /** @return list<Payment> */
     public function findByInvoice(int $invoiceId): array;
 

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -8,7 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
 {
-    private const COLUMNS = 'id, organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at';
+    private const COLUMNS = 'id, organization_id, invoice_id, amount_cents, paid_at, method, note, external_reference, idempotency_key, is_deleted, created_at, updated_at';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -20,8 +20,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $this->query->execute(
-            'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, method, note, external_reference, idempotency_key, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
                 $payment->organizationId,
                 $payment->invoiceId,
@@ -29,12 +29,43 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
                 $payment->paidAt,
                 $payment->method,
                 $payment->note,
+                $payment->externalReference,
+                $payment->idempotencyKey,
                 $now,
                 $now,
             ],
         );
 
         return $this->query->lastInsertId();
+    }
+
+    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE organization_id = ? AND idempotency_key = ?',
+            [$organizationId, $idempotencyKey],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findById(int $id): ?Payment
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** Voids a payment (soft delete). Idempotent: already-voided is a no-op. */
+    public function markVoided(int $id): void
+    {
+        $this->query->execute(
+            'UPDATE payments SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), $id],
+        );
     }
 
     /** @return list<Payment> */
@@ -94,6 +125,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
             paidAt: (string) $row['paid_at'],
             method: isset($row['method']) && $row['method'] !== '' ? (string) $row['method'] : null,
             note: isset($row['note']) && $row['note'] !== '' ? (string) $row['note'] : null,
+            externalReference: isset($row['external_reference']) && $row['external_reference'] !== '' ? (string) $row['external_reference'] : null,
+            idempotencyKey: isset($row['idempotency_key']) && $row['idempotency_key'] !== '' ? (string) $row['idempotency_key'] : null,
             isDeleted: (bool) $row['is_deleted'],
             id: (int) $row['id'],
             createdAt: (string) $row['created_at'],

--- a/tests/Payment/PdoPaymentRepositoryTest.php
+++ b/tests/Payment/PdoPaymentRepositoryTest.php
@@ -95,4 +95,42 @@ final class PdoPaymentRepositoryTest extends TestCase
     {
         self::assertSame([], $this->repository->sumPaidForInvoices([]));
     }
+
+    public function test_stores_and_finds_by_external_reference_and_idempotency_key(): void
+    {
+        $id = $this->repository->save(new Payment(
+            organizationId: 1,
+            invoiceId: 42,
+            amountCents: 1000,
+            paidAt: '2026-05-29 10:00:00',
+            externalReference: 'clear:recon:777',
+            idempotencyKey: 'clear:recon:777:v1',
+        ));
+
+        $byKey = $this->repository->findByIdempotencyKey(1, 'clear:recon:777:v1');
+        self::assertNotNull($byKey);
+        self::assertSame($id, $byKey->id);
+        self::assertSame('clear:recon:777', $byKey->externalReference);
+
+        self::assertNull($this->repository->findByIdempotencyKey(1, 'unknown'));
+        self::assertNull($this->repository->findByIdempotencyKey(2, 'clear:recon:777:v1')); // other org
+    }
+
+    public function test_void_excludes_from_totals_and_is_idempotent(): void
+    {
+        $id = $this->repository->save(new Payment(organizationId: 1, invoiceId: 42, amountCents: 1000, paidAt: '2026-05-29 10:00:00'));
+        self::assertSame(1000, $this->repository->totalPaidForInvoice(42));
+
+        $this->repository->markVoided($id);
+        self::assertSame(0, $this->repository->totalPaidForInvoice(42));
+        self::assertCount(0, $this->repository->findByInvoice(42));
+
+        // idempotent: voiding again is a no-op
+        $this->repository->markVoided($id);
+        self::assertSame(0, $this->repository->totalPaidForInvoice(42));
+
+        $voided = $this->repository->findById($id);
+        self::assertNotNull($voided);
+        self::assertTrue($voided->isDeleted);
+    }
 }

--- a/tests/Support/InMemoryPaymentRepository.php
+++ b/tests/Support/InMemoryPaymentRepository.php
@@ -26,6 +26,8 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
             paidAt: $payment->paidAt,
             method: $payment->method,
             note: $payment->note,
+            externalReference: $payment->externalReference,
+            idempotencyKey: $payment->idempotencyKey,
             isDeleted: $payment->isDeleted,
             id: $id,
             createdAt: '2026-05-29 00:00:00',
@@ -33,6 +35,45 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
         );
 
         return $id;
+    }
+
+    public function findById(int $id): ?Payment
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment
+    {
+        foreach ($this->byId as $payment) {
+            if ($payment->organizationId === $organizationId && $payment->idempotencyKey === $idempotencyKey) {
+                return $payment;
+            }
+        }
+
+        return null;
+    }
+
+    public function markVoided(int $id): void
+    {
+        $existing = $this->byId[$id] ?? null;
+        if ($existing === null || $existing->isDeleted) {
+            return;
+        }
+
+        $this->byId[$id] = new Payment(
+            organizationId: $existing->organizationId,
+            invoiceId: $existing->invoiceId,
+            amountCents: $existing->amountCents,
+            paidAt: $existing->paidAt,
+            method: $existing->method,
+            note: $existing->note,
+            externalReference: $existing->externalReference,
+            idempotencyKey: $existing->idempotencyKey,
+            isDeleted: true,
+            id: $existing->id,
+            createdAt: $existing->createdAt,
+            updatedAt: $existing->updatedAt,
+        );
     }
 
     /** @return list<Payment> */


### PR DESCRIPTION
## 概要

ADR 0009 ②後半（Clear 書き込みAPI）の**データ層の土台**。税理士サインオフ済みで gate 解除。エンドポイントは後続 PR（service payment create / void）。

Closes #109

## 内容

- 新 migration: `payments` に `external_reference`(255 NULL) / `idempotency_key`(255 NULL, **UNIQUE**)。`database/schema/payments.sql` 同期（UNIQUE は複数 NULL 許容＝手動入金は null）
- `Payment` に `externalReference` / `idempotencyKey`
- `PdoPaymentRepository`: save に新列・mapRow 読み出し、`findById` / `findByIdempotencyKey(org,key)` / `markVoided(id)`（`is_deleted=1`、冪等）。`InMemoryPaymentRepository` も同実装
- `PaymentRepositoryInterface` に 3 メソッド追加

## テスト / 検証

- `PdoPaymentRepositoryTest`: 外部参照・冪等キーの保存/検索（org 分離）、void で totals 除外＋冪等
- `composer check` green（**254 PHPStan**, 全テスト）。`composer migrations:migrate` ローカル適用確認（新列 present）

🤖 Generated with [Claude Code](https://claude.com/claude-code)