### PR TITLE
feat(frontend): 請求書の発行を確認ダイアログ化する (#121)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-30 (Issue #119)
+Last updated: 2026-05-30 (Issue #121)
 
 ## Recently merged
 
@@ -61,13 +61,14 @@ Last updated: 2026-05-30 (Issue #119)
 - **Issue #113 / PR #114** — `POST /api/invoices/{id}/payments/{paymentId}/void`（void-with-audit・冪等）✅ merged
 - **Issue #115 / PR #116** — フロント: 取引先の作成フォーム（/clients/new）✅ merged
 - **Issue #117 / PR #118** — フロント: ConfirmDialog primitive + 取引先の削除 ✅ merged
-- **Issue #119** — フロント: 取引先の編集（/clients/:id/edit）⏳ this PR
+- **Issue #119 / PR #120** — フロント: 取引先の編集（/clients/:id/edit）✅ merged
+- **Issue #121** — フロント: 請求書の発行を確認ダイアログ化 ⏳ this PR
 
 ## Active
 
 | Issue | Branch | Topic | Status |
 | --- | --- | --- | --- |
-| #119 | `feat/119-client-edit` | フロント: 取引先編集（CRUD の U 完了） | 🔄 PR pending |
+| #121 | `feat/121-issue-confirm` | フロント: 発行を ConfirmDialog 化（不可逆操作） | 🔄 PR pending |
 
 ### NeNe Clear 連携（入金消込・督促、downstream consumer）
 

--- a/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
+++ b/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
@@ -1,25 +1,38 @@
+import { useState } from 'react'
 import type { InvoiceId } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
-import { Button, Stack, Text } from '@/shared/ui'
+import { Button, ConfirmDialog, Stack, Text } from '@/shared/ui'
 import { useIssueInvoice } from '../hooks/use-issue-invoice'
 
 export interface IssueInvoiceProps {
   invoiceId: InvoiceId
 }
 
-/** Issue action — renders only for a draft invoice. */
+/** Issue action — renders only for a draft invoice. Issuing is irreversible
+ * (allocates the INV number and locks the document), so it is confirmed. */
 export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
   const { t } = useTranslation()
   const { canIssue, issue, isPending, errorMessage } = useIssueInvoice(invoiceId)
+  const [confirming, setConfirming] = useState(false)
 
   if (!canIssue) {
     return null
   }
 
+  const onConfirm = (): void => {
+    setConfirming(false)
+    issue()
+  }
+
   return (
     <Stack gap="sm">
       <div>
-        <Button onClick={issue} disabled={isPending}>
+        <Button
+          onClick={() => {
+            setConfirming(true)
+          }}
+          disabled={isPending}
+        >
           {isPending ? t('admin.invoices.issue.submitting') : t('admin.invoices.issue.action')}
         </Button>
       </div>
@@ -27,6 +40,20 @@ export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
         <Text variant="muted" role="alert">
           {errorMessage}
         </Text>
+      )}
+      {confirming && (
+        <ConfirmDialog
+          title={t('admin.invoices.issue.confirmTitle')}
+          message={t('admin.invoices.issue.confirmMessage')}
+          confirmLabel={t('admin.invoices.issue.action')}
+          cancelLabel={t('common.actions.cancel')}
+          destructive={false}
+          pending={isPending}
+          onConfirm={onConfirm}
+          onCancel={() => {
+            setConfirming(false)
+          }}
+        />
       )}
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -96,6 +96,9 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.issue.submitting': 'Issuing…',
   'admin.invoices.issue.error':
     'Could not issue. Check the registration number in company settings.',
+  'admin.invoices.issue.confirmTitle': 'Issue this invoice?',
+  'admin.invoices.issue.confirmMessage':
+    'Issuing allocates the invoice number and locks the contents (no further edits).',
   'admin.payments.title': 'Payments',
   'admin.payments.loading': 'Loading payments…',
   'admin.payments.empty': 'No payments yet.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -97,6 +97,9 @@ export const jaMessages = {
   'admin.invoices.issue.action': '発行する（適格請求書）',
   'admin.invoices.issue.submitting': '発行中…',
   'admin.invoices.issue.error': '発行できませんでした。会社情報の登録番号を確認してください。',
+  'admin.invoices.issue.confirmTitle': '請求書を発行しますか？',
+  'admin.invoices.issue.confirmMessage':
+    '発行すると番号が採番され、内容は確定（変更不可）になります。',
   'admin.payments.title': '入金',
   'admin.payments.loading': '入金を読み込み中…',
   'admin.payments.empty': '入金はまだありません。',


### PR DESCRIPTION
## 概要

発行は不可逆（INV 採番・内容ロック）なので、発行ボタンを `ConfirmDialog`（非破壊スタイル）経由にする。新規 primitive の実用例。

Closes #121

## 内容

- `features/issue-invoice`: 確認ステート + `ConfirmDialog`（`destructive={false}`、pending 連動）。確定で issue 実行
- i18n（ja/en）: `issue.confirmTitle` / `issue.confirmMessage`

## テスト

- `npm run check` green（**38 tests**）。`use-issue-invoice` の既存テストで挙動はカバー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)