### PR TITLE
feat(tenancy): User ドメインを holder ベースへ + フォールバック除去 (#159)

### DIFF
--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -15,6 +15,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\User\PdoUserRepository;
 use NeneInvoice\User\UserRepositoryInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -76,7 +78,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoUserRepository($query);
+                    return new PdoUserRepository($query, self::orgHolder($container));
                 },
             )
             ->set(
@@ -234,5 +236,17 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                     return new AuthRouteRegistrar($loginHandler, $getCurrentUserHandler);
                 },
             );
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 }

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\InvoiceDownloadToken;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -16,28 +14,22 @@ use Psr\Http\Server\RequestHandlerInterface;
  * `POST /admin/invoices/{id}/download-token`
  * Generates a time-limited public download token for the invoice PDF.
  * Capability: ManageBilling (POST on /admin/invoices/*, via CapabilityResolver).
+ * The organization is resolved upstream (OrgResolverMiddleware) into the holder.
  */
 final readonly class GenerateDownloadTokenHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GenerateDownloadTokenUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $result = $this->useCase->execute($organizationId, $id);
+        $result = $this->useCase->execute($id);
 
         return $this->json->create([
             'url'        => '/invoices/download/' . $result['rawToken'],

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\InvoiceDownloadToken;
 
 use DateTimeImmutable;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 
@@ -17,9 +18,13 @@ final readonly class GenerateDownloadTokenUseCase
 {
     private const TTL_DAYS = 7;
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private InvoiceDownloadTokenRepositoryInterface $tokens,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -27,13 +32,17 @@ final readonly class GenerateDownloadTokenUseCase
      * @return array{rawToken: string, expiresAt: string}
      * @throws InvoiceNotFoundException
      */
-    public function execute(int $organizationId, int $invoiceId): array
+    public function execute(int $invoiceId): array
     {
+        // The invoice repository is org-scoped (holder), so a foreign invoice
+        // is already invisible here.
         $invoice = $this->invoices->findById($invoiceId);
 
-        if ($invoice === null || $invoice->organizationId !== $organizationId) {
+        if ($invoice === null) {
             throw new InvoiceNotFoundException($invoiceId);
         }
+
+        $organizationId = $this->orgId->get();
 
         $rawToken  = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
         $tokenHash = hash('sha256', $rawToken);

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -40,6 +40,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 static fn (ContainerInterface $c): GenerateDownloadTokenUseCase => new GenerateDownloadTokenUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
+                    self::orgHolder($c),
                 ),
             )
             ->set(
@@ -47,7 +48,6 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 static fn (ContainerInterface $c): GenerateDownloadTokenHandler => new GenerateDownloadTokenHandler(
                     self::resolve($c, GenerateDownloadTokenUseCase::class),
                     self::resolve($c, JsonResponseFactory::class),
-                    self::resolve($c, ProblemDetailsResponseFactory::class),
                 ),
             )
             ->set(

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -26,12 +26,6 @@ final readonly class CreateUserHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $decoded = json_decode((string) $request->getBody(), true);
 
         if (!is_array($decoded)) {
@@ -52,7 +46,7 @@ final readonly class CreateUserHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
         }
 
-        $user = $this->useCase->execute($organizationId, AuthContext::userId($request), new CreateUserInput($email, $password, $role));
+        $user = $this->useCase->execute(AuthContext::userId($request), new CreateUserInput($email, $password, $role));
 
         return $this->json->create(UserResponse::toArray($user), 201);
     }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -5,30 +5,37 @@ declare(strict_types=1);
 namespace NeneInvoice\User;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
 final readonly class CreateUserUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private UserRepositoryInterface $users,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
      * Creates a user in the caller's organization. The organization is taken
-     * from the authenticated caller, never from request input, so a user cannot
+     * from the resolved org holder, never from request input, so a user cannot
      * be created in another tenant.
      *
      * @throws RoleNotAssignableException   when attempting to assign superadmin
      * @throws UserEmailConflictException   when the email is already in use
      */
-    public function execute(int $organizationId, ?int $actorUserId, CreateUserInput $input): User
+    public function execute(?int $actorUserId, CreateUserInput $input): User
     {
         if ($input->role === Role::Superadmin) {
             throw new RoleNotAssignableException($input->role);
         }
+
+        $organizationId = $this->orgId->get();
 
         $id = $this->users->save(new User(
             email: $input->email,

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -27,17 +27,16 @@ final readonly class DeleteUserHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
         $callerUserId = AuthContext::userId($request);
 
-        if ($organizationId === null || $callerUserId === null) {
+        if ($callerUserId === null) {
             return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
         }
 
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $this->useCase->execute($organizationId, $callerUserId, $id);
+        $this->useCase->execute($callerUserId, $id);
 
         return $this->json->createEmpty(204);
     }

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteUserUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private UserRepositoryInterface $users,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -21,20 +26,20 @@ final readonly class DeleteUserUseCase
      * @throws CannotDeleteSelfException
      * @throws UserNotFoundException
      */
-    public function execute(int $organizationId, int $callerUserId, int $userId): void
+    public function execute(int $callerUserId, int $userId): void
     {
         if ($userId === $callerUserId) {
             throw new CannotDeleteSelfException();
         }
 
-        $existing = $this->users->findById($userId);
+        $existing = $this->users->findInOrganization($userId);
 
-        if ($existing === null || $existing->organizationId !== $organizationId) {
+        if ($existing === null) {
             throw new UserNotFoundException($userId);
         }
 
         $this->users->delete($userId);
 
-        $this->audit->record($callerUserId, $organizationId, 'user.deleted', 'user', $userId, UserResponse::toArray($existing), null);
+        $this->audit->record($callerUserId, $this->orgId->get(), 'user.deleted', 'user', $userId, UserResponse::toArray($existing), null);
     }
 }

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -4,39 +4,32 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * `GET /admin/users/{id}` — admin reads one user in their own organization.
- * Users outside the caller's organization (or missing) return 404.
+ * Users outside the caller's organization (or missing) return 404. The
+ * organization is resolved upstream (OrgResolverMiddleware) into the
+ * request-scoped holder.
  */
 final readonly class GetUserByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
         private GetUserByIdUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $user = $this->useCase->execute($organizationId, $id);
+        $user = $this->useCase->execute($id);
 
         return $this->json->create(UserResponse::toArray($user));
     }

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -12,17 +12,17 @@ final readonly class GetUserByIdUseCase
     }
 
     /**
-     * Fetches a user that belongs to the given organization. A user from another
-     * organization (or a missing id) is reported as not found so cross-tenant
-     * existence is not leaked.
+     * Fetches a user that belongs to the resolved organization. A user from
+     * another organization (or a missing id) is reported as not found so
+     * cross-tenant existence is not leaked.
      *
      * @throws UserNotFoundException
      */
-    public function execute(int $organizationId, int $id): User
+    public function execute(int $id): User
     {
-        $user = $this->users->findById($id);
+        $user = $this->users->findInOrganization($id);
 
-        if ($user === null || $user->organizationId !== $organizationId) {
+        if ($user === null) {
             throw new UserNotFoundException($id);
         }
 

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * `GET /admin/users` — admin lists users in their own organization.
+ * `GET /admin/users` — admin lists users in their own organization. The
+ * organization is resolved upstream (OrgResolverMiddleware) into the
+ * request-scoped holder.
  */
 final readonly class ListUsersHandler implements RequestHandlerInterface
 {
@@ -22,18 +22,11 @@ final readonly class ListUsersHandler implements RequestHandlerInterface
     public function __construct(
         private ListUsersUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $query = $request->getQueryParams();
 
         $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
@@ -42,7 +35,7 @@ final readonly class ListUsersHandler implements RequestHandlerInterface
         $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
         $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($organizationId, $limit, $offset);
+        $result = $this->useCase->execute($limit, $offset);
 
         return $this->json->create([
             'items' => array_map(static fn (User $u): array => UserResponse::toArray($u), $result->items),

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -11,11 +11,11 @@ final readonly class ListUsersUseCase
     ) {
     }
 
-    public function execute(int $organizationId, int $limit, int $offset): ListUsersResult
+    public function execute(int $limit, int $offset): ListUsersResult
     {
         return new ListUsersResult(
-            $this->users->findAllByOrganization($organizationId, $limit, $offset),
-            $this->users->countByOrganization($organizationId),
+            $this->users->findAll($limit, $offset),
+            $this->users->count(),
         );
     }
 }

--- a/src/User/PdoUserRepository.php
+++ b/src/User/PdoUserRepository.php
@@ -6,14 +6,19 @@ namespace NeneInvoice\User;
 
 use Nene2\Database\DatabaseConstraintException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Auth\Role;
 
 final readonly class PdoUserRepository implements UserRepositoryInterface
 {
     private const COLUMNS = 'id, email, password_hash, role, organization_id, status, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for org-scoped operations
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -37,22 +42,32 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         return $row !== null ? $this->mapRow($row) : null;
     }
 
+    public function findInOrganization(int $id): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
     /** @return list<User> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            [$this->orgId->get(), $limit, $offset],
         );
 
         return array_map(fn (array $row): User => $this->mapRow($row), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt FROM users WHERE organization_id = ?',
-            [$organizationId],
+            [$this->orgId->get()],
         );
 
         return $row !== null ? (int) $row['cnt'] : 0;
@@ -63,6 +78,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         try {
+            // The organization is forced from the request-scoped holder.
             $this->query->execute(
                 'INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
                  VALUES (?, ?, ?, ?, ?, ?, ?)',
@@ -70,7 +86,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
                     $user->email,
                     $user->passwordHash,
                     $user->role->value,
-                    $user->organizationId,
+                    $this->orgId->get(),
                     $user->status,
                     $now,
                     $now,
@@ -91,31 +107,32 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
 
         $now = date('Y-m-d H:i:s');
 
+        // Scoped to the holder org: a user in another organization cannot be updated.
         $affected = $this->query->execute(
-            'UPDATE users SET email = ?, password_hash = ?, role = ?, organization_id = ?, status = ?, updated_at = ? WHERE id = ?',
+            'UPDATE users SET email = ?, password_hash = ?, role = ?, status = ?, updated_at = ? WHERE id = ? AND organization_id = ?',
             [
                 $user->email,
                 $user->passwordHash,
                 $user->role->value,
-                $user->organizationId,
                 $user->status,
                 $now,
                 $user->id,
+                $this->orgId->get(),
             ],
         );
 
-        if ($affected === 0 && $this->findById($user->id) === null) {
+        if ($affected === 0 && $this->findInOrganization($user->id) === null) {
             throw new UserNotFoundException($user->id);
         }
     }
 
     public function delete(int $id): void
     {
-        if ($this->findById($id) === null) {
+        if ($this->findInOrganization($id) === null) {
             throw new UserNotFoundException($id);
         }
 
-        $this->query->execute('DELETE FROM users WHERE id = ?', [$id]);
+        $this->query->execute('DELETE FROM users WHERE id = ? AND organization_id = ?', [$id, $this->orgId->get()]);
     }
 
     /** @param array<string, mixed> $row */

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -30,12 +30,6 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request);
-
-        if ($organizationId === null) {
-            return $this->problemDetails->create($request, 'organization-not-resolved', 'Organization Required', 400, 'This action requires an organization context.');
-        }
-
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
@@ -61,7 +55,7 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
         $passwordValue = $decoded['password'] ?? null;
         $password = is_string($passwordValue) && $passwordValue !== '' ? $passwordValue : null;
 
-        $user = $this->useCase->execute($organizationId, AuthContext::userId($request), $id, new UpdateUserInput($role, $status, $password));
+        $user = $this->useCase->execute(AuthContext::userId($request), $id, new UpdateUserInput($role, $status, $password));
 
         return $this->json->create(UserResponse::toArray($user));
     }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace NeneInvoice\User;
 
 use LogicException;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
 final readonly class UpdateUserUseCase
 {
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private UserRepositoryInterface $users,
         private AuditRecorderInterface $audit,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -24,11 +29,11 @@ final readonly class UpdateUserUseCase
      * @throws UserNotFoundException        when the user is missing or in another org
      * @throws RoleNotAssignableException   when attempting to assign superadmin
      */
-    public function execute(int $organizationId, ?int $actorUserId, int $userId, UpdateUserInput $input): User
+    public function execute(?int $actorUserId, int $userId, UpdateUserInput $input): User
     {
-        $existing = $this->users->findById($userId);
+        $existing = $this->users->findInOrganization($userId);
 
-        if ($existing === null || $existing->organizationId !== $organizationId) {
+        if ($existing === null) {
             throw new UserNotFoundException($userId);
         }
 
@@ -53,7 +58,7 @@ final readonly class UpdateUserUseCase
             throw new LogicException('User disappeared immediately after update.');
         }
 
-        $this->audit->record($actorUserId, $organizationId, 'user.updated', 'user', $userId, UserResponse::toArray($existing), UserResponse::toArray($updated));
+        $this->audit->record($actorUserId, $this->orgId->get(), 'user.updated', 'user', $userId, UserResponse::toArray($existing), UserResponse::toArray($updated));
 
         return $updated;
     }

--- a/src/User/UserRepositoryInterface.php
+++ b/src/User/UserRepositoryInterface.php
@@ -4,16 +4,27 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+/**
+ * Persistence for users.
+ *
+ * Identity lookups ({@see findById()}, {@see findByEmail()}) are deliberately
+ * NOT scoped to the org holder: they run on holder-less paths — login (pre-auth)
+ * and "current user" resolution from the token `sub`. Every other operation is
+ * scoped to the organization held in the request-scoped org holder (ADR 0006).
+ */
 interface UserRepositoryInterface
 {
     public function findById(int $id): ?User;
 
     public function findByEmail(string $email): ?User;
 
-    /** @return list<User> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array;
+    /** Looks up a user by id within the resolved organization (holder-scoped). */
+    public function findInOrganization(int $id): ?User;
 
-    public function countByOrganization(int $organizationId): int;
+    /** @return list<User> */
+    public function findAll(int $limit, int $offset): array;
+
+    public function count(): int;
 
     /** @throws UserEmailConflictException */
     public function save(User $user): int;

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -9,6 +9,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use Psr\Container\ContainerInterface;
 
@@ -24,15 +26,14 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         $builder
             ->set(ListUsersUseCase::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
             ->set(GetUserByIdUseCase::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
-            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c)))
-            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c)))
-            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c)))
+            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListUsersHandler::class,
                 static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
                     self::listUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -40,7 +41,6 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): GetUserByIdHandler => new GetUserByIdHandler(
                     self::getUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -126,6 +126,18 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         }
 
         return $recorder;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
     }
 
     private static function listUseCase(ContainerInterface $c): ListUsersUseCase

