### PR TITLE
fix(auth): ログイン時に利用者 status=active を必須化する (#177)

### DIFF
--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -32,6 +32,13 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
             throw new InvalidCredentialsException();
         }
 
+        // Only active users may authenticate. A deactivated / not-yet-activated
+        // account must not obtain a token. The same generic error is returned so
+        // account status is not disclosed (no enumeration of disabled accounts).
+        if ($user->status !== 'active') {
+            throw new InvalidCredentialsException();
+        }
+
         $now = time();
 
         $token = $this->tokenIssuer->issue([

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -46,14 +46,36 @@ final class LoginUseCaseTest extends TestCase
         $useCase->execute(new LoginInput('nobody@example.com', 'correct-horse'));
     }
 
-    private function repositoryWithUser(string $plainPassword): UserRepositoryInterface
+    public function test_rejects_non_active_user_even_with_valid_password(): void
+    {
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse', 'disabled'),
+            new LocalBearerTokenVerifier(self::SECRET),
+        );
+
+        $this->expectException(InvalidCredentialsException::class);
+        $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
+    }
+
+    public function test_rejects_invited_user(): void
+    {
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse', 'invited'),
+            new LocalBearerTokenVerifier(self::SECRET),
+        );
+
+        $this->expectException(InvalidCredentialsException::class);
+        $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
+    }
+
+    private function repositoryWithUser(string $plainPassword, string $status = 'active'): UserRepositoryInterface
     {
         $user = new User(
             email: 'admin@example.com',
             passwordHash: password_hash($plainPassword, PASSWORD_DEFAULT),
             role: Role::Admin,
             organizationId: 1,
-            status: 'active',
+            status: $status,
             id: 7,
         );
 


### PR DESCRIPTION
## 概要
Closes #177

セキュリティ診断（R2-1, `reports/security-assessment-2026-05-31-round2.md`）対応。`LoginUseCase` が `status` を検証せず、`disabled`/`invited` ユーザもログイン・操作可能だった。

## 変更
- パスワード検証後に `$user->status === 'active'` を必須化。非アクティブは**列挙防止のため同一の `InvalidCredentialsException`** で拒否。
- `LoginUseCaseTest`: disabled / invited 拒否ケースを追加。

## 検証
- [x] `composer check` green（253 tests）
- [x] 稼働環境で disabled→`invalid-credentials` / active→token 発行 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)