### PR TITLE
docs(daily-report): 2026-05-30 の日報を追加する

### DIFF
--- a/docs/daily-reports/2026-05-30.md
+++ b/docs/daily-reports/2026-05-30.md
@@ -1,0 +1,68 @@
+# Daily Report — 2026-05-30
+
+**Project:** NeNe Invoice (self-hosted quote / invoice / payment management, Japan qualified-invoice compliant)
+**Branch state at end of day:** `main` @ `87cd4b0`, all CI green
+**Author:** Claude (pair-driving with the maintainer)
+
+---
+
+## Summary
+
+Drove the product from a late-backend state through to a coherent, end-to-end
+working system: the full quote-to-cash backend, the complete admin frontend, and
+the entire **NeNe Clear** upstream integration (read + write). Every change landed
+issue-driven, one feature per PR, CI green before merge.
+
+## Shipped today
+
+### Backend (PHP 8.4 / NENE2)
+- Completed quote-to-cash: invoice **issue** (INV numbering + qualified-invoice
+  validation), **payments** (paid / partially_paid transitions), **direct invoice
+  create**, and authoritative **`outstanding_cents`** on read models.
+- **Audit-log read API** (`GET /admin/audit-logs`, admin-scoped).
+- **OpenAPI 3.1 contract + MCP catalog** with validators wired into `composer check`.
+- **Backend CI** (GitHub Actions) + bumped actions to Node-24-ready `@v5`.
+- **ADR 0003** (dual deployment: Tier A shared hosting / Tier B Docker).
+
+### NeNe Clear integration (the day's main arc)
+- Accepted the sibling's upstream contract → **ADR 0009**.
+- Exposed `outstanding_cents`; built a dedicated service surface **`/api/*`** with a
+  **service-token machine principal** (org-scoped, `read:invoices` / `write:payments`),
+  cleanly isolated from the operator `/admin/*` surface.
+- Read API with filters (status / overdue / client / due / outstanding).
+- **Write API** — idempotent payment create (with `external_reference`),
+  over-allocation → `422 payment-exceeds-outstanding` (carrying `outstanding_cents`),
+  and **void-with-audit** (idempotent, recomputes invoice status).
+- Separate `service-api.yaml` OpenAPI + a service-token issuing CLI tool.
+
+### Frontend (React 19 + TypeScript, strict layered conventions)
+- Authored the binding frontend standards, then scaffolded `frontend/` (Vite,
+  Tailwind v4 tokens, TanStack Query, RHF + Zod, Storybook, Vitest + MSW, strict
+  ESLint boundaries).
+- Vertical slices: login → invoices (list / create / detail / **issue** / payments /
+  outstanding) and **clients full CRUD** (create / list / edit / delete).
+- `ConfirmDialog` primitive; confirmation on the irreversible **issue** action.
+
+## Notable incidents / decisions
+- **Compliance gate honored:** the Clear write API was blocked until the maintainer
+  confirmed tax-accountant (税理士) sign-off; build proceeded only afterward, per ADR 0009.
+- **HEAD drift** from a parallel Cursor agent occurred a few times; recovered each
+  time without ever contaminating `origin/main`. Branch verified before every commit.
+- **Vite dev `base` bug** (relative `base` broke dev module resolution) surfaced on
+  first in-browser load and was fixed immediately (PR #88).
+
+## Quality
+- Backend: 263 PHPStan (level 8) clean, full PHPUnit green, OpenAPI ×2 + MCP valid.
+- Frontend: 38 tests green; `npm run check` (type-check + lint + format + knip +
+  build-storybook) green.
+- Live-verified end-to-end against the running app (operator flow + service API).
+
+## Open / next (gate-free polish)
+- Invoice list pagination.
+- Confirmation dialog on payment recording.
+- `public_html/openapi.php` to serve the specs over HTTP.
+- Tier A same-origin serving (PHP wiring for the built admin bundle).
+
+## Remaining cross-repo
+- NeNe Clear-side contract tests against the now-live `/api/*` surface.
+- Service-token operations: multi-org scope, issuance / revocation UI.


### PR DESCRIPTION
## 概要

`docs/daily-reports/` を新設し、英語の日報 `2026-05-30.md` を追加。

今日の成果（quote-to-cash 完成、NeNe Clear 上流契約 read+write 実装、フロント管理 UI＋取引先 CRUD、CI / ADR 0003・0009）と、特記事項（税理士 gate 遵守、HEAD ドリフト復旧、Vite dev base 修正）、残りの polish を記録。

ドキュメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)