### PR TITLE
feat(service-api): POST /api/invoices/{id}/payments（冪等・external_reference・過入金422）(#111)

### DIFF
--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -15,6 +15,8 @@ servers:
 tags:
   - name: ServiceInvoices
     description: Invoice reads for reconciliation (service scope).
+  - name: ServicePayments
+    description: Payment writes from reconciliation (service scope).
 security:
   - serviceToken: []
 paths:
@@ -103,6 +105,44 @@ paths:
           $ref: '#/components/responses/InsufficientScope'
         '404':
           $ref: '#/components/responses/NotFound'
+    post:
+      tags: [ServicePayments]
+      summary: Record a payment (service)
+      description: >
+        Records a payment on a confirmed bank match (ADR 0009 §3.1). Idempotent on
+        `idempotency_key`; `paid_at` is the bank value date and is stored as given;
+        `external_reference` ties the payment to the bank line. Over-allocation is
+        rejected with `payment-exceeds-outstanding` (the body carries the current
+        `outstanding_cents` so the caller can split into client credit). Requires
+        the `write:payments` scope.
+      operationId: createPayment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordPaymentRequest'
+            example:
+              amount_cents: 50000
+              paid_at: '2026-04-20'
+              method: bank_transfer
+              external_reference: clear:recon:777
+              idempotency_key: clear:recon:777:v1
+      responses:
+        '201':
+          description: Payment recorded (or idempotent replay of an existing one)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordPaymentResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientScope'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/PaymentExceedsOutstanding'
 components:
   securitySchemes:
     serviceToken:
@@ -129,6 +169,18 @@ components:
         application/problem+json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
+    PaymentExceedsOutstanding:
+      description: >
+        The payment would exceed the invoice's outstanding balance. The body
+        includes the current `outstanding_cents` so the caller can split.
+      content:
+        application/problem+json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ProblemDetails'
+              - type: object
+                properties:
+                  outstanding_cents: { type: integer }
   schemas:
     ProblemDetails:
       type: object
@@ -188,3 +240,26 @@ components:
               items:
                 $ref: '#/components/schemas/ServicePayment'
           required: [payments]
+    RecordPaymentRequest:
+      type: object
+      properties:
+        amount_cents: { type: integer, minimum: 1, description: Integer cents (positive). }
+        paid_at: { type: string, description: Bank value date (入金日); stored as given. }
+        method: { type: [string, 'null'], enum: [bank_transfer, cash, other, null] }
+        note: { type: [string, 'null'] }
+        external_reference:
+          type: [string, 'null']
+          description: Reconciliation id tying the payment to the bank line.
+        idempotency_key:
+          type: string
+          description: Retried writes with the same key return the same payment.
+      required: [amount_cents, paid_at, idempotency_key]
+    RecordPaymentResult:
+      type: object
+      properties:
+        payment:
+          $ref: '#/components/schemas/ServicePayment'
+        invoice:
+          $ref: '#/components/schemas/ServiceInvoice'
+        total_paid_cents: { type: integer }
+      required: [payment, invoice, total_paid_cents]

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #107)
+Last updated: 2026-05-30 (Issue #111)
 
 ## Recently merged
 
@@ -55,13 +55,15 @@ Last updated: 2026-05-30 (Issue #107)
 - **Issue #101 / PR #102** — `/api/*` サービス面 + サービストークン認証 + 請求書 read（Clear 向け）✅ merged
 - **Issue #103 / PR #104** — フロント: 請求書の残高 `outstanding_cents` を一覧・詳細に表示 ✅ merged
 - **Issue #105 / PR #106** — `GET /api/invoices` に read フィルタ（status/overdue/client/due/outstanding）✅ merged
-- **Issue #107** — フロント: 取引先一覧画面 + ヘッダーナビ ⏳ this PR
+- **Issue #107 / PR #108** — フロント: 取引先一覧画面 + ヘッダーナビ ✅ merged
+- **Issue #109 / PR #110** — payment external_reference / idempotency_key / void データ層 ✅ merged
+- **Issue #111** — `POST /api/invoices/{id}/payments`（冪等・external_reference・過入金422）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #107 | `feat/107-clients-list` | フロント: 取引先一覧 + ヘッダーナビ | 🔄 PR pending |
+| #111 | `feat/111-service-record-payment` | service 入金起票（idempotent + external_reference + 過入金422） | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 
@@ -72,7 +74,11 @@ Last updated: 2026-05-30 (Issue #107)
   - ①-a **済(#99)**: `outstanding_cents` を `/admin` の list/get read モデルに公開（PaymentRepo batch sum、純 read 派生・gate なし）。
   - ①-b **済(#101)**: `/api/*` サービス面 + サービストークン認証（`ServiceScope`/`ServiceAuthContext`/`ServiceScopeMiddleware`、BearerToken の保護 prefix に `/api/`）+ `GET /api/invoices` / `/api/invoices/{id}`（既存 UseCase 再利用、契約 read モデル + payments 履歴）。独立 OpenAPI `service-api.yaml`、`tools/issue-service-token.php`。ライブ確認: 401/403 分離・サービストークンで取得可。
   - ②-前半 **済(#105)**: `GET /api/invoices` の read フィルタ（status 複数 / client_id / due_before・due_after / overdue / outstanding_gt=0＝未回収）。すべて invoices 表のみで完結（payment JOIN なし、ページング整合）。任意閾値 outstanding_gt=N は follow-up。
-  - 次（②後半・別 Issue）: 書き込みAPI（payment create + `external_reference` + void、idempotency）← **税理士確認後**。複数 org スコープ・トークン発行/失効の運用。
+  - ②後半 **税理士サインオフ済み（2026-05-30）→ gate 解除**。
+    - W1 **済(#109)**: payments に `external_reference` / `idempotency_key`、`findById`/`findByIdempotencyKey`/`markVoided`（void=soft delete 流用）。
+    - W2 **済(#111)**: `POST /api/invoices/{id}/payments`。RecordPaymentUseCase を拡張（冪等 replay / `external_reference` 保存 / 過入金→`PaymentExceedsOutstandingException`=422 `payment-exceeds-outstanding` + `outstanding_cents`）して operator/service 共用。`paid_at`=入金日。ライブ確認済み。
+    - W3 次: `POST /api/invoices/{id}/payments/{paymentId}/void`（void-with-audit, 冪等）。
+  - 運用フォロー: 複数 org スコープ、トークン発行/失効 UI。
 - **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -22,6 +22,7 @@ use NeneInvoice\Invoice\QualifiedInvoiceIncompleteExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
+use NeneInvoice\Payment\PaymentExceedsOutstandingExceptionHandler;
 use NeneInvoice\Payment\PaymentRouteRegistrar;
 use NeneInvoice\Payment\PaymentValidationExceptionHandler;
 use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
@@ -128,6 +129,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $invoiceValidation = $container->get(InvoiceValidationExceptionHandler::class);
                     $qualifiedIncomplete = $container->get(QualifiedInvoiceIncompleteExceptionHandler::class);
                     $paymentValidation = $container->get(PaymentValidationExceptionHandler::class);
+                    $paymentExceeds = $container->get(PaymentExceedsOutstandingExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -197,7 +199,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Payment validation exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $paymentValidation];
+                    if (!$paymentExceeds instanceof PaymentExceedsOutstandingExceptionHandler) {
+                        throw new LogicException('Payment exceeds-outstanding exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $paymentValidation, $paymentExceeds];
                 },
             );
     }

--- a/src/Payment/PaymentExceedsOutstandingException.php
+++ b/src/Payment/PaymentExceedsOutstandingException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use DomainException;
+
+/**
+ * Thrown when a payment would exceed the invoice's outstanding balance
+ * (over-allocation). Surfaces as 422 `payment-exceeds-outstanding`, carrying the
+ * current outstanding so the caller (e.g. NeNe Clear) can split and record the
+ * remainder as client credit — ADR 0009 §3.1.5.
+ */
+final class PaymentExceedsOutstandingException extends DomainException
+{
+    public function __construct(public readonly int $outstandingCents)
+    {
+        parent::__construct('The payment would exceed the invoice outstanding balance.');
+    }
+}

--- a/src/Payment/PaymentExceedsOutstandingExceptionHandler.php
+++ b/src/Payment/PaymentExceedsOutstandingExceptionHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class PaymentExceedsOutstandingExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof PaymentExceedsOutstandingException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        $outstanding = $exception instanceof PaymentExceedsOutstandingException
+            ? $exception->outstandingCents
+            : 0;
+
+        return $this->problemDetails->create(
+            $request,
+            'payment-exceeds-outstanding',
+            'Payment Exceeds Outstanding',
+            422,
+            $exception->getMessage(),
+            ['outstanding_cents' => $outstanding],
+        );
+    }
+}

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -71,6 +71,10 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): PaymentValidationExceptionHandler => new PaymentValidationExceptionHandler(self::problemDetails($c)),
             )
             ->set(
+                PaymentExceedsOutstandingExceptionHandler::class,
+                static fn (ContainerInterface $c): PaymentExceedsOutstandingExceptionHandler => new PaymentExceedsOutstandingExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
                 PaymentRouteRegistrar::class,
                 static function (ContainerInterface $c): PaymentRouteRegistrar {
                     $record = $c->get(RecordPaymentHandler::class);

--- a/src/Payment/RecordPaymentInput.php
+++ b/src/Payment/RecordPaymentInput.php
@@ -11,6 +11,10 @@ final readonly class RecordPaymentInput
         public ?string $paidAt = null,
         public ?string $method = null,
         public ?string $note = null,
+        /** Originating system's reconciliation id (NeNe Clear) — ADR 0009. */
+        public ?string $externalReference = null,
+        /** Idempotency key; a retried write with the same key returns the same payment. */
+        public ?string $idempotencyKey = null,
     ) {
     }
 }

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -33,6 +33,7 @@ final readonly class RecordPaymentUseCase
     /**
      * @throws InvoiceNotFoundException
      * @throws PaymentValidationException
+     * @throws PaymentExceedsOutstandingException
      */
     public function execute(int $organizationId, ?int $actorUserId, int $invoiceId, RecordPaymentInput $input): RecordPaymentResult
     {
@@ -40,6 +41,15 @@ final readonly class RecordPaymentUseCase
 
         if ($invoice === null || $invoice->organizationId !== $organizationId) {
             throw new InvoiceNotFoundException($invoiceId);
+        }
+
+        // Idempotent replay: a retried write with the same key returns the existing
+        // payment instead of recording a duplicate (ADR 0009 §3.1.2).
+        if ($input->idempotencyKey !== null) {
+            $existing = $this->payments->findByIdempotencyKey($organizationId, $input->idempotencyKey);
+            if ($existing !== null) {
+                return new RecordPaymentResult($existing, $invoice, $this->payments->totalPaidForInvoice($invoiceId));
+            }
         }
 
         if ($input->amountCents <= 0) {
@@ -53,7 +63,7 @@ final readonly class RecordPaymentUseCase
         $alreadyPaid = $this->payments->totalPaidForInvoice($invoiceId);
 
         if ($alreadyPaid + $input->amountCents > $invoice->totalCents) {
-            throw new PaymentValidationException('The payment would exceed the invoice total (over-payment is not allowed).');
+            throw new PaymentExceedsOutstandingException(max(0, $invoice->totalCents - $alreadyPaid));
         }
 
         $before = InvoiceResponse::toArray($invoice);
@@ -67,6 +77,8 @@ final readonly class RecordPaymentUseCase
             paidAt: $paidAt,
             method: $input->method,
             note: $input->note,
+            externalReference: $input->externalReference,
+            idempotencyKey: $input->idempotencyKey,
         ));
 
         $totalPaid = $alreadyPaid + $input->amountCents;

--- a/src/ServiceApi/RecordServicePaymentHandler.php
+++ b/src/ServiceApi/RecordServicePaymentHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /api/invoices/{id}/payments` — records a payment from NeNe Clear on a
+ * confirmed bank match (ADR 0009 §3.1). Idempotent on `idempotency_key`; honors
+ * `paid_at` as the bank value date; stores `external_reference`; over-allocation
+ * surfaces as `422 payment-exceeds-outstanding` (handled centrally). Requires the
+ * `write:payments` scope (ServiceScopeMiddleware).
+ */
+final readonly class RecordServicePaymentHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private RecordPaymentUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        $amountValue = $decoded['amount_cents'] ?? null;
+        $amountCents = is_int($amountValue) ? $amountValue : (is_numeric($amountValue) ? (int) $amountValue : 0);
+
+        $paidAt = $this->stringOrNull($decoded, 'paid_at');
+        if ($paidAt === null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"paid_at" (bank value date) is required.');
+        }
+
+        $idempotencyKey = $this->stringOrNull($decoded, 'idempotency_key');
+        if ($idempotencyKey === null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"idempotency_key" is required.');
+        }
+
+        $result = $this->useCase->execute($organizationId, null, $invoiceId, new RecordPaymentInput(
+            amountCents: $amountCents,
+            paidAt: $paidAt,
+            method: $this->stringOrNull($decoded, 'method'),
+            note: $this->stringOrNull($decoded, 'note'),
+            externalReference: $this->stringOrNull($decoded, 'external_reference'),
+            idempotencyKey: $idempotencyKey,
+        ));
+
+        $outstanding = max(0, $result->invoice->totalCents - $result->totalPaidCents);
+
+        return $this->json->create([
+            'payment' => [
+                'payment_id' => $result->payment->id,
+                'amount_cents' => $result->payment->amountCents,
+                'paid_at' => $result->payment->paidAt,
+                'method' => $result->payment->method,
+                'external_reference' => $result->payment->externalReference,
+            ],
+            'invoice' => ServiceInvoiceResponse::listItem($result->invoice, $outstanding),
+            'total_paid_cents' => $result->totalPaidCents,
+        ], 201);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function stringOrNull(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/ServiceApi/ServiceApiRouteRegistrar.php
+++ b/src/ServiceApi/ServiceApiRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class ServiceApiRouteRegistrar
     public function __construct(
         private ListServiceInvoicesHandler $listHandler,
         private GetServiceInvoiceHandler $getHandler,
+        private RecordServicePaymentHandler $recordPaymentHandler,
     ) {
     }
 
@@ -24,8 +25,10 @@ final readonly class ServiceApiRouteRegistrar
     {
         $list = $this->listHandler;
         $get = $this->getHandler;
+        $recordPayment = $this->recordPaymentHandler;
 
         $router->get('/api/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->get('/api/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->post('/api/invoices/{id}/payments', static fn (ServerRequestInterface $r) => $recordPayment->handle($r));
     }
 }

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
 use NeneInvoice\Payment\ListPaymentsUseCase;
+use NeneInvoice\Payment\RecordPaymentUseCase;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -45,16 +46,25 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
                 ),
             )
             ->set(
+                RecordServicePaymentHandler::class,
+                static fn (ContainerInterface $c): RecordServicePaymentHandler => new RecordServicePaymentHandler(
+                    self::resolve($c, RecordPaymentUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 ServiceApiRouteRegistrar::class,
                 static function (ContainerInterface $c): ServiceApiRouteRegistrar {
                     $list = $c->get(ListServiceInvoicesHandler::class);
                     $get = $c->get(GetServiceInvoiceHandler::class);
+                    $recordPayment = $c->get(RecordServicePaymentHandler::class);
 
-                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler) {
+                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler || !$recordPayment instanceof RecordServicePaymentHandler) {
                         throw new LogicException('Service API handler services are invalid.');
                     }
 
-                    return new ServiceApiRouteRegistrar($list, $get);
+                    return new ServiceApiRouteRegistrar($list, $get, $recordPayment);
                 },
             );
     }

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Payment;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentExceedsOutstandingException;
 use NeneInvoice\Payment\PaymentValidationException;
 use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
@@ -81,8 +82,32 @@ final class RecordPaymentUseCaseTest extends TestCase
     {
         $id = $this->issuedInvoice(2200);
 
-        $this->expectException(PaymentValidationException::class);
+        $this->expectException(PaymentExceedsOutstandingException::class);
         $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2201));
+    }
+
+    public function test_over_payment_exception_carries_outstanding(): void
+    {
+        $id = $this->issuedInvoice(2200);
+        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800));
+
+        try {
+            $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2000));
+            self::fail('Expected PaymentExceedsOutstandingException');
+        } catch (PaymentExceedsOutstandingException $e) {
+            self::assertSame(1400, $e->outstandingCents); // 2200 − 800
+        }
+    }
+
+    public function test_idempotent_replay_returns_same_payment(): void
+    {
+        $id = $this->issuedInvoice(2200);
+        $first = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
+        $second = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
+
+        self::assertSame($first->payment->id, $second->payment->id);
+        // only one payment recorded despite two calls
+        self::assertSame(800, $this->payments->totalPaidForInvoice($id));
     }
 
     public function test_non_positive_amount_is_rejected(): void

--- a/tests/ServiceApi/RecordServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/RecordServicePaymentHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentExceedsOutstandingException;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\ServiceApi\RecordServicePaymentHandler;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RecordServicePaymentHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryPaymentRepository $payments;
+    private RecordServicePaymentHandler $handler;
+    private int $invoiceId;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->payments = new InMemoryPaymentRepository();
+
+        $this->invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 2200,
+            taxCents: 0,
+            totalCents: 2200,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-04-01 00:00:00',
+        ));
+
+        $this->handler = new RecordServicePaymentHandler(
+            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder()),
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    /** @param array<string, mixed> $body */
+    private function request(array $body): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest('POST', '/api/invoices/' . $this->invoiceId . '/payments')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId])
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['write:payments']])
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode($body)));
+
+        return $request;
+    }
+
+    public function test_records_payment_and_advances_status(): void
+    {
+        $response = $this->handler->handle($this->request([
+            'amount_cents' => 800,
+            'paid_at' => '2026-04-20',
+            'method' => 'bank_transfer',
+            'external_reference' => 'clear:recon:777',
+            'idempotency_key' => 'clear:recon:777:v1',
+        ]))
+        ;
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertSame(800, $body['total_paid_cents']);
+        self::assertSame('clear:recon:777', $body['payment']['external_reference']);
+        self::assertSame('partially_paid', $body['invoice']['status']);
+        self::assertSame(1400, $body['invoice']['outstanding_cents']);
+    }
+
+    public function test_idempotent_replay_does_not_double_post(): void
+    {
+        $body = ['amount_cents' => 800, 'paid_at' => '2026-04-20', 'idempotency_key' => 'k1'];
+        $this->handler->handle($this->request($body));
+        $this->handler->handle($this->request($body));
+
+        self::assertSame(800, $this->payments->totalPaidForInvoice($this->invoiceId));
+    }
+
+    public function test_missing_idempotency_key_is_422(): void
+    {
+        $response = $this->handler->handle($this->request(['amount_cents' => 800, 'paid_at' => '2026-04-20']));
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_missing_paid_at_is_422(): void
+    {
+        $response = $this->handler->handle($this->request(['amount_cents' => 800, 'idempotency_key' => 'k1']));
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_over_allocation_throws_exceeds_outstanding(): void
+    {
+        $this->expectException(PaymentExceedsOutstandingException::class);
+        $this->handler->handle($this->request([
+            'amount_cents' => 9999,
+            'paid_at' => '2026-04-20',
+            'idempotency_key' => 'k2',
+        ]));
+    }
+}


### PR DESCRIPTION
## 概要

ADR 0009 ②後半（Clear 書き込みAPI）。**税理士サインオフ済み**で gate 解除。Clear が確定マッチで入金を起票する。

Closes #111

## 内容

- **RecordPaymentUseCase を拡張**して operator/service 共用:
  - `idempotency_key` 冪等 replay（同一キーは既存 payment を返し二重起票しない）
  - `external_reference` 保存、`paid_at`=入金日（銀行 value date、与えられた値のまま）
  - 過入金は `PaymentExceedsOutstandingException`（**422 `payment-exceeds-outstanding`**、`outstanding_cents` を Problem Details extensions に同梱）に統一（operator も同スラッグに）
- `RecordServicePaymentHandler`（`POST /api/invoices/{id}/payments`、`write:payments` scope、`paid_at`/`idempotency_key` 必須）+ route + 配線
- `service-api.yaml` に `createPayment` + `RecordPaymentRequest`/`RecordPaymentResult` + 422 を記載

## テスト / 検証

- use case（冪等 replay / 過入金 outstanding 同梱 / 既存 over-pay テスト更新）/ service handler（201・replay・422・必須欠落）
- `composer check` green（**258 PHPStan**, openapi×2, mcp）
- live（:8123）: 起票 50000 → partially_paid・outstanding 60000、同一キー replay は二重起票なし、過入金 → 422 `payment-exceeds-outstanding` + `outstanding_cents`

## 次

W3: `POST …/payments/{paymentId}/void`（void-with-audit, 冪等）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)