### PR TITLE
feat(service-api): GET /api/clients/{id} — NeNe Clear 督促向けクライアント取得 (#140)

### DIFF
--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -185,6 +185,34 @@ paths:
           $ref: '#/components/responses/InsufficientScope'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/clients/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+    get:
+      tags: [ServiceInvoices]
+      summary: Get client (service)
+      description: >
+        Returns the client's contact information scoped to the service token's
+        organization. Used by NeNe Clear for dunning (督促): resolves
+        `contact_name` and `recipient_email` from an invoice's `client_id`
+        (contract §2.3).
+      operationId: getServiceClient
+      responses:
+        '200':
+          description: Client contact data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceClient'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientScope'
+        '404':
+          $ref: '#/components/responses/NotFound'
 components:
   securitySchemes:
     serviceToken:
@@ -233,6 +261,29 @@ components:
         status: { type: integer }
         detail: { type: string }
       required: [type, title, status]
+    ServiceClient:
+      type: object
+      description: >
+        Client (取引先) contact data for dunning. `recipient_email` maps to the
+        client's billing email in NeNe Invoice.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+          description: Client company name.
+        contact_name:
+          type: [string, 'null']
+          description: Primary contact person name.
+        recipient_email:
+          type: [string, 'null']
+          description: Billing / dunning email address (maps to `clients.email`).
+        billing_address:
+          type: [string, 'null']
+        registration_number:
+          type: [string, 'null']
+          description: Buyer's invoice registration number (T + 13 digits), if set.
+      required: [id, name]
     ServiceInvoice:
       type: object
       properties:

--- a/src/ServiceApi/GetServiceClientHandler.php
+++ b/src/ServiceApi/GetServiceClientHandler.php
@@ -43,7 +43,7 @@ final readonly class GetServiceClientHandler implements RequestHandlerInterface
         $client = $this->clients->findById($id);
 
         if ($client === null || $client->organizationId !== $organizationId || $client->isDeleted) {
-            return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'Client not found.');
+            return $this->problemDetails->create($request, 'client-not-found', 'Not Found', 404, 'Client not found.');
         }
 
         return $this->json->create([

--- a/src/ServiceApi/GetServiceClientHandler.php
+++ b/src/ServiceApi/GetServiceClientHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /api/clients/{id}` — returns client contact data for the service caller's
+ * organization (contract §2.3). Used by NeNe Clear for dunning (督促) to resolve
+ * the billing contact name and recipient email from a `client_id` on an invoice.
+ *
+ * `recipient_email` maps to `clients.email` — the same field the operator sees
+ * as "email" in the admin UI, renamed to match the upstream contract.
+ */
+final readonly class GetServiceClientHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ClientRepositoryInterface $clients,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
+            return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
+        }
+
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $client = $this->clients->findById($id);
+
+        if ($client === null || $client->organizationId !== $organizationId || $client->isDeleted) {
+            return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'Client not found.');
+        }
+
+        return $this->json->create([
+            'id'                  => $client->id,
+            'name'                => $client->name,
+            'contact_name'        => $client->contactName,
+            'recipient_email'     => $client->email,
+            'billing_address'     => $client->billingAddress,
+            'registration_number' => $client->registrationNumber,
+        ]);
+    }
+}

--- a/src/ServiceApi/ServiceApiRouteRegistrar.php
+++ b/src/ServiceApi/ServiceApiRouteRegistrar.php
@@ -19,6 +19,7 @@ final readonly class ServiceApiRouteRegistrar
         private GetServiceInvoiceHandler $getHandler,
         private RecordServicePaymentHandler $recordPaymentHandler,
         private VoidServicePaymentHandler $voidPaymentHandler,
+        private GetServiceClientHandler $getClientHandler,
     ) {
     }
 
@@ -28,10 +29,12 @@ final readonly class ServiceApiRouteRegistrar
         $get = $this->getHandler;
         $recordPayment = $this->recordPaymentHandler;
         $voidPayment = $this->voidPaymentHandler;
+        $getClient = $this->getClientHandler;
 
         $router->get('/api/invoices', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->get('/api/invoices/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
         $router->post('/api/invoices/{id}/payments', static fn (ServerRequestInterface $r) => $recordPayment->handle($r));
         $router->post('/api/invoices/{id}/payments/{paymentId}/void', static fn (ServerRequestInterface $r) => $voidPayment->handle($r));
+        $router->get('/api/clients/{id}', static fn (ServerRequestInterface $r) => $getClient->handle($r));
     }
 }

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
 use NeneInvoice\Payment\ListPaymentsUseCase;
@@ -63,18 +64,27 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
                 ),
             )
             ->set(
+                GetServiceClientHandler::class,
+                static fn (ContainerInterface $c): GetServiceClientHandler => new GetServiceClientHandler(
+                    self::resolve($c, ClientRepositoryInterface::class),
+                    self::json($c),
+                    self::problemDetails($c),
+                ),
+            )
+            ->set(
                 ServiceApiRouteRegistrar::class,
                 static function (ContainerInterface $c): ServiceApiRouteRegistrar {
                     $list = $c->get(ListServiceInvoicesHandler::class);
                     $get = $c->get(GetServiceInvoiceHandler::class);
                     $recordPayment = $c->get(RecordServicePaymentHandler::class);
                     $voidPayment = $c->get(VoidServicePaymentHandler::class);
+                    $getClient = $c->get(GetServiceClientHandler::class);
 
-                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler || !$recordPayment instanceof RecordServicePaymentHandler || !$voidPayment instanceof VoidServicePaymentHandler) {
+                    if (!$list instanceof ListServiceInvoicesHandler || !$get instanceof GetServiceInvoiceHandler || !$recordPayment instanceof RecordServicePaymentHandler || !$voidPayment instanceof VoidServicePaymentHandler || !$getClient instanceof GetServiceClientHandler) {
                         throw new LogicException('Service API handler services are invalid.');
                     }
 
-                    return new ServiceApiRouteRegistrar($list, $get, $recordPayment, $voidPayment);
+                    return new ServiceApiRouteRegistrar($list, $get, $recordPayment, $voidPayment, $getClient);
                 },
             );
     }

--- a/tests/ServiceApi/GetServiceClientHandlerTest.php
+++ b/tests/ServiceApi/GetServiceClientHandlerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Client\Client;
+use NeneInvoice\ServiceApi\GetServiceClientHandler;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class GetServiceClientHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+
+    private InMemoryClientRepository $clients;
+
+    private GetServiceClientHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->psr17    = new Psr17Factory();
+        $this->clients  = new InMemoryClientRepository();
+        $this->handler  = new GetServiceClientHandler(
+            $this->clients,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_returns_client_contact_data_for_service_caller(): void
+    {
+        $id = $this->clients->save(new Client(
+            organizationId: 1,
+            name: '株式会社テスト',
+            contactName: '山田太郎',
+            email: 'yamada@example.com',
+            billingAddress: '東京都渋谷区1-1-1',
+            registrationNumber: 'T1234567890123',
+        ));
+
+        $request = $this->psr17->createServerRequest('GET', "/api/clients/{$id}")
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $id]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('株式会社テスト', $body['name']);
+        self::assertSame('山田太郎', $body['contact_name']);
+        self::assertSame('yamada@example.com', $body['recipient_email']);
+        self::assertSame('東京都渋谷区1-1-1', $body['billing_address']);
+        self::assertSame('T1234567890123', $body['registration_number']);
+    }
+
+    public function test_returns_404_for_cross_org_client(): void
+    {
+        $id = $this->clients->save(new Client(organizationId: 2, name: '他社'));
+
+        $request = $this->psr17->createServerRequest('GET', "/api/clients/{$id}")
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $id]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_returns_404_for_nonexistent_client(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/api/clients/999')
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '999']);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_returns_403_when_no_org_in_token(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/api/clients/1')
+            ->withAttribute('nene2.auth.claims', ['scopes' => ['read:invoices']]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(403, $response->getStatusCode());
+    }
+}

--- a/tests/ServiceApi/GetServiceClientHandlerTest.php
+++ b/tests/ServiceApi/GetServiceClientHandlerTest.php
@@ -59,7 +59,7 @@ final class GetServiceClientHandlerTest extends TestCase
         self::assertSame('T1234567890123', $body['registration_number']);
     }
 
-    public function test_returns_404_for_cross_org_client(): void
+    public function test_returns_client_not_found_for_cross_org_client(): void
     {
         $id = $this->clients->save(new Client(organizationId: 2, name: '他社'));
 
@@ -69,9 +69,13 @@ final class GetServiceClientHandlerTest extends TestCase
 
         $response = $this->handler->handle($request);
         self::assertSame(404, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('client-not-found', (string) ($body['type'] ?? ''));
     }
 
-    public function test_returns_404_for_nonexistent_client(): void
+    public function test_returns_client_not_found_for_nonexistent_client(): void
     {
         $request = $this->psr17->createServerRequest('GET', '/api/clients/999')
             ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']])
@@ -79,6 +83,10 @@ final class GetServiceClientHandlerTest extends TestCase
 
         $response = $this->handler->handle($request);
         self::assertSame(404, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('client-not-found', (string) ($body['type'] ?? ''));
     }
 
     public function test_returns_403_when_no_org_in_token(): void


### PR DESCRIPTION
## Summary

NeNe Clear の `invoice-upstream-http-client-requirements.md` R3 を実装する。

### 実装内容

- `GET /api/clients/{id}` — org スコープで取引先の連絡先情報を返す（scope: `read:invoices`）
- レスポンス: `id`, `name`, `contact_name`, `recipient_email`（`clients.email`），`billing_address`, `registration_number`
- `recipient_email` は contract 命名に合わせて `clients.email` をリマップ
- 404: 存在しない / 他 org / 削除済み → cross-tenant 情報漏洩なし
- 403: サービストークンに org スコープなし

### 対応状況（nene-invoice 側の全ブロッカー解除）

| # | 要件 | 状態 |
|---|---|---|
| R1 | `GET /api/invoices` | ✅ |
| R2 | `GET /api/invoices/{id}` | ✅ |
| **R3** | **`GET /api/clients/{id}`** | ✅ **今回** |
| W1 | `POST /api/invoices/{id}/payments` | ✅ |
| W2 | `POST /api/invoices/{id}/payments/{paymentId}/void` | ✅ |
| A1–A5 | Auth / errors / OpenAPI / scoping | ✅ |

### テスト

`GetServiceClientHandlerTest` — 4 ケース（取得OK / cross-org 404 / 存在しない 404 / org なし 403）

## Test plan

- [ ] `composer check` green（PHPUnit 188 / PHPStan / CS / OpenAPI / MCP）
- [ ] `GET /api/clients/:id` にサービストークンでリクエスト → 200 + 連絡先情報
- [ ] 他 org の client_id → 404
- [ ] 存在しない ID → 404

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)