### PR TITLE
feat(tenancy): CompanySettings / Audit / DocumentSequence を holder ベースへ (#157)

### DIFF
--- a/src/Audit/AuditLogRepositoryInterface.php
+++ b/src/Audit/AuditLogRepositoryInterface.php
@@ -6,13 +6,18 @@ namespace NeneInvoice\Audit;
 
 /**
  * Append-only persistence for the audit trail.
+ *
+ * Reads are scoped to the organization held in the request-scoped org holder
+ * (ADR 0006). {@see append()} keeps the organization on the {@see AuditLog}
+ * itself: writes also run on holder-less paths (e.g. superadmin organization
+ * provisioning), so the write side must not depend on the holder.
  */
 interface AuditLogRepositoryInterface
 {
     public function append(AuditLog $log): int;
 
     /** @return list<AuditLog> */
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findAll(int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function count(): int;
 }

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -8,8 +8,9 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -29,7 +30,7 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoAuditLogRepository($query);
+                    return new PdoAuditLogRepository($query, self::orgHolder($c));
                 },
             )
             ->set(
@@ -53,7 +54,6 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ListAuditLogsHandler => new ListAuditLogsHandler(
                     self::resolve($c, ListAuditLogsUseCase::class),
                     self::resolve($c, JsonResponseFactory::class),
-                    self::resolve($c, ProblemDetailsResponseFactory::class),
                 ),
             )
             ->set(
@@ -84,5 +84,17 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
         }
 
         return $service;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/Audit/ListAuditLogsHandler.php
+++ b/src/Audit/ListAuditLogsHandler.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Audit;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * `GET /admin/audit-logs` — lists the audit trail for the caller's organization
- * (admin oversight; gated by `manage_users` in CapabilityResolver).
+ * (admin oversight; gated by `manage_users` in CapabilityResolver). The
+ * organization is resolved upstream (OrgResolverMiddleware) into the
+ * request-scoped holder.
  */
 final readonly class ListAuditLogsHandler implements RequestHandlerInterface
 {
@@ -23,18 +23,11 @@ final readonly class ListAuditLogsHandler implements RequestHandlerInterface
     public function __construct(
         private ListAuditLogsUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $query = $request->getQueryParams();
 
         $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
@@ -43,7 +36,7 @@ final readonly class ListAuditLogsHandler implements RequestHandlerInterface
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($limit, $offset);
 
         return $this->json->create([
             'items' => array_map(static fn (AuditLog $log): array => AuditLogResponse::toArray($log), $result->items),

--- a/src/Audit/ListAuditLogsUseCase.php
+++ b/src/Audit/ListAuditLogsUseCase.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Audit;
 
 /**
- * Lists the audit trail for an organization, most recent first.
+ * Lists the audit trail for the resolved organization, most recent first. The
+ * organization is read from the request-scoped org holder by the repository.
  */
 final readonly class ListAuditLogsUseCase
 {
@@ -14,11 +15,11 @@ final readonly class ListAuditLogsUseCase
     ) {
     }
 
-    public function execute(int $organizationId, int $limit, int $offset): ListAuditLogsResult
+    public function execute(int $limit, int $offset): ListAuditLogsResult
     {
         return new ListAuditLogsResult(
-            $this->logs->findByOrganization($organizationId, $limit, $offset),
-            $this->logs->countByOrganization($organizationId),
+            $this->logs->findAll($limit, $offset),
+            $this->logs->count(),
         );
     }
 }

--- a/src/Audit/PdoAuditLogRepository.php
+++ b/src/Audit/PdoAuditLogRepository.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\Audit;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterface
 {
     private const COLUMNS = 'id, actor_user_id, organization_id, action, entity_type, entity_id, before_json, after_json, created_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for read queries
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -36,19 +41,19 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
     }
 
     /** @return list<AuditLog> */
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM audit_logs WHERE organization_id = ? ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            [$this->orgId->get(), $limit, $offset],
         );
 
         return array_map(fn (array $row): AuditLog => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM audit_logs WHERE organization_id = ?', [$organizationId]);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM audit_logs WHERE organization_id = ?', [$this->orgId->get()]);
 
         return $row !== null ? (int) $row['cnt'] : 0;
     }

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -10,6 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
@@ -31,17 +33,16 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoCompanySettingsRepository($query);
+                    return new PdoCompanySettingsRepository($query, self::orgHolder($c));
                 },
             )
