### PR TITLE
fix(payment): 入金の冪等性と paid_at 検証を強化する (#181)

### DIFF
--- a/src/Payment/RecordPaymentHandler.php
+++ b/src/Payment/RecordPaymentHandler.php
@@ -44,10 +44,15 @@ final readonly class RecordPaymentHandler implements RequestHandlerInterface
         $noteValue = $decoded['note'] ?? null;
         $note = is_string($noteValue) && $noteValue !== '' ? $noteValue : null;
 
+        // Optional idempotency key: a retried submission with the same key returns
+        // the original payment instead of double-recording it (diagnostic R2-3).
+        $keyValue = $decoded['idempotency_key'] ?? null;
+        $idempotencyKey = is_string($keyValue) && $keyValue !== '' ? $keyValue : null;
+
         $result = $this->useCase->execute(
             AuthContext::userId($request),
             $invoiceId,
-            new RecordPaymentInput($amountCents, $paidAt, $method, $note),
+            new RecordPaymentInput($amountCents, $paidAt, $method, $note, idempotencyKey: $idempotencyKey),
         );
 
         return $this->json->create([

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -63,6 +63,22 @@ final readonly class RecordPaymentUseCase
             throw new PaymentValidationException('A payment amount must be a positive number of cents.');
         }
 
+        // Validate an explicit payment date: a malformed value must surface as a
+        // 422 (not a 500 from the DATETIME column), and a payment cannot be dated
+        // in the future (accounting integrity, diagnostic R2-4 / R2-5).
+        if ($input->paidAt !== null) {
+            $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', $input->paidAt)
+                ?: \DateTimeImmutable::createFromFormat('!Y-m-d', $input->paidAt);
+
+            if ($parsed === false) {
+                throw new PaymentValidationException('A payment date must be a valid date (YYYY-MM-DD).');
+            }
+
+            if ($parsed > new \DateTimeImmutable('now')) {
+                throw new PaymentValidationException('A payment date cannot be in the future.');
+            }
+        }
+
         if (!in_array($invoice->status, [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid], true)) {
             throw new PaymentValidationException('Payments can only be recorded against an issued invoice.');
         }

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -123,6 +123,31 @@ final class RecordPaymentUseCaseTest extends TestCase
         $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 0));
     }
 
+    public function test_malformed_paid_at_is_rejected(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000, paidAt: 'not-a-date'));
+    }
+
+    public function test_future_paid_at_is_rejected(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000, paidAt: '2999-12-31'));
+    }
+
+    public function test_valid_backdated_paid_at_is_accepted(): void
+    {
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000, paidAt: '2026-05-01'));
+
+        self::assertSame('2026-05-01', $result->payment->paidAt);
+    }
+
     public function test_payment_against_draft_is_rejected(): void
     {
         $id = $this->invoices->save(new Invoice(


### PR DESCRIPTION
## 概要
Closes #181

診断 R2-3/R2-4/R2-5 対応。

## 変更
- **R2-3 冪等性**: 管理 `RecordPaymentHandler` が `idempotency_key` を受理し UseCase の重複排除へ渡す（従来は無視→再送で二重計上）。
- **R2-4 不正 paid_at→500**: `RecordPaymentUseCase` で `paidAt` を検証し、不正日付は `PaymentValidationException`（→422）。
- **R2-5 未来日**: 未来の `paid_at` を拒否（会計整合性）。正当なバックデートは許可。
- admin/service 両経路を UseCase レベルで統一保護。

## 検証
- [x] `composer check` green（257 tests）
- [x] 稼働環境で 不正→422 / 未来→422 / 冪等キー3回→payments +1 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)