### PR TITLE
test(frontend): 単機能ブラウザ E2E を残り機能へ横展開する (#169)

### DIFF
--- a/frontend/e2e/create-invoice.spec.ts
+++ b/frontend/e2e/create-invoice.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+import { json, login } from './helpers/auth'
+
+const CLIENT = {
+  id: 5,
+  organization_id: 1,
+  name: '得意先ABC',
+  contact_name: null,
+  email: null,
+  registration_number: null,
+}
+const INVOICE = {
+  id: 7,
+  organization_id: 1,
+  client_id: 5,
+  status: 'draft',
+  invoice_number: null,
+  is_overdue: false,
+  is_qualified_invoice: false,
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  line_items: [],
+}
+
+/** Reaches /invoices/new through login → invoices list → "新規作成". */
+test.describe('Create invoice', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/clients*', (route) =>
+      route.fulfill(json({ items: [CLIENT], total: 1, limit: 100, offset: 0 })),
+    )
+    await page.route('**/admin/invoices*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [], total: 0, limit: 20, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '請求書', exact: true }).click()
+    await page.getByRole('link', { name: '新規作成' }).click()
+    await expect(page.getByRole('heading', { name: '請求書の作成' })).toBeVisible()
+  })
+
+  test('validates a missing client and an empty line item', async ({ page }) => {
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page.getByText('入力内容に誤りがあります。').first()).toBeVisible()
+    await expect(page).toHaveURL(/\/invoices\/new$/)
+  })
+
+  test('appends an extra line-item row', async ({ page }) => {
+    await expect(page.locator('#line-1-description')).toHaveCount(0)
+    await page.getByRole('button', { name: '明細を追加' }).click()
+    await expect(page.locator('#line-1-description')).toBeVisible()
+  })
+
+  test('creates an invoice and navigates to its detail', async ({ page }) => {
+    await page.route('**/admin/invoices*', (route, request) => {
+      if (request.method() === 'POST') {
+        route.fulfill(json(INVOICE, 201))
+      } else {
+        route.fulfill(json({ items: [], total: 0, limit: 20, offset: 0 }))
+      }
+    })
+    await page.route('**/admin/invoices/7', (route) => route.fulfill(json(INVOICE)))
+    await page.route('**/admin/invoices/7/payments', (route) =>
+      route.fulfill(json({ items: [], total_paid_cents: 0 })),
+    )
+
+    await page.locator('#client_id').selectOption('5')
+    await page.locator('#line-0-description').fill('設計作業')
+    await page.locator('#line-0-unit').fill('100000')
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page).toHaveURL(/\/invoices\/7$/)
+  })
+})

--- a/frontend/e2e/create-quote.spec.ts
+++ b/frontend/e2e/create-quote.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+import { json, login } from './helpers/auth'
+
+const CLIENT = {
+  id: 5,
+  organization_id: 1,
+  name: '得意先ABC',
+  contact_name: null,
+  email: null,
+  registration_number: null,
+}
+const QUOTE = {
+  id: 1,
+  organization_id: 1,
+  client_id: 5,
+  quote_number: 'EST-2026-001',
+  status: 'draft',
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  line_items: [],
+}
+
+/** Reaches /quotes/new through login → quotes list → "見積書を作成". */
+test.describe('Create quote', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/clients*', (route) =>
+      route.fulfill(json({ items: [CLIENT], total: 1, limit: 100, offset: 0 })),
+    )
+    await page.route('**/admin/quotes*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [], total: 0, limit: 20, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '見積書', exact: true }).click()
+    await page.getByRole('link', { name: '見積書を作成' }).click()
+    await expect(page.getByRole('heading', { name: '見積書を作成' })).toBeVisible()
+  })
+
+  test('validates a missing client and an empty line item', async ({ page }) => {
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    // The "client required" + "line description required" errors share copy.
+    await expect(page.getByText('入力内容に誤りがあります。').first()).toBeVisible()
+    await expect(page).toHaveURL(/\/quotes\/new$/)
+  })
+
+  test('appends an extra line-item row', async ({ page }) => {
+    await expect(page.locator('#line-1-description')).toHaveCount(0)
+    await page.getByRole('button', { name: '行を追加' }).click()
+    await expect(page.locator('#line-1-description')).toBeVisible()
+  })
+
+  test('creates a quote and navigates to its detail', async ({ page }) => {
+    await page.route('**/admin/quotes*', (route, request) => {
+      if (request.method() === 'POST') {
+        route.fulfill(json(QUOTE, 201))
+      } else {
+        route.fulfill(json({ items: [], total: 0, limit: 20, offset: 0 }))
+      }
+    })
+    await page.route('**/admin/quotes/1', (route) => route.fulfill(json(QUOTE)))
+
+    await page.locator('#client_id').selectOption('5')
+    await page.locator('#line-0-description').fill('設計作業')
+    await page.locator('#line-0-unit').fill('100000')
+    await page.getByRole('button', { name: '作成する' }).click()
+
+    await expect(page).toHaveURL(/\/quotes\/1$/)
+  })
+})

