### PR TITLE
fix(http): X-Powered-By を除去し HSTS/署名秘匿を追加する (#187)

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -3,3 +3,13 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
+
+# Hardening (Apache + mod_headers). The Server version and TLS-level HSTS are
+# ultimately the web server / TLS-terminating proxy's responsibility.
+<IfModule mod_headers.c>
+    Header always unset X-Powered-By
+    Header unset X-Powered-By
+    # HSTS only takes effect over HTTPS; harmless over plain HTTP.
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+</IfModule>
+ServerSignature Off

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -10,6 +10,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// Do not advertise the PHP version (defense in depth; `expose_php` may be On).
+header_remove('X-Powered-By');
+
 $container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
 
 $psr17Factory = $container->get(Psr17Factory::class);


### PR DESCRIPTION
## 概要
Closes #187

診断 F-3（バージョン開示）/F-5（HSTS）。

## 変更
- `public_html/index.php`: `header_remove('X-Powered-By')` — web サーバ非依存で PHP バージョン開示を抑止。
- `public_html/.htaccess`: `mod_headers` で `X-Powered-By` 除去・`Strict-Transport-Security` 付与、`ServerSignature Off`。
- `Server` バージョン秘匿と TLS 終端での HSTS は web サーバ/プロキシ設定の責務（framework の `SecurityHeadersMiddleware` は vendor 固定生成のため、アプリ層で可能な範囲を実装）。

## 検証
- [x] 稼働環境で `X-Powered-By` 出現数 **0**
- [x] `composer check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)