### PR TITLE
test(backend): ユニットテストのカバレッジ漏れを補完（+40 tests）

### DIFF
--- a/tests/Company/PdoCompanySettingsRepositoryTest.php
+++ b/tests/Company/PdoCompanySettingsRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Company;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Company\PdoCompanySettingsRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PdoCompanySettingsRepository: upsert logic (save on empty → insert,
+ * save again → update), org isolation, and field round-trip.
+ */
+final class PdoCompanySettingsRepositoryTest extends TestCase
+{
+    private PdoCompanySettingsRepository $repo;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/company_settings.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repo = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_find_returns_null_when_not_set(): void
+    {
+        self::assertNull($this->repo->findByOrganization(1));
+    }
+
+    public function test_save_inserts_and_read_back(): void
+    {
+        $settings = new CompanySettings(
+            organizationId: 1,
+            legalName: '株式会社テスト',
+            address: '東京都渋谷区1-1-1',
+            phone: '03-0000-0000',
+            email: 'info@example.com',
+            registrationNumber: 'T1234567890123',
+            bankName: 'テスト銀行',
+            bankBranch: '渋谷支店',
+            accountType: '普通',
+            accountNumber: '1234567',
+        );
+
+        $this->repo->save($settings);
+
+        $found = $this->repo->findByOrganization(1);
+        self::assertNotNull($found);
+        self::assertSame('株式会社テスト', $found->legalName);
+        self::assertSame('T1234567890123', $found->registrationNumber);
+        self::assertSame('テスト銀行', $found->bankName);
+        self::assertSame('1234567', $found->accountNumber);
+    }
+
+    public function test_save_updates_existing_record(): void
+    {
+        $this->repo->save(new CompanySettings(organizationId: 1, legalName: '旧社名'));
+        $this->repo->save(new CompanySettings(organizationId: 1, legalName: '新社名', registrationNumber: 'T9999999999999'));
+
+        $found = $this->repo->findByOrganization(1);
+        self::assertNotNull($found);
+        self::assertSame('新社名', $found->legalName);
+        self::assertSame('T9999999999999', $found->registrationNumber);
+    }
+
+    public function test_orgs_are_isolated(): void
+    {
+        $this->repo->save(new CompanySettings(organizationId: 1, legalName: 'Org 1'));
+        $this->repo->save(new CompanySettings(organizationId: 2, legalName: 'Org 2'));
+
+        self::assertSame('Org 1', $this->repo->findByOrganization(1)?->legalName);
+        self::assertSame('Org 2', $this->repo->findByOrganization(2)?->legalName);
+        self::assertNull($this->repo->findByOrganization(3));
+    }
+
+    public function test_optional_fields_are_nullable(): void
+    {
+        $this->repo->save(new CompanySettings(organizationId: 1, legalName: 'Minimal'));
+
+        $found = $this->repo->findByOrganization(1);
+        self::assertNotNull($found);
+        self::assertNull($found->address);
+        self::assertNull($found->registrationNumber);
+        self::assertNull($found->bankName);
+    }
+}

--- a/tests/Dashboard/GetDashboardHandlerTest.php
+++ b/tests/Dashboard/GetDashboardHandlerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Dashboard;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Dashboard\GetDashboardHandler;
+use NeneInvoice\Dashboard\GetDashboardSummaryUseCase;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class GetDashboardHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryPaymentRepository $payments;
+    private GetDashboardHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->psr17    = new Psr17Factory();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->payments = new InMemoryPaymentRepository();
+
+        $this->handler = new GetDashboardHandler(
+            new GetDashboardSummaryUseCase($this->invoices, $this->payments),
+            $this->payments,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_returns_summary_json_for_empty_org(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/admin/dashboard')
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 1]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(0, $body['unpaid_count']);
+        self::assertSame(0, $body['overdue_count']);
+        self::assertSame(0, $body['outstanding_total_cents']);
+        self::assertSame([], $body['recent_unpaid']);
+    }
+
+    public function test_returns_correct_counts_with_invoices(): void
+    {
+        $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 1000,
+            taxCents: 0,
+            totalCents: 1000,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-01 00:00:00',
+            dueAt: '2020-01-01 00:00:00', // overdue
+        ));
+        $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::PartiallyPaid,
+            subtotalCents: 2000,
+            taxCents: 0,
+            totalCents: 2000,
+            invoiceNumber: 'INV-2026-002',
+            issuedAt: '2026-05-01 00:00:00',
+        ));
+        $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Paid,
+            subtotalCents: 500,
+            taxCents: 0,
+            totalCents: 500,
+        ));
+
+        $request = $this->psr17->createServerRequest('GET', '/admin/dashboard')
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 1]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(2, $body['unpaid_count']);
+        self::assertSame(1, $body['overdue_count']);
+        self::assertCount(2, $body['recent_unpaid']);
+    }
+
+    public function test_returns_400_without_org_context(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/admin/dashboard');
+
+        $response = $this->handler->handle($request);
+        self::assertSame(400, $response->getStatusCode());
+    }
+}

