### PR TITLE
feat(tenancy): マルチテナント基盤 — OrgResolver + RequestScopedHolder + OrgGuard (#147)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -121,7 +121,9 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `invalid-credentials` | Login failed — wrong email or password |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `insufficient-capability` | Authenticated but lacks required capability |
-| `organization-not-resolved` | Tenant could not be resolved for the request |
+| `organization-not-resolved` | Tenant could not be resolved for the request (404; OrgResolverMiddleware) |
+| `organization-inactive` | Resolved organization is inactive (403; OrgResolverMiddleware) |
+| `organization-mismatch` | Authenticated user's org does not match the URL-resolved org (403; OrgGuardMiddleware) |
 | `invalid-state-transition` | Disallowed status change |
 | `company-settings-not-found` | Issuer profile not configured for the organization (404) |
 | `qualified-invoice-incomplete` | Missing required qualified-invoice field |

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -52,9 +52,23 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     public const ROUTE_REGISTRARS = 'nene-invoice.route_registrars';
     public const EXCEPTION_HANDLERS = 'nene-invoice.exception_handlers';
 
+    /**
+     * Container key for the shared RequestScopedHolder<int> carrying the resolved
+     * organization id. OrgResolverMiddleware writes it; every Pdo*Repository reads
+     * it to scope queries. One instance per request (shared-nothing model).
+     */
+    public const ORG_ID_HOLDER = 'nene-invoice.org_id_holder';
+
     public function register(ContainerBuilder $builder): void
     {
         $builder
+            ->set(
+                self::ORG_ID_HOLDER,
+                static function (): \Nene2\Http\RequestScopedHolder {
+                    /** @var \Nene2\Http\RequestScopedHolder<int> */
+                    return new \Nene2\Http\RequestScopedHolder();
+                },
+            )
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {

--- a/src/Auth/OrgGuardMiddleware.php
+++ b/src/Auth/OrgGuardMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Cross-checks the authenticated user's organization against the organization
+ * resolved from the request URL (ADR 0006). Runs after BearerTokenMiddleware
+ * (so the token claims are available) and after OrgResolverMiddleware (so the
+ * resolved org id is on the request attribute `nene2.org.id`).
+ *
+ * A member of org A must not operate on org B's URL even with a valid token.
+ * Superadmin (token `org` claim null) is exempt — it manages organizations
+ * cross-tenant. Routes that bypass org resolution (no `nene2.org.id`) pass
+ * through; their isolation is enforced elsewhere (service scope / public token).
+ */
+final readonly class OrgGuardMiddleware implements MiddlewareInterface
+{
+    private const ORG_ID_ATTRIBUTE = 'nene2.org.id';
+    private const CLAIMS_ATTRIBUTE = 'nene2.auth.claims';
+
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails)
+    {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $resolvedOrgId = $request->getAttribute(self::ORG_ID_ATTRIBUTE);
+
+        // No resolved org (bypass route) → nothing to guard here.
+        if (!is_int($resolvedOrgId)) {
+            return $handler->handle($request);
+        }
+
+        $claims = $request->getAttribute(self::CLAIMS_ATTRIBUTE);
+
+        // No verified claims (public route) → let auth/capability decide.
+        if (!is_array($claims)) {
+            return $handler->handle($request);
+        }
+
+        $tokenOrg = $claims['org'] ?? null;
+
+        // Superadmin (org null) operates cross-tenant.
+        if ($tokenOrg === null) {
+            return $handler->handle($request);
+        }
+
+        if (!is_int($tokenOrg) || $tokenOrg !== $resolvedOrgId) {
+            return $this->problemDetails->create(
+                $request,
+                'organization-mismatch',
+                'Forbidden',
+                403,
+                'Your account does not belong to this organization.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -15,6 +15,8 @@ use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Routing\Router;
@@ -22,6 +24,7 @@ use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Auth\AuthServiceProvider;
 use NeneInvoice\Auth\CapabilityMiddleware;
+use NeneInvoice\Auth\OrgGuardMiddleware;
 use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\Dashboard\DashboardServiceProvider;
@@ -29,7 +32,13 @@ use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
 use NeneInvoice\Invoice\InvoiceServiceProvider;
 use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadTokenServiceProvider;
 use NeneInvoice\LineItem\LineItemServiceProvider;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
 use NeneInvoice\Organization\OrganizationServiceProvider;
+use NeneInvoice\Organization\Resolution\CustomDomainResolutionStrategy;
+use NeneInvoice\Organization\Resolution\EnvResolutionStrategy;
+use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
+use NeneInvoice\Organization\Resolution\PathPrefixResolutionStrategy;
+use NeneInvoice\Organization\Resolution\SubdomainResolutionStrategy;
 use NeneInvoice\Payment\PaymentServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
 use NeneInvoice\ServiceApi\ServiceApiServiceProvider;
@@ -169,6 +178,45 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Service scope middleware service is invalid.');
                     }
 
+                    // --- Org resolution (ADR 0006): resolve tenant from the URL,
+                    // store in the shared holder, and guard token org == resolved org. ---
+                    $orgIdHolder = $container->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+                    if (!$orgIdHolder instanceof RequestScopedHolder) {
+                        throw new LogicException('Org id holder service is invalid.');
+                    }
+                    /** @var RequestScopedHolder<int> $orgIdHolder */
+
+                    $orgRepository = $container->get(OrganizationRepositoryInterface::class);
+
+                    if (!$orgRepository instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                    }
+
+                    $mode   = self::env('TENANT_RESOLUTION', 'single');
+                    $slug   = self::env('ORG_SLUG', '');
+                    $domain = self::env('BASE_DOMAIN', 'localhost');
+
+                    $strategy = match ($mode) {
+                        'subdomain'     => new SubdomainResolutionStrategy($domain),
+                        'path'          => new PathPrefixResolutionStrategy(),
+                        'custom_domain' => new CustomDomainResolutionStrategy(),
+                        default         => new EnvResolutionStrategy($slug),
+                    };
+
+                    // Sole-org fallback only in single (env) mode: a one-tenant
+                    // install needs no ORG_SLUG.
+                    $soleOrgFallback = !in_array($mode, ['subdomain', 'path', 'custom_domain'], true);
+
+                    $orgResolverMiddleware = new OrgResolverMiddleware($orgIdHolder, $orgRepository, $problemDetails, $strategy, $soleOrgFallback);
+                    $orgGuardMiddleware    = new OrgGuardMiddleware($problemDetails);
+
                     $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
 
                     if (!is_array($routeRegistrars) || !array_is_list($routeRegistrars)) {
@@ -190,7 +238,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         streamFactory: $psr17,
                         domainExceptionHandlers: $exceptionHandlers,
                         routeRegistrars: $routeRegistrars,
-                        authMiddleware: [$bearerTokenMiddleware, $capabilityMiddleware, $serviceScopeMiddleware],
+                        authMiddleware: [$orgResolverMiddleware, $bearerTokenMiddleware, $orgGuardMiddleware, $capabilityMiddleware, $serviceScopeMiddleware],
                         healthChecks: [$databaseHealthCheck],
                         debug: $config->debug,
                     );
@@ -209,5 +257,16 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(ResponseEmitter::class, static fn (ContainerInterface $container): ResponseEmitter => new ResponseEmitter());
+    }
+
+    /**
+     * Reads an environment variable loaded by the Dotenv ConfigLoader, falling
+     * back to a default. Tenant-resolution settings are env-driven (ADR 0006).
+     */
+    private static function env(string $key, string $default): string
+    {
+        $value = $_ENV[$key] ?? getenv($key);
+
+        return is_string($value) && $value !== '' ? $value : $default;
     }
 }

--- a/src/Organization/Resolution/CustomDomainResolutionStrategy.php
+++ b/src/Organization/Resolution/CustomDomainResolutionStrategy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the org by its full custom domain: org1.com → looked up against
+ * organizations.custom_domain. Use when tenants bring their own domain
+ * (CNAME → this server). Returns the raw Host header; the middleware resolves
+ * it via {@see \NeneInvoice\Organization\OrganizationRepositoryInterface::findByCustomDomain()}.
+ */
+final readonly class CustomDomainResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        $host = $request->getUri()->getHost();
+
+        if (str_contains($host, ':')) {
+            $host = explode(':', $host)[0];
+        }
+
+        return $host !== '' ? $host : null;
+    }
+}

--- a/src/Organization/Resolution/EnvResolutionStrategy.php
+++ b/src/Organization/Resolution/EnvResolutionStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the org slug from the ORG_SLUG environment variable.
+ *
+ * Intended for single-organization installs (the Tier A default) and local
+ * development. Returns null when ORG_SLUG is not set — the middleware then
+ * applies its sole-organization fallback (see {@see OrgResolverMiddleware}).
+ */
+final readonly class EnvResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function __construct(private string $orgSlug)
+    {
+    }
+
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        return $this->orgSlug !== '' ? $this->orgSlug : null;
+    }
+}

