### PR TITLE
fix(invoice): 見積の請求書変換を1回限りにする (#179)

### DIFF
--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -52,6 +52,12 @@ final readonly class ConvertQuoteToInvoiceUseCase
             throw new QuoteValidationException('Only an accepted quote can be converted to an invoice.');
         }
 
+        // One invoice per quote: re-converting an already-converted quote would
+        // create duplicate invoices (accounting integrity, diagnostic R2-2).
+        if ($this->invoices->existsForQuote($quoteId)) {
+            throw new QuoteValidationException('This quote has already been converted to an invoice.');
+        }
+
         $invoiceId = $this->invoices->save(new Invoice(
             organizationId: $organizationId,
             clientId: $quote->clientId,

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -13,6 +13,12 @@ interface InvoiceRepositoryInterface
 {
     public function findById(int $id): ?Invoice;
 
+    /**
+     * Whether an invoice already exists for the given quote in the resolved
+     * organization. Used to enforce one-invoice-per-quote on conversion.
+     */
+    public function existsForQuote(int $quoteId): bool;
+
     /** @return list<Invoice> */
     public function findAll(int $limit, int $offset): array;
 

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -30,6 +30,16 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         return $row !== null ? $this->mapRow($row) : null;
     }
 
+    public function existsForQuote(int $quoteId): bool
+    {
+        $row = $this->query->fetchOne(
+            'SELECT 1 AS hit FROM invoices WHERE quote_id = ? AND organization_id = ? AND is_deleted = 0 LIMIT 1',
+            [$quoteId, $this->orgId->get()],
+        );
+
+        return $row !== null;
+    }
+
     /** @return list<Invoice> */
     public function findAll(int $limit, int $offset): array
     {

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -84,6 +84,18 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         $this->useCase->execute(7, $quoteId);
     }
 
+    public function test_rejects_re_conversion_of_already_converted_quote(): void
+    {
+        $quoteId = $this->quote(QuoteStatus::Accepted);
+
+        // First conversion succeeds.
+        $this->useCase->execute(7, $quoteId);
+
+        // A second conversion must be rejected (one invoice per quote).
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(7, $quoteId);
+    }
+
     public function test_cross_organization_quote_not_found(): void
     {
         $quoteId = $this->quote(QuoteStatus::Accepted);

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -37,6 +37,18 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
         $this->orgId = $orgId;
     }
 
+    public function existsForQuote(int $quoteId): bool
+    {
+        $orgId = $this->orgId->get();
+        foreach ($this->byId as $invoice) {
+            if ($invoice->quoteId === $quoteId && $invoice->organizationId === $orgId && !$invoice->isDeleted) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function findById(int $id): ?Invoice
     {
         $invoice = $this->byId[$id] ?? null;


### PR DESCRIPTION
## 概要
Closes #179

診断 R2-2。`ConvertQuoteToInvoiceUseCase` に再変換防止がなく、承認済み見積を何度でも変換でき請求書が重複生成されていた（会計整合性）。

## 変更
- `InvoiceRepositoryInterface::existsForQuote(int $quoteId): bool`（holder スコープ）を追加、Pdo/InMemory 実装。
- 変換時に当該 quote 由来の invoice が既存なら `QuoteValidationException` で拒否（1見積=1請求書）。
- 二重変換拒否テストを追加。

## 検証
- [x] `composer check` green（254 tests）
- [x] 稼働環境で 1回目 201 / 2回目 422 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)