--- a/tests/DocumentSequence/PdoDocumentSequenceRepositoryTest.php
+++ b/tests/DocumentSequence/PdoDocumentSequenceRepositoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\DocumentSequence;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\DocumentSequence\DocumentType;
+use NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Direct tests for PdoDocumentSequenceRepository: atomic allocation logic,
+ * org/type/year isolation, and INSERT-fallback-on-conflict behaviour.
+ */
+final class PdoDocumentSequenceRepositoryTest extends TestCase
+{
+    private PdoDocumentSequenceRepository $repo;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/document_sequences.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repo = new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_first_call_initialises_at_one(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+    }
+
+    public function test_subsequent_calls_increment(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(3, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+    }
+
+    public function test_isolated_by_document_type(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+    }
+
+    public function test_isolated_by_organization(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(2, DocumentType::Quote->value, 2026));
+    }
+
+    public function test_isolated_by_year(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2025));
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+    }
+
+    public function test_mixed_interleaving_stays_correct(): void
+    {
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(3, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+    }
+}

--- a/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
+++ b/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\InvoiceDownloadToken;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
+use NeneInvoice\InvoiceDownloadToken\DownloadInvoicePdfHandler;
+use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadToken;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class DownloadInvoicePdfHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryInvoiceDownloadTokenRepository $tokens;
+    private DownloadInvoicePdfHandler $handler;
+    private int $invoiceId;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+
+        $invoices    = new InMemoryInvoiceRepository();
+        $lineItems   = new InMemoryLineItemRepository();
+        $payments    = new InMemoryPaymentRepository();
+        $clients     = new InMemoryClientRepository();
+        $company     = new InMemoryCompanySettingsRepository();
+        $this->tokens = new InMemoryInvoiceDownloadTokenRepository();
+
+        $clientId = $clients->save(new Client(organizationId: 1, name: '株式会社テスト'));
+        $company->save(new CompanySettings(organizationId: 1, legalName: '発行者テスト'));
+        $this->invoiceId = $invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: $clientId,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 10000,
+            taxCents: 1000,
+            totalCents: 11000,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-01 00:00:00',
+        ));
+
+        $this->handler = new DownloadInvoicePdfHandler(
+            $this->tokens,
+            new GenerateInvoicePdfUseCase($invoices, $lineItems, $payments, $company, $clients),
+            new InvoicePdfGenerator(new TaxCalculator()),
+            $this->psr17,
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_streams_pdf_for_valid_token(): void
+    {
+        $rawToken  = 'valid-test-token-abc123';
+        $tokenHash = hash('sha256', $rawToken);
+        $this->tokens->save(new InvoiceDownloadToken(
+            invoiceId: $this->invoiceId,
+            organizationId: 1,
+            tokenHash: $tokenHash,
+            expiresAt: '2099-12-31 23:59:59',
+            createdAt: '2026-05-31 00:00:00',
+        ));
+
+        $request = $this->psr17->createServerRequest('GET', "/invoices/download/{$rawToken}")
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['token' => $rawToken]);
+
+        $response = $this->handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/pdf', $response->getHeaderLine('Content-Type'));
+        self::assertStringStartsWith('inline;', $response->getHeaderLine('Content-Disposition'));
+        self::assertStringStartsWith('%PDF-', (string) $response->getBody());
+    }
+
+    public function test_returns_404_for_expired_token(): void
+    {
+        $rawToken  = 'expired-token-xyz';
+        $tokenHash = hash('sha256', $rawToken);
+        $this->tokens->save(new InvoiceDownloadToken(
+            invoiceId: $this->invoiceId,
+            organizationId: 1,
+            tokenHash: $tokenHash,
+            expiresAt: '2020-01-01 00:00:00',
+            createdAt: '2019-12-25 00:00:00',
+        ));
+
+        $request = $this->psr17->createServerRequest('GET', "/invoices/download/{$rawToken}")
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['token' => $rawToken]);
+
+        self::assertSame(404, $this->handler->handle($request)->getStatusCode());
+    }
+
+    public function test_returns_404_for_unknown_token(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/invoices/download/no-such-token')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['token' => 'no-such-token']);
+
+        self::assertSame(404, $this->handler->handle($request)->getStatusCode());
+    }
+
+    public function test_pdf_filename_contains_invoice_number(): void
+    {
+        $rawToken  = 'filename-test-token';
+        $this->tokens->save(new InvoiceDownloadToken(
+            invoiceId: $this->invoiceId,
+            organizationId: 1,
+            tokenHash: hash('sha256', $rawToken),
+            expiresAt: '2099-12-31 23:59:59',
+            createdAt: '2026-05-31 00:00:00',
+        ));
+
+        $request = $this->psr17->createServerRequest('GET', "/invoices/download/{$rawToken}")
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['token' => $rawToken]);
+
+        $response = $this->handler->handle($request);
+        self::assertStringContainsString('INV-2026-001', $response->getHeaderLine('Content-Disposition'));
+    }
+}

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\InvoiceDownloadToken;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenHandler;
+use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
+use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class GenerateDownloadTokenHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryInvoiceRepository $invoices;
+    private GenerateDownloadTokenHandler $handler;
+    private int $invoiceId;
+
+    protected function setUp(): void
+    {
+        $this->psr17    = new Psr17Factory();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $tokens         = new InMemoryInvoiceDownloadTokenRepository();
+
+        $this->invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 1000,
+            taxCents: 0,
+            totalCents: 1000,
+        ));
+
+        $this->handler = new GenerateDownloadTokenHandler(
+            new GenerateDownloadTokenUseCase($this->invoices, $tokens),
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_generates_token_and_returns_url(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/download-token")
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 1])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(201, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertStringStartsWith('/invoices/download/', (string) $body['url']);
+        self::assertNotEmpty($body['expires_at']);
+    }
+
+    public function test_returns_400_without_org_context(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/invoices/1/download-token')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '1']);
+
+        self::assertSame(400, $this->handler->handle($request)->getStatusCode());
+    }
+
+    public function test_throws_invoice_not_found_for_cross_org_invoice(): void
+    {
+        // InvoiceNotFoundException propagates to InvoiceNotFoundExceptionHandler in production.
+        // Unit tests exercise the handler in isolation, so we assert the exception directly.
+        $this->expectException(\NeneInvoice\Invoice\InvoiceNotFoundException::class);
+
+        $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/download-token")
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 2])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
+
+        $this->handler->handle($request);
+    }
+}