--- a/tests/Auth/GetCurrentUserUseCaseTest.php
+++ b/tests/Auth/GetCurrentUserUseCaseTest.php
@@ -56,13 +56,18 @@ final class GetCurrentUserUseCaseTest extends TestCase
                 return $this->user->email === $email ? $this->user : null;
             }
 
+            public function findInOrganization(int $id): ?User
+            {
+                return $this->user->id === $id ? $this->user : null;
+            }
+
             /** @return list<User> */
-            public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+            public function findAll(int $limit, int $offset): array
             {
                 return [];
             }
 
-            public function countByOrganization(int $organizationId): int
+            public function count(): int
             {
                 return 0;
             }

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -72,13 +72,18 @@ final class LoginUseCaseTest extends TestCase
                 return $this->user->email === $email ? $this->user : null;
             }
 
+            public function findInOrganization(int $id): ?User
+            {
+                return $this->user->id === $id ? $this->user : null;
+            }
+
             /** @return list<User> */
-            public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+            public function findAll(int $limit, int $offset): array
             {
                 return [];
             }
 
-            public function countByOrganization(int $organizationId): int
+            public function count(): int
             {
                 return 0;
             }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\InvoiceDownloadToken;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
 use Nene2\Routing\Router;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
@@ -22,11 +22,15 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
     private InMemoryInvoiceRepository $invoices;
     private GenerateDownloadTokenHandler $handler;
     private int $invoiceId;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
         $this->psr17    = new Psr17Factory();
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->holder   = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $tokens         = new InMemoryInvoiceDownloadTokenRepository();
 
         $this->invoiceId = $this->invoices->save(new Invoice(
@@ -39,9 +43,8 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
         ));
 
         $this->handler = new GenerateDownloadTokenHandler(
-            new GenerateDownloadTokenUseCase($this->invoices, $tokens),
+            new GenerateDownloadTokenUseCase($this->invoices, $tokens, $this->holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
-            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );
     }
 
