### PR TITLE
feat(tenancy): Payment ドメインを holder ベースへ (#155)

### DIFF
--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -8,8 +8,6 @@ use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
-use Nene2\Http\RequestScopedHolder;
-use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -24,7 +22,6 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
                 static fn (ContainerInterface $c): GetDashboardSummaryUseCase => new GetDashboardSummaryUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
-                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -57,17 +54,5 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
         }
 
         return $service;
-    }
-
-    /** @return RequestScopedHolder<int> */
-    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
-    {
-        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
-
-        if (!$holder instanceof RequestScopedHolder) {
-            throw new LogicException('Org id holder service is invalid.');
-        }
-
-        return $holder;
     }
 }

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 namespace NeneInvoice\Dashboard;
 
 use DateTimeImmutable;
-use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 
 /**
  * Assembles the dashboard summary: unpaid/overdue counts, outstanding balance,
- * and the most recent 5 unpaid invoices — all in two queries.
+ * and the most recent 5 unpaid invoices. Both repositories are org-scoped via
+ * the request holder, so no organization id is threaded here (ADR 0006).
  */
 final readonly class GetDashboardSummaryUseCase
 {
-    /**
-     * @param RequestScopedHolder<int> $orgId resolved organization for this request
-     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private PaymentRepositoryInterface $payments,
-        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -30,8 +26,7 @@ final readonly class GetDashboardSummaryUseCase
         $now  = (new DateTimeImmutable())->format('Y-m-d H:i:s');
         $data = $this->invoices->getDashboardData($now);
 
-        // Payment repo is not yet org-scoped; pass the resolved org explicitly.
-        $outstandingTotalCents = $this->payments->outstandingTotalForOrganization($this->orgId->get());
+        $outstandingTotalCents = $this->payments->outstandingTotal();
 
         return new DashboardSummary(
             unpaidCount: $data['unpaid_count'],

--- a/src/Payment/ListPaymentsHandler.php
+++ b/src/Payment/ListPaymentsHandler.php
@@ -4,39 +4,30 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * `GET /admin/invoices/{id}/payments` — lists the payments recorded against an
- * invoice in the caller's organization.
+ * invoice in the resolved organization (scoped by the repository via the holder).
  */
 final readonly class ListPaymentsHandler implements RequestHandlerInterface
 {
     public function __construct(
         private ListPaymentsUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $payments = $this->useCase->execute($organizationId, $invoiceId);
+        $payments = $this->useCase->execute($invoiceId);
 
         return $this->json->create([
             'items' => array_map(static fn (Payment $p): array => PaymentResponse::toArray($p), $payments),

--- a/src/Payment/ListPaymentsUseCase.php
+++ b/src/Payment/ListPaymentsUseCase.php
@@ -24,11 +24,11 @@ final readonly class ListPaymentsUseCase
      *
      * @throws InvoiceNotFoundException
      */
-    public function execute(int $organizationId, int $invoiceId): array
+    public function execute(int $invoiceId): array
     {
         $invoice = $this->invoices->findById($invoiceId);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($invoiceId);
         }
 

--- a/src/Payment/PaymentRepositoryInterface.php
+++ b/src/Payment/PaymentRepositoryInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace NeneInvoice\Payment;
 
 /**
- * Persistence for payments. Payments are immaterial of their own lifecycle — a
- * correction is a separate (future) refund operation, not an in-place edit.
+ * Persistence for payments. Every query is scoped to the organization held in
+ * the request-scoped org holder (ADR 0006). Payments are immaterial of their own
+ * lifecycle — a correction is a separate (future) refund operation.
  */
 interface PaymentRepositoryInterface
 {
@@ -15,7 +16,7 @@ interface PaymentRepositoryInterface
     public function findById(int $id): ?Payment;
 
     /** Returns the payment previously recorded with this idempotency key, if any. */
-    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment;
+    public function findByIdempotencyKey(string $idempotencyKey): ?Payment;
 
     /** Voids a payment (soft delete). Idempotent: voiding an already-voided one is a no-op. */
     public function markVoided(int $id): void;
@@ -39,7 +40,7 @@ interface PaymentRepositoryInterface
 
     /**
      * Total outstanding balance across all issued / partially_paid invoices for the
-     * organization: sum(invoice.total_cents) - sum(non-void payments) for those invoices.
+     * resolved organization: sum(invoice.total_cents) - sum(non-void payments).
      */
-    public function outstandingTotalForOrganization(int $organizationId): int;
+    public function outstandingTotal(): int;
 }

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -32,7 +34,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoPaymentRepository($query);
+                    return new PdoPaymentRepository($query, self::orgHolder($c));
                 },
             )
             ->set(
@@ -41,6 +43,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -56,6 +59,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -63,7 +67,6 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): RecordPaymentHandler => new RecordPaymentHandler(
                     self::resolve($c, RecordPaymentUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -71,7 +74,6 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ListPaymentsHandler => new ListPaymentsHandler(
                     self::resolve($c, ListPaymentsUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -125,5 +127,17 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
     private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
     {
         return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\Payment;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
 {
     private const COLUMNS = 'id, organization_id, invoice_id, amount_cents, paid_at, method, note, external_reference, idempotency_key, is_deleted, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -19,11 +24,12 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     {
         $now = date('Y-m-d H:i:s');
 
+        // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, method, note, external_reference, idempotency_key, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
-                $payment->organizationId,
+                $this->orgId->get(),
                 $payment->invoiceId,
                 $payment->amountCents,
                 $payment->paidAt,
@@ -39,11 +45,11 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         return $this->query->lastInsertId();
     }
 
-    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment
+    public function findByIdempotencyKey(string $idempotencyKey): ?Payment
     {
         $row = $this->query->fetchOne(
             'SELECT ' . self::COLUMNS . ' FROM payments WHERE organization_id = ? AND idempotency_key = ?',
-            [$organizationId, $idempotencyKey],
+            [$this->orgId->get(), $idempotencyKey],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
@@ -52,8 +58,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function findById(int $id): ?Payment
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM payments WHERE id = ?',
-            [$id],
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
@@ -63,8 +69,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function markVoided(int $id): void
     {
         $this->query->execute(
-            'UPDATE payments SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
-            [date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), $id],
+            'UPDATE payments SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
 
@@ -72,8 +78,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function findByInvoice(int $invoiceId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM payments WHERE invoice_id = ? AND is_deleted = 0 ORDER BY paid_at ASC, id ASC',
-            [$invoiceId],
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = 0 ORDER BY paid_at ASC, id ASC',
+            [$invoiceId, $this->orgId->get()],
         );
 
         return array_map(fn (array $row): Payment => $this->mapRow($row), $rows);
@@ -82,8 +88,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function totalPaidForInvoice(int $invoiceId): int
     {
         $row = $this->query->fetchOne(
-            'SELECT COALESCE(SUM(amount_cents), 0) AS total FROM payments WHERE invoice_id = ? AND is_deleted = 0',
-            [$invoiceId],
+            'SELECT COALESCE(SUM(amount_cents), 0) AS total FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = 0',
+            [$invoiceId, $this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['total'] : 0;
@@ -102,9 +108,9 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         $placeholders = implode(', ', array_fill(0, count($invoiceIds), '?'));
         $rows = $this->query->fetchAll(
             'SELECT invoice_id, COALESCE(SUM(amount_cents), 0) AS total
-             FROM payments WHERE is_deleted = 0 AND invoice_id IN (' . $placeholders . ')
+             FROM payments WHERE is_deleted = 0 AND organization_id = ? AND invoice_id IN (' . $placeholders . ')
              GROUP BY invoice_id',
-            $invoiceIds,
+            [$this->orgId->get(), ...$invoiceIds],
         );
 
         $totals = [];
@@ -115,7 +121,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         return $totals;
     }
 
-    public function outstandingTotalForOrganization(int $organizationId): int
+    public function outstandingTotal(): int
     {
         $row = $this->query->fetchOne(
             'SELECT
@@ -123,7 +129,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
             FROM invoices i
             LEFT JOIN payments p ON p.invoice_id = i.id
             WHERE i.organization_id = ? AND i.is_deleted = 0 AND i.status IN (\'issued\', \'partially_paid\')',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['outstanding'] : 0;

--- a/src/Payment/RecordPaymentHandler.php
+++ b/src/Payment/RecordPaymentHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -22,18 +21,11 @@ final readonly class RecordPaymentHandler implements RequestHandlerInterface
     public function __construct(
         private RecordPaymentUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
@@ -53,7 +45,6 @@ final readonly class RecordPaymentHandler implements RequestHandlerInterface
         $note = is_string($noteValue) && $noteValue !== '' ? $noteValue : null;
 
         $result = $this->useCase->execute(
-            $organizationId,
             AuthContext::userId($request),
             $invoiceId,
             new RecordPaymentInput($amountCents, $paidAt, $method, $note),

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Payment;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -23,10 +24,14 @@ use NeneInvoice\Invoice\InvoiceStatus;
  */
 final readonly class RecordPaymentUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private PaymentRepositoryInterface $payments,
         private InvoiceRepositoryInterface $invoices,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -35,18 +40,20 @@ final readonly class RecordPaymentUseCase
      * @throws PaymentValidationException
      * @throws PaymentExceedsOutstandingException
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $invoiceId, RecordPaymentInput $input): RecordPaymentResult
+    public function execute(?int $actorUserId, int $invoiceId, RecordPaymentInput $input): RecordPaymentResult
     {
+        $organizationId = $this->orgId->get();
+
         $invoice = $this->invoices->findById($invoiceId);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($invoiceId);
         }
 
         // Idempotent replay: a retried write with the same key returns the existing
         // payment instead of recording a duplicate (ADR 0009 §3.1.2).
         if ($input->idempotencyKey !== null) {
-            $existing = $this->payments->findByIdempotencyKey($organizationId, $input->idempotencyKey);
+            $existing = $this->payments->findByIdempotencyKey($input->idempotencyKey);
             if ($existing !== null) {
                 return new RecordPaymentResult($existing, $invoice, $this->payments->totalPaidForInvoice($invoiceId));
             }

--- a/src/Payment/VoidPaymentUseCase.php
+++ b/src/Payment/VoidPaymentUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -20,10 +21,14 @@ use NeneInvoice\Invoice\InvoiceStatus;
  */
 final readonly class VoidPaymentUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private PaymentRepositoryInterface $payments,
         private InvoiceRepositoryInterface $invoices,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -32,7 +37,6 @@ final readonly class VoidPaymentUseCase
      * @throws PaymentNotFoundException
      */
     public function execute(
-        int $organizationId,
         ?int $actorUserId,
         int $invoiceId,
         int $paymentId,
@@ -42,7 +46,6 @@ final readonly class VoidPaymentUseCase
 
         if (
             $payment === null
-            || $payment->organizationId !== $organizationId
             || $payment->invoiceId !== $invoiceId
         ) {
             throw new PaymentNotFoundException($paymentId);
@@ -50,7 +53,7 @@ final readonly class VoidPaymentUseCase
 
         $invoice = $this->invoices->findById($invoiceId);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($invoiceId);
         }
 
@@ -90,7 +93,7 @@ final readonly class VoidPaymentUseCase
         $after['voided_payment_id'] = $paymentId;
         $after['void_reason'] = $reason;
 
-        $this->audit->record($actorUserId, $organizationId, 'payment.voided', 'invoice', $invoiceId, $before, $after);
+        $this->audit->record($actorUserId, $this->orgId->get(), 'payment.voided', 'invoice', $invoiceId, $before, $after);
 
         $voided = $this->payments->findById($paymentId) ?? $payment;
 

--- a/src/ServiceApi/GetServiceInvoiceHandler.php
+++ b/src/ServiceApi/GetServiceInvoiceHandler.php
@@ -39,10 +39,9 @@ final readonly class GetServiceInvoiceHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        // Invoice repo is org-scoped via the holder (set by ServiceScopeMiddleware);
-        // the Payment use case is not yet migrated and still takes the org.
+        // Both repos are org-scoped via the holder (set by ServiceScopeMiddleware).
         $invoice = $this->getInvoice->execute($id);
-        $payments = $this->listPayments->execute($organizationId, $id);
+        $payments = $this->listPayments->execute($id);
 
         return $this->json->create(
             ServiceInvoiceResponse::detail($invoice->invoice, $invoice->outstandingCents, $payments),

--- a/src/ServiceApi/RecordServicePaymentHandler.php
+++ b/src/ServiceApi/RecordServicePaymentHandler.php
@@ -56,7 +56,7 @@ final readonly class RecordServicePaymentHandler implements RequestHandlerInterf
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"idempotency_key" is required.');
         }
 
-        $result = $this->useCase->execute($organizationId, null, $invoiceId, new RecordPaymentInput(
+        $result = $this->useCase->execute(null, $invoiceId, new RecordPaymentInput(
             amountCents: $amountCents,
             paidAt: $paidAt,
             method: $this->stringOrNull($decoded, 'method'),

--- a/src/ServiceApi/VoidServicePaymentHandler.php
+++ b/src/ServiceApi/VoidServicePaymentHandler.php
@@ -42,7 +42,7 @@ final readonly class VoidServicePaymentHandler implements RequestHandlerInterfac
         $reasonValue = is_array($decoded) ? ($decoded['reason'] ?? null) : null;
         $reason = is_string($reasonValue) && $reasonValue !== '' ? $reasonValue : null;
 
-        $result = $this->useCase->execute($organizationId, null, $invoiceId, $paymentId, $reason);
+        $result = $this->useCase->execute(null, $invoiceId, $paymentId, $reason);
 
         $outstanding = max(0, $result->invoice->totalCents - $result->totalPaidCents);
 

--- a/tests/Dashboard/GetDashboardHandlerTest.php
+++ b/tests/Dashboard/GetDashboardHandlerTest.php
@@ -28,10 +28,10 @@ final class GetDashboardHandlerTest extends TestCase
         $holder         = new RequestScopedHolder();
         $holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($holder);
-        $this->payments = new InMemoryPaymentRepository();
+        $this->payments = new InMemoryPaymentRepository($holder);
 
         $this->handler = new GetDashboardHandler(
-            new GetDashboardSummaryUseCase($this->invoices, $this->payments, $holder),
+            new GetDashboardSummaryUseCase($this->invoices, $this->payments),
             $this->payments,
             new JsonResponseFactory($this->psr17, $this->psr17),
         );

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -22,7 +22,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $holder = new \Nene2\Http\RequestScopedHolder();
         $holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($holder);
-        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, new InMemoryPaymentRepository(), $holder);
+        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, new InMemoryPaymentRepository($holder));
     }
 
     public function test_empty_organization_returns_zeros(): void

--- a/tests/Payment/ListPaymentsUseCaseTest.php
+++ b/tests/Payment/ListPaymentsUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Payment;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 final class ListPaymentsUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryPaymentRepository $payments;
     private ListPaymentsUseCase $useCase;
@@ -22,8 +25,10 @@ final class ListPaymentsUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->invoices  = new InMemoryInvoiceRepository();
-        $this->payments  = new InMemoryPaymentRepository();
+        $this->holder    = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices  = new InMemoryInvoiceRepository($this->holder);
+        $this->payments  = new InMemoryPaymentRepository($this->holder);
         $this->useCase   = new ListPaymentsUseCase($this->payments, $this->invoices);
         $this->invoiceId = $this->invoices->save(new Invoice(
             organizationId: 1,
@@ -40,7 +45,7 @@ final class ListPaymentsUseCaseTest extends TestCase
         $this->payments->save(new Payment(organizationId: 1, invoiceId: $this->invoiceId, amountCents: 5000, paidAt: '2026-05-01 00:00:00'));
         $this->payments->save(new Payment(organizationId: 1, invoiceId: $this->invoiceId, amountCents: 6000, paidAt: '2026-05-10 00:00:00'));
 
-        $list = $this->useCase->execute(1, $this->invoiceId);
+        $list = $this->useCase->execute($this->invoiceId);
 
         self::assertCount(2, $list);
         self::assertSame(5000, $list[0]->amountCents);
@@ -49,20 +54,21 @@ final class ListPaymentsUseCaseTest extends TestCase
 
     public function test_returns_empty_when_no_payments(): void
     {
-        $list = $this->useCase->execute(1, $this->invoiceId);
+        $list = $this->useCase->execute($this->invoiceId);
         self::assertCount(0, $list);
     }
 
     public function test_throws_for_cross_org_invoice(): void
     {
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(2, $this->invoiceId);
+        $this->holder->set(2);
+        $this->useCase->execute($this->invoiceId);
     }
 
     public function test_throws_for_nonexistent_invoice(): void
     {
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(1, 9999);
+        $this->useCase->execute(9999);
     }
 
     public function test_excludes_payments_of_other_invoices(): void
@@ -77,7 +83,7 @@ final class ListPaymentsUseCaseTest extends TestCase
         ));
         $this->payments->save(new Payment(organizationId: 1, invoiceId: $otherId, amountCents: 999, paidAt: '2026-05-01 00:00:00'));
 
-        $list = $this->useCase->execute(1, $this->invoiceId);
+        $list = $this->useCase->execute($this->invoiceId);
         self::assertCount(0, $list);
     }
 }

--- a/tests/Payment/PdoPaymentRepositoryTest.php
+++ b/tests/Payment/PdoPaymentRepositoryTest.php
@@ -7,12 +7,15 @@ namespace NeneInvoice\Tests\Payment;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Payment\Payment;
 use NeneInvoice\Payment\PdoPaymentRepository;
 use PHPUnit\Framework\TestCase;
 
 final class PdoPaymentRepositoryTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
     private PdoPaymentRepository $repository;
 
     protected function setUp(): void
@@ -35,7 +38,9 @@ final class PdoPaymentRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoPaymentRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoPaymentRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
     }
 
     public function test_saves_and_reads_back_payments_for_invoice(): void
@@ -107,13 +112,15 @@ final class PdoPaymentRepositoryTest extends TestCase
             idempotencyKey: 'clear:recon:777:v1',
         ));
 
-        $byKey = $this->repository->findByIdempotencyKey(1, 'clear:recon:777:v1');
+        $byKey = $this->repository->findByIdempotencyKey('clear:recon:777:v1');
         self::assertNotNull($byKey);
         self::assertSame($id, $byKey->id);
         self::assertSame('clear:recon:777', $byKey->externalReference);
 
-        self::assertNull($this->repository->findByIdempotencyKey(1, 'unknown'));
-        self::assertNull($this->repository->findByIdempotencyKey(2, 'clear:recon:777:v1')); // other org
+        self::assertNull($this->repository->findByIdempotencyKey('unknown'));
+
+        $this->orgId->set(2);
+        self::assertNull($this->repository->findByIdempotencyKey('clear:recon:777:v1')); // other org
     }
 
     public function test_void_excludes_from_totals_and_is_idempotent(): void

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Payment;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
@@ -18,6 +19,8 @@ use PHPUnit\Framework\TestCase;
 
 final class RecordPaymentUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryPaymentRepository $payments;
     private InMemoryInvoiceRepository $invoices;
     private RecordingAuditRecorder $audit;
@@ -25,10 +28,12 @@ final class RecordPaymentUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->payments = new InMemoryPaymentRepository();
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->payments = new InMemoryPaymentRepository($this->holder);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit);
+        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
     }
 
     private function issuedInvoice(int $totalCents = 2200): int
@@ -49,7 +54,7 @@ final class RecordPaymentUseCaseTest extends TestCase
     {
         $id = $this->issuedInvoice(2200);
 
-        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000));
 
         self::assertSame(InvoiceStatus::PartiallyPaid, $result->invoice->status);
         self::assertSame(1000, $result->totalPaidCents);
@@ -61,7 +66,7 @@ final class RecordPaymentUseCaseTest extends TestCase
     {
         $id = $this->issuedInvoice(2200);
 
-        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2200));
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2200));
 
         self::assertSame(InvoiceStatus::Paid, $result->invoice->status);
         self::assertSame(2200, $result->totalPaidCents);
@@ -71,8 +76,8 @@ final class RecordPaymentUseCaseTest extends TestCase
     {
         $id = $this->issuedInvoice(2200);
 
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1200));
-        $result = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1200));
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000));
 
         self::assertSame(InvoiceStatus::Paid, $result->invoice->status);
         self::assertSame(2200, $result->totalPaidCents);
@@ -83,16 +88,16 @@ final class RecordPaymentUseCaseTest extends TestCase
         $id = $this->issuedInvoice(2200);
 
         $this->expectException(PaymentExceedsOutstandingException::class);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2201));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2201));
     }
 
     public function test_over_payment_exception_carries_outstanding(): void
     {
         $id = $this->issuedInvoice(2200);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 800));
 
         try {
-            $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2000));
+            $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2000));
             self::fail('Expected PaymentExceedsOutstandingException');
         } catch (PaymentExceedsOutstandingException $e) {
             self::assertSame(1400, $e->outstandingCents); // 2200 − 800
@@ -102,8 +107,8 @@ final class RecordPaymentUseCaseTest extends TestCase
     public function test_idempotent_replay_returns_same_payment(): void
     {
         $id = $this->issuedInvoice(2200);
-        $first = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
-        $second = $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
+        $first = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
+        $second = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
 
         self::assertSame($first->payment->id, $second->payment->id);
         // only one payment recorded despite two calls
@@ -115,7 +120,7 @@ final class RecordPaymentUseCaseTest extends TestCase
         $id = $this->issuedInvoice(2200);
 
         $this->expectException(PaymentValidationException::class);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 0));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 0));
     }
 
     public function test_payment_against_draft_is_rejected(): void