--- a/tests/InvoiceDownloadToken/PdoInvoiceDownloadTokenRepositoryTest.php
+++ b/tests/InvoiceDownloadToken/PdoInvoiceDownloadTokenRepositoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\InvoiceDownloadToken;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadToken;
+use NeneInvoice\InvoiceDownloadToken\PdoInvoiceDownloadTokenRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoInvoiceDownloadTokenRepositoryTest extends TestCase
+{
+    private PdoInvoiceDownloadTokenRepository $repo;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/invoice_download_tokens.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->repo = new PdoInvoiceDownloadTokenRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_saves_and_finds_by_hash(): void
+    {
+        $token = new InvoiceDownloadToken(
+            invoiceId: 5,
+            organizationId: 1,
+            tokenHash: hash('sha256', 'raw-token-abc'),
+            expiresAt: '2026-06-07 00:00:00',
+            createdAt: '2026-05-31 00:00:00',
+        );
+
+        $id = $this->repo->save($token);
+        self::assertGreaterThan(0, $id);
+
+        $found = $this->repo->findByHash(hash('sha256', 'raw-token-abc'));
+        self::assertNotNull($found);
+        self::assertSame(5, $found->invoiceId);
+        self::assertSame(1, $found->organizationId);
+        self::assertSame('2026-06-07 00:00:00', $found->expiresAt);
+        self::assertSame($id, $found->id);
+    }
+
+    public function test_find_returns_null_for_unknown_hash(): void
+    {
+        self::assertNull($this->repo->findByHash(hash('sha256', 'no-such-token')));
+    }
+
+    public function test_is_expired_returns_true_for_past_expiry(): void
+    {
+        $token = new InvoiceDownloadToken(
+            invoiceId: 1,
+            organizationId: 1,
+            tokenHash: hash('sha256', 'expired-token'),
+            expiresAt: '2020-01-01 00:00:00',
+            createdAt: '2019-12-25 00:00:00',
+        );
+        $this->repo->save($token);
+
+        $found = $this->repo->findByHash(hash('sha256', 'expired-token'));
+        self::assertNotNull($found);
+        self::assertTrue($found->isExpired('2026-05-31 00:00:00'));
+    }
+
+    public function test_is_expired_returns_false_for_future_expiry(): void
+    {
+        $token = new InvoiceDownloadToken(
+            invoiceId: 1,
+            organizationId: 1,
+            tokenHash: hash('sha256', 'valid-token'),
+            expiresAt: '2099-12-31 23:59:59',
+            createdAt: '2026-05-31 00:00:00',
+        );
+        $this->repo->save($token);
+
+        $found = $this->repo->findByHash(hash('sha256', 'valid-token'));
+        self::assertNotNull($found);
+        self::assertFalse($found->isExpired('2026-05-31 00:00:00'));
+    }
+}