--- a/src/Organization/Resolution/OrgResolutionStrategyInterface.php
+++ b/src/Organization/Resolution/OrgResolutionStrategyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the organization slug (or custom-domain identifier) from an incoming
+ * HTTP request. Implementations cover the resolution modes of ADR 0006:
+ *
+ *  - {@see EnvResolutionStrategy}          — ORG_SLUG env var (single / dev)
+ *  - {@see PathPrefixResolutionStrategy}   — /org1/admin/... → "org1"
+ *  - {@see SubdomainResolutionStrategy}    — org1.example.com → "org1"
+ *  - {@see CustomDomainResolutionStrategy} — org1.com → looked up by custom_domain
+ *
+ * Returns null when this strategy cannot determine an org from the request.
+ */
+interface OrgResolutionStrategyInterface
+{
+    public function resolve(ServerRequestInterface $request): ?string;
+}

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Resolves the current organization from the request and stores its id in a
+ * shared {@see RequestScopedHolder} that downstream repositories read to scope
+ * every query (ADR 0006). This is the single point where tenant context enters
+ * the request, making per-query org filtering impossible to forget.
+ *
+ * Bypass paths (superadmin org management, health, auth, service API, public
+ * download) skip resolution and pass through with the holder unset. Repositories
+ * on those routes must not call {@see RequestScopedHolder::get()}.
+ *
+ * Resolution:
+ *  1. strategy->resolve() → slug or custom-domain identifier
+ *  2. sole-org fallback (single mode only): if unresolved and exactly one org
+ *     exists, use it — keeps zero-config single-org installs working
+ *  3. findBySlug() ?? findByCustomDomain()
+ *  4. 404 if unresolved/not found, 403 if inactive
+ */
+final readonly class OrgResolverMiddleware implements MiddlewareInterface
+{
+    /** @var list<string> */
+    private const BYPASS_PREFIXES = [
+        '/health',
+        '/auth/',
+        '/api/',
+        '/invoices/download/',
+        '/admin/organizations',
+    ];
+
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     * @param bool $soleOrgFallback enable the single-org convenience fallback (Env/single mode)
+     */
+    public function __construct(
+        private RequestScopedHolder $orgId,
+        private OrganizationRepositoryInterface $repository,
+        private ProblemDetailsResponseFactory $problemDetails,
+        private OrgResolutionStrategyInterface $strategy,
+        private bool $soleOrgFallback,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath();
+
+        foreach (self::BYPASS_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return $handler->handle($request);
+            }
+        }
+
+        $identifier = $this->strategy->resolve($request);
+
+        $org = $identifier !== null
+            ? ($this->repository->findBySlug($identifier) ?? $this->repository->findByCustomDomain($identifier))
+            : ($this->soleOrgFallback ? $this->soleOrganization() : null);
+
+        if ($org === null) {
+            return $identifier === null
+                ? $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Not Resolved', 404, 'Could not determine the organization for this request. Check the TENANT_RESOLUTION configuration.')
+                : $this->problemDetails->create($request, 'organization-not-found', 'Organization Not Found', 404, "No organization found for '{$identifier}'.");
+        }
+
+        if (!$org->isActive) {
+            return $this->problemDetails->create($request, 'organization-inactive', 'Organization Inactive', 403, 'This organization is currently inactive.');
+        }
+
+        $this->orgId->set($org->id ?? 0);
+
+        return $handler->handle(
+            $request->withAttribute('nene2.org.id', $org->id)
+                ->withAttribute('nene2.org.slug', $org->slug),
+        );
+    }
+
+    /**
+     * Returns the only organization when exactly one exists, else null. Used by
+     * the single-org fallback so an install with one tenant needs no ORG_SLUG.
+     */
+    private function soleOrganization(): ?\NeneInvoice\Organization\Organization
+    {
+        if ($this->repository->count() !== 1) {
+            return null;
+        }
+
+        return $this->repository->findAll(1, 0)[0] ?? null;
+    }
+}

