### PR TITLE
feat(tenancy): Quote ドメインを holder ベースへ (#153)

### DIFF
--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -41,10 +41,10 @@ final readonly class ConvertQuoteToInvoiceUseCase
     {
         $organizationId = $this->orgId->get();
 
-        // The quote repo is not yet org-scoped, so guard the org here.
+        // The quote repo is org-scoped via the holder; cross-org → null.
         $quote = $this->quotes->findById($quoteId);
 
-        if ($quote === null || $quote->organizationId !== $organizationId) {
+        if ($quote === null) {
             throw new QuoteNotFoundException($quoteId);
         }
 

--- a/src/Quote/ChangeQuoteStatusHandler.php
+++ b/src/Quote/ChangeQuoteStatusHandler.php
@@ -26,12 +26,6 @@ final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
@@ -43,7 +37,7 @@ final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"status" must be one of: draft, sent, accepted, rejected, expired.');
         }
 
-        $quote = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, $target);
+        $quote = $this->useCase->execute(AuthContext::userId($request), $id, $target);
 
         return $this->json->create(QuoteResponse::toArray($quote));
     }

--- a/src/Quote/ChangeQuoteStatusUseCase.php
+++ b/src/Quote/ChangeQuoteStatusUseCase.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class ChangeQuoteStatusUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private QuoteRepositoryInterface $quotes,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -19,11 +24,11 @@ final readonly class ChangeQuoteStatusUseCase
      * @throws QuoteNotFoundException
      * @throws InvalidStateTransitionException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $id, QuoteStatus $target): Quote