-            ->set(GetCompanySettingsUseCase::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c)))
-            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c)))
+            ->set(GetCompanySettingsUseCase::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c), self::orgHolder($c)))
+            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 GetCompanySettingsHandler::class,
                 static fn (ContainerInterface $c): GetCompanySettingsHandler => new GetCompanySettingsHandler(
                     self::getUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -139,5 +140,17 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
         }
 
         return $p;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/Company/CompanySettingsRepositoryInterface.php
+++ b/src/Company/CompanySettingsRepositoryInterface.php
@@ -6,11 +6,13 @@ namespace NeneInvoice\Company;
 
 /**
  * Persistence for the per-organization issuer profile. There is at most one row
- * per organization; {@see save()} upserts.
+ * per organization; {@see save()} upserts. Every query is scoped to the
+ * organization held in the request-scoped org holder (ADR 0006) — the
+ * organization is never passed as a method argument.
  */
 interface CompanySettingsRepositoryInterface
 {
-    public function findByOrganization(int $organizationId): ?CompanySettings;
+    public function find(): ?CompanySettings;
 
     public function save(CompanySettings $settings): void;
 }

--- a/src/Company/GetCompanySettingsHandler.php
+++ b/src/Company/GetCompanySettingsHandler.php
@@ -4,35 +4,27 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * `GET /admin/company-settings` — the issuer profile for the caller's organization.
- * Returns 404 when settings have not been configured yet.
+ * Returns 404 when settings have not been configured yet. The organization is
+ * resolved upstream (OrgResolverMiddleware) into the request-scoped holder.
  */
 final readonly class GetCompanySettingsHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GetCompanySettingsUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
-        $settings = $this->useCase->execute($organizationId);
+        $settings = $this->useCase->execute();
 
         return $this->json->create(CompanySettingsResponse::toArray($settings));
     }

--- a/src/Company/GetCompanySettingsUseCase.php
+++ b/src/Company/GetCompanySettingsUseCase.php
@@ -4,20 +4,26 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
+use Nene2\Http\RequestScopedHolder;
+
 final readonly class GetCompanySettingsUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private CompanySettingsRepositoryInterface $repository,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /** @throws CompanySettingsNotFoundException */