--- a/tests/Payment/ListPaymentsUseCaseTest.php
+++ b/tests/Payment/ListPaymentsUseCaseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Payment;
+
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\ListPaymentsUseCase;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ListPaymentsUseCaseTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryPaymentRepository $payments;
+    private ListPaymentsUseCase $useCase;
+    private int $invoiceId;
+
+    protected function setUp(): void
+    {
+        $this->invoices  = new InMemoryInvoiceRepository();
+        $this->payments  = new InMemoryPaymentRepository();
+        $this->useCase   = new ListPaymentsUseCase($this->payments, $this->invoices);
+        $this->invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 10000,
+            taxCents: 1000,
+            totalCents: 11000,
+        ));
+    }
+
+    public function test_returns_payments_for_invoice(): void
+    {
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $this->invoiceId, amountCents: 5000, paidAt: '2026-05-01 00:00:00'));
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $this->invoiceId, amountCents: 6000, paidAt: '2026-05-10 00:00:00'));
+
+        $list = $this->useCase->execute(1, $this->invoiceId);
+
+        self::assertCount(2, $list);
+        self::assertSame(5000, $list[0]->amountCents);
+        self::assertSame(6000, $list[1]->amountCents);
+    }
+
+    public function test_returns_empty_when_no_payments(): void
+    {
+        $list = $this->useCase->execute(1, $this->invoiceId);
+        self::assertCount(0, $list);
+    }
+
+    public function test_throws_for_cross_org_invoice(): void
+    {
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->execute(2, $this->invoiceId);
+    }
+
+    public function test_throws_for_nonexistent_invoice(): void
+    {
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->execute(1, 9999);
+    }
+
+    public function test_excludes_payments_of_other_invoices(): void
+    {
+        $otherId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 1000,
+            taxCents: 0,
+            totalCents: 1000,
+        ));
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $otherId, amountCents: 999, paidAt: '2026-05-01 00:00:00'));
+
+        $list = $this->useCase->execute(1, $this->invoiceId);
+        self::assertCount(0, $list);
+    }
+}

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Quote\CreateQuoteInput;
+use NeneInvoice\Quote\CreateQuoteUseCase;
+use NeneInvoice\Quote\GetQuoteByIdUseCase;
+use NeneInvoice\Quote\ListQuotesUseCase;
+use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for GetQuoteByIdUseCase and ListQuotesUseCase:
+ * org-scope isolation, line-item inclusion, and pagination.
+ */
+final class QuoteQueryUseCasesTest extends TestCase
+{
+    private InMemoryQuoteRepository $quotes;
+    private InMemoryLineItemRepository $lineItems;
+    private ?int $quoteId;
+
+    protected function setUp(): void
+    {
+        $this->quotes    = new InMemoryQuoteRepository();
+        $this->lineItems = new InMemoryLineItemRepository();
+        $clients         = new InMemoryClientRepository();
+        $clientId        = $clients->save(new Client(organizationId: 1, name: 'Acme'));
+
+        $createUseCase = new CreateQuoteUseCase(
+            $this->quotes,
+            $this->lineItems,
+            $clients,
+            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
+            new TaxCalculator(),
+            new RecordingAuditRecorder(),
+        );
+
+        $this->quoteId = $createUseCase->execute(1, null, new CreateQuoteInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('コンサル', 1, 50000, 1000)],
+            validUntil: null,
+            notes: null,
+        ))->quote->id;
+    }
+
+    // ----------------------------- GetQuoteById -----------------------------
+
+    public function test_get_returns_quote_with_line_items(): void
+    {
+        self::assertNotNull($this->quoteId);
+        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
+        $result  = $useCase->execute(1, $this->quoteId);
+
+        self::assertSame($this->quoteId, $result->quote->id);
+        self::assertCount(1, $result->lines);
+        self::assertSame('コンサル', $result->lines[0]->description);
+    }
+
+    public function test_get_hides_quote_from_another_organization(): void
+    {
+        self::assertNotNull($this->quoteId);
+        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
+
+        $this->expectException(QuoteNotFoundException::class);
+        $useCase->execute(2, $this->quoteId);
+    }
+
+    public function test_get_throws_for_nonexistent_id(): void
+    {
+        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
+
+        $this->expectException(QuoteNotFoundException::class);
+        $useCase->execute(1, 9999);
+    }
+
+    // ------------------------------ ListQuotes ------------------------------
+
+    public function test_list_is_scoped_to_organization(): void
+    {
+        $clients2  = new InMemoryClientRepository();
+        $client2Id = $clients2->save(new Client(organizationId: 2, name: 'OtherOrg'));
+        $quotes2   = new InMemoryQuoteRepository();
+
+        (new CreateQuoteUseCase(
+            $quotes2,
+            new InMemoryLineItemRepository(),
+            $clients2,
+            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
+            new TaxCalculator(),
+            new RecordingAuditRecorder(),
+        ))->execute(2, null, new CreateQuoteInput(
+            clientId: $client2Id,
+            lines: [new LineItemInput('Other', 1, 10000, 1000)],
+            validUntil: null,
+            notes: null,
+        ));
+
+        $useCase = new ListQuotesUseCase($this->quotes);
+
+        // org 1 sees 1 quote, org 2 sees its own separately
+        self::assertSame(1, $useCase->execute(1, 20, 0)->total);
+        self::assertSame(0, $useCase->execute(2, 20, 0)->total);
+    }
+
+    public function test_list_pagination_limit_and_offset(): void
+    {
+        $clients = new InMemoryClientRepository();
+        $cid     = $clients->save(new Client(organizationId: 1, name: 'Acme'));
+        $create  = new CreateQuoteUseCase(
+            $this->quotes,
+            $this->lineItems,
+            $clients,
+            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
+            new TaxCalculator(),
+            new RecordingAuditRecorder(),
+        );
+
+        // setUp already has 1 quote; add 4 more
+        for ($i = 0; $i < 4; $i++) {
+            $create->execute(1, null, new CreateQuoteInput(
+                clientId: $cid,
+                lines: [new LineItemInput("Item {$i}", 1, 1000, 1000)],
+                validUntil: null,
+                notes: null,
+            ));
+        }
+
+        $useCase = new ListQuotesUseCase($this->quotes);
+        $page    = $useCase->execute(1, 3, 0);
+        self::assertSame(5, $page->total);
+        self::assertCount(3, $page->items);
+
+        $page2 = $useCase->execute(1, 3, 3);
+        self::assertCount(2, $page2->items);
+    }
+}

