### PR TITLE
test(frontend): feature hooks と残りの entity mutations の UT を追加する (#165)

### DIFF
--- a/frontend/src/entities/auth/mutations.test.ts
+++ b/frontend/src/entities/auth/mutations.test.ts
@@ -1,0 +1,48 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { hasAuthToken, setAuthToken } from '@/shared/api/client'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useLogin } from './mutations'
+
+describe('useLogin', () => {
+  it('stores the bearer token on success', async () => {
+    setAuthToken(null)
+    const { result } = renderHookWithProviders(() => useLogin())
+    result.current.mutate({ email: 'admin@example.com', password: 'correct-horse' })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data).toBe('test-token')
+    expect(hasAuthToken()).toBe(true)
+  })
+
+  it('surfaces an AppError and leaves the session unauthenticated on 401', async () => {
+    setAuthToken(null)
+    server.use(
+      http.post(
+        '/auth/login',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/invalid-credentials',
+              title: 'Unauthorized',
+              status: 401,
+            }),
+            { status: 401, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useLogin())
+    result.current.mutate({ email: 'nobody@example.com', password: 'wrong' })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.slug).toBe('invalid-credentials')
+    expect(hasAuthToken()).toBe(false)
+  })
+})

--- a/frontend/src/entities/company-settings/mutations.test.ts
+++ b/frontend/src/entities/company-settings/mutations.test.ts
@@ -1,0 +1,68 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import type { UpdateCompanySettingsInput } from './model'
+import { useUpdateCompanySettings } from './mutations'
+
+const input: UpdateCompanySettingsInput = {
+  legal_name: '株式会社あやね',
+  address: null,
+  phone: null,
+  email: null,
+  registration_number: 'T1234567890123',
+  bank_name: null,
+  bank_branch: null,
+  account_type: null,
+  account_number: null,
+}
+
+describe('useUpdateCompanySettings', () => {
+  it('puts and returns the mapped settings', async () => {
+    server.use(
+      http.put('/admin/company-settings', () =>
+        HttpResponse.json({
+          organization_id: 1,
+          legal_name: '株式会社あやね',
+          registration_number: 'T1234567890123',
+        }),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useUpdateCompanySettings())
+    result.current.mutate(input)
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+    expect(result.current.data?.legal_name).toBe('株式会社あやね')
+    expect(result.current.data?.registration_number).toBe('T1234567890123')
+    expect(result.current.data?.address).toBeNull()
+  })
+
+  it('surfaces an AppError on a 422 invalid registration number', async () => {
+    server.use(
+      http.put(
+        '/admin/company-settings',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/invalid-registration-number',
+              title: 'Validation Failed',
+              status: 422,
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useUpdateCompanySettings())
+    result.current.mutate({ ...input, registration_number: 'BAD' })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    expect(result.current.error?.slug).toBe('invalid-registration-number')
+  })
+})

--- a/frontend/src/features/create-client/hooks/use-create-client.test.ts
+++ b/frontend/src/features/create-client/hooks/use-create-client.test.ts
@@ -1,0 +1,45 @@
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import type { SyntheticEvent } from 'react'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useCreateClient } from './use-create-client'
+
+const fakeSubmitEvent = { preventDefault: () => {} } as unknown as SyntheticEvent
+
+describe('useCreateClient', () => {
+  it('has no error message before submitting', () => {
+    const { result } = renderHookWithProviders(() => useCreateClient())
+    expect(result.current.errorMessage).toBeNull()
+    expect(result.current.isPending).toBe(false)
+  })
+
+  it('surfaces an error message when creation fails', async () => {
+    server.use(
+      http.post(
+        '/admin/clients',
+        () =>
+          new HttpResponse(
+            JSON.stringify({
+              type: 'https://nene-invoice.dev/problems/validation-failed',
+              title: 'Validation Failed',
+              status: 422,
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/problem+json' } },
+          ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useCreateClient())
+
+    act(() => {
+      result.current.form.setValue('name', '新規取引先')
+      result.current.onSubmit(fakeSubmitEvent)
+    })
+
+    await waitFor(() => {
+      expect(result.current.errorMessage).not.toBeNull()
+    })
+  })
+})

--- a/frontend/src/features/create-quote/hooks/use-create-quote.test.ts
+++ b/frontend/src/features/create-quote/hooks/use-create-quote.test.ts
@@ -1,0 +1,32 @@
+import { act, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useCreateQuote } from './use-create-quote'
+
+describe('useCreateQuote', () => {
+  it('loads selectable clients from the API', async () => {
+    const { result } = renderHookWithProviders(() => useCreateQuote())
+    expect(result.current.clientsLoading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.clientsLoading).toBe(false)
+    })
+    expect(result.current.clients).toHaveLength(1)
+  })
+
+  it('starts with one line and appends more via addLine', () => {
+    const { result } = renderHookWithProviders(() => useCreateQuote())
+    expect(result.current.lines.fields).toHaveLength(1)
+
+    act(() => {
+      result.current.addLine()
+    })
+    expect(result.current.lines.fields).toHaveLength(2)
+  })
+
+  it('has no error message initially', () => {
+    const { result } = renderHookWithProviders(() => useCreateQuote())
+    expect(result.current.errorMessage).toBeNull()
+    expect(result.current.isPending).toBe(false)
+  })
+})

--- a/frontend/src/features/edit-company-settings/hooks/use-edit-company-settings.test.ts
+++ b/frontend/src/features/edit-company-settings/hooks/use-edit-company-settings.test.ts
@@ -1,0 +1,33 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useEditCompanySettings } from './use-edit-company-settings'
+
+describe('useEditCompanySettings', () => {
+  it('loads the current settings and prefills the form', async () => {
+    const { result } = renderHookWithProviders(() => useEditCompanySettings())
+    expect(result.current.kind).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.form.getValues('legal_name')).toBe('テスト株式会社')
+      // null fields from the API become empty strings in the form.
+      expect(result.current.form.getValues('address')).toBe('')
+      expect(result.current.savedMessage).toBeNull()
+    }
+  })
+
+  it('exposes an error state when settings cannot be loaded', async () => {
+    server.use(http.get('/admin/company-settings', () => new HttpResponse(null, { status: 500 })))
+
+    const { result } = renderHookWithProviders(() => useEditCompanySettings())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('error')
+    })
+  })
+})