-    public function execute(int $organizationId): CompanySettings
+    public function execute(): CompanySettings
     {
-        $settings = $this->repository->findByOrganization($organizationId);
+        $settings = $this->repository->find();
 
         if ($settings === null) {
-            throw new CompanySettingsNotFoundException($organizationId);
+            throw new CompanySettingsNotFoundException($this->orgId->get());
         }
 
         return $settings;

--- a/src/Company/PdoCompanySettingsRepository.php
+++ b/src/Company/PdoCompanySettingsRepository.php
@@ -5,21 +5,26 @@ declare(strict_types=1);
 namespace NeneInvoice\Company;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoCompanySettingsRepository implements CompanySettingsRepositoryInterface
 {
     private const COLUMNS = 'organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
-    public function findByOrganization(int $organizationId): ?CompanySettings
+    public function find(): ?CompanySettings
     {
         $row = $this->query->fetchOne(
             'SELECT ' . self::COLUMNS . ' FROM company_settings WHERE organization_id = ?',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? $this->mapRow($row) : null;
@@ -28,7 +33,9 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
     public function save(CompanySettings $settings): void
     {
         $now = date('Y-m-d H:i:s');
-        $exists = $this->findByOrganization($settings->organizationId) !== null;
+        // The organization is forced from the request-scoped holder.
+        $organizationId = $this->orgId->get();
+        $exists = $this->find() !== null;
 
         if ($exists) {
             $this->query->execute(
@@ -45,7 +52,7 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
                     $settings->accountNumber,
                     $settings->logoUrl,
                     $now,
-                    $settings->organizationId,
+                    $organizationId,
                 ],
             );
 
@@ -56,7 +63,7 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
             'INSERT INTO company_settings (organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
-                $settings->organizationId,
+                $organizationId,
                 $settings->legalName,
                 $settings->address,
                 $settings->phone,

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -26,12 +26,6 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $decoded = json_decode((string) $request->getBody(), true);
 
         if (!is_array($decoded)) {
@@ -44,7 +38,7 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"legal_name" is required.');
         }
 
-        $settings = $this->useCase->execute($organizationId, AuthContext::userId($request), new UpdateCompanySettingsInput(
+        $settings = $this->useCase->execute(AuthContext::userId($request), new UpdateCompanySettingsInput(
             legalName: $legalName,
             address: $this->optional($decoded, 'address'),
             phone: $this->optional($decoded, 'phone'),

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace NeneInvoice\Company;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
 final readonly class UpdateCompanySettingsUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private CompanySettingsRepositoryInterface $repository,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -21,13 +26,14 @@ final readonly class UpdateCompanySettingsUseCase
      *
      * @throws InvalidRegistrationNumberException
      */
-    public function execute(int $organizationId, ?int $actorUserId, UpdateCompanySettingsInput $input): CompanySettings
+    public function execute(?int $actorUserId, UpdateCompanySettingsInput $input): CompanySettings
     {
         if ($input->registrationNumber !== null && !RegistrationNumber::isValid($input->registrationNumber)) {
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
 
-        $existing = $this->repository->findByOrganization($organizationId);
+        $organizationId = $this->orgId->get();
+        $existing = $this->repository->find();
 
         $this->repository->save(new CompanySettings(
             organizationId: $organizationId,
@@ -43,7 +49,7 @@ final readonly class UpdateCompanySettingsUseCase
             logoUrl: $input->logoUrl,
         ));
 
-        $saved = $this->repository->findByOrganization($organizationId);
+        $saved = $this->repository->find();
 
         if ($saved === null) {
             throw new LogicException('Company settings disappeared immediately after save.');

--- a/src/DocumentSequence/DocumentNumberGenerator.php
+++ b/src/DocumentSequence/DocumentNumberGenerator.php
@@ -6,7 +6,8 @@ namespace NeneInvoice\DocumentSequence;
 
 /**
  * Generates a formatted document number such as `EST-2026-001`, allocating the
- * next sequence per organization, document type, and year.
+ * next sequence per organization (resolved from the request-scoped org holder),
+ * document type, and year.
  */
 final readonly class DocumentNumberGenerator
 {
@@ -15,9 +16,9 @@ final readonly class DocumentNumberGenerator
     ) {
     }
 
-    public function next(int $organizationId, DocumentType $type, int $year): string
+    public function next(DocumentType $type, int $year): string
     {
-        $sequence = $this->sequences->nextNumber($organizationId, $type->value, $year);
+        $sequence = $this->sequences->nextNumber($type->value, $year);
 
         return sprintf('%s%d-%03d', $type->prefix(), $year, $sequence);
     }

--- a/src/DocumentSequence/DocumentSequenceRepositoryInterface.php
+++ b/src/DocumentSequence/DocumentSequenceRepositoryInterface.php
@@ -8,7 +8,8 @@ interface DocumentSequenceRepositoryInterface
 {
     /**
      * Atomically allocates and returns the next sequence number for the given
-     * organization, document type, and year (starting at 1 each year).
+     * document type and year (starting at 1 each year). The organization is read
+     * from the request-scoped org holder (ADR 0006).
      */
-    public function nextNumber(int $organizationId, string $docType, int $year): int;
+    public function nextNumber(string $docType, int $year): int;
 }

--- a/src/DocumentSequence/DocumentSequenceServiceProvider.php
+++ b/src/DocumentSequence/DocumentSequenceServiceProvider.php
@@ -8,6 +8,8 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -27,7 +29,7 @@ final readonly class DocumentSequenceServiceProvider implements ServiceProviderI
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoDocumentSequenceRepository($query);
+                    return new PdoDocumentSequenceRepository($query, self::orgHolder($c));
                 },
             )
             ->set(
@@ -42,5 +44,17 @@ final readonly class DocumentSequenceServiceProvider implements ServiceProviderI
                     return new DocumentNumberGenerator($repo);
                 },
             );
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/DocumentSequence/PdoDocumentSequenceRepository.php
+++ b/src/DocumentSequence/PdoDocumentSequenceRepository.php
@@ -6,17 +6,24 @@ namespace NeneInvoice\DocumentSequence;
 
 use Nene2\Database\DatabaseConstraintException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 use RuntimeException;
 
 final readonly class PdoDocumentSequenceRepository implements DocumentSequenceRepositoryInterface
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
-    public function nextNumber(int $organizationId, string $docType, int $year): int
+    public function nextNumber(string $docType, int $year): int
     {
+        $organizationId = $this->orgId->get();
+
         // Increment the existing counter; if there is no row yet for this
         // org/type/year, create it. A concurrent INSERT (unique conflict) means
         // another caller created the row first, so we increment instead.

--- a/src/Invoice/GenerateInvoicePdfUseCase.php
+++ b/src/Invoice/GenerateInvoicePdfUseCase.php
@@ -46,7 +46,7 @@ final readonly class GenerateInvoicePdfUseCase
         $outstanding = max(0, $invoice->totalCents - $this->payments->totalPaidForInvoice($invoiceId));
         $withLines   = new InvoiceWithLines($invoice, $lines, $outstanding);
 
-        $company = $this->companySettings->findByOrganization($organizationId)
+        $company = $this->companySettings->find()
             ?? new \NeneInvoice\Company\CompanySettings(
                 organizationId: $organizationId,
                 legalName: '（会社情報未設定）',

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -60,14 +60,14 @@ final readonly class IssueInvoiceUseCase
         }
 
         if ($input->qualified) {
-            $settings = $this->companySettings->findByOrganization($organizationId);
+            $settings = $this->companySettings->find();
 
             if ($settings === null || $settings->registrationNumber === null) {
                 throw new QualifiedInvoiceIncompleteException('A qualified invoice requires the issuer registration number to be configured in company settings.');
             }
         }
 
-        $number = $this->numbers->next($organizationId, DocumentType::Invoice, (int) date('Y'));
+        $number = $this->numbers->next(DocumentType::Invoice, (int) date('Y'));
 
         $this->invoices->update(new Invoice(
             organizationId: $invoice->organizationId,

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -70,7 +70,7 @@ final readonly class CreateQuoteUseCase
         }
 
         $totals = $this->taxCalculator->calculate($input->lines);
-        $number = $this->numbers->next($organizationId, DocumentType::Quote, (int) date('Y'));
+        $number = $this->numbers->next(DocumentType::Quote, (int) date('Y'));
 
         $quoteId = $this->quotes->save(new Quote(
             organizationId: $organizationId,

--- a/tests/Audit/AuditLogTest.php
+++ b/tests/Audit/AuditLogTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Audit;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorder;
 use NeneInvoice\Audit\PdoAuditLogRepository;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 final class AuditLogTest extends TestCase
 {
     private PdoAuditLogRepository $repository;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -35,7 +38,9 @@ final class AuditLogTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoAuditLogRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoAuditLogRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
     }
 
     public function test_recorder_persists_before_and_after_snapshots(): void
@@ -44,7 +49,7 @@ final class AuditLogTest extends TestCase
 
         $recorder->record(7, 1, 'client.updated', 'client', 42, ['name' => '前'], ['name' => '後']);
 
-        $logs = $this->repository->findByOrganization(1, 10, 0);
+        $logs = $this->repository->findAll(10, 0);
         self::assertCount(1, $logs);
         self::assertSame('client.updated', $logs[0]->action);
         self::assertSame(7, $logs[0]->actorUserId);
@@ -55,16 +60,21 @@ final class AuditLogTest extends TestCase
 
     public function test_logs_are_scoped_and_counted_per_organization(): void
     {
+        // append keeps the organization on the log itself, so it is recorded
+        // with an explicit org regardless of the read-side holder.
         $recorder = new AuditRecorder($this->repository);
         $recorder->record(1, 1, 'client.created', 'client', 1, null, ['name' => 'A']);
         $recorder->record(1, 1, 'client.deleted', 'client', 1, ['name' => 'A'], null);
         $recorder->record(1, 2, 'client.created', 'client', 9, null, ['name' => 'B']);
 
-        self::assertSame(2, $this->repository->countByOrganization(1));
-        self::assertSame(1, $this->repository->countByOrganization(2));
+        $this->holder->set(1);
+        self::assertSame(2, $this->repository->count());
+        $this->holder->set(2);
+        self::assertSame(1, $this->repository->count());
 
-        // Most recent first.
-        $logs = $this->repository->findByOrganization(1, 10, 0);
+        // Most recent first (org 1).
+        $this->holder->set(1);
+        $logs = $this->repository->findAll(10, 0);
         self::assertSame('client.deleted', $logs[0]->action);
     }
 }

--- a/tests/Audit/ListAuditLogsUseCaseTest.php
+++ b/tests/Audit/ListAuditLogsUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Audit;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditLog;
 use NeneInvoice\Audit\ListAuditLogsUseCase;
 use NeneInvoice\Tests\Support\InMemoryAuditLogRepository;
@@ -13,10 +14,14 @@ final class ListAuditLogsUseCaseTest extends TestCase
 {
     private InMemoryAuditLogRepository $logs;
     private ListAuditLogsUseCase $useCase;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
-        $this->logs = new InMemoryAuditLogRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->logs = new InMemoryAuditLogRepository($this->holder);
         $this->useCase = new ListAuditLogsUseCase($this->logs);
     }
 
@@ -26,7 +31,7 @@ final class ListAuditLogsUseCaseTest extends TestCase
         $this->logs->append(new AuditLog(action: 'invoice.issued', entityType: 'invoice', organizationId: 1, entityId: 10));
         $this->logs->append(new AuditLog(action: 'client.created', entityType: 'client', organizationId: 2, entityId: 99));
 
-        $result = $this->useCase->execute(1, 20, 0);
+        $result = $this->useCase->execute(20, 0);
 
         self::assertSame(2, $result->total);
         self::assertCount(2, $result->items);
@@ -40,7 +45,7 @@ final class ListAuditLogsUseCaseTest extends TestCase
             $this->logs->append(new AuditLog(action: 'invoice.created', entityType: 'invoice', organizationId: 1, entityId: $i));
         }
 
-        $page = $this->useCase->execute(1, 2, 2);
+        $page = $this->useCase->execute(2, 2);
 
         self::assertSame(5, $page->total);
         self::assertCount(2, $page->items);
@@ -48,7 +53,8 @@ final class ListAuditLogsUseCaseTest extends TestCase
 
     public function test_empty_for_organization_with_no_logs(): void
     {
-        $result = $this->useCase->execute(7, 20, 0);
+        $this->holder->set(7);
+        $result = $this->useCase->execute(20, 0);
 
         self::assertSame(0, $result->total);
         self::assertSame([], $result->items);

--- a/tests/Company/CompanySettingsTest.php
+++ b/tests/Company/CompanySettingsTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Company;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettingsNotFoundException;
 use NeneInvoice\Company\GetCompanySettingsUseCase;
 use NeneInvoice\Company\InvalidRegistrationNumberException;
@@ -20,6 +21,8 @@ final class CompanySettingsTest extends TestCase
 {
     private PdoCompanySettingsRepository $repository;
     private RecordingAuditRecorder $audit;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -43,20 +46,22 @@ final class CompanySettingsTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
     }
 
     public function test_get_throws_when_not_configured(): void
     {
         $this->expectException(CompanySettingsNotFoundException::class);
-        (new GetCompanySettingsUseCase($this->repository))->execute(1);
+        (new GetCompanySettingsUseCase($this->repository, $this->holder))->execute();
     }
 
     public function test_update_upserts_and_get_returns_settings(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit);
+        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder);
 
-        $created = $update->execute(1, 5, new UpdateCompanySettingsInput(
+        $created = $update->execute(5, new UpdateCompanySettingsInput(
             legalName: '株式会社あやね',
             registrationNumber: 'T1234567890123',
             bankName: 'みずほ',
@@ -65,9 +70,9 @@ final class CompanySettingsTest extends TestCase
         self::assertSame('T1234567890123', $created->registrationNumber);
 
         // Upsert: a second update replaces, not duplicates.
-        $update->execute(1, 5, new UpdateCompanySettingsInput(legalName: '株式会社あやね（改）'));
+        $update->execute(5, new UpdateCompanySettingsInput(legalName: '株式会社あやね（改）'));
 
-        $fetched = (new GetCompanySettingsUseCase($this->repository))->execute(1);
+        $fetched = (new GetCompanySettingsUseCase($this->repository, $this->holder))->execute();
         self::assertSame('株式会社あやね（改）', $fetched->legalName);
         self::assertNull($fetched->registrationNumber);
     }
@@ -75,7 +80,7 @@ final class CompanySettingsTest extends TestCase
     public function test_update_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new UpdateCompanySettingsUseCase($this->repository, $this->audit))->execute(1, 5, new UpdateCompanySettingsInput(
+        (new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder))->execute(5, new UpdateCompanySettingsInput(
             legalName: 'X',
             registrationNumber: 'bad',
         ));
@@ -83,11 +88,16 @@ final class CompanySettingsTest extends TestCase
 
     public function test_settings_are_scoped_per_organization(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit);
-        $update->execute(1, 5, new UpdateCompanySettingsInput(legalName: 'Org One'));
-        $update->execute(2, 5, new UpdateCompanySettingsInput(legalName: 'Org Two'));
+        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder);
+        $this->holder->set(1);
+        $update->execute(5, new UpdateCompanySettingsInput(legalName: 'Org One'));
+        $this->holder->set(2);
+        $update->execute(5, new UpdateCompanySettingsInput(legalName: 'Org Two'));
 
-        self::assertSame('Org One', (new GetCompanySettingsUseCase($this->repository))->execute(1)->legalName);
-        self::assertSame('Org Two', (new GetCompanySettingsUseCase($this->repository))->execute(2)->legalName);
+        $get = new GetCompanySettingsUseCase($this->repository, $this->holder);
+        $this->holder->set(1);
+        self::assertSame('Org One', $get->execute()->legalName);
+        $this->holder->set(2);
+        self::assertSame('Org Two', $get->execute()->legalName);
     }
 }

--- a/tests/Company/PdoCompanySettingsRepositoryTest.php
+++ b/tests/Company/PdoCompanySettingsRepositoryTest.php
@@ -7,17 +7,21 @@ namespace NeneInvoice\Tests\Company;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\Company\PdoCompanySettingsRepository;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PdoCompanySettingsRepository: upsert logic (save on empty → insert,
- * save again → update), org isolation, and field round-trip.
+ * save again → update), org isolation, and field round-trip. The organization is
+ * read from the request-scoped holder; save() forces it.
  */
 final class PdoCompanySettingsRepositoryTest extends TestCase
 {
     private PdoCompanySettingsRepository $repo;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -39,12 +43,14 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repo = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new PdoCompanySettingsRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
     }
 
     public function test_find_returns_null_when_not_set(): void
     {
-        self::assertNull($this->repo->findByOrganization(1));
+        self::assertNull($this->repo->find());
     }
 
     public function test_save_inserts_and_read_back(): void
@@ -64,7 +70,7 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
 
         $this->repo->save($settings);
 
-        $found = $this->repo->findByOrganization(1);
+        $found = $this->repo->find();
         self::assertNotNull($found);
         self::assertSame('株式会社テスト', $found->legalName);
         self::assertSame('T1234567890123', $found->registrationNumber);
@@ -77,7 +83,7 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
         $this->repo->save(new CompanySettings(organizationId: 1, legalName: '旧社名'));
         $this->repo->save(new CompanySettings(organizationId: 1, legalName: '新社名', registrationNumber: 'T9999999999999'));
 
-        $found = $this->repo->findByOrganization(1);
+        $found = $this->repo->find();
         self::assertNotNull($found);
         self::assertSame('新社名', $found->legalName);
         self::assertSame('T9999999999999', $found->registrationNumber);
@@ -85,19 +91,30 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
 
     public function test_orgs_are_isolated(): void
     {
+        $this->holder->set(1);
         $this->repo->save(new CompanySettings(organizationId: 1, legalName: 'Org 1'));
+        $this->holder->set(2);
         $this->repo->save(new CompanySettings(organizationId: 2, legalName: 'Org 2'));
 
-        self::assertSame('Org 1', $this->repo->findByOrganization(1)?->legalName);
-        self::assertSame('Org 2', $this->repo->findByOrganization(2)?->legalName);
-        self::assertNull($this->repo->findByOrganization(3));
+        $this->holder->set(1);
+        $orgOne = $this->repo->find();
+        self::assertNotNull($orgOne);
+        self::assertSame('Org 1', $orgOne->legalName);
+
+        $this->holder->set(2);
+        $orgTwo = $this->repo->find();
+        self::assertNotNull($orgTwo);
+        self::assertSame('Org 2', $orgTwo->legalName);
+
+        $this->holder->set(3);
+        self::assertNull($this->repo->find());
     }
 
     public function test_optional_fields_are_nullable(): void
     {
         $this->repo->save(new CompanySettings(organizationId: 1, legalName: 'Minimal'));
 
-        $found = $this->repo->findByOrganization(1);
+        $found = $this->repo->find();
         self::assertNotNull($found);
         self::assertNull($found->address);
         self::assertNull($found->registrationNumber);

--- a/tests/DocumentSequence/DocumentNumberGeneratorTest.php
+++ b/tests/DocumentSequence/DocumentNumberGeneratorTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\DocumentSequence;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\DocumentSequence\DocumentType;
 use NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository;
@@ -15,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 final class DocumentNumberGeneratorTest extends TestCase
 {
     private DocumentNumberGenerator $generator;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -36,28 +39,32 @@ final class DocumentNumberGeneratorTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
         $this->generator = new DocumentNumberGenerator(
-            new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo)),
+            new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder),
         );
     }
 
     public function test_numbers_increment_sequentially_with_format(): void
     {
-        self::assertSame('EST-2026-001', $this->generator->next(1, DocumentType::Quote, 2026));
-        self::assertSame('EST-2026-002', $this->generator->next(1, DocumentType::Quote, 2026));
-        self::assertSame('EST-2026-003', $this->generator->next(1, DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-001', $this->generator->next(DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-002', $this->generator->next(DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-003', $this->generator->next(DocumentType::Quote, 2026));
     }
 
     public function test_sequences_are_isolated_by_org_type_and_year(): void
     {
-        self::assertSame('EST-2026-001', $this->generator->next(1, DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-001', $this->generator->next(DocumentType::Quote, 2026));
         // Different document type → its own counter.
-        self::assertSame('INV-2026-001', $this->generator->next(1, DocumentType::Invoice, 2026));
+        self::assertSame('INV-2026-001', $this->generator->next(DocumentType::Invoice, 2026));
         // Different organization → its own counter.
-        self::assertSame('EST-2026-001', $this->generator->next(2, DocumentType::Quote, 2026));
+        $this->holder->set(2);
+        self::assertSame('EST-2026-001', $this->generator->next(DocumentType::Quote, 2026));
+        $this->holder->set(1);
         // Different year → resets.
-        self::assertSame('EST-2027-001', $this->generator->next(1, DocumentType::Quote, 2027));
+        self::assertSame('EST-2027-001', $this->generator->next(DocumentType::Quote, 2027));
         // Original counter continues.
-        self::assertSame('EST-2026-002', $this->generator->next(1, DocumentType::Quote, 2026));
+        self::assertSame('EST-2026-002', $this->generator->next(DocumentType::Quote, 2026));
     }
 }

--- a/tests/DocumentSequence/PdoDocumentSequenceRepositoryTest.php
+++ b/tests/DocumentSequence/PdoDocumentSequenceRepositoryTest.php
@@ -7,17 +7,21 @@ namespace NeneInvoice\Tests\DocumentSequence;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\DocumentSequence\DocumentType;
 use NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Direct tests for PdoDocumentSequenceRepository: atomic allocation logic,
- * org/type/year isolation, and INSERT-fallback-on-conflict behaviour.
+ * org/type/year isolation, and INSERT-fallback-on-conflict behaviour. The
+ * organization is read from the request-scoped holder.
  */
 final class PdoDocumentSequenceRepositoryTest extends TestCase
 {
     private PdoDocumentSequenceRepository $repo;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -39,45 +43,49 @@ final class PdoDocumentSequenceRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repo = new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new PdoDocumentSequenceRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
     }
 
     public function test_first_call_initialises_at_one(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
     }
 
     public function test_subsequent_calls_increment(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
-        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
-        self::assertSame(3, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
+        self::assertSame(3, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
     }
 
     public function test_isolated_by_document_type(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
     }
 
     public function test_isolated_by_organization(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
-        self::assertSame(1, $this->repo->nextNumber(2, DocumentType::Quote->value, 2026));
+        $this->holder->set(1);
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
+        $this->holder->set(2);
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
     }
 
     public function test_isolated_by_year(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2025));
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2025));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
     }
 
     public function test_mixed_interleaving_stays_correct(): void
     {
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
-        self::assertSame(1, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
-        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
-        self::assertSame(2, $this->repo->nextNumber(1, DocumentType::Invoice->value, 2026));
-        self::assertSame(3, $this->repo->nextNumber(1, DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
+        self::assertSame(1, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
+        self::assertSame(2, $this->repo->nextNumber(DocumentType::Invoice->value, 2026));
+        self::assertSame(3, $this->repo->nextNumber(DocumentType::Quote->value, 2026));
     }
 }

--- a/tests/Support/InMemoryAuditLogRepository.php
+++ b/tests/Support/InMemoryAuditLogRepository.php
@@ -4,18 +4,35 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditLog;
 use NeneInvoice\Audit\AuditLogRepositoryInterface;
 
 /**
  * In-memory fake for use-case tests (no database). Returns logs most-recent-first
- * (descending id), mirroring PdoAuditLogRepository.
+ * (descending id), mirroring PdoAuditLogRepository. Reads are scoped to the
+ * request-scoped org holder (defaulting to organization 1); {@see append()}
+ * keeps the organization on the log itself, like the Pdo repository.
  */
 final class InMemoryAuditLogRepository implements AuditLogRepositoryInterface
 {
     /** @var array<int, AuditLog> */
     private array $byId = [];
     private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
 
     public function append(AuditLog $log): int
     {
@@ -36,8 +53,9 @@ final class InMemoryAuditLogRepository implements AuditLogRepositoryInterface
     }
 
     /** @return list<AuditLog> */
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
+        $organizationId = $this->orgId->get();
         $matches = array_values(array_filter(
             $this->byId,
             static fn (AuditLog $log): bool => $log->organizationId === $organizationId,
@@ -48,8 +66,10 @@ final class InMemoryAuditLogRepository implements AuditLogRepositoryInterface
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
+        $organizationId = $this->orgId->get();
+
         return count(array_filter(
             $this->byId,
             static fn (AuditLog $log): bool => $log->organizationId === $organizationId,

--- a/tests/Support/InMemoryCompanySettingsRepository.php
+++ b/tests/Support/InMemoryCompanySettingsRepository.php
@@ -4,24 +4,57 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\Company\PdoCompanySettingsRepository}.
+ * The holder defaults to organization 1 for single-org tests.
  */
 final class InMemoryCompanySettingsRepository implements CompanySettingsRepositoryInterface
 {
     /** @var array<int, CompanySettings> */
     private array $byOrganization = [];
 
-    public function findByOrganization(int $organizationId): ?CompanySettings
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
     {
-        return $this->byOrganization[$organizationId] ?? null;
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
+    public function find(): ?CompanySettings
+    {
+        return $this->byOrganization[$this->orgId->get()] ?? null;
     }
 
     public function save(CompanySettings $settings): void
     {
-        $this->byOrganization[$settings->organizationId] = $settings;
+        // The organization is forced from the request-scoped holder.
+        $organizationId = $this->orgId->get();
+        $this->byOrganization[$organizationId] = new CompanySettings(
+            organizationId: $organizationId,
+            legalName: $settings->legalName,
+            address: $settings->address,
+            phone: $settings->phone,
+            email: $settings->email,
+            registrationNumber: $settings->registrationNumber,
+            bankName: $settings->bankName,
+            bankBranch: $settings->bankBranch,
+            accountType: $settings->accountType,
+            accountNumber: $settings->accountNumber,
+            logoUrl: $settings->logoUrl,
+            createdAt: $settings->createdAt,
+            updatedAt: $settings->updatedAt,
+        );
     }
 }

--- a/tests/Support/InMemoryDocumentSequenceRepository.php
+++ b/tests/Support/InMemoryDocumentSequenceRepository.php
@@ -4,19 +4,37 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\DocumentSequence\DocumentSequenceRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). The organization is read from
+ * the request-scoped org holder, mirroring
+ * {@see \NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository}. The holder
+ * defaults to organization 1 for single-org tests.
  */
 final class InMemoryDocumentSequenceRepository implements DocumentSequenceRepositoryInterface
 {
     /** @var array<string, int> */
     private array $counters = [];
 
-    public function nextNumber(int $organizationId, string $docType, int $year): int
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
     {
-        $key = $organizationId . ':' . $docType . ':' . $year;
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
+    public function nextNumber(string $docType, int $year): int
+    {
+        $key = $this->orgId->get() . ':' . $docType . ':' . $year;
         $next = ($this->counters[$key] ?? 0) + 1;
         $this->counters[$key] = $next;
 


### PR DESCRIPTION
## 概要
Closes #157

ADR 0006 のマルチテナント多重防御パターン移植エピックの一環。CompanySettings / Audit（read） / DocumentSequence の各リポジトリを `RequestScopedHolder<int>` ベースへ移行し、org をメソッド引数から排除して SQL レベルでテナント分離を構造的に強制する（Client / Invoice / Quote / Payment と同一パターン）。

## 変更点
- **CompanySettings**: `findByOrganization($org)` → `find()`（holder 読み取り）、`save` は holder org を強制。`GetCompanySettings` / `UpdateCompanySettings` use case とハンドラから org threading を撤去。
- **Audit（read）**: `findByOrganization` / `countByOrganization` → `findAll` / `count`（holder）。`append`（write）は **意図的に従来通り** log の org を尊重 — superadmin の組織プロビジョニング監査が holder 未セット経路で走るため、書き込み側は holder 非依存を維持。
- **DocumentSequence**: `nextNumber($org, $docType, $year)` → `nextNumber($docType, $year)`。`DocumentNumberGenerator::next` も org 引数を撤去。
- 消費側（`IssueInvoiceUseCase` / `GenerateInvoicePdfUseCase` / `CreateQuoteUseCase`）の company settings / numbering 呼び出しを簡素化。
- InMemory フェイク 3 種を holder 対応（既定 org 1）、関連テストを holder ベースのクロステナント分離検証へ更新。

## セルフレビューチェックリスト
- [x] `composer check` green（251 tests / 924 assertions、PHPStan level 8 / php-cs-fixer / OpenAPI / MCP）
- [x] 全クエリ（read）が holder の `organization_id` で絞られ、org はメソッド引数に存在しない
- [x] Audit write（append）は holder 非依存を維持（superadmin 経路の回帰なし）
- [x] 命名は用語レジストリと整合（新規 problem slug の追加なし）
- [x] 会計・税務コンプライアンス: 採番ロジック（DocumentSequence）の挙動は不変、org 解決元のみ変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)