### PR TITLE
test(frontend): pure ロジック / mapper / mutations の UT を追加する (#163)

### DIFF
--- a/frontend/src/entities/auth/mapper.test.ts
+++ b/frontend/src/entities/auth/mapper.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import type { CurrentUserDto } from './api-types'
+import { toCurrentUser } from './mapper'
+
+describe('toCurrentUser', () => {
+  it('maps an org-scoped user', () => {
+    const dto: CurrentUserDto = {
+      id: 7,
+      email: 'admin@example.com',
+      role: 'admin',
+      organization_id: 1,
+    }
+    const user = toCurrentUser(dto)
+    expect(user.id).toBe(7)
+    expect(user.email).toBe('admin@example.com')
+    expect(user.role).toBe('admin')
+    expect(user.organization_id).toBe(1)
+  })
+
+  it('treats a superadmin (no organization) as null org', () => {
+    const dto: CurrentUserDto = {
+      id: 1,
+      email: 'root@example.com',
+      role: 'superadmin',
+    }
+    expect(toCurrentUser(dto).organization_id).toBeNull()
+  })
+})

--- a/frontend/src/entities/company-settings/mapper.test.ts
+++ b/frontend/src/entities/company-settings/mapper.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type { CompanySettingsDto } from './api-types'
+import { toCompanySettings } from './mapper'
+
+describe('toCompanySettings', () => {
+  it('maps a fully-populated profile', () => {
+    const dto: CompanySettingsDto = {
+      organization_id: 1,
+      legal_name: '株式会社あやね',
+      address: '東京都渋谷区1-1-1',
+      phone: '03-0000-0000',
+      email: 'info@example.com',
+      registration_number: 'T1234567890123',
+      bank_name: 'みずほ',
+      bank_branch: '渋谷支店',
+      account_type: '普通',
+      account_number: '1234567',
+    }
+
+    const settings = toCompanySettings(dto)
+    expect(settings.legal_name).toBe('株式会社あやね')
+    expect(settings.registration_number).toBe('T1234567890123')
+    expect(settings.account_number).toBe('1234567')
+  })
+
+  it('normalises omitted optional fields to null', () => {
+    const settings = toCompanySettings({ organization_id: 2, legal_name: 'Minimal' })
+    expect(settings.organization_id).toBe(2)
+    expect(settings.legal_name).toBe('Minimal')
+    expect(settings.address).toBeNull()
+    expect(settings.registration_number).toBeNull()
+    expect(settings.bank_name).toBeNull()
+    expect(settings.account_number).toBeNull()
+  })
+})

--- a/frontend/src/entities/dashboard/mapper.test.ts
+++ b/frontend/src/entities/dashboard/mapper.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { buildInvoiceDto } from '@tests/factories/invoice'
+import type { DashboardSummaryDto } from './api-types'
+import { toDashboardSummary } from './mapper'
+
+describe('toDashboardSummary', () => {
+  it('maps the counts and the recent-unpaid invoice list', () => {
+    const dto: DashboardSummaryDto = {
+      unpaid_count: 2,
+      overdue_count: 1,
+      outstanding_total_cents: 250000,
+      recent_unpaid: [buildInvoiceDto({ id: 11 }), buildInvoiceDto({ id: 12 })],
+    }
+
+    const summary = toDashboardSummary(dto)
+    expect(summary.unpaid_count).toBe(2)
+    expect(summary.overdue_count).toBe(1)
+    expect(summary.outstanding_total_cents).toBe(250000)
+    expect(summary.recent_unpaid).toHaveLength(2)
+    expect(summary.recent_unpaid[0]?.id).toBe(11)
+  })
+
+  it('handles an empty recent-unpaid list', () => {
+    const summary = toDashboardSummary({
+      unpaid_count: 0,
+      overdue_count: 0,
+      outstanding_total_cents: 0,
+      recent_unpaid: [],
+    })
+    expect(summary.recent_unpaid).toEqual([])
+  })
+})

--- a/frontend/src/entities/payment/mutations.test.ts
+++ b/frontend/src/entities/payment/mutations.test.ts
@@ -1,0 +1,70 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useRecordPayment } from './mutations'
+
+describe('useRecordPayment', () => {
+  it('posts a payment and returns the mapped result', async () => {
+    server.use(
+      http.post('/admin/invoices/:id/payments', () =>
+        HttpResponse.json(
+          {
+            payment: {
+              id: 3,
+              organization_id: 1,
+              invoice_id: 7,
+              amount_cents: 50000,
+              paid_at: '2026-05-30',
+              method: 'bank_transfer',
+              note: null,
+            },
+            total_paid_cents: 50000,
+          },
+          { status: 201 },
+        ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useRecordPayment())
+    result.current.mutate({
+      invoice_id: 7,
+      amount_cents: 50000,
+      method: 'bank_transfer',
+      note: null,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.payment.id).toBe(3)
+    expect(result.current.data?.payment.method).toBe('bank_transfer')
+    expect(result.current.data?.total_paid_cents).toBe(50000)
+  })
+
+  it('surfaces an AppError when the amount exceeds the outstanding balance', async () => {
+    server.use(
+      http.post(
+        '/admin/invoices/:id/payments',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/payment-exceeds-balance',
+              title: 'Unprocessable Entity',
+              status: 422,
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useRecordPayment())
+    result.current.mutate({ invoice_id: 7, amount_cents: 999999, method: null, note: null })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.slug).toBe('payment-exceeds-balance')
+  })
+})

--- a/frontend/src/entities/quote/mapper.test.ts
+++ b/frontend/src/entities/quote/mapper.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { QuoteDto, QuoteWithLinesDto } from './api-types'
+import { toQuote, toQuotePage, toQuoteWithLines } from './mapper'
+
+const dto: QuoteDto = {
+  id: 7,
+  organization_id: 1,
+  client_id: 5,
+  quote_number: 'EST-2026-007',
+  status: 'draft',
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+}
+
+describe('toQuote', () => {
+  it('brands the id and maps the core fields', () => {
+    const quote = toQuote(dto)
+    expect(quote.id).toBe(7)
+    expect(quote.quote_number).toBe('EST-2026-007')
+    expect(quote.status).toBe('draft')
+    expect(quote.total_cents).toBe(110000)
+  })
+
+  it('normalises optional fields to null', () => {
+    const quote = toQuote(dto)
+    expect(quote.issued_at).toBeNull()
+    expect(quote.valid_until).toBeNull()
+    expect(quote.notes).toBeNull()
+  })
+})
+
+describe('toQuotePage', () => {
+  it('maps items and pagination', () => {
+    const page = toQuotePage({ items: [dto], total: 1, limit: 20, offset: 0 })
+    expect(page.items).toHaveLength(1)
+    expect(page.items[0]?.id).toBe(7)
+    expect(page.total).toBe(1)
+    expect(page.limit).toBe(20)
+  })
+})
+
+describe('toQuoteWithLines', () => {
+  it('computes line_subtotal_cents when absent (quantity × unit price)', () => {
+    const withLines: QuoteWithLinesDto = {
+      ...dto,
+      line_items: [
+        { description: '作業', quantity: 3, unit_price_cents: 1000, tax_rate_bps: 1000 },
+      ],
+    }
+    expect(toQuoteWithLines(withLines).line_items[0]?.line_subtotal_cents).toBe(3000)
+  })
+
+  it('keeps a provided line_subtotal_cents', () => {
+    const withLines: QuoteWithLinesDto = {
+      ...dto,
+      line_items: [
+        {
+          description: 'x',
+          quantity: 2,
+          unit_price_cents: 1000,
+          tax_rate_bps: 1000,
+          line_subtotal_cents: 9999,
+        },
+      ],
+    }
+    expect(toQuoteWithLines(withLines).line_items[0]?.line_subtotal_cents).toBe(9999)
+  })
+
+  it('defaults to an empty line list when none are provided', () => {
+    expect(toQuoteWithLines({ ...dto }).line_items).toEqual([])
+  })
+})

--- a/frontend/src/entities/quote/mutations.test.ts
+++ b/frontend/src/entities/quote/mutations.test.ts
@@ -1,0 +1,77 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { toQuoteId } from './ids'
+import { useChangeQuoteStatus, useConvertQuote, useCreateQuote } from './mutations'
+
+describe('useCreateQuote', () => {
+  it('posts and returns the mapped quote with lines', async () => {
+    const { result } = renderHookWithProviders(() => useCreateQuote())
+    result.current.mutate({
+      client_id: 5,
+      line_items: [
+        { description: '作業', quantity: 1, unit_price_cents: 100000, tax_rate_bps: 1000 },
+      ],
+      valid_until: null,
+      notes: null,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.id).toBe(1)
+    expect(result.current.data?.status).toBe('draft')
+    expect(result.current.data?.total_cents).toBe(110000)
+  })
+
+  it('surfaces an AppError on a 422 response', async () => {
+    server.use(
+      http.post(
+        '/admin/quotes',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/validation-failed',
+              title: 'Validation Failed',
+              status: 422,
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useCreateQuote())
+    result.current.mutate({ client_id: 5, line_items: [], valid_until: null, notes: null })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.slug).toBe('validation-failed')
+  })
+})
+
+describe('useChangeQuoteStatus', () => {
+  it('patches and returns the updated status', async () => {
+    const { result } = renderHookWithProviders(() => useChangeQuoteStatus())
+    result.current.mutate({ id: toQuoteId(1), status: 'sent' })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.status).toBe('sent')
+  })
+})
+
+describe('useConvertQuote', () => {
+  it('converts the quote and returns the new invoice', async () => {
+    const { result } = renderHookWithProviders(() => useConvertQuote())
+    result.current.mutate(toQuoteId(1))
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.id).toBe(10)
+  })
+})

--- a/frontend/src/shared/i18n/locales.test.ts
+++ b/frontend/src/shared/i18n/locales.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_LOCALE, LOCALES, resolveLocale } from './locales'
+
+describe('resolveLocale', () => {
+  it('defaults to ja for null or undefined input', () => {
+    expect(resolveLocale(null)).toBe('ja')
+    expect(resolveLocale(undefined)).toBe('ja')
+  })
+
+  it('maps en-prefixed input to en, case-insensitively', () => {
+    expect(resolveLocale('en')).toBe('en')
+    expect(resolveLocale('en-US')).toBe('en')
+    expect(resolveLocale('EN')).toBe('en')
+  })
+
+  it('maps any other input to ja', () => {
+    expect(resolveLocale('ja')).toBe('ja')
+    expect(resolveLocale('ja-JP')).toBe('ja')
+    expect(resolveLocale('fr')).toBe('ja')
+    expect(resolveLocale('')).toBe('ja')
+  })
+})
+
+describe('locale metadata', () => {
+  it('uses ja as the default locale', () => {
+    expect(DEFAULT_LOCALE).toBe('ja')
+  })
+
+  it('exposes ja and en with stable label keys', () => {
+    expect(LOCALES.map((l) => l.id)).toEqual(['ja', 'en'])
+    expect(LOCALES.map((l) => l.labelKey)).toEqual(['common.locale.ja', 'common.locale.en'])
+  })
+})

--- a/frontend/src/shared/i18n/translate.test.ts
+++ b/frontend/src/shared/i18n/translate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { jaMessages } from './messages/ja'
+import { translate, type MessageCatalog } from './translate'
+
+describe('translate', () => {
+  it('returns the value from the active catalog', () => {
+    const catalog: MessageCatalog = { 'common.appName': 'Custom Name' }
+    expect(translate(catalog, 'common.appName')).toBe('Custom Name')
+  })
+
+  it('falls back to the authoritative ja catalog for missing keys', () => {
+    expect(translate({}, 'common.appName')).toBe(jaMessages['common.appName'])
+    expect(translate({}, 'common.appName')).toBe('NeNe Invoice 管理')
+  })
+
+  it('interpolates {{placeholder}} params', () => {
+    expect(translate(jaMessages, 'admin.account.signedInAs', { email: 'a@example.com' })).toBe(
+      'a@example.com でログイン中',
+    )
+  })
+
+  it('coerces numeric params to strings', () => {
+    const catalog: MessageCatalog = { 'common.appName': '{{count}} items' }
+    expect(translate(catalog, 'common.appName', { count: 3 })).toBe('3 items')
+  })
+
+  it('leaves the template unchanged when params are omitted', () => {
+    expect(translate(jaMessages, 'admin.account.signedInAs')).toBe('{{email}} でログイン中')
+  })
+
+  it('keeps the placeholder when a referenced param is absent', () => {
+    expect(translate(jaMessages, 'admin.account.signedInAs', {})).toBe('{{email}} でログイン中')
+  })
+})

--- a/frontend/src/shared/lib/format-money.test.ts
+++ b/frontend/src/shared/lib/format-money.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatTaxRate, formatYen } from './format-money'
+
+describe('formatYen', () => {
+  it('formats integer cents 1:1 to yen with thousands separators', () => {
+    expect(formatYen(116480)).toBe('¥116,480')
+    expect(formatYen(1000000)).toBe('¥1,000,000')
+  })
+
+  it('handles zero', () => {
+    expect(formatYen(0)).toBe('¥0')
+  })
+})
+
+describe('formatTaxRate', () => {
+  it('converts basis points to a percent label', () => {
+    expect(formatTaxRate(1000)).toBe('10%')
+    expect(formatTaxRate(800)).toBe('8%')
+    expect(formatTaxRate(0)).toBe('0%')
+  })
+})


