### PR TITLE
feat(tenancy): Invoice ドメイン（+Dashboard/公開DL）を holder ベースへ (#151)

### DIFF
--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -7,8 +7,9 @@ namespace NeneInvoice\Dashboard;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -23,6 +24,7 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
                 static fn (ContainerInterface $c): GetDashboardSummaryUseCase => new GetDashboardSummaryUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -31,7 +33,6 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
                     self::resolve($c, GetDashboardSummaryUseCase::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, JsonResponseFactory::class),
-                    self::resolve($c, ProblemDetailsResponseFactory::class),
                 ),
             )
             ->set(
@@ -56,5 +57,17 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
         }
 
         return $service;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/Dashboard/GetDashboardHandler.php
+++ b/src/Dashboard/GetDashboardHandler.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Dashboard;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceResponse;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
@@ -15,12 +13,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/dashboard` — returns the admin dashboard summary.
- * Capability: ViewBilling (GET on /admin/invoices path prefix in CapabilityResolver).
- *
- * Note: the path `/admin/dashboard` is NOT under `/admin/invoices` so we need
- * to ensure CapabilityResolver handles it. We gate it at ViewBilling by listing
- * it explicitly in CapabilityResolver.
+ * `GET /admin/dashboard` — returns the admin dashboard summary for the resolved
+ * organization (scoped by the repository via the org holder).
+ * Capability: ViewBilling (listed explicitly in CapabilityResolver).
  */
 final readonly class GetDashboardHandler implements RequestHandlerInterface
 {
@@ -28,19 +23,12 @@ final readonly class GetDashboardHandler implements RequestHandlerInterface
         private GetDashboardSummaryUseCase $useCase,
         private PaymentRepositoryInterface $payments,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
-        $summary = $this->useCase->execute($organizationId);
+        $summary = $this->useCase->execute();
 
         $invoiceIds  = array_filter(
             array_map(static fn (Invoice $i): ?int => $i->id, $summary->recentUnpaid),

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Dashboard;
 
 use DateTimeImmutable;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 
@@ -14,18 +15,23 @@ use NeneInvoice\Payment\PaymentRepositoryInterface;
  */
 final readonly class GetDashboardSummaryUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private PaymentRepositoryInterface $payments,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
-    public function execute(int $organizationId): DashboardSummary
+    public function execute(): DashboardSummary
     {
         $now  = (new DateTimeImmutable())->format('Y-m-d H:i:s');
-        $data = $this->invoices->getDashboardData($organizationId, $now);
+        $data = $this->invoices->getDashboardData($now);
 
-        $outstandingTotalCents = $this->payments->outstandingTotalForOrganization($organizationId);
+        // Payment repo is not yet org-scoped; pass the resolved org explicitly.
+        $outstandingTotalCents = $this->payments->outstandingTotalForOrganization($this->orgId->get());
 
         return new DashboardSummary(
             unpaidCount: $data['unpaid_count'],

--- a/src/Invoice/ConvertQuoteToInvoiceHandler.php
+++ b/src/Invoice/ConvertQuoteToInvoiceHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -20,22 +19,15 @@ final readonly class ConvertQuoteToInvoiceHandler implements RequestHandlerInter
     public function __construct(
         private ConvertQuoteToInvoiceUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $quoteId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $result = $this->useCase->execute($organizationId, AuthContext::userId($request), $quoteId);
+        $result = $this->useCase->execute(AuthContext::userId($request), $quoteId);
 
         return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines), 201);
     }

--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
@@ -20,11 +21,15 @@ use NeneInvoice\Quote\QuoteValidationException;
  */
 final readonly class ConvertQuoteToInvoiceUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private QuoteRepositoryInterface $quotes,
         private InvoiceRepositoryInterface $invoices,
         private LineItemRepositoryInterface $lineItems,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -32,8 +37,11 @@ final readonly class ConvertQuoteToInvoiceUseCase
      * @throws QuoteNotFoundException
      * @throws QuoteValidationException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $quoteId): InvoiceWithLines
+    public function execute(?int $actorUserId, int $quoteId): InvoiceWithLines
     {
+        $organizationId = $this->orgId->get();
+
+        // The quote repo is not yet org-scoped, so guard the org here.
         $quote = $this->quotes->findById($quoteId);
 
         if ($quote === null || $quote->organizationId !== $organizationId) {

--- a/src/Invoice/CreateInvoiceHandler.php
+++ b/src/Invoice/CreateInvoiceHandler.php
@@ -27,12 +27,6 @@ final readonly class CreateInvoiceHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $decoded = json_decode((string) $request->getBody(), true);
 
         if (!is_array($decoded)) {
@@ -70,7 +64,6 @@ final readonly class CreateInvoiceHandler implements RequestHandlerInterface
         }
 
         $result = $this->useCase->execute(
-            $organizationId,
             AuthContext::userId($request),
             new CreateInvoiceInput(
                 clientId: (int) $clientId,

--- a/src/Invoice/CreateInvoiceUseCase.php
+++ b/src/Invoice/CreateInvoiceUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\LineItem\LineItem;
@@ -25,21 +26,28 @@ final readonly class CreateInvoiceUseCase
     /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private LineItemRepositoryInterface $lineItems,
         private ClientRepositoryInterface $clients,
         private TaxCalculator $taxCalculator,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /** @throws InvoiceValidationException */
-    public function execute(int $organizationId, ?int $actorUserId, CreateInvoiceInput $input): InvoiceWithLines
+    public function execute(?int $actorUserId, CreateInvoiceInput $input): InvoiceWithLines
     {
+        $organizationId = $this->orgId->get();
+
+        // The client repo is org-scoped, so a cross-org client surfaces as null.
         $client = $this->clients->findById($input->clientId);
 
-        if ($client === null || $client->organizationId !== $organizationId) {
+        if ($client === null) {
             throw new InvoiceValidationException('The selected client does not exist in your organization.');
         }
 

--- a/src/Invoice/GenerateInvoicePdfUseCase.php
+++ b/src/Invoice/GenerateInvoicePdfUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\Invoice\Pdf\InvoicePdfData;
@@ -17,21 +18,27 @@ use NeneInvoice\Payment\PaymentRepositoryInterface;
  */
 final readonly class GenerateInvoicePdfUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private LineItemRepositoryInterface $lineItems,
         private PaymentRepositoryInterface $payments,
         private CompanySettingsRepositoryInterface $companySettings,
         private ClientRepositoryInterface $clients,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /** @throws InvoiceNotFoundException */
-    public function execute(int $organizationId, int $invoiceId): InvoicePdfData
+    public function execute(int $invoiceId): InvoicePdfData
     {
+        $organizationId = $this->orgId->get();
+
         $invoice = $this->invoices->findById($invoiceId);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($invoiceId);
         }
 

--- a/src/Invoice/GetInvoiceByIdHandler.php
+++ b/src/Invoice/GetInvoiceByIdHandler.php
@@ -4,38 +4,30 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/invoices/{id}` — returns an invoice and its line items.
+ * `GET /admin/invoices/{id}` — returns an invoice and its line items in the
+ * resolved organization (scoped by the repository via the org holder).
  */
 final readonly class GetInvoiceByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GetInvoiceByIdUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $result = $this->useCase->execute($organizationId, $id);
