### PR TITLE
fix(auth): OrgGuard の null-org 免除を superadmin ロールに限定する (#183)

### DIFF
--- a/src/Auth/OrgGuardMiddleware.php
+++ b/src/Auth/OrgGuardMiddleware.php
@@ -48,9 +48,21 @@ final readonly class OrgGuardMiddleware implements MiddlewareInterface
 
         $tokenOrg = $claims['org'] ?? null;
 
-        // Superadmin (org null) operates cross-tenant.
+        // Superadmin (org null) operates cross-tenant — but only when the role
+        // claim actually says superadmin. A null org paired with a non-superadmin
+        // role is an inconsistent token and must not bypass the org check.
         if ($tokenOrg === null) {
-            return $handler->handle($request);
+            if (($claims['role'] ?? null) === Role::Superadmin->value) {
+                return $handler->handle($request);
+            }
+
+            return $this->problemDetails->create(
+                $request,
+                'organization-mismatch',
+                'Forbidden',
+                403,
+                'Your account does not belong to this organization.',
+            );
         }
 
         if (!is_int($tokenOrg) || $tokenOrg !== $resolvedOrgId) {

--- a/tests/Auth/OrgGuardMiddlewareTest.php
+++ b/tests/Auth/OrgGuardMiddlewareTest.php
@@ -57,6 +57,19 @@ final class OrgGuardMiddlewareTest extends TestCase
         self::assertSame(200, $this->middleware->process($request, $this->okHandler())->getStatusCode());
     }
 
+    public function test_rejects_null_org_with_non_superadmin_role(): void
+    {
+        // A null org is only legitimate for a superadmin; a null org paired with
+        // any other role is an inconsistent token and must not bypass the guard.
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute('nene2.org.id', 7)
+            ->withAttribute('nene2.auth.claims', ['sub' => 1, 'role' => 'admin', 'org' => null]);
+
+        $response = $this->middleware->process($request, $this->okHandler());
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('organization-mismatch', (string) $response->getBody());
+    }
+
     public function test_passes_when_no_resolved_org(): void
     {
         // Bypass route: no nene2.org.id attribute.


### PR DESCRIPTION
## 概要
Closes #183

診断 R2-6（多層防御 / secret 依存）。`OrgGuardMiddleware` は token の `org` が null のとき role を確認せず cross-tenant を許可していた。

## 変更
- `org === null` の免除を `role === 'superadmin'` の場合に限定。null org かつ非 superadmin は `organization-mismatch`(403)。
- 「null org + 非 superadmin → 403」テストを追加。

## 検証
- [x] `composer check` green（258 tests）
- [x] 稼働環境で 偽造`{role:admin,org:null}`→403 / 正規 superadmin→200 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)