@@ -60,24 +63,21 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
         self::assertNotEmpty($body['expires_at']);
     }
 
-    public function test_returns_400_without_org_context(): void
-    {
-        $request = $this->psr17->createServerRequest('POST', '/admin/invoices/1/download-token')
-            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '1']);
-
-        self::assertSame(400, $this->handler->handle($request)->getStatusCode());
-    }
-
     public function test_throws_invoice_not_found_for_cross_org_invoice(): void
     {
-        // InvoiceNotFoundException propagates to InvoiceNotFoundExceptionHandler in production.
-        // Unit tests exercise the handler in isolation, so we assert the exception directly.
+        // The holder resolves a different organization than the invoice's, so the
+        // org-scoped invoice repository hides it (InvoiceNotFoundException, which
+        // propagates to InvoiceNotFoundExceptionHandler in production).
+        $this->holder->set(2);
+
         $this->expectException(\NeneInvoice\Invoice\InvoiceNotFoundException::class);
 
         $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/download-token")
-            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => 2])
             ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
 
         $this->handler->handle($request);
     }
+
+    // Note: the "no org context" case is now handled upstream by
+    // OrgResolverMiddleware (404), not by this handler (ADR 0006).
 }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\InvoiceDownloadToken;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
@@ -20,18 +21,23 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
 
     private GenerateDownloadTokenUseCase $useCase;
 
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+
     protected function setUp(): void
     {
-        $this->invoices = new InMemoryInvoiceRepository();
+        $this->holder   = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->tokens   = new InMemoryInvoiceDownloadTokenRepository();
-        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens);
+        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->holder);
     }
 
     public function test_generates_token_for_invoice_in_org(): void
     {
         $id = $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 100, totalCents: 1100));
 
