### PR TITLE
test(frontend): E2E の cold-compile 起因 flaky をタイムアウト調整で解消する (#175)

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? 'list' : 'html',
+  // The dev server compiles routes on first navigation, so the very first
+  // login / route transition can be slow. Generous per-test and assertion
+  // timeouts absorb that cold-compile cost and keep the suite non-flaky.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
   use: {
     baseURL: `http://localhost:${String(PORT)}`,
     // The app picks its locale from navigator.language; pin it to Japanese (the


### PR DESCRIPTION
## 概要
Closes #175

vite dev はルート初回遷移時にチャンクをコンパイルするため、最初のログイン/遷移が稀に 30s（既定のテストタイムアウト）を超え、`edit-client › requires a name` が flaky になっていた（リトライで pass）。

## 変更
`playwright.config.ts`:
- per-test `timeout: 60_000`（既定 30s → 60s）— cold-compile を含むログインに余裕
- `expect: { timeout: 10_000 }`（既定 5s）— ルート初回コンパイル時のアサート待ちに余裕

## 検証
- フルスイート: **38 passed / flaky 0**
- 旧 flaky spec を `edit-client --repeat-each=4`: **16 passed / flaky 0**

## セルフレビューチェックリスト
- [x] `npm run e2e` 安定（フル + 反復で flaky 0）
- [x] `npm run lint` / `format` green
- [x] 挙動・スタブは不変（タイムアウト設定のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)