### PR TITLE
fix(i18n): ルート error boundary の文言をメッセージカタログ化する (#161)

### DIFF
--- a/frontend/src/app/root-error-boundary.tsx
+++ b/frontend/src/app/root-error-boundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { env } from '@/shared/config/env'
+import { useTranslation } from '@/shared/i18n'
 import { Button, Stack, Text } from '@/shared/ui'
 
 interface RootErrorBoundaryProps {
@@ -8,6 +9,32 @@ interface RootErrorBoundaryProps {
 
 interface RootErrorBoundaryState {
   hasError: boolean
+}
+
+/**
+ * Fallback UI rendered when the boundary trips. Split into a function component
+ * so the translated copy can use {@link useTranslation} — the class boundary
+ * itself cannot call hooks. The boundary sits inside `I18nProvider`
+ * (see app/providers.tsx), so the i18n context is available here.
+ */
+function RootErrorFallback({ onReset }: { onReset: () => void }): ReactNode {
+  const { t } = useTranslation()
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl items-center px-inline-md py-stack-xl">
+      <Stack gap="md">
+        <Text as="h1" variant="heading-md">
+          {t('admin.error.title')}
+        </Text>
+        <Text variant="muted">{t('admin.error.body')}</Text>
+        <div>
+          <Button variant="ghost" onClick={onReset}>
+            {t('admin.error.home')}
+          </Button>
+        </div>
+      </Stack>
+    </main>
+  )
 }
 
 /**
@@ -35,21 +62,7 @@ export class RootErrorBoundary extends Component<RootErrorBoundaryProps, RootErr
 
   override render(): ReactNode {
     if (this.state.hasError) {
-      return (
-        <main className="mx-auto flex min-h-screen max-w-3xl items-center px-inline-md py-stack-xl">
-          <Stack gap="md">
-            <Text as="h1" variant="heading-md">
-              予期しないエラーが発生しました
-            </Text>
-            <Text variant="muted">管理 UI でエラーが発生しました。</Text>
-            <div>
-              <Button variant="ghost" onClick={this.handleReset}>
-                ホームへ戻る
-              </Button>
-            </div>
-          </Stack>
-        </main>
-      )
+      return <RootErrorFallback onReset={this.handleReset} />
     }
 
     return this.props.children

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -210,4 +210,7 @@ export const enMessages: MessageCatalog = {
   'admin.settings.error': 'Could not save. Check your input.',
   'admin.settings.savedMessage': 'Saved successfully.',
   'admin.forbidden.title': 'You do not have access.',
+  'admin.error.title': 'An unexpected error occurred',
+  'admin.error.body': 'The admin UI encountered an error.',
+  'admin.error.home': 'Back to home',
 }

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -210,4 +210,7 @@ export const jaMessages = {
   'admin.settings.error': '保存できませんでした。入力内容を確認してください。',
   'admin.settings.savedMessage': '保存しました。',
   'admin.forbidden.title': 'アクセス権限がありません。',
+  'admin.error.title': '予期しないエラーが発生しました',
+  'admin.error.body': '管理 UI でエラーが発生しました。',
+  'admin.error.home': 'ホームへ戻る',
 } as const


### PR DESCRIPTION
## 概要
Closes #161

言語切り替え前提（ADR 0005）で全画面文言は `frontend/src/shared/i18n/messages/{ja,en}.ts` で管理する方針。`root-error-boundary.tsx` の 3 文言だけがハードコード（日本語）で残っていたため、カタログ経由に統一した。

## 変更点
- `ja.ts` / `en.ts` に `admin.error.title` / `admin.error.body` / `admin.error.home` を追加（既存のフラット dotted 命名に整合、en/ja キー完全一致を維持）。
- `RootErrorBoundary`（React の制約でクラス必須）のフォールバック UI を関数コンポーネント `RootErrorFallback` に切り出し、`useTranslation` で翻訳。当 boundary は `I18nProvider` の内側（`app/providers.tsx`）にあるため i18n コンテキストを参照可能。

## セルフレビューチェックリスト
- [x] `npm run type-check` / `lint` / `format` green
- [x] `npm run test`（42 tests）green
- [x] `npm run knip`（未使用エクスポートなし）green
- [x] `npm run build`（本番バンドル）green
- [x] en/ja カタログのキー数が一致（206 ↔ 206）
- [x] 画面に直書きの UI 文言が残っていない（コードコメントの日本語のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)