### PR TITLE
test(frontend): 単機能ブラウザ E2E（Playwright）を導入する (#167)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -40,3 +40,37 @@ jobs:
 
       - name: Audit (fail on high/critical)
         run: npm audit --audit-level=high
+
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser E2E tests
+        run: npm run e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          retention-days: 7

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,3 +5,7 @@ coverage
 *.local
 .vite
 node_modules/.tmp
+test-results
+playwright-report
+blob-report
+playwright/.cache

--- a/frontend/e2e/company-settings.spec.ts
+++ b/frontend/e2e/company-settings.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+import { json, login, problem } from './helpers/auth'
+
+const SETTINGS = {
+  organization_id: 1,
+  legal_name: 'テスト株式会社',
+  address: null,
+  phone: null,
+  email: null,
+  registration_number: null,
+  bank_name: null,
+  bank_branch: null,
+  account_type: null,
+  account_number: null,
+}
+
+/** Reaches /settings through login → "設定" nav; the form is prefilled from GET. */
+test.describe('Company settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/company-settings', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json(SETTINGS))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '設定' }).click()
+    await expect(page.locator('#legal_name')).toHaveValue('テスト株式会社')
+  })
+
+  test('requires a legal name', async ({ page }) => {
+    await page.locator('#legal_name').fill('')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page.getByText('法人名は必須です。')).toBeVisible()
+  })
+
+  test('saves and shows a confirmation message', async ({ page }) => {
+    await page.route('**/admin/company-settings', (route, request) => {
+      if (request.method() === 'PUT') {
+        route.fulfill(json({ ...SETTINGS, legal_name: '株式会社あやね' }))
+      } else {
+        route.fulfill(json(SETTINGS))
+      }
+    })
+
+    await page.locator('#legal_name').fill('株式会社あやね')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page.getByText('保存しました。')).toBeVisible()
+  })
+
+  test('shows an error when the server rejects the input', async ({ page }) => {
+    await page.route('**/admin/company-settings', (route, request) => {
+      if (request.method() === 'PUT') {
+        route.fulfill(problem('invalid-registration-number', 422))
+      } else {
+        route.fulfill(json(SETTINGS))
+      }
+    })
+
+    await page.locator('#registration_number').fill('BAD')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page.getByText('保存できませんでした。', { exact: false })).toBeVisible()
+  })
+})