@@ -130,16 +135,16 @@ final class RecordPaymentUseCaseTest extends TestCase
         ));
 
         $this->expectException(PaymentValidationException::class);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1000));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000));
     }
 
     public function test_payment_against_fully_paid_invoice_is_rejected(): void
     {
         $id = $this->issuedInvoice(2200);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 2200));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2200));
 
         $this->expectException(PaymentValidationException::class);
-        $this->useCase->execute(1, 7, $id, new RecordPaymentInput(amountCents: 1));
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1));
     }
 
     public function test_cross_organization_invoice_not_found(): void
@@ -147,6 +152,7 @@ final class RecordPaymentUseCaseTest extends TestCase
         $id = $this->issuedInvoice(2200);
 
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(2, 7, $id, new RecordPaymentInput(amountCents: 1000));
+        $this->holder->set(2);
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000));
     }
 }

--- a/tests/Payment/VoidPaymentUseCaseTest.php
+++ b/tests/Payment/VoidPaymentUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Payment;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Payment\PaymentNotFoundException;
@@ -17,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 
 final class VoidPaymentUseCaseTest extends TestCase
 {
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryPaymentRepository $payments;
     private RecordingAuditRecorder $audit;
@@ -26,11 +29,13 @@ final class VoidPaymentUseCaseTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->invoices = new InMemoryInvoiceRepository();
-        $this->payments = new InMemoryPaymentRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
+        $this->payments = new InMemoryPaymentRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit);
-        $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, $this->audit);
+        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
+        $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
 
         $this->invoiceId = $this->invoices->save(new Invoice(
             organizationId: 1,
@@ -46,7 +51,7 @@ final class VoidPaymentUseCaseTest extends TestCase
 
     private function recordPayment(int $amount): int
     {
-        $result = $this->record->execute(1, null, $this->invoiceId, new RecordPaymentInput(amountCents: $amount, paidAt: '2026-04-20'));
+        $result = $this->record->execute(null, $this->invoiceId, new RecordPaymentInput(amountCents: $amount, paidAt: '2026-04-20'));
 
         return (int) $result->payment->id;
     }
@@ -56,7 +61,7 @@ final class VoidPaymentUseCaseTest extends TestCase
         $paymentId = $this->recordPayment(2200);
         self::assertSame(InvoiceStatus::Paid, $this->invoices->findById($this->invoiceId)?->status);
 
-        $result = $this->void->execute(1, null, $this->invoiceId, $paymentId, 'operator reversal');
+        $result = $this->void->execute(null, $this->invoiceId, $paymentId, 'operator reversal');
 
         self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
         self::assertSame(0, $result->totalPaidCents);
@@ -70,7 +75,7 @@ final class VoidPaymentUseCaseTest extends TestCase
         $first = $this->recordPayment(800);
         $this->recordPayment(600); // total 1400 → partially_paid
 
-        $result = $this->void->execute(1, null, $this->invoiceId, $first, null);
+        $result = $this->void->execute(null, $this->invoiceId, $first, null);
 
         self::assertSame(InvoiceStatus::PartiallyPaid, $result->invoice->status);
         self::assertSame(600, $result->totalPaidCents);
@@ -79,8 +84,8 @@ final class VoidPaymentUseCaseTest extends TestCase
     public function test_void_is_idempotent(): void
     {
         $paymentId = $this->recordPayment(800);
-        $this->void->execute(1, null, $this->invoiceId, $paymentId, null);
-        $again = $this->void->execute(1, null, $this->invoiceId, $paymentId, null);
+        $this->void->execute(null, $this->invoiceId, $paymentId, null);
+        $again = $this->void->execute(null, $this->invoiceId, $paymentId, null);
 
         self::assertSame(InvoiceStatus::Issued, $again->invoice->status);
         self::assertSame(0, $again->totalPaidCents);
@@ -89,7 +94,7 @@ final class VoidPaymentUseCaseTest extends TestCase
     public function test_unknown_payment_is_not_found(): void
     {
         $this->expectException(PaymentNotFoundException::class);
-        $this->void->execute(1, null, $this->invoiceId, 999, null);
+        $this->void->execute(null, $this->invoiceId, 999, null);
     }
 
     public function test_cross_organization_payment_is_not_found(): void
@@ -97,6 +102,7 @@ final class VoidPaymentUseCaseTest extends TestCase
         $paymentId = $this->recordPayment(800);
 
         $this->expectException(PaymentNotFoundException::class);
-        $this->void->execute(2, null, $this->invoiceId, $paymentId, null);
+        $this->holder->set(2);
+        $this->void->execute(null, $this->invoiceId, $paymentId, null);
     }
 }

--- a/tests/ServiceApi/RecordServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/RecordServicePaymentHandlerTest.php
@@ -30,8 +30,10 @@ final class RecordServicePaymentHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->psr17 = new Psr17Factory();
-        $this->invoices = new InMemoryInvoiceRepository();
-        $this->payments = new InMemoryPaymentRepository();
+        $holder = new \Nene2\Http\RequestScopedHolder();
+        $holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($holder);
+        $this->payments = new InMemoryPaymentRepository($holder);
 
         $this->invoiceId = $this->invoices->save(new Invoice(
             organizationId: 1,
@@ -45,7 +47,7 @@ final class RecordServicePaymentHandlerTest extends TestCase
         ));
 
         $this->handler = new RecordServicePaymentHandler(
-            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder()),
+            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), $holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );

--- a/tests/ServiceApi/VoidServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/VoidServicePaymentHandlerTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 final class VoidServicePaymentHandlerTest extends TestCase
 {
     private Psr17Factory $psr17;
+    /** @var \Nene2\Http\RequestScopedHolder<int> */
+    private \Nene2\Http\RequestScopedHolder $holder;
     private InMemoryInvoiceRepository $invoices;
     private InMemoryPaymentRepository $payments;
     private VoidServicePaymentHandler $handler;
@@ -30,8 +32,11 @@ final class VoidServicePaymentHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->psr17    = new Psr17Factory();
-        $this->invoices = new InMemoryInvoiceRepository();
-        $this->payments = new InMemoryPaymentRepository();
+        $this->holder = new \Nene2\Http\RequestScopedHolder();
+        $this->holder->set(1);
+        $holder = $this->holder;
+        $this->invoices = new InMemoryInvoiceRepository($holder);
+        $this->payments = new InMemoryPaymentRepository($holder);
 
         $this->invoiceId = $this->invoices->save(new Invoice(
             organizationId: 1,
@@ -52,7 +57,7 @@ final class VoidServicePaymentHandlerTest extends TestCase
         ));
 
         $this->handler = new VoidServicePaymentHandler(
-            new VoidPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder()),
+            new VoidPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), $holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );
@@ -97,8 +102,10 @@ final class VoidServicePaymentHandlerTest extends TestCase
     public function test_throws_payment_not_found_for_cross_org(): void
     {
         // VoidPaymentUseCase throws PaymentNotFoundException for cross-org access.
-        // In production this is handled by PaymentNotFoundExceptionHandler.
+        // In production this is handled by PaymentNotFoundExceptionHandler. The
+        // holder is set by ServiceScopeMiddleware from the token org (here: 2).
         $this->expectException(\NeneInvoice\Payment\PaymentNotFoundException::class);
+        $this->holder->set(2);
 
         $request = $this->psr17->createServerRequest('POST', "/api/invoices/{$this->invoiceId}/payments/{$this->paymentId}/void")
             ->withAttribute('nene2.auth.claims', ['org' => 2, 'scopes' => ['write:payments']])

--- a/tests/Support/InMemoryPaymentRepository.php
+++ b/tests/Support/InMemoryPaymentRepository.php
@@ -4,17 +4,34 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Payment\Payment;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\Payment\PdoPaymentRepository}.
+ * The holder defaults to organization 1 for single-org tests.
  */
 final class InMemoryPaymentRepository implements PaymentRepositoryInterface
 {
     /** @var array<int, Payment> */
     private array $byId = [];
     private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
 
     public function save(Payment $payment): int
     {
@@ -39,13 +56,15 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
 
     public function findById(int $id): ?Payment
     {
-        return $this->byId[$id] ?? null;
+        $payment = $this->byId[$id] ?? null;
+
+        return $payment !== null && $payment->organizationId === $this->orgId->get() ? $payment : null;
     }
 
-    public function findByIdempotencyKey(int $organizationId, string $idempotencyKey): ?Payment
+    public function findByIdempotencyKey(string $idempotencyKey): ?Payment
     {
         foreach ($this->byId as $payment) {
-            if ($payment->organizationId === $organizationId && $payment->idempotencyKey === $idempotencyKey) {
+            if ($payment->organizationId === $this->orgId->get() && $payment->idempotencyKey === $idempotencyKey) {
                 return $payment;
             }
         }
@@ -81,7 +100,7 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
     {
         return array_values(array_filter(
             $this->byId,
-            static fn (Payment $p): bool => $p->invoiceId === $invoiceId && !$p->isDeleted,
+            fn (Payment $p): bool => $p->invoiceId === $invoiceId && !$p->isDeleted && $p->organizationId === $this->orgId->get(),
         ));
     }
 
@@ -114,10 +133,10 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
         return $totals;
     }
 
-    public function outstandingTotalForOrganization(int $organizationId): int
+    public function outstandingTotal(): int
     {
-        // Sum payments for all invoices in this org (InMemory: we don't track invoices here,
-        // so we return 0 — tests that need this should use integration setup).
+        // InMemory: invoices are tracked separately, so this fake returns 0.
+        // Tests that need a real total use integration (Pdo) setup.
         return 0;
     }
 }


### PR DESCRIPTION
## Summary
#153（Quote）に続く Payment ドメインの holder ベース移行。

- **`PdoPaymentRepository`** — holder 注入、全クエリ（findById/findByInvoice/totalPaidForInvoice/sumPaidForInvoices 含む）に `organization_id = ?` を強制。`findByIdempotencyKey(org,key)`→`findByIdempotencyKey(key)`、`outstandingTotalForOrganization(org)`→`outstandingTotal()`。
- **Payment UseCase ×3**（Record/Void/List）— org を holder から取得、cross-org PHP チェックを SQL スコープに置換。
- **Dashboard UseCase** — Payment が holder 化されたため org 引数を完全撤去（getDashboardData/outstandingTotal とも holder）。
- ハンドラ（Payment admin ×2 / ServiceApi ×2 / GetServiceInvoice）— org 引数除去。
- `InMemoryPaymentRepository` を holder 化。251 tests green。

## Test plan
- [ ] `composer check` green（251 / PHPStan / CS / OpenAPI / MCP）
- [ ] 別 org の payment id → 404（SQL レベル）
- [ ] サービストークン org で `/api/*` の payment 操作が holder で動作

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)