### PR TITLE
fix(installer): DB 既存データ時はセットアップを拒否する (#185)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -29,6 +29,50 @@ if (file_exists(INSTALLED_MARKER)) {
 }
 
 // -------------------------------------------------------------------
+// Guard (defense in depth): マーカーが失われていても、DB に既存ユーザが
+// いれば「未インストール」と誤判定して再セットアップ（.env 上書き・管理者
+// 作成）されるのを防ぐ。ephemeral な var/ で .installed が消えるデプロイ対策。
+// -------------------------------------------------------------------
+function databaseAlreadyProvisioned(): bool
+{
+    if (!is_file(ENV_FILE)) {
+        return false;
+    }
+
+    $env = parse_ini_file(ENV_FILE) ?: [];
+
+    if (($env['DB_ADAPTER'] ?? 'mysql') !== 'mysql' || empty($env['DB_NAME'])) {
+        return false;
+    }
+
+    try {
+        $dsn = sprintf(
+            'mysql:host=%s;port=%s;dbname=%s;charset=%s',
+            $env['DB_HOST'] ?? '127.0.0.1',
+            $env['DB_PORT'] ?? '3306',
+            $env['DB_NAME'],
+            $env['DB_CHARSET'] ?? 'utf8mb4',
+        );
+        $pdo = new PDO($dsn, $env['DB_USER'] ?? '', $env['DB_PASSWORD'] ?? '', [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_TIMEOUT => 3,
+        ]);
+        $count = (int) $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+
+        return $count > 0;
+    } catch (\Throwable) {
+        // No env / unreachable DB / no schema yet → genuinely not provisioned.
+        return false;
+    }
+}
+
+if (databaseAlreadyProvisioned()) {
+    http_response_code(403);
+    echo '<p style="font-family:sans-serif;color:#c00;padding:2em">既にプロビジョニング済みのデータベースが検出されました。再インストールはできません。install.php を削除してください。</p>';
+    exit;
+}
+
+// -------------------------------------------------------------------
 // ヘルパー
 // -------------------------------------------------------------------
 function h(string $s): string


### PR DESCRIPTION
## 概要
Closes #185

診断 **F-1 (High)**。`install.php` は `var/.installed` マーカー＋手動削除のみが防御で、マーカー喪失時（ephemeral `var/` ＋ 永続 DB の再デプロイ、DB 直接 seed 等）に無認証で `.env` 上書き・管理者作成が可能だった。

## 変更
- マーカーに加え、**DB に既存ユーザが存在すればセットアップを拒否**する `databaseAlreadyProvisioned()` を追加（多層防御）。接続不可/スキーマ未作成時は「未プロビジョニング」とみなし通常のインストールを許可。

## 検証
- [x] 稼働環境（既存ユーザあり）で `GET /install.php` → **403**「プロビジョニング済み」
- [x] `composer check` green（install.php も cs-fixer 対象、クリーン）

## 運用推奨（レポート記載）
インストーラは配備 Web ルートから除外、または初回完了後に削除するのが望ましい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)