--- a/frontend/e2e/create-client.spec.ts
+++ b/frontend/e2e/create-client.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+import { json, login, problem } from './helpers/auth'
+
+const CLIENT = {
+  id: 9,
+  organization_id: 1,
+  name: '新規取引先',
+  contact_name: null,
+  email: null,
+  billing_address: null,
+  registration_number: null,
+}
+
+/** Reaches /clients/new through login → clients list → "新規作成". */
+test.describe('Create client', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/clients', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [], total: 0, limit: 100, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '取引先' }).click()
+    await page.getByRole('link', { name: '新規作成' }).click()
+    await expect(page.getByRole('heading', { name: '取引先の作成' })).toBeVisible()
+  })
+
+  test('requires a name', async ({ page }) => {
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page.getByText('名称を入力してください。')).toBeVisible()
+    await expect(page).toHaveURL(/\/clients\/new$/)
+  })
+
+  test('creates a client and returns to the list', async ({ page }) => {
+    await page.route('**/admin/clients', (route, request) => {
+      if (request.method() === 'POST') {
+        route.fulfill(json(CLIENT, 201))
+      } else {
+        route.fulfill(json({ items: [], total: 0, limit: 100, offset: 0 }))
+      }
+    })
+
+    await page.locator('#name').fill('新規取引先')
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page).toHaveURL(/\/clients$/)
+    await expect(page.getByRole('heading', { name: '取引先一覧' })).toBeVisible()
+  })
+
+  test('shows an error when the server rejects the input', async ({ page }) => {
+    await page.route('**/admin/clients', (route, request) => {
+      if (request.method() === 'POST') {
+        route.fulfill(problem('invalid-registration-number', 422))
+      } else {
+        route.fulfill(json({ items: [], total: 0, limit: 100, offset: 0 }))
+      }
+    })
+
+    await page.locator('#name').fill('株式会社テスト')
+    await page.locator('#registration_number').fill('BAD')
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page.getByText('取引先を作成できませんでした。', { exact: false })).toBeVisible()
+    await expect(page).toHaveURL(/\/clients\/new$/)
+  })
+})

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,0 +1,47 @@
+import type { Page } from '@playwright/test'
+
+/** JSON helper for `page.route` fulfilments. */
+export function json(body: unknown, status = 200) {
+  return { status, contentType: 'application/json', body: JSON.stringify(body) }
+}
+
+/** RFC 7807 problem+json helper for error fulfilments. */
+export function problem(slug: string, status: number) {
+  return {
+    status,
+    contentType: 'application/problem+json',
+    body: JSON.stringify({
+      type: `https://nene-invoice.dev/problems/${slug}`,
+      title: 'Error',
+      status,
+    }),
+  }
+}
+
+const CURRENT_USER = { id: 1, email: 'admin@example.com', role: 'admin', organization_id: 1 }
+const EMPTY_DASHBOARD = {
+  unpaid_count: 0,
+  overdue_count: 0,
+  outstanding_total_cents: 0,
+  recent_unpaid: [],
+}
+
+/**
+ * Logs in through the real sign-in form (stubbing `/auth/login`, `/admin/me`,
+ * `/admin/dashboard`) and waits for the authenticated app shell. After this the
+ * in-memory token is set; reach features by clicking nav links, never by
+ * `page.goto` (a full reload clears the token).
+ */
+export async function login(page: Page): Promise<void> {
+  await page.route('**/auth/login', (route) => route.fulfill(json({ token: 'e2e-token' })))
+  await page.route('**/admin/me', (route) => route.fulfill(json(CURRENT_USER)))
+  await page.route('**/admin/dashboard', (route) => route.fulfill(json(EMPTY_DASHBOARD)))
+
+  await page.goto('/')
+  await page.locator('#email').fill('admin@example.com')
+  await page.locator('#password').fill('correct-horse')
+  await page.getByRole('button', { name: 'ログイン' }).click()
+
+  // The primary nav only renders once the auth gate reveals the app shell.
+  await page.getByRole('link', { name: '取引先' }).waitFor()
+}

--- a/frontend/e2e/sign-in.spec.ts
+++ b/frontend/e2e/sign-in.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test'
+import { json, problem } from './helpers/auth'
+
+/**
+ * Sign-in is the only feature reachable without an existing session, so it needs
+ * no login helper. Covers client-side validation boundaries and the server-side
+ * auth-failure path.
+ */
+test.describe('Sign in', () => {
+  test('shows validation messages when submitting an empty form', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByText('有効なメールアドレスを入力してください。')).toBeVisible()
+    await expect(page.getByText('パスワードを入力してください。')).toBeVisible()
+  })
+
+  test('rejects a malformed email address', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('#email').fill('not-an-email')
+    await page.locator('#password').fill('secret')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByText('有効なメールアドレスを入力してください。')).toBeVisible()
+  })
+
+  test('requires a password even with a valid email', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('#email').fill('admin@example.com')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByText('パスワードを入力してください。')).toBeVisible()
+  })
+
+  test('surfaces an error on invalid credentials', async ({ page }) => {
+    await page.route('**/auth/login', (route) => route.fulfill(problem('invalid-credentials', 401)))
+
+    await page.goto('/')
+    await page.locator('#email').fill('admin@example.com')
+    await page.locator('#password').fill('wrong-password')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByText('メールアドレスまたはパスワードが正しくありません。')).toBeVisible()
+  })
+
+  test('signs in and reveals the authenticated app shell', async ({ page }) => {
+    await page.route('**/auth/login', (route) => route.fulfill(json({ token: 'e2e-token' })))
+    await page.route('**/admin/dashboard', (route) =>
+      route.fulfill(
+        json({ unpaid_count: 0, overdue_count: 0, outstanding_total_cents: 0, recent_unpaid: [] }),
+      ),
+    )
+    await page.route('**/admin/me', (route) =>
+      route.fulfill(json({ id: 1, email: 'admin@example.com', role: 'admin', organization_id: 1 })),
+    )
+
+    await page.goto('/')
+    await page.locator('#email').fill('admin@example.com')
+    await page.locator('#password').fill('correct-horse')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByRole('link', { name: '取引先' })).toBeVisible()
+  })
+})

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -105,6 +105,16 @@ export default tseslint.config(
       globals: { ...globals.browser, ...globals.node },
     },
   },