--- a/frontend/e2e/edit-client.spec.ts
+++ b/frontend/e2e/edit-client.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+import { json, login, problem } from './helpers/auth'
+
+const CLIENT = {
+  id: 5,
+  organization_id: 1,
+  name: '得意先ABC',
+  contact_name: '山田',
+  email: null,
+  billing_address: null,
+  registration_number: 'T9876543210123',
+}
+
+/** Reaches /clients/5/edit through login → clients list → "編集". */
+test.describe('Edit client', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/clients*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [CLIENT], total: 1, limit: 100, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+    await page.route('**/admin/clients/5', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json(CLIENT))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '取引先', exact: true }).click()
+    await page.getByRole('link', { name: '編集' }).click()
+    await expect(page.getByRole('heading', { name: '取引先の編集' })).toBeVisible()
+  })
+
+  test('prefills the form from the loaded client', async ({ page }) => {
+    await expect(page.locator('#name')).toHaveValue('得意先ABC')
+    await expect(page.locator('#registration_number')).toHaveValue('T9876543210123')
+  })
+
+  test('requires a name', async ({ page }) => {
+    await page.locator('#name').fill('')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page.getByText('名称を入力してください。')).toBeVisible()
+  })
+
+  test('saves and returns to the list', async ({ page }) => {
+    await page.route('**/admin/clients/5', (route, request) => {
+      if (request.method() === 'PATCH') {
+        route.fulfill(json({ ...CLIENT, name: '得意先ABC（改）' }))
+      } else {
+        route.fulfill(json(CLIENT))
+      }
+    })
+
+    await page.locator('#name').fill('得意先ABC（改）')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page).toHaveURL(/\/clients$/)
+  })
+
+  test('shows an error when the server rejects the input', async ({ page }) => {
+    await page.route('**/admin/clients/5', (route, request) => {
+      if (request.method() === 'PATCH') {
+        route.fulfill(problem('invalid-registration-number', 422))
+      } else {
+        route.fulfill(json(CLIENT))
+      }
+    })
+
+    await page.locator('#registration_number').fill('BAD')
+    await page.getByRole('button', { name: '保存する' }).click()
+
+    await expect(page.getByText('保存できませんでした。', { exact: false })).toBeVisible()
+  })
+})

--- a/frontend/e2e/view-invoice.spec.ts
+++ b/frontend/e2e/view-invoice.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+import { json, login } from './helpers/auth'
+
+const ISSUED_INVOICE = {
+  id: 1,
+  organization_id: 1,
+  client_id: 5,
+  status: 'issued',
+  invoice_number: 'INV-2026-001',
+  is_overdue: false,
+  is_qualified_invoice: false,
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  issued_at: '2026-05-01',
+  line_items: [],
+}
+
+/** Reaches /invoices/1 through login → invoices list → the invoice-number link. */
+test.describe('View invoice', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/invoices*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [ISSUED_INVOICE], total: 1, limit: 20, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+    await page.route('**/admin/invoices/1', (route) => route.fulfill(json(ISSUED_INVOICE)))
+    await page.route('**/admin/invoices/1/payments', (route) =>
+      route.fulfill(json({ items: [], total_paid_cents: 0 })),
+    )
+
+    await login(page)
+    await page.getByRole('link', { name: '請求書', exact: true }).click()
+    await page.getByRole('link', { name: 'INV-2026-001' }).click()
+    await expect(page.getByRole('button', { name: 'クライアント向けリンクを生成' })).toBeVisible()
+  })
+
+  test('generates a shareable download link and shows the copy action', async ({ page }) => {
+    await page.route('**/admin/invoices/1/download-token', (route) =>
+      route.fulfill(
+        json({ url: '/invoices/download/abc123', expires_at: '2026-06-06 12:00:00' }, 201),
+      ),
+    )
+
+    await page.getByRole('button', { name: 'クライアント向けリンクを生成' }).click()
+
+    await expect(page.getByText('/invoices/download/abc123', { exact: false })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'コピー' })).toBeVisible()
+  })
+
+  test('shows an error when link generation fails', async ({ page }) => {
+    await page.route('**/admin/invoices/1/download-token', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
+    )
+
+    await page.getByRole('button', { name: 'クライアント向けリンクを生成' }).click()
+
+    await expect(page.getByText('リンクの生成に失敗しました。')).toBeVisible()
+  })
+})