--- a/frontend/src/features/list-quotes/hooks/use-list-quotes.test.ts
+++ b/frontend/src/features/list-quotes/hooks/use-list-quotes.test.ts
@@ -1,0 +1,86 @@
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useListQuotes } from './use-list-quotes'
+
+const quoteDto = (id: number) => ({
+  id,
+  organization_id: 1,
+  client_id: 5,
+  quote_number: `EST-2026-00${String(id)}`,
+  status: 'draft',
+  subtotal_cents: 1000,
+  tax_cents: 100,
+  total_cents: 1100,
+})
+
+describe('useListQuotes', () => {
+  it('exposes the empty state when there are no quotes', async () => {
+    const { result } = renderHookWithProviders(() => useListQuotes())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('empty')
+    })
+  })
+
+  it('starts loading then exposes the ready list', async () => {
+    server.use(
+      http.get('/admin/quotes', () =>
+        HttpResponse.json({ items: [quoteDto(1)], total: 1, limit: 20, offset: 0 }),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useListQuotes())
+    expect(result.current.kind).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.quotes).toHaveLength(1)
+      expect(result.current.pagination.totalPages).toBe(1)
+      expect(result.current.pagination.hasNext).toBe(false)
+    }
+  })
+
+  it('paginates and advances to page 2', async () => {
+    server.use(
+      http.get('/admin/quotes', ({ request }) => {
+        const offset = Number(new URL(request.url).searchParams.get('offset') ?? '0')
+        const items = offset === 0 ? [quoteDto(1)] : [quoteDto(2)]
+        return HttpResponse.json({ items, total: 25, limit: 20, offset })
+      }),
+    )
+
+    const { result } = renderHookWithProviders(() => useListQuotes())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.pagination.totalPages).toBe(2)
+      expect(result.current.pagination.hasNext).toBe(true)
+      act(() => {
+        result.current.pagination.nextPage()
+      })
+    }
+
+    await waitFor(() => {
+      if (result.current.kind === 'ready') {
+        expect(result.current.pagination.page).toBe(2)
+        expect(result.current.pagination.hasPrev).toBe(true)
+      }
+    })
+  })
+
+  it('exposes an error state on a 5xx response', async () => {
+    server.use(http.get('/admin/quotes', () => new HttpResponse(null, { status: 500 })))
+
+    const { result } = renderHookWithProviders(() => useListQuotes())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('error')
+    })
+  })
+})