--- a/src/Organization/Resolution/PathPrefixResolutionStrategy.php
+++ b/src/Organization/Resolution/PathPrefixResolutionStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the org slug from the first URL path segment: /org1/admin/... → "org1".
+ *
+ * Best for shared-host deployments where wildcard subdomains are not available.
+ * Bypass paths (health, auth, service API, public download, superadmin org
+ * management) return null so the middleware passes them through unresolved.
+ */
+final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    /** @var list<string> */
+    private const BYPASS_PREFIXES = [
+        '/health',
+        '/auth/',
+        '/api/',
+        '/invoices/download/',
+        '/admin/organizations',
+    ];
+
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        $path = $request->getUri()->getPath();
+
+        foreach (self::BYPASS_PREFIXES as $bypass) {
+            if (str_starts_with($path, $bypass)) {
+                return null;
+            }
+        }
+
+        $parts     = explode('/', ltrim($path, '/'), 2);
+        $candidate = $parts[0];
+
+        return $candidate !== '' ? $candidate : null;
+    }
+}

--- a/src/Organization/Resolution/SubdomainResolutionStrategy.php
+++ b/src/Organization/Resolution/SubdomainResolutionStrategy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the org slug from the subdomain: org1.example.com → "org1".
+ *
+ * Configure BASE_DOMAIN=example.com. Requests to the bare base domain (no
+ * subdomain) return null.
+ */
+final readonly class SubdomainResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function __construct(private string $baseDomain)
+    {
+    }
+
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        $host = $request->getUri()->getHost();
+
+        if (str_contains($host, ':')) {
+            $host = explode(':', $host)[0];
+        }
+
+        $baseParts = explode('.', $this->baseDomain);
+        $hostParts = explode('.', $host);
+
+        // Host must have more segments than baseDomain to carry a subdomain.
+        if (count($hostParts) <= count($baseParts)) {
+            return null;
+        }
+
+        // The tail must match baseDomain.
+        $tail = array_slice($hostParts, -count($baseParts));
+        if ($tail !== $baseParts) {
+            return null;
+        }
+
+        return $hostParts[0];
+    }
+}

