### PR TITLE
feat(tenancy): Client ドメインを holder ベースへ — SQL 層で org 強制 (#149)

### DIFF
--- a/src/Client/ClientRepositoryInterface.php
+++ b/src/Client/ClientRepositoryInterface.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 /**
- * Persistence for clients. All reads exclude soft-deleted rows; `delete` is a
- * soft delete (sets `is_deleted`).
+ * Persistence for clients. Every query is scoped to the organization held in the
+ * request-scoped org holder (ADR 0006) — callers never pass an organization id,
+ * so cross-tenant access is impossible to express. Reads exclude soft-deleted
+ * rows; `delete` is a soft delete (sets `is_deleted`).
  */
 interface ClientRepositoryInterface
 {
     public function findById(int $id): ?Client;
 
     /** @return list<Client> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findAll(int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function count(): int;
 
     public function save(Client $client): int;
 

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
@@ -31,20 +33,19 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoClientRepository($query);
+                    return new PdoClientRepository($query, self::orgHolder($c));
                 },
             )
             ->set(ListClientsUseCase::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
             ->set(GetClientByIdUseCase::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
-            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c)))
-            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c)))
-            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c)))
+            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListClientsHandler::class,
                 static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
                     self::listUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -52,7 +53,6 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): GetClientByIdHandler => new GetClientByIdHandler(
                     self::getUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -76,7 +76,6 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): DeleteClientHandler => new DeleteClientHandler(
                     self::deleteUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -152,6 +151,18 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
         }
 
         return $repo;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 
     private static function audit(ContainerInterface $c): AuditRecorderInterface

--- a/src/Client/CreateClientHandler.php
+++ b/src/Client/CreateClientHandler.php
@@ -25,12 +25,6 @@ final readonly class CreateClientHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $decoded = json_decode((string) $request->getBody(), true);
 
         if (!is_array($decoded)) {
@@ -43,7 +37,7 @@ final readonly class CreateClientHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
         }
 
-        $client = $this->useCase->execute($organizationId, AuthContext::userId($request), new CreateClientInput(
+        $client = $this->useCase->execute(AuthContext::userId($request), new CreateClientInput(
             name: $name,
             contactName: ClientField::optionalString($decoded, 'contact_name'),
             email: ClientField::optionalString($decoded, 'email'),

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -5,28 +5,35 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class CreateClientUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private ClientRepositoryInterface $clients,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
-     * Creates a client in the caller's organization. The organization is taken
-     * from the authenticated caller, never from request input.
+     * Creates a client in the resolved organization (the repository forces the
+     * org from the request-scoped holder, never from request input).
      *
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, ?int $actorUserId, CreateClientInput $input): Client
+    public function execute(?int $actorUserId, CreateClientInput $input): Client
     {
         if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
+
+        $organizationId = $this->orgId->get();
 
         $id = $this->clients->save(new Client(
             organizationId: $organizationId,

--- a/src/Client/DeleteClientHandler.php
+++ b/src/Client/DeleteClientHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -13,29 +12,23 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `DELETE /admin/clients/{id}` — soft-deletes a client in the caller's organization.
+ * `DELETE /admin/clients/{id}` — soft-deletes a client in the resolved
+ * organization (scoped by the repository via the request-scoped org holder).
  */
 final readonly class DeleteClientHandler implements RequestHandlerInterface
 {
     public function __construct(
         private DeleteClientUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $this->useCase->execute($organizationId, AuthContext::userId($request), $id);
+        $this->useCase->execute(AuthContext::userId($request), $id);
 
         return $this->json->createEmpty(204);
     }

--- a/src/Client/DeleteClientUseCase.php
+++ b/src/Client/DeleteClientUseCase.php
@@ -4,32 +4,38 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteClientUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private ClientRepositoryInterface $clients,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
-     * Soft-deletes a client within the caller's organization. Cross-organization
-     * targets are reported as not found.
+     * Soft-deletes a client in the resolved organization. The repository scopes
+     * the lookup/delete to the request org, so cross-organization targets
+     * surface as not found.
      *
      * @throws ClientNotFoundException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $id): void
+    public function execute(?int $actorUserId, int $id): void
     {
         $existing = $this->clients->findById($id);
 
-        if ($existing === null || $existing->organizationId !== $organizationId) {
+        if ($existing === null) {
             throw new ClientNotFoundException($id);
         }
 
         $this->clients->delete($id);
 
-        $this->audit->record($actorUserId, $organizationId, 'client.deleted', 'client', $id, ClientResponse::toArray($existing), null);
+        $this->audit->record($actorUserId, $this->orgId->get(), 'client.deleted', 'client', $id, ClientResponse::toArray($existing), null);
     }
 }

--- a/src/Client/GetClientByIdHandler.php
+++ b/src/Client/GetClientByIdHandler.php
@@ -4,39 +4,31 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/clients/{id}` — reads one client in the caller's organization.
- * Clients outside the caller's organization (or missing) return 404.
+ * `GET /admin/clients/{id}` — reads one client in the resolved organization.
+ * The org is set by OrgResolverMiddleware and enforced in the repository, so
+ * clients outside the caller's organization (or missing) return 404.
  */
 final readonly class GetClientByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GetClientByIdUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $client = $this->useCase->execute($organizationId, $id);
+        $client = $this->useCase->execute($id);
 
         return $this->json->create(ClientResponse::toArray($client));
     }

--- a/src/Client/GetClientByIdUseCase.php
+++ b/src/Client/GetClientByIdUseCase.php
@@ -12,17 +12,17 @@ final readonly class GetClientByIdUseCase
     }
 
     /**
-     * Fetches a client that belongs to the given organization. A client from
-     * another organization (or a missing/soft-deleted id) is reported as not
-     * found so cross-tenant existence is not leaked.
+     * Fetches a client in the current organization. The repository scopes the
+     * read to the request-scoped org, so a client from another organization (or
+     * a missing/soft-deleted id) surfaces as not found — no cross-tenant leak.
      *
      * @throws ClientNotFoundException
      */
-    public function execute(int $organizationId, int $id): Client
+    public function execute(int $id): Client
     {
         $client = $this->clients->findById($id);
 
-        if ($client === null || $client->organizationId !== $organizationId) {
+        if ($client === null) {
             throw new ClientNotFoundException($id);
         }
 

--- a/src/Client/ListClientsHandler.php
+++ b/src/Client/ListClientsHandler.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/clients` — lists clients in the caller's organization.
+ * `GET /admin/clients` — lists clients in the resolved organization (scoped by
+ * the repository via the request-scoped org holder).
  */
 final readonly class ListClientsHandler implements RequestHandlerInterface
 {
@@ -22,18 +21,11 @@ final readonly class ListClientsHandler implements RequestHandlerInterface
     public function __construct(
         private ListClientsUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $query = $request->getQueryParams();
 
         $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
@@ -42,7 +34,7 @@ final readonly class ListClientsHandler implements RequestHandlerInterface
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($limit, $offset);
 
         return $this->json->create([
             'items' => array_map(static fn (Client $c): array => ClientResponse::toArray($c), $result->items),

--- a/src/Client/ListClientsUseCase.php
+++ b/src/Client/ListClientsUseCase.php
@@ -11,11 +11,11 @@ final readonly class ListClientsUseCase
     ) {
     }
 
-    public function execute(int $organizationId, int $limit, int $offset): ListClientsResult
+    public function execute(int $limit, int $offset): ListClientsResult
     {
         return new ListClientsResult(
-            $this->clients->findAllByOrganization($organizationId, $limit, $offset),
-            $this->clients->countByOrganization($organizationId),
+            $this->clients->findAll($limit, $offset),
+            $this->clients->count(),
         );
     }
 }

--- a/src/Client/PdoClientRepository.php
+++ b/src/Client/PdoClientRepository.php
@@ -5,42 +5,47 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoClientRepository implements ClientRepositoryInterface
 {
     private const COLUMNS = 'id, organization_id, name, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     public function findById(int $id): ?Client
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM clients WHERE id = ? AND is_deleted = 0',
-            [$id],
+            'SELECT ' . self::COLUMNS . ' FROM clients WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$id, $this->orgId->get()],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
     }
 
     /** @return list<Client> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM clients WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            [$this->orgId->get(), $limit, $offset],
         );
 
         return array_map(fn (array $row): Client => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt FROM clients WHERE organization_id = ? AND is_deleted = 0',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['cnt'] : 0;
@@ -50,11 +55,13 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
     {
         $now = date('Y-m-d H:i:s');
 
+        // The organization is forced from the request-scoped holder, never from
+        // the entity — a write always lands in the caller's resolved org.
         $this->query->execute(
             'INSERT INTO clients (organization_id, name, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
-                $client->organizationId,
+                $this->orgId->get(),
                 $client->name,
                 $client->contactName,
                 $client->email,
@@ -77,7 +84,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE clients SET name = ?, contact_name = ?, email = ?, billing_address = ?, registration_number = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            'UPDATE clients SET name = ?, contact_name = ?, email = ?, billing_address = ?, registration_number = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
             [
                 $client->name,
                 $client->contactName,
@@ -86,6 +93,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
                 $client->registrationNumber,
                 $now,
                 $client->id,
+                $this->orgId->get(),
             ],
         );
 
@@ -101,8 +109,8 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE clients SET is_deleted = 1, deleted_at = ? WHERE id = ?',
-            [date('Y-m-d H:i:s'), $id],
+            'UPDATE clients SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
 

--- a/src/Client/UpdateClientHandler.php
+++ b/src/Client/UpdateClientHandler.php
@@ -26,12 +26,6 @@ final readonly class UpdateClientHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
@@ -47,7 +41,7 @@ final readonly class UpdateClientHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
         }
 
-        $client = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new UpdateClientInput(
+        $client = $this->useCase->execute(AuthContext::userId($request), $id, new UpdateClientInput(
             name: $name,
             contactName: ClientField::optionalString($decoded, 'contact_name'),
             email: ClientField::optionalString($decoded, 'email'),

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -5,29 +5,35 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class UpdateClientUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private ClientRepositoryInterface $clients,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
-     * Updates a client within the caller's organization. A client from another
-     * organization (or soft-deleted) is reported as not found.
+     * Updates a client in the resolved organization. The repository scopes the
+     * read/write to the request org, so a client from another organization (or
+     * soft-deleted) surfaces as not found.
      *
      * @throws ClientNotFoundException
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $id, UpdateClientInput $input): Client
+    public function execute(?int $actorUserId, int $id, UpdateClientInput $input): Client
     {
         $existing = $this->clients->findById($id);
 
-        if ($existing === null || $existing->organizationId !== $organizationId) {
+        if ($existing === null) {
             throw new ClientNotFoundException($id);
         }
 
@@ -54,7 +60,7 @@ final readonly class UpdateClientUseCase
             throw new LogicException('Client disappeared immediately after update.');
         }
 
-        $this->audit->record($actorUserId, $organizationId, 'client.updated', 'client', $id, ClientResponse::toArray($existing), ClientResponse::toArray($updated));
+        $this->audit->record($actorUserId, $this->orgId->get(), 'client.updated', 'client', $id, ClientResponse::toArray($existing), ClientResponse::toArray($updated));
 
         return $updated;
     }

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -9,6 +9,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
@@ -28,7 +30,7 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
         $builder
             ->set(
                 ServiceScopeMiddleware::class,
-                static fn (ContainerInterface $c): ServiceScopeMiddleware => new ServiceScopeMiddleware(self::problemDetails($c)),
+                static fn (ContainerInterface $c): ServiceScopeMiddleware => new ServiceScopeMiddleware(self::problemDetails($c), self::orgHolder($c)),
             )
             ->set(
                 ListServiceInvoicesHandler::class,
@@ -113,5 +115,17 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
     private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
     {
         return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/ServiceApi/ServiceScopeMiddleware.php
+++ b/src/ServiceApi/ServiceScopeMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\ServiceApi;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -16,11 +17,19 @@ use Psr\Http\Server\RequestHandlerInterface;
  * protected `/api/` prefix). Here we additionally require the token to be a
  * **service principal** carrying the required scope — a human/operator token
  * (no `scopes` claim) is rejected from the service surface.
+ *
+ * `/api/*` bypasses OrgResolverMiddleware (org comes from the service token, not
+ * the URL), so this middleware sets the request-scoped org holder from the
+ * token's `org` claim — the same holder org-scoped repositories read (ADR 0006).
  */
 final readonly class ServiceScopeMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -42,7 +51,9 @@ final readonly class ServiceScopeMiddleware implements MiddlewareInterface
             );
         }
 
-        if (ServiceAuthContext::organizationId($request) === null) {
+        $organizationId = ServiceAuthContext::organizationId($request);
+
+        if ($organizationId === null) {
             return $this->problemDetails->create(
                 $request,
                 'insufficient-scope',
@@ -51,6 +62,9 @@ final readonly class ServiceScopeMiddleware implements MiddlewareInterface
                 'The service token is not scoped to an organization.',
             );
         }
+
+        // Make the service token's org available to org-scoped repositories.
+        $this->orgId->set($organizationId);
 
         return $handler->handle($request);
     }

--- a/tests/Client/ClientQueryUseCasesTest.php
+++ b/tests/Client/ClientQueryUseCasesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Client;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Client\ClientNotFoundException;
 use NeneInvoice\Client\GetClientByIdUseCase;
@@ -13,11 +14,15 @@ use PHPUnit\Framework\TestCase;
 
 final class ClientQueryUseCasesTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryClientRepository $repo;
 
     protected function setUp(): void
     {
-        $this->repo = new InMemoryClientRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new InMemoryClientRepository($this->holder);
         $this->repo->save(new Client(organizationId: 1, name: 'A'));
         $this->repo->save(new Client(organizationId: 1, name: 'B'));
         $this->repo->save(new Client(organizationId: 2, name: 'C'));
@@ -25,7 +30,7 @@ final class ClientQueryUseCasesTest extends TestCase
 
     public function test_list_is_scoped_to_organization(): void
     {
-        $result = (new ListClientsUseCase($this->repo))->execute(1, 10, 0);
+        $result = (new ListClientsUseCase($this->repo))->execute(10, 0);
 
         self::assertSame(2, $result->total);
         self::assertCount(2, $result->items);
@@ -36,15 +41,15 @@ final class ClientQueryUseCasesTest extends TestCase
 
     public function test_get_returns_client_in_same_organization(): void
     {
-        $client = (new GetClientByIdUseCase($this->repo))->execute(1, 1);
+        $client = (new GetClientByIdUseCase($this->repo))->execute(1);
 
         self::assertSame('A', $client->name);
     }
 
     public function test_get_hides_client_from_another_organization(): void
     {
-        // id 3 belongs to org 2; an org-1 caller must not see it.
+        // id 3 belongs to org 2; an org-1 caller must not see it (SQL-scoped).
         $this->expectException(ClientNotFoundException::class);
-        (new GetClientByIdUseCase($this->repo))->execute(1, 3);
+        (new GetClientByIdUseCase($this->repo))->execute(3);
     }
 }

--- a/tests/Client/ClientWriteUseCasesTest.php
+++ b/tests/Client/ClientWriteUseCasesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Client;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Client\ClientNotFoundException;
 use NeneInvoice\Client\CreateClientInput;
@@ -18,18 +19,25 @@ use PHPUnit\Framework\TestCase;
 
 final class ClientWriteUseCasesTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryClientRepository $repo;
     private RecordingAuditRecorder $audit;
 
     protected function setUp(): void
     {
-        $this->repo = new InMemoryClientRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new InMemoryClientRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
     }
 
-    public function test_create_forces_caller_organization_and_audits(): void
+    public function test_create_forces_resolved_organization_and_audits(): void
     {
-        $client = (new CreateClientUseCase($this->repo, $this->audit))->execute(7, 42, new CreateClientInput(name: 'Acme'));
+        // The org comes from the request-scoped holder, never from input.
+        $this->holder->set(7);
+
+        $client = (new CreateClientUseCase($this->repo, $this->audit, $this->holder))->execute(42, new CreateClientInput(name: 'Acme'));
 
         self::assertSame(7, $client->organizationId);
 
@@ -46,14 +54,14 @@ final class ClientWriteUseCasesTest extends TestCase
     public function test_create_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new CreateClientUseCase($this->repo, $this->audit))->execute(1, 1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
+        (new CreateClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
     }
 
     public function test_update_records_before_and_after(): void
     {
         $id = $this->repo->save(new Client(organizationId: 1, name: 'Before'));
 
-        (new UpdateClientUseCase($this->repo, $this->audit))->execute(1, 9, $id, new UpdateClientInput(name: 'After'));
+        (new UpdateClientUseCase($this->repo, $this->audit, $this->holder))->execute(9, $id, new UpdateClientInput(name: 'After'));
 
         self::assertCount(1, $this->audit->records);
         $record = $this->audit->records[0];
@@ -67,14 +75,14 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new UpdateClientUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
+        (new UpdateClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
     }
 
     public function test_delete_soft_deletes_and_records_before_only(): void
     {
         $id = $this->repo->save(new Client(organizationId: 1, name: 'Temp'));
 
-        (new DeleteClientUseCase($this->repo, $this->audit))->execute(1, 5, $id);
+        (new DeleteClientUseCase($this->repo, $this->audit, $this->holder))->execute(5, $id);
 
         self::assertNull($this->repo->findById($id));
 
@@ -89,6 +97,6 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new DeleteClientUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrg);
+        (new DeleteClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrg);
     }
 }

--- a/tests/Client/PdoClientRepositoryTest.php
+++ b/tests/Client/PdoClientRepositoryTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Client;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Client\ClientNotFoundException;
 use NeneInvoice\Client\PdoClientRepository;
@@ -14,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 final class PdoClientRepositoryTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
     private PdoClientRepository $repository;
 
     protected function setUp(): void
@@ -36,7 +39,9 @@ final class PdoClientRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoClientRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoClientRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
     }
 
     public function test_saves_and_reads_back_a_client(): void
@@ -61,11 +66,28 @@ final class PdoClientRepositoryTest extends TestCase
     {
         $this->repository->save(new Client(organizationId: 1, name: 'A'));
         $this->repository->save(new Client(organizationId: 1, name: 'B'));
+
+        $this->orgId->set(2);
         $this->repository->save(new Client(organizationId: 2, name: 'C'));
 
-        self::assertSame(2, $this->repository->countByOrganization(1));
-        self::assertCount(2, $this->repository->findAllByOrganization(1, 10, 0));
-        self::assertSame(1, $this->repository->countByOrganization(2));
+        $this->orgId->set(1);
+        self::assertSame(2, $this->repository->count());
+        self::assertCount(2, $this->repository->findAll(10, 0));
+
+        $this->orgId->set(2);
+        self::assertSame(1, $this->repository->count());
+    }
+
+    public function test_find_by_id_is_scoped_to_organization(): void
+    {
+        $id = $this->repository->save(new Client(organizationId: 1, name: 'Acme'));
+
+        // A caller in another org must not read the row even by direct id.
+        $this->orgId->set(2);
+        self::assertNull($this->repository->findById($id));
+
+        $this->orgId->set(1);
+        self::assertNotNull($this->repository->findById($id));
     }
 
     public function test_soft_delete_hides_client_from_reads(): void
@@ -75,8 +97,8 @@ final class PdoClientRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->countByOrganization(1));
-        self::assertCount(0, $this->repository->findAllByOrganization(1, 10, 0));
+        self::assertSame(0, $this->repository->count());
+        self::assertCount(0, $this->repository->findAll(10, 0));
     }
 
     public function test_delete_throws_for_unknown_client(): void

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -88,7 +88,9 @@ final class QuoteQueryUseCasesTest extends TestCase
 
     public function test_list_is_scoped_to_organization(): void
     {
-        $clients2  = new InMemoryClientRepository();
+        $org2      = new \Nene2\Http\RequestScopedHolder();
+        $org2->set(2);
+        $clients2  = new InMemoryClientRepository($org2);
         $client2Id = $clients2->save(new Client(organizationId: 2, name: 'OtherOrg'));
         $quotes2   = new InMemoryQuoteRepository();
 

--- a/tests/ServiceApi/ServiceScopeMiddlewareTest.php
+++ b/tests/ServiceApi/ServiceScopeMiddlewareTest.php
@@ -5,42 +5,35 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\ServiceApi;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
+use NeneInvoice\Tests\Support\RecordingRequestHandler;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
 final class ServiceScopeMiddlewareTest extends TestCase
 {
     private const CLAIMS = 'nene2.auth.claims';
 
     private Psr17Factory $psr17;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private ServiceScopeMiddleware $middleware;
 
     protected function setUp(): void
     {
         $this->psr17 = new Psr17Factory();
+        $this->holder = new RequestScopedHolder();
         $this->middleware = new ServiceScopeMiddleware(
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+            $this->holder,
         );
     }
 
-    private function handler(): RequestHandlerInterface
+    private function handler(): RecordingRequestHandler
     {
-        $psr17 = $this->psr17;
-
-        return new class ($psr17) implements RequestHandlerInterface {
-            public function __construct(private readonly Psr17Factory $psr17)
-            {
-            }
-
-            public function handle(ServerRequestInterface $request): ResponseInterface
-            {
-                return $this->psr17->createResponse(200);
-            }
-        };
+        return new RecordingRequestHandler($this->psr17);
     }
 
     private function request(string $path, mixed $claims): ServerRequestInterface
@@ -53,11 +46,13 @@ final class ServiceScopeMiddlewareTest extends TestCase
     public function test_service_token_with_scope_passes(): void
     {
         $response = $this->middleware->process(
-            $this->request('/api/invoices', ['org' => 1, 'scopes' => ['read:invoices']]),
+            $this->request('/api/invoices', ['org' => 9, 'scopes' => ['read:invoices']]),
             $this->handler(),
         );
 
         self::assertSame(200, $response->getStatusCode());
+        // The service token's org is published to the holder for repositories.
+        self::assertSame(9, $this->holder->get());
     }
 
     public function test_operator_token_without_scopes_is_rejected(): void

--- a/tests/Support/InMemoryClientRepository.php
+++ b/tests/Support/InMemoryClientRepository.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Client\ClientNotFoundException;
 use NeneInvoice\Client\ClientRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database). Soft-deleted clients are
- * excluded from reads, matching the PDO implementation.
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\Client\PdoClientRepository}.
+ * `save` keeps the entity's org so tests can seed cross-tenant fixtures; reads
+ * then prove the holder-based isolation. Soft-deleted clients are excluded.
+ *
+ * The holder defaults to organization 1 so existing single-org tests keep
+ * working without wiring; pass a preset holder to test other organizations.
  */
 final class InMemoryClientRepository implements ClientRepositoryInterface
 {
@@ -18,29 +24,45 @@ final class InMemoryClientRepository implements ClientRepositoryInterface
     private array $byId = [];
     private int $nextId = 1;
 
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
     public function findById(int $id): ?Client
     {
         $client = $this->byId[$id] ?? null;
 
-        return $client !== null && !$client->isDeleted ? $client : null;
+        return $client !== null && !$client->isDeleted && $client->organizationId === $this->orgId->get()
+            ? $client
+            : null;
     }
 
     /** @return list<Client> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
-            static fn (Client $c): bool => $c->organizationId === $organizationId && !$c->isDeleted,
+            fn (Client $c): bool => $c->organizationId === $this->orgId->get() && !$c->isDeleted,
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         return count(array_filter(
             $this->byId,
-            static fn (Client $c): bool => $c->organizationId === $organizationId && !$c->isDeleted,
+            fn (Client $c): bool => $c->organizationId === $this->orgId->get() && !$c->isDeleted,
         ));
     }
 


### PR DESCRIPTION
## Summary

#147 の基盤（OrgResolver + RequestScopedHolder）に続く Client ドメインのリファレンス移行。テナント分離を**リポジトリ SQL 層で構造的に保証**する。

### 変更

- **`PdoClientRepository`** — `RequestScopedHolder<int>` を注入し、全クエリに `organization_id = ?` を holder から強制:
  - `findById`: `WHERE id = ? AND organization_id = ? AND is_deleted = 0`（**単体取得もSQLで org スコープ** — PHP チェック非依存）
  - `findAll`/`count`/`update`/`delete`: holder org でスコープ
  - `save`: org を holder から強制（entity の org は信用しない）
- **`ClientRepositoryInterface`** — `findAllByOrganization`/`countByOrganization` → `findAll`/`count`（org 引数除去）
- **Client UseCase ×5** — `$organizationId` 引数を除去。repo が holder スコープ。監査 org も holder から。
- **Client ハンドラ ×5** — `AuthContext::organizationId` 読み取りと org-null ガードを除去（org は OrgResolver が holder にセット済み）
- **`ServiceScopeMiddleware`** — `/api/*` は OrgResolver をバイパスするため、サービストークンの `org` を holder にセット。これで `/api/clients/{id}` 等が holder ベース repo で正しく動作。

### テスト

- `InMemoryClientRepository` / `PdoClientRepository` を holder 対応。
- **cross-tenant `findById` の SQL スコープを直接検証**（別 org の id → null）。
- 252 tests green。

## Test plan

- [ ] `composer check` green（PHPUnit 252 / PHPStan level 8 / CS / OpenAPI / MCP）
- [ ] `/admin/clients` 系が OrgResolver の holder で動作
- [ ] `/api/clients/{id}` がサービストークン org の holder で動作（ServiceScope セット）
- [ ] 別 org の client id → 404（SQL レベル、PHP チェック非依存）

## 後続

Invoice → Quote → Payment → CompanySettings → Audit → DocumentSequence → InvoiceDownloadToken、最後に User / ServiceAPI ハンドラ / 公開DL。

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)