### PR DESCRIPTION
## 概要
Closes #163

フロントのユニットテスト網羅を強化。テスト基盤（Vitest + MSW + `renderHookWithProviders` + factories）は整備済みだったが、純粋ロジックと一部 entity の mapper / mutations が未カバーだったため追加した。

## 追加テスト（9ファイル / +32 tests）
**純粋ロジック（deterministic）**
- `shared/lib/format-money` — `formatYen`（cents→¥, 桁区切り, 0）/ `formatTaxRate`（bps→%）
- `shared/i18n/locales` — `resolveLocale`（en 前方一致・大文字小文字・既定 ja）/ メタデータ
- `shared/i18n/translate` — アクティブカタログ優先・**ja フォールバック**・`{{}}` 補間・欠落プレースホルダ保持（**言語切替要件の中核ロジック**）

**entity mapper（純粋）**
- `quote/mapper` — `toQuote` / `toQuotePage` / `toQuoteWithLines`（`line_subtotal_cents` の `quantity × unit_price` フォールバック含む）
- `company-settings/mapper` — optional の null 正規化
- `dashboard/mapper` — `recent_unpaid` の invoice マッピング
- `auth/mapper` — superadmin の `organization_id` null 化

**entity mutations（MSW）**
- `quote/mutations` — `useCreateQuote` / `useChangeQuoteStatus` / `useConvertQuote`（+ 422 で `AppError.slug`）
- `payment/mutations` — `useRecordPayment`（+ 残高超過 422）

## セルフレビューチェックリスト
- [x] `npm run type-check` / `lint` / `format` green
- [x] `npm run test`：**14→23 ファイル / 42→74 tests** すべて green
- [x] `npm run knip`（未使用エクスポートなし）green
- [x] 既存のテスト基盤（factories / MSW デフォルトハンドラ / `renderHookWithProviders`）に準拠、新規ヘルパ追加なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)