--- a/tests/Auth/OrgGuardMiddlewareTest.php
+++ b/tests/Auth/OrgGuardMiddlewareTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneInvoice\Auth\OrgGuardMiddleware;
+use NeneInvoice\Tests\Support\RecordingRequestHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class OrgGuardMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private OrgGuardMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->psr17      = new Psr17Factory();
+        $this->middleware = new OrgGuardMiddleware(
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    private function okHandler(): RecordingRequestHandler
+    {
+        return new RecordingRequestHandler($this->psr17);
+    }
+
+    public function test_passes_when_token_org_matches_resolved_org(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute('nene2.org.id', 7)
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 7]);
+
+        self::assertSame(200, $this->middleware->process($request, $this->okHandler())->getStatusCode());
+    }
+
+    public function test_rejects_when_token_org_differs(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute('nene2.org.id', 7)
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 8]);
+
+        $response = $this->middleware->process($request, $this->okHandler());
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('organization-mismatch', (string) $response->getBody());
+    }
+
+    public function test_superadmin_with_null_org_passes(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute('nene2.org.id', 7)
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'superadmin', 'org' => null]);
+
+        self::assertSame(200, $this->middleware->process($request, $this->okHandler())->getStatusCode());
+    }
+
+    public function test_passes_when_no_resolved_org(): void
+    {
+        // Bypass route: no nene2.org.id attribute.
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/api/invoices')
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 8]);
+
+        self::assertSame(200, $this->middleware->process($request, $this->okHandler())->getStatusCode());
+    }
+
+    public function test_passes_when_no_claims(): void
+    {
+        // Public route: resolved org but no verified claims.
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute('nene2.org.id', 7);
+
+        self::assertSame(200, $this->middleware->process($request, $this->okHandler())->getStatusCode());
+    }
+}

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Organization\Resolution;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\Resolution\EnvResolutionStrategy;
+use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
+use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
+use NeneInvoice\Tests\Support\RecordingRequestHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class OrgResolverMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryOrganizationRepository $orgs;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private ProblemDetailsResponseFactory $problemDetails;
+
+    protected function setUp(): void
+    {
+        $this->psr17          = new Psr17Factory();
+        $this->orgs           = new InMemoryOrganizationRepository();
+        $this->holder         = new RequestScopedHolder();
+        $this->problemDetails = new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/');
+    }
+
+    private function passthroughHandler(): RecordingRequestHandler
+    {
+        return new RecordingRequestHandler($this->psr17);
+    }
+
+    private function middleware(string $slug, bool $fallback): OrgResolverMiddleware
+    {
+        return new OrgResolverMiddleware(
+            $this->holder,
+            $this->orgs,
+            $this->problemDetails,
+            new EnvResolutionStrategy($slug),
+            $fallback,
+        );
+    }
+
+    public function test_resolves_org_by_slug_and_sets_holder(): void
+    {
+        $id = $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $handler = $this->passthroughHandler();
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+
+        $response = $this->middleware('acme', false)->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $this->holder->get());
+        self::assertSame($id, $handler->seen?->getAttribute('nene2.org.id'));
+    }
+
+    public function test_bypass_paths_skip_resolution(): void
+    {
+        $handler = $this->passthroughHandler();
+
+        foreach (['/health', '/auth/login', '/api/invoices', '/invoices/download/x', '/admin/organizations'] as $path) {
+            $request  = $this->psr17->createServerRequest('GET', "https://app.example.com{$path}");
+            $response = $this->middleware('', false)->process($request, $handler);
+            self::assertSame(200, $response->getStatusCode(), "bypass failed for {$path}");
+        }
+    }
+
+    public function test_unresolved_returns_404_org_not_resolved(): void
+    {
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+        $response = $this->middleware('', false)->process($request, $this->passthroughHandler());
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('organization-not-resolved', (string) $response->getBody());
+    }
+
+    public function test_unknown_slug_returns_404_org_not_found(): void
+    {
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+        $response = $this->middleware('ghost', false)->process($request, $this->passthroughHandler());
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('organization-not-found', (string) $response->getBody());
+    }
+
+    public function test_inactive_org_returns_403(): void
+    {
+        $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: false));
+
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+        $response = $this->middleware('acme', false)->process($request, $this->passthroughHandler());
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('organization-inactive', (string) $response->getBody());
+    }
+
+    public function test_sole_org_fallback_uses_only_organization(): void
+    {
+        $id = $this->orgs->save(new Organization(name: 'Only', slug: 'only', plan: 'free', isActive: true));
+
+        $handler  = $this->passthroughHandler();
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+        $response = $this->middleware('', true)->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $this->holder->get());
+    }
+
+    public function test_sole_org_fallback_inert_when_multiple_orgs(): void
+    {
+        $this->orgs->save(new Organization(name: 'A', slug: 'a', plan: 'free', isActive: true));
+        $this->orgs->save(new Organization(name: 'B', slug: 'b', plan: 'free', isActive: true));
+
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+        $response = $this->middleware('', true)->process($request, $this->passthroughHandler());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/tests/Organization/Resolution/ResolutionStrategiesTest.php
+++ b/tests/Organization/Resolution/ResolutionStrategiesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Organization\Resolution;
+
+use NeneInvoice\Organization\Resolution\CustomDomainResolutionStrategy;
+use NeneInvoice\Organization\Resolution\EnvResolutionStrategy;
+use NeneInvoice\Organization\Resolution\PathPrefixResolutionStrategy;
+use NeneInvoice\Organization\Resolution\SubdomainResolutionStrategy;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class ResolutionStrategiesTest extends TestCase
+{
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+    }
+
+    public function test_env_returns_slug_when_set(): void
+    {
+        $strategy = new EnvResolutionStrategy('acme');
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+
+        self::assertSame('acme', $strategy->resolve($request));
+    }
+
+    public function test_env_returns_null_when_empty(): void
+    {
+        $strategy = new EnvResolutionStrategy('');
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+
+        self::assertNull($strategy->resolve($request));
+    }
+
+    public function test_path_prefix_extracts_first_segment(): void
+    {
+        $strategy = new PathPrefixResolutionStrategy();
+        $request  = $this->psr17->createServerRequest('GET', 'https://app.example.com/acme/admin/invoices');
+
+        self::assertSame('acme', $strategy->resolve($request));
+    }
+
+    public function test_path_prefix_bypasses_reserved_prefixes(): void
+    {
+        $strategy = new PathPrefixResolutionStrategy();
+
+        foreach (['/health', '/auth/login', '/api/invoices', '/invoices/download/tok', '/admin/organizations'] as $path) {
+            $request = $this->psr17->createServerRequest('GET', "https://app.example.com{$path}");
+            self::assertNull($strategy->resolve($request), "expected bypass for {$path}");
+        }
+    }
+
+    public function test_subdomain_extracts_label(): void
+    {
+        $strategy = new SubdomainResolutionStrategy('example.com');
+        $request  = $this->psr17->createServerRequest('GET', 'https://acme.example.com/admin/invoices');
+
+        self::assertSame('acme', $strategy->resolve($request));
+    }
+
+    public function test_subdomain_returns_null_for_bare_domain(): void
+    {
+        $strategy = new SubdomainResolutionStrategy('example.com');
+        $request  = $this->psr17->createServerRequest('GET', 'https://example.com/admin/invoices');
+
+        self::assertNull($strategy->resolve($request));
+    }
+
+    public function test_subdomain_returns_null_when_tail_mismatch(): void
+    {
+        $strategy = new SubdomainResolutionStrategy('example.com');
+        $request  = $this->psr17->createServerRequest('GET', 'https://acme.other.org/admin/invoices');
+
+        self::assertNull($strategy->resolve($request));
+    }
+
+    public function test_custom_domain_returns_host(): void
+    {
+        $strategy = new CustomDomainResolutionStrategy();
+        $request  = $this->psr17->createServerRequest('GET', 'https://billing.acme.co.jp/admin/invoices');
+
+        self::assertSame('billing.acme.co.jp', $strategy->resolve($request));
+    }
+}

