### PR TITLE
feat: overdue 表示（issued/partially_paid かつ due_at 超過）(#132)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1217,6 +1217,11 @@ components:
         status:
           type: string
           enum: [draft, issued, partially_paid, paid]
+        is_overdue:
+          type: boolean
+          description: >
+            Computed read-only field. True when status is issued or partially_paid
+            and due_at is in the past. Always false for draft and paid invoices.
         is_qualified_invoice:
           type: boolean
         issued_at:
@@ -1240,7 +1245,7 @@ components:
           type: [string, 'null']
         updated_at:
           type: [string, 'null']
-      required: [id, organization_id, client_id, status, is_qualified_invoice, subtotal_cents, tax_cents, total_cents]
+      required: [id, organization_id, client_id, status, is_overdue, is_qualified_invoice, subtotal_cents, tax_cents, total_cents]
     InvoiceWithLines:
       allOf:
         - $ref: '#/components/schemas/Invoice'

--- a/frontend/src/entities/invoice/mapper.test.ts
+++ b/frontend/src/entities/invoice/mapper.test.ts
@@ -7,6 +7,7 @@ const dto: InvoiceDto = {
   organization_id: 1,
   client_id: 5,
   status: 'issued',
+  is_overdue: false,
   is_qualified_invoice: true,
   invoice_number: 'INV-2026-001',
   subtotal_cents: 106000,
@@ -32,6 +33,11 @@ describe('toInvoice', () => {
   it('maps outstanding_cents when present and null when absent', () => {
     expect(toInvoice({ ...dto, outstanding_cents: 1400 }).outstanding_cents).toBe(1400)
     expect(toInvoice(dto).outstanding_cents).toBeNull()
+  })
+
+  it('maps is_overdue from the DTO', () => {
+    expect(toInvoice({ ...dto, is_overdue: true }).is_overdue).toBe(true)
+    expect(toInvoice({ ...dto, is_overdue: false }).is_overdue).toBe(false)
   })
 })
 

--- a/frontend/src/entities/invoice/mapper.ts
+++ b/frontend/src/entities/invoice/mapper.ts
@@ -8,7 +8,7 @@ export function toInvoice(dto: InvoiceDto): Invoice {
     id: toInvoiceId(dto.id),
     invoice_number: dto.invoice_number ?? null,
     status: dto.status,
-    client_id: dto.client_id,
+    is_overdue: dto.is_overdue,
     is_qualified_invoice: dto.is_qualified_invoice,
     issued_at: dto.issued_at ?? null,
     due_at: dto.due_at ?? null,

--- a/frontend/src/entities/invoice/model.ts
+++ b/frontend/src/entities/invoice/model.ts
@@ -9,7 +9,8 @@ export interface Invoice {
   id: InvoiceId
   invoice_number: string | null
   status: InvoiceStatus
-  client_id: number
+  /** Computed: issued/partially_paid and due_at is in the past. */
+  is_overdue: boolean
   is_qualified_invoice: boolean
   issued_at: string | null
   due_at: string | null

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -68,7 +68,12 @@ export function ListInvoices() {
                     </Link>
                   </td>
                   <td className="py-stack-sm pr-inline-md">
-                    {t(`admin.invoices.status.${invoice.status}`)}
+                    <span>{t(`admin.invoices.status.${invoice.status}`)}</span>
+                    {invoice.is_overdue && (
+                      <span className="ml-inline-sm text-error text-caption font-medium">
+                        {t('admin.invoices.status.overdue')}
+                      </span>
+                    )}
                   </td>
                   <td className="py-stack-sm pr-inline-md">{invoice.client_id}</td>
                   <td className="py-stack-sm pr-inline-md text-right">

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -65,6 +65,11 @@ export function ViewInvoice({ invoiceId }: ViewInvoiceProps) {
         </div>
         <Stack direction="row" gap="md">
           <Text variant="muted">{t(`admin.invoices.status.${invoice.status}`)}</Text>
+          {invoice.is_overdue && (
+            <Text variant="muted" className="text-error font-medium">
+              {t('admin.invoices.status.overdue')}
+            </Text>
+          )}
           {invoice.is_qualified_invoice && (
             <Text variant="muted">{t('admin.invoices.detail.qualified')}</Text>
           )}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -336,6 +336,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/invoices/{id}/pdf": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier. */
+                id: components["parameters"]["IdPathParam"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Download invoice PDF
+         * @description Generates and streams the invoice as a PDF (適格請求書 layout when is_qualified_invoice is true). Requires ViewBilling capability. Returns application/pdf with Content-Disposition: attachment.
+         */
+        get: operations["getInvoicePdf"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/invoices/{id}/issue": {
         parameters: {
             query?: never;
@@ -580,6 +603,8 @@ export interface components {
             invoice_number?: string | null;
             /** @enum {string} */
             status: "draft" | "issued" | "partially_paid" | "paid";
+            /** @description Computed read-only field. True when status is issued or partially_paid and due_at is in the past. Always false for draft and paid invoices. */
+            is_overdue: boolean;
             is_qualified_invoice: boolean;
             issued_at?: string | null;
             due_at?: string | null;
@@ -1581,6 +1606,32 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InvoiceWithLines"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["InsufficientCapability"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getInvoicePdf: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier. */
+                id: components["parameters"]["IdPathParam"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description PDF binary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/pdf": string;
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -64,6 +64,7 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.status.issued': 'Issued',
   'admin.invoices.status.partially_paid': 'Partially paid',
   'admin.invoices.status.paid': 'Paid',
+  'admin.invoices.status.overdue': 'Overdue',
   'admin.invoices.pagination.prev': 'Previous',
   'admin.invoices.pagination.next': 'Next',
   'admin.invoices.pagination.info': 'Page {{page}} of {{total}}',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -66,6 +66,7 @@ export const jaMessages = {
   'admin.invoices.status.issued': '発行済み',
   'admin.invoices.status.partially_paid': '一部入金',
   'admin.invoices.status.paid': '入金済み',
+  'admin.invoices.status.overdue': '期限超過',
   'admin.invoices.pagination.prev': '前のページ',
   'admin.invoices.pagination.next': '次のページ',
   'admin.invoices.pagination.info': '{{page}} / {{total}} ページ',

--- a/frontend/tests/factories/invoice.ts
+++ b/frontend/tests/factories/invoice.ts
@@ -10,6 +10,7 @@ export function buildInvoiceDto(overrides: Partial<InvoiceDto> = {}): InvoiceDto
     organization_id: 1,
     client_id: 5,
     status: 'issued',
+    is_overdue: false,
     is_qualified_invoice: true,
     invoice_number: 'INV-2026-001',
     subtotal_cents: 106000,

--- a/src/Invoice/InvoiceResponse.php
+++ b/src/Invoice/InvoiceResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use DateTimeImmutable;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemResponse;
 
@@ -29,6 +30,7 @@ final class InvoiceResponse
             'quote_id' => $invoice->quoteId,
             'invoice_number' => $invoice->invoiceNumber,
             'status' => $invoice->status->value,
+            'is_overdue' => self::computeIsOverdue($invoice),
             'is_qualified_invoice' => $invoice->isQualifiedInvoice,
             'issued_at' => $invoice->issuedAt,
             'due_at' => $invoice->dueAt,
@@ -49,5 +51,18 @@ final class InvoiceResponse
         }
 
         return $data;
+    }
+
+    private static function computeIsOverdue(Invoice $invoice): bool
+    {
+        if ($invoice->status !== InvoiceStatus::Issued && $invoice->status !== InvoiceStatus::PartiallyPaid) {
+            return false;
+        }
+
+        if ($invoice->dueAt === null) {
+            return false;
+        }
+
+        return $invoice->dueAt < (new DateTimeImmutable())->format('Y-m-d H:i:s');
     }
 }

--- a/tests/Invoice/InvoiceResponseOverdueTest.php
+++ b/tests/Invoice/InvoiceResponseOverdueTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceResponse;
+use NeneInvoice\Invoice\InvoiceStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that InvoiceResponse::toArray sets is_overdue correctly.
+ *
+ * is_overdue is true iff status is issued/partially_paid AND due_at is in the past.
+ */
+final class InvoiceResponseOverdueTest extends TestCase
+{
+    public function test_issued_with_past_due_at_is_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Issued, '2020-01-01 00:00:00');
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertTrue($data['is_overdue']);
+    }
+
+    public function test_partially_paid_with_past_due_at_is_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::PartiallyPaid, '2020-01-01 00:00:00');
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertTrue($data['is_overdue']);
+    }
+
+    public function test_issued_with_future_due_at_is_not_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Issued, '2099-12-31 23:59:59');
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertFalse($data['is_overdue']);
+    }
+
+    public function test_issued_with_null_due_at_is_not_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Issued, null);
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertFalse($data['is_overdue']);
+    }
+
+    public function test_draft_is_never_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Draft, '2020-01-01 00:00:00');
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertFalse($data['is_overdue']);
+    }
+
+    public function test_paid_is_never_overdue(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Paid, '2020-01-01 00:00:00');
+        $data    = InvoiceResponse::toArray($invoice);
+
+        self::assertFalse($data['is_overdue']);
+    }
+
+    private function makeInvoice(InvoiceStatus $status, ?string $dueAt): Invoice
+    {
+        return new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: $status,
+            subtotalCents: 1000,
+            taxCents: 100,
+            totalCents: 1100,
+            dueAt: $dueAt,
+            id: 1,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

### バックエンド

- `InvoiceResponse::toArray()` に `is_overdue: bool` を追加（computed — DB カラム追加なし）
  - `status in [issued, partially_paid]` かつ `due_at < now()` のとき `true`
  - draft / paid は常に `false`; `due_at` が null でも `false`
- OpenAPI `Invoice` スキーマに `is_overdue: boolean`（required）を追加
- `npm run codegen` で `schema.gen.ts` を再生成

### フロントエンド

- `model.ts` — `is_overdue: boolean` を追加
- `mapper.ts` — DTO から `is_overdue` をマッピング
- 請求書**一覧**: status 列にインライン「期限超過」赤テキストバッジ
- 請求書**詳細**: status 行に「期限超過」バッジ
- i18n: `admin.invoices.status.overdue`（ja/en）

## Test plan

- [ ] バックエンド `composer check` green（PHPUnit 179 / PHPStan / CS / OpenAPI / MCP）
- [ ] フロントエンド `npm run check` green（42 tests）
- [ ] `due_at` が過去の発行済み請求書の一覧行に「期限超過」が表示される
- [ ] 同詳細画面でも「期限超過」が表示される
- [ ] 入金済み / 下書きには「期限超過」が表示されない
- [ ] `due_at` が未来の発行済み請求書には「期限超過」が表示されない

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)