--- a/tests/ServiceApi/VoidServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/VoidServicePaymentHandlerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceApi;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Payment\VoidPaymentUseCase;
+use NeneInvoice\ServiceApi\VoidServicePaymentHandler;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class VoidServicePaymentHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryInvoiceRepository $invoices;
+    private InMemoryPaymentRepository $payments;
+    private VoidServicePaymentHandler $handler;
+    private int $invoiceId;
+    private int $paymentId;
+
+    protected function setUp(): void
+    {
+        $this->psr17    = new Psr17Factory();
+        $this->invoices = new InMemoryInvoiceRepository();
+        $this->payments = new InMemoryPaymentRepository();
+
+        $this->invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: InvoiceStatus::Paid,
+            subtotalCents: 1000,
+            taxCents: 0,
+            totalCents: 1000,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-01 00:00:00',
+        ));
+        $this->paymentId = $this->payments->save(new Payment(
+            organizationId: 1,
+            invoiceId: $this->invoiceId,
+            amountCents: 1000,
+            paidAt: '2026-05-10 00:00:00',
+            externalReference: 'clear-ref-001',
+        ));
+
+        $this->handler = new VoidServicePaymentHandler(
+            new VoidPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder()),
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    public function test_voids_payment_and_returns_json(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/api/invoices/{$this->invoiceId}/payments/{$this->paymentId}/void")
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['write:payments']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId, 'paymentId' => (string) $this->paymentId]);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertTrue($body['payment']['voided']);
+        self::assertSame(0, $body['total_paid_cents']);
+    }
+
+    public function test_reason_field_is_optional(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/api/invoices/{$this->invoiceId}/payments/{$this->paymentId}/void")
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['write:payments']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId, 'paymentId' => (string) $this->paymentId])
+            ->withBody($this->psr17->createStream('{"reason":"reconciliation reversal"}'));
+
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_returns_403_without_org_in_token(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', '/api/invoices/1/payments/1/void')
+            ->withAttribute('nene2.auth.claims', ['scopes' => ['write:payments']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '1', 'paymentId' => '1']);
+
+        $response = $this->handler->handle($request);
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_throws_payment_not_found_for_cross_org(): void
+    {
+        // VoidPaymentUseCase throws PaymentNotFoundException for cross-org access.
+        // In production this is handled by PaymentNotFoundExceptionHandler.
+        $this->expectException(\NeneInvoice\Payment\PaymentNotFoundException::class);
+
+        $request = $this->psr17->createServerRequest('POST', "/api/invoices/{$this->invoiceId}/payments/{$this->paymentId}/void")
+            ->withAttribute('nene2.auth.claims', ['org' => 2, 'scopes' => ['write:payments']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId, 'paymentId' => (string) $this->paymentId]);
+
+        $this->handler->handle($request);
+    }
+
+    public function test_idempotent_on_already_voided_payment(): void
+    {
+        $params = ['id' => (string) $this->invoiceId, 'paymentId' => (string) $this->paymentId];
+        $makeReq = fn () => $this->psr17->createServerRequest('POST', '/void')
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['write:payments']])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, $params);
+
+        self::assertSame(200, $this->handler->handle($makeReq())->getStatusCode());
+        // Second void of the same payment is idempotent
+        self::assertSame(200, $this->handler->handle($makeReq())->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary

バックエンドのテストカバレッジを精査し、漏れていたユニットテストを補完。191 → 231 tests（882 assertions）green。

### 追加テスト

**Query UseCase（org スコープ分離・ページング）**
- `Quote/QuoteQueryUseCasesTest` — GetQuoteByIdUseCase / ListQuotesUseCase
- `Payment/ListPaymentsUseCaseTest` — cross-org 404、他請求書の入金除外

**Repository（直接テスト）**
- `DocumentSequence/PdoDocumentSequenceRepositoryTest` — 採番の org/type/year 分離、連番
- `InvoiceDownloadToken/PdoInvoiceDownloadTokenRepositoryTest` — hash 保存/検索、isExpired
- `Company/PdoCompanySettingsRepositoryTest` — upsert（insert/update 分岐）、org 分離

**HTTP Handler**
- `Dashboard/GetDashboardHandlerTest` — サマリー JSON、件数計算、org 必須
- `InvoiceDownloadToken/GenerateDownloadTokenHandlerTest` — トークン生成、cross-org
- `InvoiceDownloadToken/DownloadInvoicePdfHandlerTest` — PDF 配信、期限切れ/不正トークン 404
- `ServiceApi/VoidServicePaymentHandlerTest` — void、冪等、cross-org、403

## Test plan

- [ ] `composer check` green（PHPUnit 231 / PHPStan level 8 / CS / OpenAPI / MCP）

🤖 Generated with [Claude Code](https://claude.com/claude-code)