--- a/tests/Support/RecordingRequestHandler.php
+++ b/tests/Support/RecordingRequestHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Test double that records the request it received and returns a 200. Used to
+ * assert what a middleware passed downstream (e.g. request attributes).
+ */
+final class RecordingRequestHandler implements RequestHandlerInterface
+{
+    public ?ServerRequestInterface $seen = null;
+
+    public function __construct(private readonly Psr17Factory $psr17 = new Psr17Factory())
+    {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->seen = $request;
+
+        return $this->psr17->createResponse(200);
+    }
+}


### PR DESCRIPTION
## Summary

ADR 0006 のマルチテナントを SQL 層で構造的に保証するための基盤（nene-records パターンの第一段）。**非破壊**。

### 追加

- **`RequestScopedHolder<int>` DI**（`ApplicationServiceProvider::ORG_ID_HOLDER`）— OrgResolver が書き、後続 PR で全リポジトリが読む共有 holder。
- **`src/Organization/Resolution/`**:
  - `OrgResolutionStrategyInterface` + `Env`/`PathPrefix`/`Subdomain`/`CustomDomain` 戦略
  - `OrgResolverMiddleware` — URL→slug→org 解決、holder + リクエスト属性 `nene2.org.id` 付与。inactive=403 / not-found=404。**single モードは唯一org フォールバック**（ORG_SLUG 空でも 1 org install が動作）。
  - バイパス: `/health` `/auth/` `/api/` `/invoices/download/` `/admin/organizations`