+        $result = $this->useCase->execute($id);
 
         return $this->json->create(
             InvoiceResponse::toArray($result->invoice, $result->lines, $result->outstandingCents),

--- a/src/Invoice/GetInvoiceByIdUseCase.php
+++ b/src/Invoice/GetInvoiceByIdUseCase.php
@@ -18,11 +18,11 @@ final readonly class GetInvoiceByIdUseCase
     }
 
     /** @throws InvoiceNotFoundException */
-    public function execute(int $organizationId, int $id): InvoiceWithLines
+    public function execute(int $id): InvoiceWithLines
     {
         $invoice = $this->invoices->findById($id);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($id);
         }
 

--- a/src/Invoice/GetInvoicePdfHandler.php
+++ b/src/Invoice/GetInvoicePdfHandler.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
@@ -23,22 +21,15 @@ final readonly class GetInvoicePdfHandler implements RequestHandlerInterface
         private GenerateInvoicePdfUseCase $useCase,
         private InvoicePdfGenerator $generator,
         private Psr17Factory $psr17,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $pdfData = $this->useCase->execute($organizationId, $id);
+        $pdfData = $this->useCase->execute($id);
         $bytes   = $this->generator->generate($pdfData);
 
         $invoice  = $pdfData->invoiceWithLines->invoice;

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -5,34 +5,31 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 /**
- * Persistence for invoices. Reads exclude soft-deleted rows; `delete` is soft.
+ * Persistence for invoices. Every query is scoped to the organization held in
+ * the request-scoped org holder (ADR 0006); callers never pass an organization
+ * id. Reads exclude soft-deleted rows; `delete` is soft.
  */
 interface InvoiceRepositoryInterface
 {
     public function findById(int $id): ?Invoice;
 
     /** @return list<Invoice> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findAll(int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function count(): int;
 
     /** @return list<Invoice> */
-    public function findByOrganizationFiltered(
-        int $organizationId,
-        InvoiceListFilter $filter,
-        int $limit,
-        int $offset,
-    ): array;
+    public function findFiltered(InvoiceListFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int;
+    public function countFiltered(InvoiceListFilter $filter): int;
 
     /**
      * Returns counts and recent unpaid invoices for the dashboard in a single query.
-     * `$now` is a comparable datetime string (e.g. `Y-m-d H:i:s`); defaults to now().
+     * `$now` is a comparable datetime string (e.g. `Y-m-d H:i:s`).
      *
      * @return array{unpaid_count: int, overdue_count: int, recent_unpaid: list<Invoice>}
      */
-    public function getDashboardData(int $organizationId, string $now): array;
+    public function getDashboardData(string $now): array;
 
     public function save(Invoice $invoice): int;
 

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
@@ -40,7 +42,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoInvoiceRepository($query);
+                    return new PdoInvoiceRepository($query, self::orgHolder($c));
                 },
             )
             ->set(
@@ -50,6 +52,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -60,6 +63,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, ClientRepositoryInterface::class),
                     self::resolve($c, TaxCalculator::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -70,6 +74,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, CompanySettingsRepositoryInterface::class),
                     self::resolve($c, DocumentNumberGenerator::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -92,7 +97,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ConvertQuoteToInvoiceHandler => new ConvertQuoteToInvoiceHandler(
                     self::resolve($c, ConvertQuoteToInvoiceUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -100,7 +104,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ListInvoicesHandler => new ListInvoicesHandler(
                     self::resolve($c, ListInvoicesUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -108,7 +111,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): GetInvoiceByIdHandler => new GetInvoiceByIdHandler(
                     self::resolve($c, GetInvoiceByIdUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -124,7 +126,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): IssueInvoiceHandler => new IssueInvoiceHandler(
                     self::resolve($c, IssueInvoiceUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -153,6 +154,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, CompanySettingsRepositoryInterface::class),
                     self::resolve($c, ClientRepositoryInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -161,7 +163,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, GenerateInvoicePdfUseCase::class),
                     self::resolve($c, InvoicePdfGenerator::class),
                     self::resolve($c, Psr17Factory::class),
-                    self::resolve($c, ProblemDetailsResponseFactory::class),
                 ),
             )
             ->set(
@@ -207,5 +208,17 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
     private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
     {
         return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/Invoice/IssueInvoiceHandler.php
+++ b/src/Invoice/IssueInvoiceHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -21,18 +20,11 @@ final readonly class IssueInvoiceHandler implements RequestHandlerInterface
     public function __construct(
         private IssueInvoiceUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
@@ -43,7 +35,7 @@ final readonly class IssueInvoiceHandler implements RequestHandlerInterface
         $dueAtValue = $decoded['due_at'] ?? null;
         $dueAt = is_string($dueAtValue) && $dueAtValue !== '' ? $dueAtValue : null;
 
-        $result = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new IssueInvoiceInput($qualified, $dueAt));
+        $result = $this->useCase->execute(AuthContext::userId($request), $id, new IssueInvoiceInput($qualified, $dueAt));
 
         return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines));
     }

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
@@ -20,12 +21,16 @@ use NeneInvoice\LineItem\LineItemRepositoryInterface;
  */
 final readonly class IssueInvoiceUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private LineItemRepositoryInterface $lineItems,
         private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -34,11 +39,13 @@ final readonly class IssueInvoiceUseCase
      * @throws InvoiceValidationException
      * @throws QualifiedInvoiceIncompleteException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $id, IssueInvoiceInput $input): InvoiceWithLines
+    public function execute(?int $actorUserId, int $id, IssueInvoiceInput $input): InvoiceWithLines
     {
+        $organizationId = $this->orgId->get();
+
         $invoice = $this->invoices->findById($id);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($id);
         }
 

--- a/src/Invoice/ListInvoicesHandler.php
+++ b/src/Invoice/ListInvoicesHandler.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/invoices` — lists invoice headers in the caller's organization.
+ * `GET /admin/invoices` — lists invoice headers in the resolved organization
+ * (scoped by the repository via the org holder).
  */
 final readonly class ListInvoicesHandler implements RequestHandlerInterface
 {
@@ -22,18 +21,11 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
     public function __construct(
         private ListInvoicesUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $query = $request->getQueryParams();
 
         $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
@@ -42,7 +34,7 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($limit, $offset);
         $outstanding = $result->outstandingByInvoiceId;
 
         return $this->json->create([

--- a/src/Invoice/ListInvoicesUseCase.php
+++ b/src/Invoice/ListInvoicesUseCase.php
@@ -15,17 +15,16 @@ final readonly class ListInvoicesUseCase
     }
 
     public function execute(
-        int $organizationId,
         int $limit,
         int $offset,
         ?InvoiceListFilter $filter = null,
     ): ListInvoicesResult {
         if ($filter !== null && !$filter->isEmpty()) {
-            $items = $this->invoices->findByOrganizationFiltered($organizationId, $filter, $limit, $offset);
-            $total = $this->invoices->countByOrganizationFiltered($organizationId, $filter);
+            $items = $this->invoices->findFiltered($filter, $limit, $offset);
+            $total = $this->invoices->countFiltered($filter);
         } else {
-            $items = $this->invoices->findAllByOrganization($organizationId, $limit, $offset);
-            $total = $this->invoices->countByOrganization($organizationId);
+            $items = $this->invoices->findAll($limit, $offset);
+            $total = $this->invoices->count();
         }
 
         $ids = [];

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -5,55 +5,56 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
 {
     private const COLUMNS = 'id, organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     public function findById(int $id): ?Invoice
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE id = ? AND is_deleted = 0',
-            [$id],
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$id, $this->orgId->get()],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
     }
 
     /** @return list<Invoice> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM invoices WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            [$this->orgId->get(), $limit, $offset],
         );
 
         return array_map(fn (array $row): Invoice => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt FROM invoices WHERE organization_id = ? AND is_deleted = 0',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['cnt'] : 0;
     }
 
     /** @return list<Invoice> */
-    public function findByOrganizationFiltered(
-        int $organizationId,
-        InvoiceListFilter $filter,
-        int $limit,
-        int $offset,
-    ): array {
-        [$where, $params] = $this->buildWhere($organizationId, $filter);
+    public function findFiltered(InvoiceListFilter $filter, int $limit, int $offset): array
+    {
+        [$where, $params] = $this->buildWhere($filter);
 
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM invoices WHERE ' . $where . ' ORDER BY id DESC LIMIT ? OFFSET ?',
@@ -63,9 +64,9 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         return array_map(fn (array $row): Invoice => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int
+    public function countFiltered(InvoiceListFilter $filter): int
     {
-        [$where, $params] = $this->buildWhere($organizationId, $filter);
+        [$where, $params] = $this->buildWhere($filter);
 
         $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM invoices WHERE ' . $where, $params);
 
@@ -75,11 +76,11 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     /**
      * @return array{0: string, 1: list<int|string>}
      */
-    private function buildWhere(int $organizationId, InvoiceListFilter $filter): array
+    private function buildWhere(InvoiceListFilter $filter): array
     {
         $clauses = ['organization_id = ?', 'is_deleted = 0'];
         /** @var list<int|string> $params */
-        $params = [$organizationId];
+        $params = [$this->orgId->get()];
 
         if ($filter->statuses !== []) {
             $placeholders = implode(', ', array_fill(0, count($filter->statuses), '?'));
@@ -120,15 +121,17 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     /**
      * @return array{unpaid_count: int, overdue_count: int, recent_unpaid: list<Invoice>}
      */
-    public function getDashboardData(int $organizationId, string $now): array
+    public function getDashboardData(string $now): array
     {
+        $orgId = $this->orgId->get();
+
         $countsRow = $this->query->fetchOne(
             'SELECT
                 SUM(CASE WHEN status IN (\'issued\', \'partially_paid\') THEN 1 ELSE 0 END) AS unpaid_count,
                 SUM(CASE WHEN status IN (\'issued\', \'partially_paid\') AND due_at IS NOT NULL AND due_at < ? THEN 1 ELSE 0 END) AS overdue_count
             FROM invoices
             WHERE organization_id = ? AND is_deleted = 0',
-            [$now, $organizationId],
+            [$now, $orgId],
         );
 
         $unpaidCount  = $countsRow !== null ? (int) ($countsRow['unpaid_count'] ?? 0) : 0;
@@ -140,7 +143,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
             WHERE organization_id = ? AND is_deleted = 0 AND status IN (\'issued\', \'partially_paid\')
             ORDER BY id DESC
             LIMIT 5',
-            [$organizationId],
+            [$orgId],
         );
 
         return [
@@ -154,11 +157,12 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     {
         $now = date('Y-m-d H:i:s');
 
+        // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO invoices (organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
-                $invoice->organizationId,
+                $this->orgId->get(),
                 $invoice->clientId,
                 $invoice->quoteId,
                 $invoice->invoiceNumber,
@@ -187,7 +191,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE invoices SET client_id = ?, quote_id = ?, invoice_number = ?, status = ?, is_qualified_invoice = ?, issued_at = ?, due_at = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            'UPDATE invoices SET client_id = ?, quote_id = ?, invoice_number = ?, status = ?, is_qualified_invoice = ?, issued_at = ?, due_at = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
             [
                 $invoice->clientId,
                 $invoice->quoteId,
@@ -202,6 +206,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
                 $invoice->notes,
                 $now,
                 $invoice->id,
+                $this->orgId->get(),
             ],
         );
 
@@ -217,8 +222,8 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE invoices SET is_deleted = 1, deleted_at = ? WHERE id = ?',
-            [date('Y-m-d H:i:s'), $id],
+            'UPDATE invoices SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
 

--- a/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
+++ b/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 
 use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Routing\Router;
 use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -19,15 +20,23 @@ use Psr\Http\Server\RequestHandlerInterface;
  * `GET /invoices/download/{token}` — public PDF download, no authentication.
  * Validates the token (existence + expiry + invoice not deleted), then streams
  * the PDF. Expired or invalid tokens yield 404 to avoid oracle attacks.
+ *
+ * This route bypasses OrgResolverMiddleware, so the org holder is unset on entry.
+ * The validated token record carries the organization; this handler sets the
+ * holder from it before invoking the (org-scoped) PDF use case (ADR 0006).
  */
 final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterface
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
     public function __construct(
         private InvoiceDownloadTokenRepositoryInterface $tokens,
         private GenerateInvoicePdfUseCase $pdfData,
         private InvoicePdfGenerator $pdfGenerator,
         private Psr17Factory $psr17,
         private ProblemDetailsResponseFactory $problemDetails,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -45,8 +54,11 @@ final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterfac
             return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'Download link not found or expired.');
         }
 
+        // Public route (no OrgResolver): scope the org from the validated token.
+        $this->orgId->set($record->organizationId);
+
         try {
-            $pdfData = $this->pdfData->execute($record->organizationId, $record->invoiceId);
+            $pdfData = $this->pdfData->execute($record->invoiceId);
         } catch (InvoiceNotFoundException) {
             return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'Invoice not found.');
         }

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
@@ -56,6 +58,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                     self::resolve($c, InvoicePdfGenerator::class),
                     self::resolve($c, Psr17Factory::class),
                     self::resolve($c, ProblemDetailsResponseFactory::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -81,5 +84,17 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
         }
 
         return $service;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/ServiceApi/GetServiceInvoiceHandler.php
+++ b/src/ServiceApi/GetServiceInvoiceHandler.php
@@ -39,7 +39,9 @@ final readonly class GetServiceInvoiceHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $invoice = $this->getInvoice->execute($organizationId, $id);
+        // Invoice repo is org-scoped via the holder (set by ServiceScopeMiddleware);
+        // the Payment use case is not yet migrated and still takes the org.
+        $invoice = $this->getInvoice->execute($id);
         $payments = $this->listPayments->execute($organizationId, $id);
 
         return $this->json->create(

--- a/src/ServiceApi/ListServiceInvoicesHandler.php
+++ b/src/ServiceApi/ListServiceInvoicesHandler.php
@@ -46,7 +46,7 @@ final readonly class ListServiceInvoicesHandler implements RequestHandlerInterfa
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset, $this->filterFrom($query));
+        $result = $this->useCase->execute($limit, $offset, $this->filterFrom($query));
         $outstanding = $result->outstandingByInvoiceId;
 
         return $this->json->create([

--- a/tests/Dashboard/GetDashboardHandlerTest.php
+++ b/tests/Dashboard/GetDashboardHandlerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Dashboard;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Dashboard\GetDashboardHandler;
 use NeneInvoice\Dashboard\GetDashboardSummaryUseCase;
 use NeneInvoice\Invoice\Invoice;
@@ -25,14 +25,15 @@ final class GetDashboardHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->psr17    = new Psr17Factory();
-        $this->invoices = new InMemoryInvoiceRepository();
+        $holder         = new RequestScopedHolder();
+        $holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($holder);
         $this->payments = new InMemoryPaymentRepository();
 
         $this->handler = new GetDashboardHandler(
-            new GetDashboardSummaryUseCase($this->invoices, $this->payments),
+            new GetDashboardSummaryUseCase($this->invoices, $this->payments, $holder),
             $this->payments,
             new JsonResponseFactory($this->psr17, $this->psr17),
-            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );
     }
 
@@ -97,11 +98,6 @@ final class GetDashboardHandlerTest extends TestCase
         self::assertCount(2, $body['recent_unpaid']);
     }
 
-    public function test_returns_400_without_org_context(): void
-    {
-        $request = $this->psr17->createServerRequest('GET', '/admin/dashboard');
-
-        $response = $this->handler->handle($request);
-        self::assertSame(400, $response->getStatusCode());
-    }
+    // Note: the "no org context" case is now handled upstream by
+    // OrgResolverMiddleware (404), not by this handler (ADR 0006).
 }

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -19,13 +19,15 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->invoices = new InMemoryInvoiceRepository();
-        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, new InMemoryPaymentRepository());
+        $holder = new \Nene2\Http\RequestScopedHolder();
+        $holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($holder);
+        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, new InMemoryPaymentRepository(), $holder);
     }
 
     public function test_empty_organization_returns_zeros(): void
     {
-        $summary = $this->useCase->execute(1);
+        $summary = $this->useCase->execute();
 
         self::assertSame(0, $summary->unpaidCount);
         self::assertSame(0, $summary->overdueCount);
@@ -40,7 +42,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Paid, subtotalCents: 500, taxCents: 0, totalCents: 500));
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Draft, subtotalCents: 500, taxCents: 0, totalCents: 500));
 
-        $summary = $this->useCase->execute(1);
+        $summary = $this->useCase->execute();
 
         self::assertSame(2, $summary->unpaidCount);
         self::assertCount(2, $summary->recentUnpaid);
@@ -51,7 +53,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000, dueAt: '2020-01-01 00:00:00'));
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 2000, taxCents: 0, totalCents: 2000, dueAt: '2099-12-31 23:59:59'));
 
-        $summary = $this->useCase->execute(1);
+        $summary = $this->useCase->execute();
 
         self::assertSame(2, $summary->unpaidCount);
         self::assertSame(1, $summary->overdueCount);
@@ -62,7 +64,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
         $this->invoices->save(new Invoice(organizationId: 2, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 2000, taxCents: 0, totalCents: 2000));
 
-        $summary = $this->useCase->execute(1);
+        $summary = $this->useCase->execute();
 
         self::assertSame(1, $summary->unpaidCount);
     }
@@ -73,7 +75,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
             $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
         }
 
-        $summary = $this->useCase->execute(1);
+        $summary = $this->useCase->execute();
 
         self::assertSame(7, $summary->unpaidCount);
         self::assertCount(5, $summary->recentUnpaid);

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Invoice;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\ConvertQuoteToInvoiceUseCase;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\LineItem\LineItem;
@@ -20,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryQuoteRepository $quotes;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryLineItemRepository $lineItems;
@@ -28,11 +31,13 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
         $this->quotes = new InMemoryQuoteRepository();
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, $this->invoices, $this->lineItems, $this->audit);
+        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, $this->invoices, $this->lineItems, $this->audit, $this->holder);
     }
 
     private function quote(QuoteStatus $status): int
@@ -59,7 +64,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
     {
         $quoteId = $this->quote(QuoteStatus::Accepted);
 
-        $result = $this->useCase->execute(1, 7, $quoteId);
+        $result = $this->useCase->execute(7, $quoteId);
 
         self::assertSame(InvoiceStatus::Draft, $result->invoice->status);
         self::assertSame($quoteId, $result->invoice->quoteId);
@@ -76,7 +81,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         $quoteId = $this->quote(QuoteStatus::Sent);
 
         $this->expectException(QuoteValidationException::class);
-        $this->useCase->execute(1, 7, $quoteId);
+        $this->useCase->execute(7, $quoteId);
     }
 
     public function test_cross_organization_quote_not_found(): void
@@ -84,6 +89,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         $quoteId = $this->quote(QuoteStatus::Accepted);
 
         $this->expectException(QuoteNotFoundException::class);
-        $this->useCase->execute(2, 7, $quoteId);
+        $this->holder->set(2);
+        $this->useCase->execute(7, $quoteId);
     }
 }

--- a/tests/Invoice/CreateInvoiceUseCaseTest.php
+++ b/tests/Invoice/CreateInvoiceUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Invoice;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Invoice\CreateInvoiceInput;
 use NeneInvoice\Invoice\CreateInvoiceUseCase;
@@ -20,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 
 final class CreateInvoiceUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryLineItemRepository $lineItems;
     private InMemoryClientRepository $clients;
@@ -28,9 +31,11 @@ final class CreateInvoiceUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
-        $this->clients = new InMemoryClientRepository();
+        $this->clients = new InMemoryClientRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
         $this->useCase = new CreateInvoiceUseCase(
             $this->invoices,
@@ -38,6 +43,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
             $this->clients,
             new TaxCalculator(),
             $this->audit,
+            $this->holder,
         );
     }
 
@@ -50,7 +56,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
     {
         $clientId = $this->client();
 
-        $result = $this->useCase->execute(1, 7, new CreateInvoiceInput(
+        $result = $this->useCase->execute(7, new CreateInvoiceInput(
             clientId: $clientId,
             lines: [
                 new LineItemInput('Std', 1, 1000, 1000),
@@ -74,7 +80,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
         $clientId = $this->client(2);
 
         $this->expectException(InvoiceValidationException::class);
-        $this->useCase->execute(1, 7, new CreateInvoiceInput(
+        $this->useCase->execute(7, new CreateInvoiceInput(
             clientId: $clientId,
             lines: [new LineItemInput('Std', 1, 1000, 1000)],
         ));
@@ -85,7 +91,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
         $clientId = $this->client();
 
         $this->expectException(InvoiceValidationException::class);
-        $this->useCase->execute(1, 7, new CreateInvoiceInput(clientId: $clientId, lines: []));
+        $this->useCase->execute(7, new CreateInvoiceInput(clientId: $clientId, lines: []));
     }
 
     public function test_disallowed_tax_rate_rejected(): void
@@ -93,7 +99,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
         $clientId = $this->client();
 
         $this->expectException(InvoiceValidationException::class);
-        $this->useCase->execute(1, 7, new CreateInvoiceInput(
+        $this->useCase->execute(7, new CreateInvoiceInput(
             clientId: $clientId,
             lines: [new LineItemInput('Std', 1, 1000, 500)],
         ));

--- a/tests/Invoice/InvoiceOutstandingTest.php
+++ b/tests/Invoice/InvoiceOutstandingTest.php
@@ -47,7 +47,7 @@ final class InvoiceOutstandingTest extends TestCase
         $this->payments->save(new Payment(organizationId: 1, invoiceId: $id, amountCents: 800, paidAt: '2026-05-30 10:00:00'));
 
         $useCase = new GetInvoiceByIdUseCase($this->invoices, $this->lineItems, $this->payments);
-        $result = $useCase->execute(1, $id);
+        $result = $useCase->execute($id);
 
         self::assertSame(1400, $result->outstandingCents);
     }
@@ -58,7 +58,7 @@ final class InvoiceOutstandingTest extends TestCase
         $this->payments->save(new Payment(organizationId: 1, invoiceId: $id, amountCents: 1000, paidAt: '2026-05-30 10:00:00'));
 
         $useCase = new GetInvoiceByIdUseCase($this->invoices, $this->lineItems, $this->payments);
-        self::assertSame(0, $useCase->execute(1, $id)->outstandingCents);
+        self::assertSame(0, $useCase->execute($id)->outstandingCents);
     }
 
     public function test_list_returns_outstanding_per_invoice(): void
@@ -68,7 +68,7 @@ final class InvoiceOutstandingTest extends TestCase
         $unpaidId = $this->issuedInvoice(5000);
 
         $useCase = new ListInvoicesUseCase($this->invoices, $this->payments);
-        $result = $useCase->execute(1, 20, 0);
+        $result = $useCase->execute(20, 0);
 
         self::assertSame(0, $result->outstandingByInvoiceId[$paidId] ?? null);
         self::assertSame(5000, $result->outstandingByInvoiceId[$unpaidId] ?? null);

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Invoice;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\Invoice\Invoice;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 
 final class IssueInvoiceUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryLineItemRepository $lineItems;
     private InMemoryCompanySettingsRepository $companySettings;
@@ -32,7 +35,9 @@ final class IssueInvoiceUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->companySettings = new InMemoryCompanySettingsRepository();
         $this->audit = new RecordingAuditRecorder();
@@ -42,6 +47,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             $this->audit,
+            $this->holder,
         );
     }
 
@@ -79,7 +85,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $this->registerIssuer();
         $id = $this->draftInvoice();
 
-        $result = $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+        $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
 
         self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
         self::assertTrue($result->invoice->isQualifiedInvoice);
@@ -92,7 +98,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
     {
         $id = $this->draftInvoice();
 
-        $result = $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: false));
+        $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: false));
 
         self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
         self::assertFalse($result->invoice->isQualifiedInvoice);
@@ -104,17 +110,17 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $id = $this->draftInvoice();
 
         $this->expectException(QualifiedInvoiceIncompleteException::class);
-        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
     }
 
     public function test_only_draft_invoice_can_be_issued(): void
     {
         $this->registerIssuer();
         $id = $this->draftInvoice();
-        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
 
         $this->expectException(InvoiceValidationException::class);
-        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
     }
 
     public function test_invoice_without_line_items_cannot_be_issued(): void
@@ -123,7 +129,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $id = $this->draftInvoice(withLines: false);
 
         $this->expectException(InvoiceValidationException::class);
-        $this->useCase->execute(1, 7, $id, new IssueInvoiceInput(qualified: true));
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
     }
 
     public function test_cross_organization_invoice_not_found(): void
@@ -132,6 +138,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $id = $this->draftInvoice();
 
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(2, 7, $id, new IssueInvoiceInput(qualified: true));
+        $this->holder->set(2);
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
     }
 }

--- a/tests/Invoice/PdoInvoiceRepositoryTest.php
+++ b/tests/Invoice/PdoInvoiceRepositoryTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Invoice;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -16,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 final class PdoInvoiceRepositoryTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
     private PdoInvoiceRepository $repository;
 
     protected function setUp(): void
@@ -38,7 +41,9 @@ final class PdoInvoiceRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoInvoiceRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoInvoiceRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
     }
 
     public function test_saves_draft_without_number_then_reads_back(): void
@@ -67,7 +72,7 @@ final class PdoInvoiceRepositoryTest extends TestCase
         $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
         $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
 
-        self::assertSame(2, $this->repository->countByOrganization(1));
+        self::assertSame(2, $this->repository->count());
     }
 
     public function test_issue_assigns_number_and_qualified_flag(): void
@@ -94,13 +99,20 @@ final class PdoInvoiceRepositoryTest extends TestCase
         self::assertTrue($issued->isQualifiedInvoice);
     }
 
-    public function test_list_and_count_scoped_to_organization(): void
+    public function test_list_count_and_find_by_id_scoped_to_organization(): void
     {
-        $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+        $org1Id = $this->repository->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
+
+        $this->orgId->set(2);
         $this->repository->save(new Invoice(organizationId: 2, clientId: 9, status: InvoiceStatus::Draft, subtotalCents: 0, taxCents: 0, totalCents: 0));
 
-        self::assertSame(1, $this->repository->countByOrganization(1));
-        self::assertCount(1, $this->repository->findAllByOrganization(1, 10, 0));
+        $this->orgId->set(1);
+        self::assertSame(1, $this->repository->count());
+        self::assertCount(1, $this->repository->findAll(10, 0));
+
+        // A caller in another org must not read the row even by direct id.
+        $this->orgId->set(2);
+        self::assertNull($this->repository->findById($org1Id));
     }
 
     public function test_soft_delete_and_unknown_delete_throws(): void
@@ -122,24 +134,24 @@ final class PdoInvoiceRepositoryTest extends TestCase
 
         // status filter
         $issued = new InvoiceListFilter(statuses: ['issued']);
-        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $issued));
+        self::assertSame(2, $this->repository->countFiltered($issued));
 
         // client filter
         $client5 = new InvoiceListFilter(clientId: 5);
-        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $client5));
+        self::assertSame(2, $this->repository->countFiltered($client5));
 
         // outstanding only (open = issued/partially_paid) excludes the paid one
         $open = new InvoiceListFilter(outstandingOnly: true);
-        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $open));
+        self::assertSame(2, $this->repository->countFiltered($open));
 
         // overdue as of 2026-06-01: INV-2 (due 02-28) is overdue, INV-3 (due 12-31) is not
         $overdue = new InvoiceListFilter(overdueOnly: true, today: '2026-06-01');
-        $rows = $this->repository->findByOrganizationFiltered(1, $overdue, 10, 0);
+        $rows = $this->repository->findFiltered($overdue, 10, 0);
         self::assertCount(1, $rows);
         self::assertSame('INV-2', $rows[0]->invoiceNumber);
 
         // due_before
         $dueBeforeMarch = new InvoiceListFilter(dueBefore: '2026-03-01');
-        self::assertSame(2, $this->repository->countByOrganizationFiltered(1, $dueBeforeMarch)); // 01-31 and 02-28
+        self::assertSame(2, $this->repository->countFiltered($dueBeforeMarch)); // 01-31 and 02-28
     }
 }

--- a/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
+++ b/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
@@ -35,10 +35,12 @@ final class DownloadInvoicePdfHandlerTest extends TestCase
     {
         $this->psr17 = new Psr17Factory();
 
-        $invoices    = new InMemoryInvoiceRepository();
+        // The handler sets this holder from the validated token record's org.
+        $holder      = new \Nene2\Http\RequestScopedHolder();
+        $invoices    = new InMemoryInvoiceRepository($holder);
         $lineItems   = new InMemoryLineItemRepository();
         $payments    = new InMemoryPaymentRepository();
-        $clients     = new InMemoryClientRepository();
+        $clients     = new InMemoryClientRepository($holder);
         $company     = new InMemoryCompanySettingsRepository();
         $this->tokens = new InMemoryInvoiceDownloadTokenRepository();
 
@@ -57,10 +59,11 @@ final class DownloadInvoicePdfHandlerTest extends TestCase
 
         $this->handler = new DownloadInvoicePdfHandler(
             $this->tokens,
-            new GenerateInvoicePdfUseCase($invoices, $lineItems, $payments, $company, $clients),
+            new GenerateInvoicePdfUseCase($invoices, $lineItems, $payments, $company, $clients, $holder),
             new InvoicePdfGenerator(new TaxCalculator()),
             $this->psr17,
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+            $holder,
         );
     }
 

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -11,7 +12,10 @@ use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\InvoiceStatus;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\Invoice\PdoInvoiceRepository}.
+ * `save` keeps the entity's org so tests can seed cross-tenant fixtures. The
+ * holder defaults to organization 1 for single-org tests.
  */
 final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
 {
@@ -19,54 +23,67 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
     private array $byId = [];
     private int $nextId = 1;
 
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
     public function findById(int $id): ?Invoice
     {
         $invoice = $this->byId[$id] ?? null;
 
-        return $invoice !== null && !$invoice->isDeleted ? $invoice : null;
+        return $invoice !== null && !$invoice->isDeleted && $invoice->organizationId === $this->orgId->get()
+            ? $invoice
+            : null;
     }
 
     /** @return list<Invoice> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
-            static fn (Invoice $i): bool => $i->organizationId === $organizationId && !$i->isDeleted,
+            fn (Invoice $i): bool => $i->organizationId === $this->orgId->get() && !$i->isDeleted,
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         return count(array_filter(
             $this->byId,
-            static fn (Invoice $i): bool => $i->organizationId === $organizationId && !$i->isDeleted,
+            fn (Invoice $i): bool => $i->organizationId === $this->orgId->get() && !$i->isDeleted,
         ));
     }
 
     /** @return list<Invoice> */
-    public function findByOrganizationFiltered(
-        int $organizationId,
-        InvoiceListFilter $filter,
-        int $limit,
-        int $offset,
-    ): array {
-        return array_slice($this->filtered($organizationId, $filter), $offset, $limit);
+    public function findFiltered(InvoiceListFilter $filter, int $limit, int $offset): array
+    {
+        return array_slice($this->filtered($filter), $offset, $limit);
     }
 
-    public function countByOrganizationFiltered(int $organizationId, InvoiceListFilter $filter): int
+    public function countFiltered(InvoiceListFilter $filter): int
     {
-        return count($this->filtered($organizationId, $filter));
+        return count($this->filtered($filter));
     }
 
     /** @return list<Invoice> */
-    private function filtered(int $organizationId, InvoiceListFilter $filter): array
+    private function filtered(InvoiceListFilter $filter): array
     {
-        $open = [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid];
+        $open  = [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid];
+        $orgId = $this->orgId->get();
 
-        return array_values(array_filter($this->byId, function (Invoice $i) use ($organizationId, $filter, $open): bool {
-            if ($i->organizationId !== $organizationId || $i->isDeleted) {
+        return array_values(array_filter($this->byId, function (Invoice $i) use ($orgId, $filter, $open): bool {
+            if ($i->organizationId !== $orgId || $i->isDeleted) {
                 return false;
             }
             if ($filter->statuses !== [] && !in_array($i->status->value, $filter->statuses, true)) {
@@ -95,11 +112,12 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
     /**
      * @return array{unpaid_count: int, overdue_count: int, recent_unpaid: list<Invoice>}
      */
-    public function getDashboardData(int $organizationId, string $now): array
+    public function getDashboardData(string $now): array
     {
+        $orgId  = $this->orgId->get();
         $unpaid = array_values(array_filter(
             $this->byId,
-            static fn (Invoice $i): bool => $i->organizationId === $organizationId
+            static fn (Invoice $i): bool => $i->organizationId === $orgId
                 && !$i->isDeleted
                 && in_array($i->status, [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid], true),
         ));


### PR DESCRIPTION
## Summary

#149（Client）に続く Invoice ドメインの holder ベース移行。テナント分離をリポジトリ SQL 層で構造的に保証する。

### 変更
- **`PdoInvoiceRepository`** — holder 注入。全クエリ（`findById` / `findFiltered` / `getDashboardData` 含む）に `organization_id = ?` を強制。書き込みは holder org を強制。
  - メソッド改名: `findAllByOrganization`→`findAll`、`countByOrganization`→`count`、`findByOrganizationFiltered`→`findFiltered`、`countByOrganizationFiltered`→`countFiltered`、`getDashboardData(org,now)`→`getDashboardData(now)`
- **Invoice UseCase ×6**（List/Get/Create/Issue/Convert/GeneratePdf）+ **Dashboard UseCase** — org を holder から取得。未移行依存（Company/DocSeq/Quote/Payment/Audit）には holder 値を明示的に渡す。
- **ハンドラ**（Invoice ×6 / Dashboard / ServiceApi ×2 / 公開DL）— `AuthContext::organizationId` 読み取りと org-null ガードを除去。
- **公開ダウンロード** — `/invoices/download/{token}` は OrgResolver バイパスのため、`DownloadInvoicePdfHandler` が検証済みトークンレコードの org を holder にセットしてから PDF 生成。

### テスト
- `InMemoryInvoiceRepository` を holder 化（reads scope by holder、save は entity org でクロス org fixture 可）。
- cross-tenant `findById` の SQL スコープを直接検証。
- 251 tests green。

## Test plan
- [ ] `composer check` green（PHPUnit 251 / PHPStan level 8 / CS / OpenAPI / MCP）
- [ ] `/admin/invoices` 系・`/admin/dashboard` が OrgResolver の holder で動作
- [ ] `/api/invoices` がサービストークン org の holder で動作
- [ ] 公開 PDF ダウンロード（時限トークン）が token レコード org で動作
- [ ] 別 org の invoice id → 404（SQL レベル）

## 後続
Quote → Payment → CompanySettings → Audit → DocumentSequence、最後に User / フォールバック除去。

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)