### PR TITLE
feat(backend): public_html/openapi.php — OpenAPI spec の HTTP 配信 (#128)

### DIFF
--- a/public_html/openapi.php
+++ b/public_html/openapi.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Serves OpenAPI spec documents over HTTP without authentication.
+ *
+ * Usage:
+ *   GET /openapi.php             — operator API spec (docs/openapi/openapi.yaml)
+ *   GET /openapi.php?spec=service — service API spec (docs/openapi/service-api.yaml)
+ */
+
+$specMap = [
+    'operator' => dirname(__DIR__) . '/docs/openapi/openapi.yaml',
+    'service'  => dirname(__DIR__) . '/docs/openapi/service-api.yaml',
+];
+
+$specKey = isset($_GET['spec']) && is_string($_GET['spec']) ? $_GET['spec'] : 'operator';
+
+if (!array_key_exists($specKey, $specMap)) {
+    http_response_code(404);
+    header('Content-Type: application/problem+json; charset=utf-8');
+    echo json_encode([
+        'type'   => 'https://nene-invoice.dev/problems/not-found',
+        'title'  => 'Not Found',
+        'status' => 404,
+        'detail' => sprintf('Unknown spec "%s". Valid values: operator, service.', $specKey),
+    ], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+$filePath = $specMap[$specKey];
+
+if (!file_exists($filePath)) {
+    http_response_code(404);
+    header('Content-Type: application/problem+json; charset=utf-8');
+    echo json_encode([
+        'type'   => 'https://nene-invoice.dev/problems/not-found',
+        'title'  => 'Not Found',
+        'status' => 404,
+        'detail' => 'Spec file not found on this server.',
+    ], JSON_THROW_ON_ERROR);
+    exit;
+}
+
+header('Content-Type: application/yaml; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Cache-Control: public, max-age=3600');
+readfile($filePath);

--- a/tests/OpenApi/OpenApiServeTest.php
+++ b/tests/OpenApi/OpenApiServeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\OpenApi;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sanity checks for the public_html/openapi.php spec-serving script.
+ *
+ * This is a standalone PHP file (no DI container), so we verify:
+ * - The entry-point file exists and is parseable PHP.
+ * - The spec files it references are present on disk.
+ * - Unknown spec keys are not resolvable to a real path.
+ */
+final class OpenApiServeTest extends TestCase
+{
+    private string $scriptPath;
+
+    private string $docsOpenApiDir;
+
+    protected function setUp(): void
+    {
+        $this->scriptPath     = dirname(__DIR__, 2) . '/public_html/openapi.php';
+        $this->docsOpenApiDir = dirname(__DIR__, 2) . '/docs/openapi';
+    }
+
+    public function test_script_file_exists(): void
+    {
+        self::assertFileExists($this->scriptPath);
+    }
+
+    public function test_script_is_syntactically_valid_php(): void
+    {
+        exec('php -l ' . escapeshellarg($this->scriptPath) . ' 2>&1', $output, $exitCode);
+        self::assertSame(0, $exitCode, implode("\n", $output));
+    }
+
+    public function test_operator_spec_file_exists(): void
+    {
+        self::assertFileExists($this->docsOpenApiDir . '/openapi.yaml');
+    }
+
+    public function test_service_spec_file_exists(): void
+    {
+        self::assertFileExists($this->docsOpenApiDir . '/service-api.yaml');
+    }
+
+    #[DataProvider('validSpecProvider')]
+    public function test_valid_spec_keys_resolve_to_existing_files(string $spec): void
+    {
+        $specMap = [
+            'operator' => $this->docsOpenApiDir . '/openapi.yaml',
+            'service'  => $this->docsOpenApiDir . '/service-api.yaml',
+        ];
+
+        self::assertArrayHasKey($spec, $specMap);
+        self::assertFileExists($specMap[$spec]);
+    }
+
+    /** @return list<array{string}> */
+    public static function validSpecProvider(): array
+    {
+        return [['operator'], ['service']];
+    }
+
+    public function test_unknown_spec_key_is_not_in_the_map(): void
+    {
+        $specMap = ['operator', 'service'];
+        self::assertNotContains('unknown', $specMap);
+        self::assertNotContains('', $specMap);
+        self::assertNotContains('../etc/passwd', $specMap);
+    }
+}


### PR DESCRIPTION
## Summary

- `public_html/openapi.php` を追加 — NENE2 ルーター不使用の standalone PHP スクリプト
- `GET /openapi.php` → オペレーター API spec（`docs/openapi/openapi.yaml`）
- `GET /openapi.php?spec=service` → サービス API spec（`docs/openapi/service-api.yaml`）
- `Content-Type: application/yaml; charset=utf-8`
- `Access-Control-Allow-Origin: *`（Swagger UI / tooling 向け CORS）
- `Cache-Control: public, max-age=3600`
- 不正な `spec` 値 → `404 application/problem+json`（パストラバーサル防止: allowlist のみ）

## Test plan

- [ ] `composer check` green（PHPUnit 170 / PHPStan level 8 / CS Fixer / OpenAPI / MCP）
- [ ] `GET /openapi.php` → 200 + `application/yaml`、内容が `openapi.yaml` と一致
- [ ] `GET /openapi.php?spec=service` → 200 + `application/yaml`、内容が `service-api.yaml` と一致
- [ ] `GET /openapi.php?spec=invalid` → 404 + `application/problem+json`
- [ ] Swagger UI 等のツールから `http://localhost:8080/openapi.php` を読み込めること

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)