--- a/frontend/e2e/view-quote.spec.ts
+++ b/frontend/e2e/view-quote.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+import { json, login } from './helpers/auth'
+
+const QUOTE = {
+  id: 1,
+  organization_id: 1,
+  client_id: 5,
+  quote_number: 'EST-2026-001',
+  status: 'draft',
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  line_items: [],
+}
+const INVOICE = {
+  id: 10,
+  organization_id: 1,
+  client_id: 5,
+  status: 'draft',
+  invoice_number: null,
+  is_overdue: false,
+  is_qualified_invoice: false,
+  subtotal_cents: 100000,
+  tax_cents: 10000,
+  total_cents: 110000,
+  line_items: [],
+}
+
+/** Reaches /quotes/1 through login → quotes list → the quote-number link. */
+test.describe('View quote', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/admin/quotes*', (route, request) => {
+      if (request.method() === 'GET') {
+        route.fulfill(json({ items: [QUOTE], total: 1, limit: 20, offset: 0 }))
+      } else {
+        route.fallback()
+      }
+    })
+
+    await login(page)
+    await page.getByRole('link', { name: '見積書', exact: true }).click()
+    await expect(page.getByRole('link', { name: 'EST-2026-001' })).toBeVisible()
+  })
+
+  test('offers "send" for a draft quote but not conversion', async ({ page }) => {
+    await page.route('**/admin/quotes/1', (route) => route.fulfill(json(QUOTE)))
+    await page.getByRole('link', { name: 'EST-2026-001' }).click()
+
+    await expect(page.getByRole('button', { name: '送付する' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '請求書に変換する' })).toHaveCount(0)
+  })
+
+  test('offers conversion only once the quote is accepted', async ({ page }) => {
+    await page.route('**/admin/quotes/1', (route) =>
+      route.fulfill(json({ ...QUOTE, status: 'accepted' })),
+    )
+    await page.getByRole('link', { name: 'EST-2026-001' }).click()
+
+    await expect(page.getByRole('button', { name: '請求書に変換する' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '送付する' })).toHaveCount(0)
+  })
+
+  test('converts an accepted quote into an invoice', async ({ page }) => {
+    await page.route('**/admin/quotes/1', (route) =>
+      route.fulfill(json({ ...QUOTE, status: 'accepted' })),
+    )
+    await page.route('**/admin/quotes/1/convert', (route) => route.fulfill(json(INVOICE, 201)))
+    await page.route('**/admin/invoices/10', (route) => route.fulfill(json(INVOICE)))
+    await page.route('**/admin/invoices/10/payments', (route) =>
+      route.fulfill(json({ items: [], total_paid_cents: 0 })),
+    )
+
+    await page.getByRole('link', { name: 'EST-2026-001' }).click()
+    await page.getByRole('button', { name: '請求書に変換する' }).click()
+
+    await expect(page).toHaveURL(/\/invoices\/10$/)
+  })
+})


### PR DESCRIPTION
## 概要
Closes #170

#167 で確立した Playwright パターンを残りの単機能へ横展開。境界線・バリデーション・主要アクション経路を実ブラウザで検証する（今回 +15 tests、E2E 全体で **26 tests**）。

## 追加 spec
- **edit-client**: 読込→フォーム prefill、名称必須、保存→一覧遷移、サーバ 422 エラー
- **create-quote**: 取引先未選択＋空明細のバリデーション、明細行の追加、作成→詳細遷移
- **create-invoice**: バリデーション、明細追加、作成→詳細遷移
- **view-quote**: draft で「送付する」可視・変換不可、accepted で「請求書に変換する」可視、変換→請求書詳細へ遷移
- **view-invoice**: 発行済でリンク生成→URL/「コピー」表示、生成失敗時のエラー表示

## 実装メモ（レビュー観点）
- **ルートグロブとクエリ文字列**: 一覧 GET は実 URL に `?limit=&offset=` が付くため、`**/admin/quotes*` のように末尾 `*` を付与（`*` は `/` を跨がないので `**/admin/quotes/1` 等の詳細とは衝突しない）。
- **ナビリンクの exact 指定**: ログイン後のダッシュボードに「請求書一覧 →」等のリンクがあり、`getByRole('link', { name: '請求書' })` が曖昧になるため `exact: true` を指定。

## セルフレビューチェックリスト
- [x] `npm run e2e`：**26 passed**（Chromium, ja-JP）
- [x] `npm run lint` / `format` / `knip` green
- [x] バックエンド非依存（全 API を `page.route` でスタブ）
- [x] 既存 `e2e/helpers/auth.ts` のログインヘルパーに準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)