-        $result = $this->useCase->execute(1, $id);
+        $result = $this->useCase->execute($id);
 
         self::assertNotEmpty($result['rawToken']);
         self::assertNotEmpty($result['expiresAt']);
@@ -44,16 +50,17 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
 
     public function test_throws_for_wrong_org(): void
     {
+        // Invoice belongs to org 2; the holder resolves org 1, so it is invisible.
         $id = $this->invoices->save(new Invoice(organizationId: 2, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
 
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(1, $id);
+        $this->useCase->execute($id);
     }
 
     public function test_raw_token_is_url_safe_base64(): void
     {
         $id     = $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
-        $result = $this->useCase->execute(1, $id);
+        $result = $this->useCase->execute($id);
 
         self::assertMatchesRegularExpression('/^[A-Za-z0-9\-_]+$/', $result['rawToken']);
     }

--- a/tests/Support/InMemoryUserRepository.php
+++ b/tests/Support/InMemoryUserRepository.php
@@ -4,19 +4,39 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\User\User;
 use NeneInvoice\User\UserEmailConflictException;
 use NeneInvoice\User\UserNotFoundException;
 use NeneInvoice\User\UserRepositoryInterface;
 
 /**
- * In-memory fake for use-case tests (no database).
+ * In-memory fake for use-case tests (no database). Identity lookups
+ * ({@see findById()}, {@see findByEmail()}) are global, mirroring the
+ * holder-less login / current-user paths. Org-scoped operations read the
+ * request-scoped holder (defaulting to organization 1). {@see save()} keeps the
+ * entity's organization so cross-org fixtures can be seeded while reads prove
+ * isolation.
  */
 final class InMemoryUserRepository implements UserRepositoryInterface
 {
     /** @var array<int, User> */
     private array $byId = [];
     private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
 
     public function findById(int $id): ?User
     {
@@ -34,9 +54,17 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         return null;
     }
 
-    /** @return list<User> */
-    public function findAllByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findInOrganization(int $id): ?User
     {
+        $user = $this->byId[$id] ?? null;
+
+        return $user !== null && $user->organizationId === $this->orgId->get() ? $user : null;
+    }
+
+    /** @return list<User> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $organizationId = $this->orgId->get();
         $matches = array_values(array_filter(
             $this->byId,
             static fn (User $u): bool => $u->organizationId === $organizationId,
@@ -45,8 +73,10 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function count(): int
     {
+        $organizationId = $this->orgId->get();
+
         return count(array_filter(
             $this->byId,
             static fn (User $u): bool => $u->organizationId === $organizationId,
@@ -78,7 +108,7 @@ final class InMemoryUserRepository implements UserRepositoryInterface
 
     public function update(User $user): void
     {
-        if ($user->id === null || !isset($this->byId[$user->id])) {
+        if ($user->id === null || $this->findInOrganization($user->id) === null) {
             throw new UserNotFoundException($user->id ?? 0);
         }
 
@@ -87,7 +117,7 @@ final class InMemoryUserRepository implements UserRepositoryInterface
 
     public function delete(int $id): void
     {
-        if (!isset($this->byId[$id])) {
+        if ($this->findInOrganization($id) === null) {
             throw new UserNotFoundException($id);
         }
 

--- a/tests/User/PdoUserRepositoryTest.php
+++ b/tests/User/PdoUserRepositoryTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\User;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Auth\Role;
 use NeneInvoice\User\PdoUserRepository;
 use NeneInvoice\User\User;
@@ -17,6 +18,9 @@ use PHPUnit\Framework\TestCase;
 final class PdoUserRepositoryTest extends TestCase
 {
     private PdoUserRepository $repository;
+    private PdoDatabaseQueryExecutor $executor;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
@@ -38,9 +42,10 @@ final class PdoUserRepositoryTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
-        $this->repository = new PdoUserRepository(
-            new PdoDatabaseQueryExecutor($factory, $pdo),
-        );
+        $this->executor = new PdoDatabaseQueryExecutor($factory, $pdo);
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoUserRepository($this->executor, $this->holder);
     }
 
     public function test_finds_user_by_email_and_id_after_save(): void
@@ -68,12 +73,15 @@ final class PdoUserRepositoryTest extends TestCase
 
     public function test_superadmin_may_have_null_organization(): void
     {
-        $id = $this->repository->save(new User(
-            email: 'root@example.com',
-            passwordHash: 'hashed',
-            role: Role::Superadmin,
-            organizationId: null,
-        ));
+        // Superadmins are seeded directly (no org holder), not created through the
+        // org-scoped save() path, so insert the row directly to exercise mapping.
+        $now = '2026-05-29 00:00:00';
+        $this->executor->execute(
+            'INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (?, ?, ?, NULL, ?, ?, ?)',
+            ['root@example.com', 'hashed', Role::Superadmin->value, 'active', $now, $now],
+        );
+        $id = $this->executor->lastInsertId();
 
         $user = $this->repository->findById($id);
         self::assertNotNull($user);
@@ -83,14 +91,20 @@ final class PdoUserRepositoryTest extends TestCase
 
     public function test_lists_and_counts_users_scoped_to_organization(): void
     {
+        // save() forces the holder org, so set it per fixture.
+        $this->holder->set(1);
         $this->repository->save(new User(email: 'a@org1', passwordHash: 'h', role: Role::Admin, organizationId: 1));
         $this->repository->save(new User(email: 'b@org1', passwordHash: 'h', role: Role::Member, organizationId: 1));
+        $this->holder->set(2);
         $this->repository->save(new User(email: 'c@org2', passwordHash: 'h', role: Role::Member, organizationId: 2));
 
-        self::assertSame(2, $this->repository->countByOrganization(1));
-        self::assertSame(1, $this->repository->countByOrganization(2));
+        $this->holder->set(1);
+        self::assertSame(2, $this->repository->count());
+        $this->holder->set(2);
+        self::assertSame(1, $this->repository->count());
 
-        $org1 = $this->repository->findAllByOrganization(1, 10, 0);
+        $this->holder->set(1);
+        $org1 = $this->repository->findAll(10, 0);
         self::assertCount(2, $org1);
         self::assertSame('a@org1', $org1[0]->email);
     }
@@ -122,6 +136,23 @@ final class PdoUserRepositoryTest extends TestCase
         self::assertSame('active', $updated->status);
     }
 
+    public function test_update_is_scoped_to_organization(): void
+    {
+        // A user in org 1 cannot be updated while the holder resolves org 2.
+        $id = $this->repository->save(new User(email: 'scoped@org1', passwordHash: 'h', role: Role::Member, organizationId: 1));
+
+        $this->holder->set(2);
+        $this->expectException(UserNotFoundException::class);
+        $this->repository->update(new User(
+            email: 'scoped@org1',
+            passwordHash: 'h',
+            role: Role::Admin,
+            organizationId: 1,
+            status: 'active',
+            id: $id,
+        ));
+    }
+
     public function test_throws_when_deleting_unknown_user(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -135,6 +166,6 @@ final class PdoUserRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->countByOrganization(1));
+        self::assertSame(0, $this->repository->count());
     }
 }

--- a/tests/User/UserQueryUseCasesTest.php
+++ b/tests/User/UserQueryUseCasesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\User;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Auth\Role;
 use NeneInvoice\Tests\Support\InMemoryUserRepository;
 use NeneInvoice\User\GetUserByIdUseCase;
@@ -15,11 +16,15 @@ use PHPUnit\Framework\TestCase;
 final class UserQueryUseCasesTest extends TestCase
 {
     private InMemoryUserRepository $repo;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
     private int $org1User;
 
     protected function setUp(): void
     {
-        $this->repo = new InMemoryUserRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new InMemoryUserRepository($this->holder);
         $this->org1User = $this->repo->save(new User('a@org1', 'h', Role::Admin, 1));
         $this->repo->save(new User('b@org1', 'h', Role::Member, 1));
         $this->repo->save(new User('c@org2', 'h', Role::Admin, 2));
@@ -27,7 +32,7 @@ final class UserQueryUseCasesTest extends TestCase
 
     public function test_list_is_scoped_to_organization(): void
     {
-        $result = (new ListUsersUseCase($this->repo))->execute(1, 10, 0);
+        $result = (new ListUsersUseCase($this->repo))->execute(10, 0);
 
         self::assertSame(2, $result->total);
         self::assertCount(2, $result->items);
@@ -38,7 +43,7 @@ final class UserQueryUseCasesTest extends TestCase
 
     public function test_get_returns_user_in_same_organization(): void
     {
-        $user = (new GetUserByIdUseCase($this->repo))->execute(1, $this->org1User);
+        $user = (new GetUserByIdUseCase($this->repo))->execute($this->org1User);
 
         self::assertSame('a@org1', $user->email);
     }
@@ -50,6 +55,6 @@ final class UserQueryUseCasesTest extends TestCase
         self::assertNotNull($org2UserId);
 
         $this->expectException(UserNotFoundException::class);
-        (new GetUserByIdUseCase($this->repo))->execute(1, $org2UserId);
+        (new GetUserByIdUseCase($this->repo))->execute($org2UserId);
     }
 }

--- a/tests/User/UserWriteUseCasesTest.php
+++ b/tests/User/UserWriteUseCasesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\User;
 
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Auth\Role;
 use NeneInvoice\Tests\Support\InMemoryUserRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -23,16 +24,20 @@ final class UserWriteUseCasesTest extends TestCase
 {
     private InMemoryUserRepository $repo;
     private RecordingAuditRecorder $audit;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
 
     protected function setUp(): void
     {
-        $this->repo = new InMemoryUserRepository();
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new InMemoryUserRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
     }
 
     public function test_create_hashes_password_forces_org_and_audits(): void
     {
-        $user = (new CreateUserUseCase($this->repo, $this->audit))->execute(1, 99, new CreateUserInput('m@org1', 'secret', Role::Member));
+        $user = (new CreateUserUseCase($this->repo, $this->audit, $this->holder))->execute(99, new CreateUserInput('m@org1', 'secret', Role::Member));
 
         self::assertSame(1, $user->organizationId);
         self::assertSame(Role::Member, $user->role);
@@ -47,23 +52,23 @@ final class UserWriteUseCasesTest extends TestCase
     public function test_create_blocks_superadmin_role(): void
     {
         $this->expectException(RoleNotAssignableException::class);
-        (new CreateUserUseCase($this->repo, $this->audit))->execute(1, 1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
+        (new CreateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
     }
 
     public function test_create_rejects_duplicate_email(): void
     {
-        $create = new CreateUserUseCase($this->repo, $this->audit);
-        $create->execute(1, 1, new CreateUserInput('dup@org1', 'secret', Role::Member));
+        $create = new CreateUserUseCase($this->repo, $this->audit, $this->holder);
+        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Member));
 
         $this->expectException(UserEmailConflictException::class);
-        $create->execute(1, 1, new CreateUserInput('dup@org1', 'secret', Role::Admin));
+        $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Admin));
     }
 
     public function test_update_records_before_and_after(): void
     {
         $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
 
-        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 7, $id, new UpdateUserInput(Role::Admin, 'active'));
+        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(7, $id, new UpdateUserInput(Role::Admin, 'active'));
 
         self::assertSame('user.updated', $this->audit->records[0]['action']);
         self::assertSame('member', $this->audit->records[0]['before']['role'] ?? null);
@@ -75,7 +80,7 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
+        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
     }
 
     public function test_update_blocks_superadmin_escalation(): void
@@ -83,7 +88,7 @@ final class UserWriteUseCasesTest extends TestCase
         $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
 
         $this->expectException(RoleNotAssignableException::class);
-        (new UpdateUserUseCase($this->repo, $this->audit))->execute(1, 1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
+        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
     }
 
     public function test_delete_blocks_self(): void
@@ -91,7 +96,7 @@ final class UserWriteUseCasesTest extends TestCase
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
 
         $this->expectException(CannotDeleteSelfException::class);
-        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $caller);
+        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $caller);
     }
 
     public function test_delete_blocks_cross_organization_target(): void
@@ -100,7 +105,7 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $otherOrgUser);
+        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $otherOrgUser);
     }
 
     public function test_delete_removes_user_and_audits(): void
@@ -108,7 +113,7 @@ final class UserWriteUseCasesTest extends TestCase
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
         $target = $this->repo->save(new User('t@org1', 'h', Role::Member, 1));
 
-        (new DeleteUserUseCase($this->repo, $this->audit))->execute(1, $caller, $target);
+        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $target);
 
         self::assertNull($this->repo->findById($target));
         self::assertSame('user.deleted', $this->audit->records[0]['action']);


### PR DESCRIPTION
## 概要
Closes #159

ADR 0006 のマルチテナント多重防御パターン移植エピックの**最終ステップ**。User ドメインを `RequestScopedHolder<int>` ベースへ移行し、残る org threading / `AuthContext::organizationId` 読み取りを全廃する。これでエピックの全ドメイン（Client / Invoice / Quote / Payment / CompanySettings / Audit / DocumentSequence / User）が holder ベースに揃う。

## 変更点
### User ドメイン（二面性に注意）
- **意図的に holder 非依存を維持**:
  - `findById($id)` — GetCurrentUser（token `sub` 解決）
  - `findByEmail($email)` — login（pre-auth、holder 未セット）
- **holder スコープ化**:
  - 新規 `findInOrganization($id)`（`WHERE id = ? AND organization_id = ?`）で Get/Update/Delete の手動 org 突合（`$user->organizationId !== $organizationId`）を置換 — SQL レベルでの分離。
  - `findAllByOrganization` / `countByOrganization` → `findAll` / `count`（holder）。
  - `save` は holder org を強制。`update` / `delete` は WHERE に `organization_id = ?`（holder）を追加し、クロステナント更新/削除を構造的に不可能化。
- use case 5 種から `$organizationId` 引数を撤去。handler 5 種から `AuthContext::organizationId` 読み取りを撤去（`AuthContext::userId` は actor 記録用に残す）。

### 公開ダウンロード（generate 側）
- `GenerateDownloadTokenUseCase` を holder ベース化。Invoice リポジトリが既に holder スコープのため、冗長な `!== $organizationId` 突合を撤去。handler から org 読み取りを撤去。

### フォールバック除去
- UseCase に残る `int $organizationId` 引数はゼロに（全ドメイン）。
- `AuthContext::organizationId` のスコープ用途は全廃 — `AuthContext` は OrgGuard の token-org 突合のためにのみ残る。
- `/api/*` の `ServiceAuthContext::organizationId` 読み取りは **意図的に残置**（サービストークンの scope 403 ガード。holder は ServiceScopeMiddleware がセット）。

## セルフレビューチェックリスト
- [x] `composer check` green（251 tests / 925 assertions、PHPStan level 8 / php-cs-fixer / OpenAPI / MCP）
- [x] 認証前/自己参照経路（login・GetCurrentUser）は holder 非依存を維持
- [x] org スコープの全 read/update/delete が SQL レベルで `organization_id` 強制
- [x] superadmin の null org は seeder 経由（テストは直接 INSERT で検証、save 経路には乗らない）
- [x] UseCase 層から org 引数が完全に消えた（`grep` で確認）
- [x] 命名は用語レジストリと整合（新規 problem slug の追加なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)