--- a/frontend/src/features/view-dashboard/hooks/use-view-dashboard.test.ts
+++ b/frontend/src/features/view-dashboard/hooks/use-view-dashboard.test.ts
@@ -1,0 +1,57 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { buildInvoiceDto } from '@tests/factories/invoice'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useViewDashboard } from './use-view-dashboard'
+
+describe('useViewDashboard', () => {
+  it('starts loading then exposes the ready summary', async () => {
+    const { result } = renderHookWithProviders(() => useViewDashboard())
+    expect(result.current.kind).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.unpaidCount).toBe(0)
+      expect(result.current.recentUnpaid).toEqual([])
+    }
+  })
+
+  it('maps counts and the recent-unpaid list', async () => {
+    server.use(
+      http.get('/admin/dashboard', () =>
+        HttpResponse.json({
+          unpaid_count: 3,
+          overdue_count: 1,
+          outstanding_total_cents: 250000,
+          recent_unpaid: [buildInvoiceDto({ id: 11 })],
+        }),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useViewDashboard())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.unpaidCount).toBe(3)
+      expect(result.current.overdueCount).toBe(1)
+      expect(result.current.outstandingTotalCents).toBe(250000)
+      expect(result.current.recentUnpaid[0]?.id).toBe(11)
+    }
+  })
+
+  it('exposes an error state on a 5xx response', async () => {
+    server.use(http.get('/admin/dashboard', () => new HttpResponse(null, { status: 500 })))
+
+    const { result } = renderHookWithProviders(() => useViewDashboard())
+    await waitFor(() => {
+      expect(result.current.kind).toBe('error')
+    })
+  })
+})

--- a/frontend/src/features/view-invoice/hooks/use-generate-download-link.test.ts
+++ b/frontend/src/features/view-invoice/hooks/use-generate-download-link.test.ts
@@ -1,0 +1,58 @@
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { toInvoiceId } from '@/entities/invoice'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useGenerateDownloadLink } from './use-generate-download-link'
+
+describe('useGenerateDownloadLink', () => {
+  it('only allows generation for an issued invoice', () => {
+    const issued = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), true))
+    expect(issued.result.current.canGenerate).toBe(true)
+
+    const draft = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), false))
+    expect(draft.result.current.canGenerate).toBe(false)
+  })
+
+  it('generates a link and truncates the expiry to a date', async () => {
+    server.use(
+      http.post('/admin/invoices/:id/download-token', () =>
+        HttpResponse.json(
+          { url: '/invoices/download/abc123', expires_at: '2026-06-06 12:34:56' },
+          { status: 201 },
+        ),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), true))
+    expect(result.current.downloadUrl).toBeNull()
+
+    act(() => {
+      result.current.generate()
+    })
+
+    await waitFor(() => {
+      expect(result.current.downloadUrl).toBe('/invoices/download/abc123')
+    })
+    expect(result.current.expiresAt).toBe('2026-06-06')
+  })
+
+  it('surfaces an error message when generation fails', async () => {
+    server.use(
+      http.post(
+        '/admin/invoices/:id/download-token',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    )
+
+    const { result } = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), true))
+    act(() => {
+      result.current.generate()
+    })
+
+    await waitFor(() => {
+      expect(result.current.errorMessage).not.toBeNull()
+    })
+  })
+})

