### PR TITLE
feat(frontend): 入金記録を確認ダイアログ化する (#124)

### DIFF
--- a/frontend/src/features/manage-payments/hooks/use-manage-payments.test.ts
+++ b/frontend/src/features/manage-payments/hooks/use-manage-payments.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react'
+import { act, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { toInvoiceId } from '@/entities/invoice'
@@ -34,5 +34,28 @@ describe('useManagePayments (feature)', () => {
 
     expect(result.current.visible).toBe(false)
     expect(result.current.canRecord).toBe(false)
+  })
+
+  it('opens the confirm dialog on valid submission and closes on cancel', async () => {
+    const { result } = renderHookWithProviders(() => useManagePayments(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.canRecord).toBe(true)
+    })
+
+    act(() => {
+      result.current.form.setValue('amount_cents', 10000)
+      result.current.onSubmit({ preventDefault: () => {} } as unknown as React.SyntheticEvent)
+    })
+
+    await waitFor(() => {
+      expect(result.current.confirming).toBe(true)
+    })
+
+    act(() => {
+      result.current.onCancel()
+    })
+
+    expect(result.current.confirming).toBe(false)
   })
 })

--- a/frontend/src/features/manage-payments/hooks/use-manage-payments.ts
+++ b/frontend/src/features/manage-payments/hooks/use-manage-payments.ts
@@ -1,11 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import type { SyntheticEvent } from 'react'
+import { useState } from 'react'
 import { useForm, type UseFormReturn } from 'react-hook-form'
 import { z } from 'zod'
 import { invoiceKeys, useInvoice, type InvoiceId } from '@/entities/invoice'
 import { usePaymentList, useRecordPayment, type Payment } from '@/entities/payment'
 import { useTranslation } from '@/shared/i18n'
+import { formatYen } from '@/shared/lib/format-money'
 
 export const PAYMENT_METHODS = ['bank_transfer', 'cash', 'other'] as const
 
@@ -28,6 +30,11 @@ export interface UseManagePayments {
   paymentsError: boolean
   form: UseFormReturn<RecordPaymentFormValues>
   onSubmit: (event: SyntheticEvent) => void
+  /** Truthy while the confirm dialog is open. */
+  confirming: boolean
+  confirmTitle: string
+  onConfirm: () => void
+  onCancel: () => void
   isRecording: boolean
   errorMessage: string | null
 }
@@ -44,9 +51,18 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
     defaultValues: { amount_cents: 0, method: '', note: '' },
   })
 
+  const [pending, setPending] = useState<RecordPaymentFormValues | null>(null)
+
   const status = invoice.data?.status
 
   const submit = form.handleSubmit((values) => {
+    setPending(values)
+  })
+
+  const onConfirm = (): void => {
+    if (!pending) return
+    const values = pending
+    setPending(null)
     record.mutate(
       {
         invoice_id: invoiceId,
@@ -62,6 +78,14 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
         },
       },
     )
+  }
+
+  const onCancel = (): void => {
+    setPending(null)
+  }
+
+  const confirmTitle = t('admin.payments.record.confirmTitle', {
+    amount: formatYen(pending?.amount_cents ?? 0),
   })
 
   return {
@@ -75,6 +99,10 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
     onSubmit: (event) => {
       void submit(event)
     },
+    confirming: pending !== null,
+    confirmTitle,
+    onConfirm,
+    onCancel,
     isRecording: record.isPending,
     errorMessage: record.isError ? t('admin.payments.record.error') : null,
   }

--- a/frontend/src/features/manage-payments/ui/ManagePayments.tsx
+++ b/frontend/src/features/manage-payments/ui/ManagePayments.tsx
@@ -1,7 +1,17 @@
 import type { InvoiceId } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
 import { formatYen } from '@/shared/lib/format-money'
-import { Button, EmptyState, Field, Input, Select, Spinner, Stack, Text } from '@/shared/ui'
+import {
+  Button,
+  ConfirmDialog,
+  EmptyState,
+  Field,
+  Input,
+  Select,
+  Spinner,
+  Stack,
+  Text,
+} from '@/shared/ui'
 import { PAYMENT_METHODS, useManagePayments } from '../hooks/use-manage-payments'
 
 export interface ManagePaymentsProps {
@@ -19,6 +29,10 @@ export function ManagePayments({ invoiceId }: ManagePaymentsProps) {
     paymentsLoading,
     form,
     onSubmit,
+    confirming,
+    confirmTitle,
+    onConfirm,
+    onCancel,
     isRecording,
     errorMessage,
   } = useManagePayments(invoiceId)
@@ -132,6 +146,18 @@ export function ManagePayments({ invoiceId }: ManagePaymentsProps) {
             </div>
           </Stack>
         </form>
+      )}
+      {confirming && (
+        <ConfirmDialog
+          title={confirmTitle}
+          message={t('admin.payments.record.confirmMessage')}
+          confirmLabel={t('admin.payments.record.submit')}
+          cancelLabel={t('common.actions.cancel')}
+          destructive={false}
+          pending={isRecording}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
       )}
     </Stack>
   )

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -117,6 +117,9 @@ export const enMessages: MessageCatalog = {
   'admin.payments.record.note': 'Note',
   'admin.payments.record.submit': 'Record',
   'admin.payments.record.submitting': 'Recording…',
+  'admin.payments.record.confirmTitle': 'Record {{amount}} as a payment?',
+  'admin.payments.record.confirmMessage':
+    'Recording will update the payment status of the invoice.',
   'admin.payments.record.error':
     'Could not record the payment. Check the amount (no over-payment).',
   'admin.payments.record.invalid': 'Enter a valid amount.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -118,6 +118,8 @@ export const jaMessages = {
   'admin.payments.record.note': '備考',
   'admin.payments.record.submit': '記録する',
   'admin.payments.record.submitting': '記録中…',
+  'admin.payments.record.confirmTitle': '{{amount}} を入金として記録しますか？',
+  'admin.payments.record.confirmMessage': '記録すると請求書の入金状態が更新されます。',
   'admin.payments.record.error':
     '入金を記録できませんでした。金額（過入金でないか）を確認してください。',
   'admin.payments.record.invalid': '金額を正しく入力してください。',


### PR DESCRIPTION
## Summary

- 入金記録フォームの送信前に `ConfirmDialog` を挟み、誤操作（金額間違い等）を防止
- バリデーション通過後に保留値を `useState` で保持し、確認後にミューテーションを実行
- キャンセルするとダイアログを閉じてフォームの入力内容は保持
- i18n 追加（ja / en）: `confirmTitle`（金額を `{{amount}}` 補間）・`confirmMessage`
- フック単体テストに confirming 状態ケースを追加（39 テスト全 pass）

## Test plan

- [ ] `npm run check` green（type-check / lint / format / test / knip / build-storybook）
- [ ] 発行済み請求書詳細で入金フォームに金額を入力 → 「記録する」でダイアログ表示
- [ ] ダイアログタイトルに入力金額が表示されること
- [ ] 「キャンセル」でダイアログを閉じてフォームに金額が残ること
- [ ] 「記録する」で API 呼び出し → 入金一覧に反映

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)