### PR TITLE
feat(service-api): POST /api/invoices/{id}/payments/{paymentId}/void（void-with-audit・冪等）(#113)

### DIFF
--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -35,12 +35,15 @@ architecture: **ADR 0009**.
   the operator's `organization_id`(s) and to `read:invoices` + `write:payments`.
 - **Writes:** idempotent payment create (with `external_reference`) and
   void-with-audit; over-allocation rejected (`payment-exceeds-outstanding`).
-- **Status:** contract accepted (ADR 0009). **Read API shipped** (#101):
-  `GET /api/invoices` and `GET /api/invoices/{id}` (with `outstanding_cents` +
-  payment history) behind service-token auth; OpenAPI `docs/openapi/service-api.yaml`;
-  mint tokens with `php tools/issue-service-token.php --org=N --scopes=read:invoices`.
-  Write API (payment create / void) and read filters are sequenced follow-ups
-  (write API gated on 税理士 sign-off).
+- **Status:** contract accepted (ADR 0009); **read + write API shipped** (§2/§3).
+  Read: `GET /api/invoices` (+ filters: status/overdue/client/due/outstanding) and
+  `GET /api/invoices/{id}` (with `outstanding_cents` + payment history). Write
+  (税理士 sign-off given 2026-05-30): `POST /api/invoices/{id}/payments` (idempotent,
+  `external_reference`, over-allocation → `payment-exceeds-outstanding`) and
+  `POST …/payments/{paymentId}/void` (void-with-audit, idempotent). All behind
+  service-token auth; OpenAPI `docs/openapi/service-api.yaml`. Mint tokens:
+  `php tools/issue-service-token.php --org=N --scopes=read:invoices,write:payments`.
+  Remaining: Clear-side contract tests; ops (multi-org tokens, issuance/revocation UI).
 
 ## Environment variables (planned)
 

--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -143,6 +143,48 @@ paths:
           $ref: '#/components/responses/NotFound'
         '422':
           $ref: '#/components/responses/PaymentExceedsOutstanding'
+  /api/invoices/{id}/payments/{paymentId}/void:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+      - name: paymentId
+        in: path
+        required: true
+        schema: { type: integer, minimum: 1 }
+    post:
+      tags: [ServicePayments]
+      summary: Void a payment (service)
+      description: >
+        Reverses a payment on a match reversal (ADR 0009 §3.2). Void-with-audit
+        (no hard delete); the invoice status is recomputed from the remaining
+        payments. Idempotent — voiding an already-voided payment is a no-op
+        success. Requires the `write:payments` scope.
+      operationId: voidPayment
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: [string, 'null'] }
+            example:
+              reason: operator reversal
+      responses:
+        '200':
+          description: Payment voided (or already void)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordPaymentResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientScope'
+        '404':
+          $ref: '#/components/responses/NotFound'
 components:
   securitySchemes:
     serviceToken:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #111)
+Last updated: 2026-05-30 (Issue #113)
 
 ## Recently merged
 
@@ -57,13 +57,14 @@ Last updated: 2026-05-30 (Issue #111)
 - **Issue #105 / PR #106** — `GET /api/invoices` に read フィルタ（status/overdue/client/due/outstanding）✅ merged
 - **Issue #107 / PR #108** — フロント: 取引先一覧画面 + ヘッダーナビ ✅ merged
 - **Issue #109 / PR #110** — payment external_reference / idempotency_key / void データ層 ✅ merged
-- **Issue #111** — `POST /api/invoices/{id}/payments`（冪等・external_reference・過入金422）⏳ this PR
+- **Issue #111 / PR #112** — `POST /api/invoices/{id}/payments`（冪等・external_reference・過入金422）✅ merged
+- **Issue #113** — `POST /api/invoices/{id}/payments/{paymentId}/void`（void-with-audit・冪等）⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #111 | `feat/111-service-record-payment` | service 入金起票（idempotent + external_reference + 過入金422） | 🔄 PR pending |
+| #113 | `feat/113-service-void-payment` | service 入金 void（void-with-audit・冪等・status 再計算） | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 
@@ -77,8 +78,8 @@ Last updated: 2026-05-30 (Issue #111)
   - ②後半 **税理士サインオフ済み（2026-05-30）→ gate 解除**。
     - W1 **済(#109)**: payments に `external_reference` / `idempotency_key`、`findById`/`findByIdempotencyKey`/`markVoided`（void=soft delete 流用）。
     - W2 **済(#111)**: `POST /api/invoices/{id}/payments`。RecordPaymentUseCase を拡張（冪等 replay / `external_reference` 保存 / 過入金→`PaymentExceedsOutstandingException`=422 `payment-exceeds-outstanding` + `outstanding_cents`）して operator/service 共用。`paid_at`=入金日。ライブ確認済み。
-    - W3 次: `POST /api/invoices/{id}/payments/{paymentId}/void`（void-with-audit, 冪等）。
-  - 運用フォロー: 複数 org スコープ、トークン発行/失効 UI。
+    - W3 **済(#113)**: `POST /api/invoices/{id}/payments/{paymentId}/void`。VoidPaymentUseCase（soft delete 流用の void-with-audit `payment.voided`、status 再計算 paid→partially_paid/issued、冪等）。`payment-not-found`(404) 追加。ライブ確認済み。
+  - **②（読み取り＋書き込み）= 契約 §2/§3 完了**。残りは契約テスト（Clear 側）、運用フォロー: 複数 org スコープ、トークン発行/失効 UI。
 - **コンプライアンス gate**: 書き込みAPI PR の前に、`paid_at`=入金日・外部起票・過入金は Clear 側 client_credit の各点を **税理士確認**（accounting-compliance.md は拘束）。
 
 ### Frontend 画面の進め方（縦スライス）

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -23,6 +23,7 @@ use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
 use NeneInvoice\Payment\PaymentExceedsOutstandingExceptionHandler;
+use NeneInvoice\Payment\PaymentNotFoundExceptionHandler;
 use NeneInvoice\Payment\PaymentRouteRegistrar;
 use NeneInvoice\Payment\PaymentValidationExceptionHandler;
 use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
@@ -130,6 +131,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $qualifiedIncomplete = $container->get(QualifiedInvoiceIncompleteExceptionHandler::class);
                     $paymentValidation = $container->get(PaymentValidationExceptionHandler::class);
                     $paymentExceeds = $container->get(PaymentExceedsOutstandingExceptionHandler::class);
+                    $paymentNotFound = $container->get(PaymentNotFoundExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -203,7 +205,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Payment exceeds-outstanding exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $paymentValidation, $paymentExceeds];
+                    if (!$paymentNotFound instanceof PaymentNotFoundExceptionHandler) {
+                        throw new LogicException('Payment not-found exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $paymentValidation, $paymentExceeds, $paymentNotFound];
                 },
             );
     }

--- a/src/Payment/PaymentNotFoundException.php
+++ b/src/Payment/PaymentNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use DomainException;
+
+/**
+ * Thrown when a payment id (or external reference) is not found in the caller's
+ * organization / invoice. Surfaces as 404 `payment-not-found`.
+ */
+final class PaymentNotFoundException extends DomainException
+{
+    public function __construct(public readonly int $paymentId)
+    {
+        parent::__construct(sprintf('Payment %d was not found.', $paymentId));
+    }
+}

--- a/src/Payment/PaymentNotFoundExceptionHandler.php
+++ b/src/Payment/PaymentNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class PaymentNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof PaymentNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'payment-not-found', 'Payment Not Found', 404, $exception->getMessage());
+    }
+}

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -51,6 +51,14 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                VoidPaymentUseCase::class,
+                static fn (ContainerInterface $c): VoidPaymentUseCase => new VoidPaymentUseCase(
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
+                ),
+            )
+            ->set(
                 RecordPaymentHandler::class,
                 static fn (ContainerInterface $c): RecordPaymentHandler => new RecordPaymentHandler(
                     self::resolve($c, RecordPaymentUseCase::class),
@@ -73,6 +81,10 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
             ->set(
                 PaymentExceedsOutstandingExceptionHandler::class,
                 static fn (ContainerInterface $c): PaymentExceedsOutstandingExceptionHandler => new PaymentExceedsOutstandingExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                PaymentNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): PaymentNotFoundExceptionHandler => new PaymentNotFoundExceptionHandler(self::problemDetails($c)),
             )
             ->set(
                 PaymentRouteRegistrar::class,

--- a/src/Payment/VoidPaymentUseCase.php
+++ b/src/Payment/VoidPaymentUseCase.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceResponse;
+use NeneInvoice\Invoice\InvoiceStatus;
+
+/**
+ * Voids a payment on a reconciliation reversal (ADR 0009 §3.2). This is a
+ * **void-with-audit**, never a hard delete — financial history is preserved
+ * (accounting-compliance.md). The invoice status is recomputed from the
+ * remaining valid payments. Idempotent: voiding an already-voided payment is a
+ * no-op success.
+ */
+final readonly class VoidPaymentUseCase
+{
+    public function __construct(
+        private PaymentRepositoryInterface $payments,
+        private InvoiceRepositoryInterface $invoices,
+        private AuditRecorderInterface $audit,
+    ) {
+    }
+
+    /**
+     * @throws InvoiceNotFoundException
+     * @throws PaymentNotFoundException
+     */
+    public function execute(
+        int $organizationId,
+        ?int $actorUserId,
+        int $invoiceId,
+        int $paymentId,
+        ?string $reason,
+    ): RecordPaymentResult {
+        $payment = $this->payments->findById($paymentId);
+
+        if (
+            $payment === null
+            || $payment->organizationId !== $organizationId
+            || $payment->invoiceId !== $invoiceId
+        ) {
+            throw new PaymentNotFoundException($paymentId);
+        }
+
+        $invoice = $this->invoices->findById($invoiceId);
+
+        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+            throw new InvoiceNotFoundException($invoiceId);
+        }
+
+        // Idempotent: already voided → return current state without re-voiding.
+        if ($payment->isDeleted) {
+            return new RecordPaymentResult($payment, $invoice, $this->payments->totalPaidForInvoice($invoiceId));
+        }
+
+        $before = InvoiceResponse::toArray($invoice);
+
+        $this->payments->markVoided($paymentId);
+
+        $totalPaid = $this->payments->totalPaidForInvoice($invoiceId);
+        $newStatus = $this->recomputeStatus($invoice, $totalPaid);
+
+        $updatedInvoice = new Invoice(
+            organizationId: $invoice->organizationId,
+            clientId: $invoice->clientId,
+            status: $newStatus,
+            subtotalCents: $invoice->subtotalCents,
+            taxCents: $invoice->taxCents,
+            totalCents: $invoice->totalCents,
+            isQualifiedInvoice: $invoice->isQualifiedInvoice,
+            quoteId: $invoice->quoteId,
+            invoiceNumber: $invoice->invoiceNumber,
+            issuedAt: $invoice->issuedAt,
+            dueAt: $invoice->dueAt,
+            notes: $invoice->notes,
+            id: $invoice->id,
+            createdAt: $invoice->createdAt,
+            updatedAt: $invoice->updatedAt,
+        );
+
+        $this->invoices->update($updatedInvoice);
+
+        $after = InvoiceResponse::toArray($updatedInvoice);
+        $after['voided_payment_id'] = $paymentId;
+        $after['void_reason'] = $reason;
+
+        $this->audit->record($actorUserId, $organizationId, 'payment.voided', 'invoice', $invoiceId, $before, $after);
+
+        $voided = $this->payments->findById($paymentId) ?? $payment;
+
+        return new RecordPaymentResult($voided, $updatedInvoice, $totalPaid);
+    }
+
+    /**
+     * After a void, recompute from the remaining valid payments. An issued invoice
+     * with no remaining payments returns to `issued`; partial → `partially_paid`;
+     * fully covered → `paid`. (Drafts cannot have payments.)
+     */
+    private function recomputeStatus(Invoice $invoice, int $totalPaid): InvoiceStatus
+    {
+        if ($totalPaid <= 0) {
+            return InvoiceStatus::Issued;
+        }
+
+        return $totalPaid >= $invoice->totalCents ? InvoiceStatus::Paid : InvoiceStatus::PartiallyPaid;
+    }
+}

--- a/src/ServiceApi/ServiceApiRouteRegistrar.php
+++ b/src/ServiceApi/ServiceApiRouteRegistrar.php
@@ -18,6 +18,7 @@ final readonly class ServiceApiRouteRegistrar
         private ListServiceInvoicesHandler $listHandler,
         private GetServiceInvoiceHandler $getHandler,
         private RecordServicePaymentHandler $recordPaymentHandler,
+        private VoidServicePaymentHandler $voidPaymentHandler,
     ) {
     }
 
@@ -26,9 +27,11 @@ final readonly class ServiceApiRouteRegistrar
         $list = $this->listHandler;
         $get = $this->getHandler;
         $recordPayment = $this->recordPaymentHandler;
+        $voidPayment = $this->voidPaymentHandler;
 
         $router->get('/api/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->get('/api/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
         $router->post('/api/invoices/{id}/payments', static fn (ServerRequestInterface $r) => $recordPayment->handle($r));
+        $router->post('/api/invoices/{id}/payments/{paymentId}/void', static fn (ServerRequestInterface $r) => $voidPayment->handle($r));
     }
 }

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -13,6 +13,7 @@ use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
 use NeneInvoice\Payment\ListPaymentsUseCase;
 use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Payment\VoidPaymentUseCase;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -54,17 +55,26 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
                 ),
             )
             ->set(
+                VoidServicePaymentHandler::class,
+                static fn (ContainerInterface $c): VoidServicePaymentHandler => new VoidServicePaymentHandler(
+                    self::resolve($c, VoidPaymentUseCase::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 ServiceApiRouteRegistrar::class,
                 static function (ContainerInterface $c): ServiceApiRouteRegistrar {
                     $list = $c->get(ListServiceInvoicesHandler::class);
                     $get = $c->get(GetServiceInvoiceHandler::class);
                     $recordPayment = $c->get(RecordServicePaymentHandler::class);
+                    $voidPayment = $c->get(VoidServicePaymentHandler::class);
 
-                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler || !$recordPayment instanceof RecordServicePaymentHandler) {
+                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler || !$recordPayment instanceof RecordServicePaymentHandler || !$voidPayment instanceof VoidServicePaymentHandler) {
                         throw new LogicException('Service API handler services are invalid.');
                     }
 
-                    return new ServiceApiRouteRegistrar($list, $get, $recordPayment);
+                    return new ServiceApiRouteRegistrar($list, $get, $recordPayment, $voidPayment);
                 },
             );
     }