--- a/frontend/src/features/view-quote/hooks/use-view-quote.test.ts
+++ b/frontend/src/features/view-quote/hooks/use-view-quote.test.ts
@@ -1,0 +1,83 @@
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { toQuoteId } from '@/entities/quote'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useViewQuote } from './use-view-quote'
+
+const quoteDto = (status: string) => ({
+  id: 1,
+  organization_id: 1,
+  client_id: 5,
+  quote_number: 'EST-2026-001',
+  status,
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  line_items: [],
+})
+
+describe('useViewQuote', () => {
+  it('starts loading then exposes the quote', async () => {
+    const { result } = renderHookWithProviders(() => useViewQuote(toQuoteId(1)))
+    expect(result.current.kind).toBe('loading')
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+  })
+
+  it('derives capability flags from a draft quote', async () => {
+    server.use(http.get('/admin/quotes/:id', () => HttpResponse.json(quoteDto('draft'))))
+
+    const { result } = renderHookWithProviders(() => useViewQuote(toQuoteId(1)))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.canSend).toBe(true)
+      expect(result.current.canAccept).toBe(false)
+      expect(result.current.canConvert).toBe(false)
+    }
+  })
+
+  it('allows conversion only once a quote is accepted', async () => {
+    server.use(http.get('/admin/quotes/:id', () => HttpResponse.json(quoteDto('accepted'))))
+
+    const { result } = renderHookWithProviders(() => useViewQuote(toQuoteId(1)))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      expect(result.current.canConvert).toBe(true)
+      expect(result.current.canSend).toBe(false)
+    }
+  })
+
+  it('surfaces an action error when a status change fails', async () => {
+    server.use(
+      http.get('/admin/quotes/:id', () => HttpResponse.json(quoteDto('draft'))),
+      http.patch('/admin/quotes/:id', () => new HttpResponse(null, { status: 422 })),
+    )
+
+    const { result } = renderHookWithProviders(() => useViewQuote(toQuoteId(1)))
+    await waitFor(() => {
+      expect(result.current.kind).toBe('ready')
+    })
+
+    if (result.current.kind === 'ready') {
+      act(() => {
+        result.current.changeStatus('sent')
+      })
+    }
+
+    await waitFor(() => {
+      if (result.current.kind === 'ready') {
+        expect(result.current.actionError).not.toBeNull()
+      }
+    })
+  })
+})


### PR DESCRIPTION
## 概要
Closes #165

#163 に続き、残る「意味のある」未テスト領域をカバー。状態機械を持つ feature hooks と、未テストの entity mutations に UT を追加した。

## 追加テスト（9ファイル / +25 tests）
**feature hooks**
- `use-list-quotes` — loading/ready/empty/error + ページング（page2 遷移）
- `use-view-dashboard` — loading/ready/error + カウント/recent_unpaid マッピング
- `use-view-quote` — status→capability フラグ（draft/accepted）、status 変更失敗時の actionError
- `use-generate-download-link` — `canGenerate=isIssued`、生成後の URL・期限（10文字スライス）、error
- `use-edit-company-settings` — loading/ready のフォーム prefill（null→空文字）、error
- `use-create-quote` — クライアント読込、`useFieldArray` の addLine
- `use-create-client` — 初期状態、送信失敗時の errorMessage

**entity mutations**
- `auth/mutations` — `useLogin`（成功でトークン保存・`hasAuthToken()` true、401 で `AppError.slug` ＆ 未認証維持）
- `company-settings/mutations` — `useUpdateCompanySettings`（成功でマッピング、422 で slug）

## 対象外（意味の薄い UT）
- `model.ts` / `api-types.ts` / `query-keys.ts` / `ids.ts` / `enum.ts` — 型定義・定数・ブランド cast のみでロジックなし
- `use-sign-in` フック単体 — `SignInForm.test.tsx` の統合テストで実質カバー済み

## セルフレビューチェックリスト
- [x] `npm run type-check` / `lint` / `format` green
- [x] `npm run test`：**23→32 ファイル / 74→99 tests** すべて green
- [x] `npm run knip`（未使用エクスポートなし）green
- [x] 既存基盤（MSW デフォルトハンドラ・`renderHookWithProviders`・factories）に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)