+    public function execute(?int $actorUserId, int $id, QuoteStatus $target): Quote
     {
         $quote = $this->quotes->findById($id);
 
-        if ($quote === null || $quote->organizationId !== $organizationId) {
+        if ($quote === null) {
             throw new QuoteNotFoundException($id);
         }
 
@@ -60,7 +65,7 @@ final readonly class ChangeQuoteStatusUseCase
 
         $this->audit->record(
             $actorUserId,
-            $organizationId,
+            $this->orgId->get(),
             'quote.status_changed',
             'quote',
             $id,

--- a/src/Quote/CreateQuoteHandler.php
+++ b/src/Quote/CreateQuoteHandler.php
@@ -26,12 +26,6 @@ final readonly class CreateQuoteHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $decoded = json_decode((string) $request->getBody(), true);
 
         if (!is_array($decoded)) {
@@ -69,7 +63,6 @@ final readonly class CreateQuoteHandler implements RequestHandlerInterface
         }
 
         $result = $this->useCase->execute(
-            $organizationId,
             AuthContext::userId($request),
             new CreateQuoteInput(
                 clientId: (int) $clientId,

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
@@ -24,6 +25,9 @@ final readonly class CreateQuoteUseCase
     /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private QuoteRepositoryInterface $quotes,
         private LineItemRepositoryInterface $lineItems,
@@ -31,15 +35,19 @@ final readonly class CreateQuoteUseCase
         private DocumentNumberGenerator $numbers,
         private TaxCalculator $taxCalculator,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /** @throws QuoteValidationException */
-    public function execute(int $organizationId, ?int $actorUserId, CreateQuoteInput $input): QuoteWithLines
+    public function execute(?int $actorUserId, CreateQuoteInput $input): QuoteWithLines
     {
+        $organizationId = $this->orgId->get();
+
+        // The client repo is org-scoped, so a cross-org client surfaces as null.
         $client = $this->clients->findById($input->clientId);
 
-        if ($client === null || $client->organizationId !== $organizationId) {
+        if ($client === null) {
             throw new QuoteValidationException('The selected client does not exist in your organization.');
         }
 

--- a/src/Quote/GetQuoteByIdHandler.php
+++ b/src/Quote/GetQuoteByIdHandler.php
@@ -4,38 +4,30 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/quotes/{id}` — returns a quote and its line items.
+ * `GET /admin/quotes/{id}` — returns a quote and its line items in the resolved
+ * organization (scoped by the repository via the org holder).
  */
 final readonly class GetQuoteByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GetQuoteByIdUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $result = $this->useCase->execute($organizationId, $id);
+        $result = $this->useCase->execute($id);
 
         return $this->json->create(QuoteResponse::toArray($result->quote, $result->lines));
     }

--- a/src/Quote/GetQuoteByIdUseCase.php
+++ b/src/Quote/GetQuoteByIdUseCase.php
@@ -21,11 +21,11 @@ final readonly class GetQuoteByIdUseCase
      *
      * @throws QuoteNotFoundException
      */
-    public function execute(int $organizationId, int $id): QuoteWithLines
+    public function execute(int $id): QuoteWithLines
     {
         $quote = $this->quotes->findById($id);
 
-        if ($quote === null || $quote->organizationId !== $organizationId) {
+        if ($quote === null) {
             throw new QuoteNotFoundException($id);
         }
 

--- a/src/Quote/ListQuotesHandler.php
+++ b/src/Quote/ListQuotesHandler.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/quotes` — lists quote headers in the caller's organization.
+ * `GET /admin/quotes` — lists quote headers in the resolved organization
+ * (scoped by the repository via the org holder).
  */
 final readonly class ListQuotesHandler implements RequestHandlerInterface
 {
@@ -22,18 +21,11 @@ final readonly class ListQuotesHandler implements RequestHandlerInterface
     public function __construct(
         private ListQuotesUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $query = $request->getQueryParams();
 
         $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
@@ -42,7 +34,7 @@ final readonly class ListQuotesHandler implements RequestHandlerInterface
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($limit, $offset);
 
         return $this->json->create([
             'items' => array_map(static fn (Quote $q): array => QuoteResponse::toArray($q), $result->items),

--- a/src/Quote/ListQuotesUseCase.php
+++ b/src/Quote/ListQuotesUseCase.php
@@ -11,11 +11,11 @@ final readonly class ListQuotesUseCase
     ) {
     }
 
-    public function execute(int $organizationId, int $limit, int $offset): ListQuotesResult
+    public function execute(int $limit, int $offset): ListQuotesResult
     {
         return new ListQuotesResult(
-            $this->quotes->findAllByOrganization($organizationId, $limit, $offset),
-            $this->quotes->countByOrganization($organizationId),
+            $this->quotes->findAll($limit, $offset),
+            $this->quotes->count(),
         );
     }
 }

--- a/src/Quote/PdoQuoteRepository.php
+++ b/src/Quote/PdoQuoteRepository.php
@@ -5,42 +5,47 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
 {
     private const COLUMNS = 'id, organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     public function findById(int $id): ?Quote
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE id = ? AND is_deleted = 0',
-            [$id],
+            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$id, $this->orgId->get()],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
     }
 
     /** @return list<Quote> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM quotes WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            [$this->orgId->get(), $limit, $offset],
         );
 
         return array_map(fn (array $row): Quote => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt FROM quotes WHERE organization_id = ? AND is_deleted = 0',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['cnt'] : 0;
@@ -50,11 +55,12 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
     {
         $now = date('Y-m-d H:i:s');
 
+        // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO quotes (organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
-                $quote->organizationId,
+                $this->orgId->get(),
                 $quote->clientId,
                 $quote->quoteNumber,
                 $quote->status->value,
@@ -81,7 +87,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE quotes SET client_id = ?, status = ?, issued_at = ?, valid_until = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            'UPDATE quotes SET client_id = ?, status = ?, issued_at = ?, valid_until = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
             [
                 $quote->clientId,
                 $quote->status->value,
@@ -93,6 +99,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
                 $quote->notes,
                 $now,
                 $quote->id,
+                $this->orgId->get(),
             ],
         );
 
@@ -108,8 +115,8 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE quotes SET is_deleted = 1, deleted_at = ? WHERE id = ?',
-            [date('Y-m-d H:i:s'), $id],
+            'UPDATE quotes SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
 

--- a/src/Quote/QuoteRepositoryInterface.php
+++ b/src/Quote/QuoteRepositoryInterface.php
@@ -5,16 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 /**
- * Persistence for quotes. Reads exclude soft-deleted rows; `delete` is soft.
+ * Persistence for quotes. Every query is scoped to the organization held in the
+ * request-scoped org holder (ADR 0006). Reads exclude soft-deleted rows;
+ * `delete` is soft.
  */
 interface QuoteRepositoryInterface
 {
     public function findById(int $id): ?Quote;
 
     /** @return list<Quote> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findAll(int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function count(): int;
 
     public function save(Quote $quote): int;
 

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
@@ -35,7 +37,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoQuoteRepository($query);
+                    return new PdoQuoteRepository($query, self::orgHolder($c));
                 },
             )
             ->set(TaxCalculator::class, static fn (ContainerInterface $c): TaxCalculator => new TaxCalculator())
@@ -48,6 +50,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                     self::resolve($c, DocumentNumberGenerator::class),
                     self::resolve($c, TaxCalculator::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -55,6 +58,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ChangeQuoteStatusUseCase => new ChangeQuoteStatusUseCase(
                     self::quotes($c),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(ListQuotesUseCase::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
@@ -78,7 +82,6 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ListQuotesHandler => new ListQuotesHandler(
                     self::resolve($c, ListQuotesUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -86,7 +89,6 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): GetQuoteByIdHandler => new GetQuoteByIdHandler(
                     self::resolve($c, GetQuoteByIdUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -135,6 +137,18 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
         }
 
         return $repo;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 
     /**

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -33,7 +33,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
     {
         $this->holder = new RequestScopedHolder();
         $this->holder->set(1);
-        $this->quotes = new InMemoryQuoteRepository();
+        $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->audit = new RecordingAuditRecorder();

--- a/tests/Quote/ChangeQuoteStatusUseCaseTest.php
+++ b/tests/Quote/ChangeQuoteStatusUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Quote;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Quote\ChangeQuoteStatusUseCase;
 use NeneInvoice\Quote\InvalidStateTransitionException;
 use NeneInvoice\Quote\Quote;
@@ -15,15 +16,19 @@ use PHPUnit\Framework\TestCase;
 
 final class ChangeQuoteStatusUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryQuoteRepository $quotes;
     private RecordingAuditRecorder $audit;
     private ChangeQuoteStatusUseCase $useCase;
 
     protected function setUp(): void
     {
-        $this->quotes = new InMemoryQuoteRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit);
+        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit, $this->holder);
     }
 
     private function draft(): int
@@ -43,7 +48,7 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
     {
         $id = $this->draft();
 
-        $quote = $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
+        $quote = $this->useCase->execute(7, $id, QuoteStatus::Sent);
 
         self::assertSame(QuoteStatus::Sent, $quote->status);
         self::assertNotNull($quote->issuedAt);
@@ -55,9 +60,9 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
     public function test_sent_to_accepted_is_allowed(): void
     {
         $id = $this->draft();
-        $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
 
-        $quote = $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+        $quote = $this->useCase->execute(7, $id, QuoteStatus::Accepted);
         self::assertSame(QuoteStatus::Accepted, $quote->status);
     }
 
@@ -66,17 +71,17 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
         $id = $this->draft();
 
         $this->expectException(InvalidStateTransitionException::class);
-        $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+        $this->useCase->execute(7, $id, QuoteStatus::Accepted);
     }
 
     public function test_accepted_is_terminal(): void
     {
         $id = $this->draft();
-        $this->useCase->execute(1, 7, $id, QuoteStatus::Sent);
-        $this->useCase->execute(1, 7, $id, QuoteStatus::Accepted);
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
+        $this->useCase->execute(7, $id, QuoteStatus::Accepted);
 
         $this->expectException(InvalidStateTransitionException::class);
-        $this->useCase->execute(1, 7, $id, QuoteStatus::Rejected);
+        $this->useCase->execute(7, $id, QuoteStatus::Rejected);
     }
 
     public function test_cross_organization_quote_not_found(): void
@@ -84,6 +89,7 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
         $id = $this->draft();
 
         $this->expectException(QuoteNotFoundException::class);
-        $this->useCase->execute(2, 7, $id, QuoteStatus::Sent);
+        $this->holder->set(2);
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
     }
 }

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Quote;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemInput;
@@ -22,6 +23,8 @@ use PHPUnit\Framework\TestCase;
 
 final class CreateQuoteUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryQuoteRepository $quotes;
     private InMemoryLineItemRepository $lineItems;
     private InMemoryClientRepository $clients;
@@ -31,9 +34,11 @@ final class CreateQuoteUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->quotes = new InMemoryQuoteRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
-        $this->clients = new InMemoryClientRepository();
+        $this->clients = new InMemoryClientRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
         $this->clientId = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
 
@@ -44,12 +49,13 @@ final class CreateQuoteUseCaseTest extends TestCase
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             $this->audit,
+            $this->holder,
         );
     }
 
     public function test_creates_quote_with_computed_totals_number_lines_and_audit(): void
     {
-        $result = $this->useCase->execute(1, 42, new CreateQuoteInput(
+        $result = $this->useCase->execute(42, new CreateQuoteInput(
             clientId: $this->clientId,
             lines: [
                 new LineItemInput('Standard', 1, 1000, 1000), // ¥1000 @10% → 100
@@ -77,18 +83,18 @@ final class CreateQuoteUseCaseTest extends TestCase
         $otherClient = $this->clients->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(QuoteValidationException::class);
-        $this->useCase->execute(1, 1, new CreateQuoteInput($otherClient, [new LineItemInput('X', 1, 1000, 1000)]));
+        $this->useCase->execute(1, new CreateQuoteInput($otherClient, [new LineItemInput('X', 1, 1000, 1000)]));
     }
 
     public function test_rejects_empty_lines(): void
     {
         $this->expectException(QuoteValidationException::class);
-        $this->useCase->execute(1, 1, new CreateQuoteInput($this->clientId, []));
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, []));
     }
 
     public function test_rejects_disallowed_tax_rate(): void
     {
         $this->expectException(QuoteValidationException::class);
-        $this->useCase->execute(1, 1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, 500)]));
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, 500)]));
     }
 }

--- a/tests/Quote/PdoQuoteRepositoryTest.php
+++ b/tests/Quote/PdoQuoteRepositoryTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Quote;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Quote\PdoQuoteRepository;
 use NeneInvoice\Quote\Quote;
 use NeneInvoice\Quote\QuoteNotFoundException;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 final class PdoQuoteRepositoryTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
     private PdoQuoteRepository $repository;
 
     protected function setUp(): void
@@ -37,7 +40,9 @@ final class PdoQuoteRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoQuoteRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoQuoteRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
     }
 
     private function draft(int $org, int $client, string $number): Quote
@@ -67,13 +72,20 @@ final class PdoQuoteRepositoryTest extends TestCase
 
     public function test_list_and_count_scoped_to_organization(): void
     {
-        $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
+        $org1QuoteId = $this->repository->save($this->draft(1, 5, 'EST-2026-001'));
         $this->repository->save($this->draft(1, 5, 'EST-2026-002'));
+
+        $this->orgId->set(2);
         $this->repository->save($this->draft(2, 9, 'EST-2026-001'));
 
-        self::assertSame(2, $this->repository->countByOrganization(1));
-        self::assertCount(2, $this->repository->findAllByOrganization(1, 10, 0));
-        self::assertSame(1, $this->repository->countByOrganization(2));
+        $this->orgId->set(1);
+        self::assertSame(2, $this->repository->count());
+        self::assertCount(2, $this->repository->findAll(10, 0));
+
+        $this->orgId->set(2);
+        self::assertSame(1, $this->repository->count());
+        // A caller in another org must not read the row even by direct id.
+        self::assertNull($this->repository->findById($org1QuoteId));
     }
 
     public function test_update_changes_status_and_totals(): void
@@ -106,7 +118,7 @@ final class PdoQuoteRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->countByOrganization(1));
+        self::assertSame(0, $this->repository->count());
     }
 
     public function test_delete_throws_for_unknown_quote(): void

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Quote;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemInput;
@@ -22,32 +23,40 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for GetQuoteByIdUseCase and ListQuotesUseCase:
- * org-scope isolation, line-item inclusion, and pagination.
+ * org-scope isolation (holder-based), line-item inclusion, and pagination.
  */
 final class QuoteQueryUseCasesTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryQuoteRepository $quotes;
     private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private CreateQuoteUseCase $create;
+    private int $clientId;
     private ?int $quoteId;
 
     protected function setUp(): void
     {
-        $this->quotes    = new InMemoryQuoteRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->quotes    = new InMemoryQuoteRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
-        $clients         = new InMemoryClientRepository();
-        $clientId        = $clients->save(new Client(organizationId: 1, name: 'Acme'));
+        $this->clients   = new InMemoryClientRepository($this->holder);
+        $this->clientId  = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
 
-        $createUseCase = new CreateQuoteUseCase(
+        $this->create = new CreateQuoteUseCase(
             $this->quotes,
             $this->lineItems,
-            $clients,
+            $this->clients,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             new RecordingAuditRecorder(),
+            $this->holder,
         );
 
-        $this->quoteId = $createUseCase->execute(1, null, new CreateQuoteInput(
-            clientId: $clientId,
+        $this->quoteId = $this->create->execute(null, new CreateQuoteInput(
+            clientId: $this->clientId,
             lines: [new LineItemInput('コンサル', 1, 50000, 1000)],
             validUntil: null,
             notes: null,
@@ -59,8 +68,7 @@ final class QuoteQueryUseCasesTest extends TestCase
     public function test_get_returns_quote_with_line_items(): void
     {
         self::assertNotNull($this->quoteId);
-        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
-        $result  = $useCase->execute(1, $this->quoteId);
+        $result = (new GetQuoteByIdUseCase($this->quotes, $this->lineItems))->execute($this->quoteId);
 
         self::assertSame($this->quoteId, $result->quote->id);
         self::assertCount(1, $result->lines);
@@ -70,68 +78,37 @@ final class QuoteQueryUseCasesTest extends TestCase
     public function test_get_hides_quote_from_another_organization(): void
     {
         self::assertNotNull($this->quoteId);
-        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
+        $this->holder->set(2);
 
         $this->expectException(QuoteNotFoundException::class);
-        $useCase->execute(2, $this->quoteId);
+        (new GetQuoteByIdUseCase($this->quotes, $this->lineItems))->execute($this->quoteId);
     }
 
     public function test_get_throws_for_nonexistent_id(): void
     {
-        $useCase = new GetQuoteByIdUseCase($this->quotes, $this->lineItems);
-
         $this->expectException(QuoteNotFoundException::class);
-        $useCase->execute(1, 9999);
+        (new GetQuoteByIdUseCase($this->quotes, $this->lineItems))->execute(9999);
     }
 
     // ------------------------------ ListQuotes ------------------------------
 
     public function test_list_is_scoped_to_organization(): void
     {
-        $org2      = new \Nene2\Http\RequestScopedHolder();
-        $org2->set(2);
-        $clients2  = new InMemoryClientRepository($org2);
-        $client2Id = $clients2->save(new Client(organizationId: 2, name: 'OtherOrg'));
-        $quotes2   = new InMemoryQuoteRepository();
-
-        (new CreateQuoteUseCase(
-            $quotes2,
-            new InMemoryLineItemRepository(),
-            $clients2,
-            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
-            new TaxCalculator(),
-            new RecordingAuditRecorder(),
-        ))->execute(2, null, new CreateQuoteInput(
-            clientId: $client2Id,
-            lines: [new LineItemInput('Other', 1, 10000, 1000)],
-            validUntil: null,
-            notes: null,
-        ));
-
         $useCase = new ListQuotesUseCase($this->quotes);
 
-        // org 1 sees 1 quote, org 2 sees its own separately
-        self::assertSame(1, $useCase->execute(1, 20, 0)->total);
-        self::assertSame(0, $useCase->execute(2, 20, 0)->total);
+        // org 1 has the quote from setUp; org 2 sees none (holder-scoped)
+        self::assertSame(1, $useCase->execute(20, 0)->total);
+
+        $this->holder->set(2);
+        self::assertSame(0, $useCase->execute(20, 0)->total);
     }
 
     public function test_list_pagination_limit_and_offset(): void
     {
-        $clients = new InMemoryClientRepository();
-        $cid     = $clients->save(new Client(organizationId: 1, name: 'Acme'));
-        $create  = new CreateQuoteUseCase(
-            $this->quotes,
-            $this->lineItems,
-            $clients,
-            new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
-            new TaxCalculator(),
-            new RecordingAuditRecorder(),
-        );
-
         // setUp already has 1 quote; add 4 more
         for ($i = 0; $i < 4; $i++) {
-            $create->execute(1, null, new CreateQuoteInput(
-                clientId: $cid,
+            $this->create->execute(null, new CreateQuoteInput(
+                clientId: $this->clientId,
                 lines: [new LineItemInput("Item {$i}", 1, 1000, 1000)],
                 validUntil: null,
                 notes: null,
@@ -139,11 +116,11 @@ final class QuoteQueryUseCasesTest extends TestCase
         }
 
         $useCase = new ListQuotesUseCase($this->quotes);
-        $page    = $useCase->execute(1, 3, 0);
+        $page    = $useCase->execute(3, 0);
         self::assertSame(5, $page->total);
         self::assertCount(3, $page->items);
 
-        $page2 = $useCase->execute(1, 3, 3);
+        $page2 = $useCase->execute(3, 3);
         self::assertCount(2, $page2->items);
     }
 }

--- a/tests/Support/InMemoryQuoteRepository.php
+++ b/tests/Support/InMemoryQuoteRepository.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Quote\Quote;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\Quote\PdoQuoteRepository}.
+ * `save` keeps the entity's org so tests can seed cross-tenant fixtures. The
+ * holder defaults to organization 1 for single-org tests.
  */
 final class InMemoryQuoteRepository implements QuoteRepositoryInterface
 {
@@ -17,29 +21,45 @@ final class InMemoryQuoteRepository implements QuoteRepositoryInterface
     private array $byId = [];
     private int $nextId = 1;
 
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
     public function findById(int $id): ?Quote
     {
         $quote = $this->byId[$id] ?? null;
 
-        return $quote !== null && !$quote->isDeleted ? $quote : null;
+        return $quote !== null && !$quote->isDeleted && $quote->organizationId === $this->orgId->get()
+            ? $quote
+            : null;
     }
 
     /** @return list<Quote> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
-            static fn (Quote $q): bool => $q->organizationId === $organizationId && !$q->isDeleted,
+            fn (Quote $q): bool => $q->organizationId === $this->orgId->get() && !$q->isDeleted,
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         return count(array_filter(
             $this->byId,
-            static fn (Quote $q): bool => $q->organizationId === $organizationId && !$q->isDeleted,
+            fn (Quote $q): bool => $q->organizationId === $this->orgId->get() && !$q->isDeleted,
         ));
     }
 


### PR DESCRIPTION
## Summary
#151（Invoice）に続く Quote ドメインの holder ベース移行。

- **`PdoQuoteRepository`** — holder 注入、全クエリ（findById 含む）に `organization_id = ?` を強制。`findAllByOrganization`/`countByOrganization`→`findAll`/`count`。
- **Quote UseCase ×4**（Create/ChangeStatus/List/Get）— org を holder から取得、cross-org PHP チェックを SQL スコープに置換。
- **`ConvertQuoteToInvoiceUseCase`**（Invoice）— Quote が holder 化されたため org チェックを簡略化。
- ハンドラ ×4 — `AuthContext::organizationId` 読み取り除去。
- `InMemoryQuoteRepository` を holder 化、cross-tenant findById を直接検証。251 tests green。

## Test plan
- [ ] `composer check` green（251 / PHPStan / CS / OpenAPI / MCP）
- [ ] 別 org の quote id → 404（SQL レベル）
- [ ] accepted quote の請求書変換が holder で動作

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)