--- a/src/ServiceApi/VoidServicePaymentHandler.php
+++ b/src/ServiceApi/VoidServicePaymentHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Payment\VoidPaymentUseCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /api/invoices/{id}/payments/{paymentId}/void` — reverses a payment on a
+ * reconciliation reversal (ADR 0009 §3.2). Void-with-audit (no hard delete);
+ * recomputes invoice status; idempotent. Requires the `write:payments` scope.
+ */
+final readonly class VoidServicePaymentHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private VoidPaymentUseCase $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+        $paymentId = is_array($params) && isset($params['paymentId']) ? (int) $params['paymentId'] : 0;
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        $reasonValue = is_array($decoded) ? ($decoded['reason'] ?? null) : null;
+        $reason = is_string($reasonValue) && $reasonValue !== '' ? $reasonValue : null;
+
+        $result = $this->useCase->execute($organizationId, null, $invoiceId, $paymentId, $reason);
+
+        $outstanding = max(0, $result->invoice->totalCents - $result->totalPaidCents);
+
+        return $this->json->create([
+            'payment' => [
+                'payment_id' => $result->payment->id,
+                'amount_cents' => $result->payment->amountCents,
+                'paid_at' => $result->payment->paidAt,
+                'method' => $result->payment->method,
+                'external_reference' => $result->payment->externalReference,
+                'voided' => true,
+            ],
+            'invoice' => ServiceInvoiceResponse::listItem($result->invoice, $outstanding),
+            'total_paid_cents' => $result->totalPaidCents,
+        ]);
+    }
+}

--- a/tests/Payment/VoidPaymentUseCaseTest.php
+++ b/tests/Payment/VoidPaymentUseCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Payment;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentNotFoundException;
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Payment\VoidPaymentUseCase;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class VoidPaymentUseCaseTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryPaymentRepository $payments;
+    private RecordingAuditRecorder $audit;
+    private RecordPaymentUseCase $record;
+    private VoidPaymentUseCase $void;
+    private int $invoiceId;
+
+    protected function setUp(): void
+    {
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->payments = new InMemoryPaymentRepository();
+        $this->audit = new RecordingAuditRecorder();
+        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit);
+        $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, $this->audit);
+
+        $this->invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 2200,
+            taxCents: 0,
+            totalCents: 2200,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-04-01 00:00:00',
+        ));
+    }
+
+    private function recordPayment(int $amount): int
+    {
+        $result = $this->record->execute(1, null, $this->invoiceId, new RecordPaymentInput(amountCents: $amount, paidAt: '2026-04-20'));
+
+        return (int) $result->payment->id;
+    }
+
+    public function test_void_full_payment_returns_invoice_to_issued(): void
+    {
+        $paymentId = $this->recordPayment(2200);
+        self::assertSame(InvoiceStatus::Paid, $this->invoices->findById($this->invoiceId)?->status);
+
+        $result = $this->void->execute(1, null, $this->invoiceId, $paymentId, 'operator reversal');
+
+        self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
+        self::assertSame(0, $result->totalPaidCents);
+        $lastAudit = end($this->audit->records);
+        self::assertIsArray($lastAudit);
+        self::assertSame('payment.voided', $lastAudit['action']);
+    }
+
+    public function test_void_one_of_two_payments_keeps_partially_paid(): void
+    {
+        $first = $this->recordPayment(800);
+        $this->recordPayment(600); // total 1400 → partially_paid
+
+        $result = $this->void->execute(1, null, $this->invoiceId, $first, null);
+
+        self::assertSame(InvoiceStatus::PartiallyPaid, $result->invoice->status);
+        self::assertSame(600, $result->totalPaidCents);
+    }
+
+    public function test_void_is_idempotent(): void
+    {
+        $paymentId = $this->recordPayment(800);
+        $this->void->execute(1, null, $this->invoiceId, $paymentId, null);
+        $again = $this->void->execute(1, null, $this->invoiceId, $paymentId, null);
+
+        self::assertSame(InvoiceStatus::Issued, $again->invoice->status);
+        self::assertSame(0, $again->totalPaidCents);
+    }
+
+    public function test_unknown_payment_is_not_found(): void
+    {
+        $this->expectException(PaymentNotFoundException::class);
+        $this->void->execute(1, null, $this->invoiceId, 999, null);
+    }
+
+    public function test_cross_organization_payment_is_not_found(): void
+    {
+        $paymentId = $this->recordPayment(800);
+
+        $this->expectException(PaymentNotFoundException::class);
+        $this->void->execute(2, null, $this->invoiceId, $paymentId, null);
+    }
+}


### PR DESCRIPTION
## 概要

ADR 0009 §3.2。マッチ取消で Clear が入金を void する。これで上流契約の **§2（read + filters）/ §3（write: create + void）が完了**。

Closes #113

## 内容

- **VoidPaymentUseCase**: ハードデリートせず `markVoided`（soft delete 流用の **void-with-audit**）、invoice status を残存入金から**再計算**（paid→partially_paid/issued）、`payment.voided` 監査（before/after + voided_payment_id + reason）、**冪等**（void 済みは no-op 成功）
- `PaymentNotFoundException` + handler（**404 `payment-not-found`**）、`EXCEPTION_HANDLERS` 登録
- `VoidServicePaymentHandler`（`POST …/{paymentId}/void`、`write:payments` scope）+ route + 配線
- `service-api.yaml` に `voidPayment` を記載

## テスト / 検証

- `VoidPaymentUseCaseTest`（full→issued / partial→partially_paid / 冪等 / not-found / cross-org）
- `composer check` green（**263 PHPStan**, openapi×2, mcp）
- live（:8123）: payment void → invoice `issued`・outstanding 復元、再 void は 200 no-op、unknown → 404 `payment-not-found`

## 残り

Clear 側の契約テスト、運用（複数 org スコープ、トークン発行/失効 UI）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)