+  {
+    // Browser E2E specs run under the Playwright (node) runner, not the typed
+    // app project, so they use the untyped recommended rules.
+    files: ['e2e/**/*.ts', 'playwright.config.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      globals: { ...globals.node },
+    },
+  },
   ...storybook.configs['flat/recommended'],
   eslintConfigPrettier,
 )

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}"],
+  "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "e2e/**/*.ts"],
+  "entry": ["e2e/**/*.spec.ts"],
   "ignore": ["src/shared/api/schema.gen.ts"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.0",
+        "@playwright/test": "^1.60.0",
         "@storybook/addon-a11y": "^9.1.5",
         "@storybook/react-vite": "^9.1.5",
         "@tailwindcss/vite": "^4.1.17",
@@ -1867,6 +1868,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -8079,6 +8096,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "format:fix": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^9.1.5",
     "@storybook/react-vite": "^9.1.5",
     "@tailwindcss/vite": "^4.1.17",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 5180
+
+/**
+ * Single-feature browser tests. The app talks to the API over relative paths,
+ * which each spec stubs via `page.route` — no live backend is needed, so the
+ * tests are deterministic and focus on UI behaviour (validation, boundaries,
+ * navigation). Auth is in-memory and lost on reload, so specs log in and then
+ * navigate within the SPA (see e2e/helpers/auth.ts).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'list' : 'html',
+  use: {
+    baseURL: `http://localhost:${String(PORT)}`,
+    // The app picks its locale from navigator.language; pin it to Japanese (the
+    // primary locale) so the specs can assert on the ja message catalog.
+    locale: 'ja-JP',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `npx vite --port ${String(PORT)} --strictPort`,
+    url: `http://localhost:${String(PORT)}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})


### PR DESCRIPTION
## 概要
Closes #167

単機能ごとのブラウザ E2E テストを **Playwright（Chromium）** で導入。境界線・バリデーション・サーバエラー経路を実ブラウザで検証する。バックエンドは `page.route` でスタブし、決定論的に UI 挙動へ集中する。

## 設計のポイント
- **webServer**: vite dev を Playwright が起動。API リクエストは全て `page.route` でスタブするため、稼働中バックエンド不要。
- **認証**: in-memory トークン（リロードで消失）のため、各 spec は実ログインフォームを通過 → SPA 内ナビゲーションで機能へ到達（`e2e/helpers/auth.ts`）。`page.goto` での深いリンクはトークンを失うため使わない。
- **ロケール**: アプリは `navigator.language` でロケール決定 → Playwright の `locale: 'ja-JP'` で日本語 UI に固定し、ja メッセージカタログの文言でアサート（入力は `id`、エラーは可視テキストでロケール非依存に到達）。

## 対象 spec（11 tests）
- **sign-in**（認証不要）: 空送信のバリデーション2件、メール形式不正、パスワード必須、認証失敗(401)エラー、成功でアプリシェル表示
- **create-client**: 名称必須、作成成功→一覧へ遷移、サーバ 422 エラー表示
- **company-settings**: 法人名必須、保存成功メッセージ、サーバ 422 エラー表示

## CI
- `frontend-ci.yml` に独立 `e2e` ジョブを追加（`npx playwright install --with-deps chromium` → `npm run e2e`、失敗時 `playwright-report` を artifact 化）。

## セルフレビューチェックリスト
- [x] `npm run e2e`：**11 passed**（Chromium, ja-JP）
- [x] `npm run check`：type-check / lint / format / test / knip / build-storybook すべて green（e2e は eslint・knip 設定に統合済み）
- [x] 成果物（`test-results` / `playwright-report`）は `.gitignore` 済み
- [x] バックエンド非依存（全 API を `page.route` でスタブ）で決定論的

## 補足
今回は検証密度の高いフォーム系3機能で基盤＋パターンを確立。同パターンで create-quote / create-invoice / edit-client / view-quote 等へ横展開可能（必要なら続けて追加します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)