- **`src/Auth/OrgGuardMiddleware`** — token の `org` != URL 解決 org → 403 `organization-mismatch`。superadmin（org=null）例外。
- middleware 連鎖: `[OrgResolver → BearerToken → OrgGuard → Capability → ServiceScope]`（`RuntimeServiceProvider`、`TENANT_RESOLUTION` で strategy 選択）。
- 用語レジストリに `organization-inactive` / `organization-mismatch` 追加。

### 非破壊性

リポジトリはまだ holder を読まない（従来の `$organizationId` 引数で動作）。holder は二重にセットされるのみ。既存 251 tests green。後続 PR でドメインごとに holder ベースへ移行。

## Test plan

- [ ] `composer check` green（PHPUnit 251 / PHPStan level 8 / CS / OpenAPI / MCP）
- [ ] 戦略 4 種の解決/バイパス（ResolutionStrategiesTest）
- [ ] OrgResolver: slug 解決→holder セット、バイパス、404/403、唯一org フォールバック
- [ ] OrgGuard: 一致 pass / 不一致 403 / superadmin pass / 未解決・未認証 pass
- [ ] single モード（既定）で `/health` ブート回帰（HealthEndpointTest）

## 後続

ドメイン別リポジトリの holder 化（#148〜）、User/ServiceAPI/公開DL の holder セット、インストーラ ORG_SLUG 出力。

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)