### PR TITLE
fix(auth): /auth/login に IP 単位のレート制限を追加する (#189)

### DIFF
--- a/database/migrations/20260531000000_create_login_attempts_table.php
+++ b/database/migrations/20260531000000_create_login_attempts_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateLoginAttemptsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('login_attempts')
+            ->addColumn('ip_address', 'string', ['limit' => 45, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addIndex(['ip_address', 'created_at'], ['name' => 'idx_login_attempts_ip_time'])
+            ->create();
+    }
+}

--- a/database/schema/login_attempts.sql
+++ b/database/schema/login_attempts.sql
@@ -1,0 +1,9 @@
+-- Schema snapshot for the login_attempts table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- Records failed login attempts per source IP for throttling (security: F-2).
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ip_address VARCHAR(45) NOT NULL,
+    created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_login_attempts_ip_time ON login_attempts (ip_address, created_at);

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -176,3 +176,13 @@ CREATE TABLE IF NOT EXISTS `invoice_download_tokens` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 SET foreign_key_checks = 1;
+
+-- ---------------------------------------------------------------------------
+-- login_attempts — failed login throttling per source IP (security: F-2).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `login_attempts` (
+    `id`         INT         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `ip_address` VARCHAR(45) NOT NULL,
+    `created_at` DATETIME    NOT NULL,
+    KEY `idx_login_attempts_ip_time` (`ip_address`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -119,6 +119,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `role-not-assignable` | Role cannot be assigned via user management, e.g. superadmin (422) |
 | `cannot-delete-self` | A user cannot delete their own account (409) |
 | `invalid-credentials` | Login failed — wrong email or password |
+| `too-many-requests` | Too many failed login attempts from the source IP (429; login throttling) |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request (404; OrgResolverMiddleware) |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -80,6 +80,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
   /admin/me:
     get:
       tags: [Auth]
@@ -894,6 +896,17 @@ components:
             $ref: '#/components/schemas/ProblemDetails'
     EmailConflict:
       description: User email already in use.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    TooManyRequests:
+      description: Too many failed login attempts from the source IP.
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying.
+          schema:
+            type: integer
       content:
         application/problem+json:
           schema:

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -151,6 +151,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): LoginUseCaseInterface {
                     $users = $container->get(UserRepositoryInterface::class);
                     $tokenIssuer = $container->get(TokenIssuerInterface::class);
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('User repository service is invalid.');
@@ -160,7 +161,11 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Token issuer service is invalid.');
                     }
 
-                    return new LoginUseCase($users, $tokenIssuer);
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new LoginUseCase($users, $tokenIssuer, new PdoLoginThrottle($query));
                 },
             )
             ->set(

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -37,8 +37,17 @@ final readonly class LoginHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "email" and "password" are required.');
         }
 
+        $serverParams = $request->getServerParams();
+        $ip = isset($serverParams['REMOTE_ADDR']) && is_string($serverParams['REMOTE_ADDR'])
+            ? $serverParams['REMOTE_ADDR']
+            : null;
+
         try {
-            $output = $this->useCase->execute(new LoginInput($email, $password));
+            $output = $this->useCase->execute(new LoginInput($email, $password, $ip));
+        } catch (TooManyLoginAttemptsException $e) {
+            return $this->problemDetails
+                ->create($request, 'too-many-requests', 'Too Many Requests', 429, $e->getMessage())
+                ->withHeader('Retry-After', (string) $e->retryAfterSeconds);
         } catch (InvalidCredentialsException $e) {
             return $this->problemDetails->create($request, 'invalid-credentials', 'Invalid Credentials', 401, $e->getMessage());
         }

--- a/src/Auth/LoginInput.php
+++ b/src/Auth/LoginInput.php
@@ -9,6 +9,8 @@ final readonly class LoginInput
     public function __construct(
         public string $email,
         public string $password,
+        /** Source IP for brute-force throttling; null disables throttling (e.g. tests). */
+        public ?string $ipAddress = null,
     ) {
     }
 }

--- a/src/Auth/LoginThrottleInterface.php
+++ b/src/Auth/LoginThrottleInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Tracks failed login attempts per source IP for brute-force throttling
+ * (security: diagnostic F-2). Keyed by IP rather than account so a flood of
+ * failures cannot lock a victim's account (lockout DoS).
+ */
+interface LoginThrottleInterface
+{
+    /** Number of failed attempts from this IP at or after the given datetime. */
+    public function countFailuresSince(string $ipAddress, string $since): int;
+
+    /** Record a failed attempt from this IP (now). */
+    public function recordFailure(string $ipAddress): void;
+
+    /** Clear this IP's failure history after a successful authentication. */
+    public function clearFailures(string $ipAddress): void;
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -18,25 +18,45 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
 {
     private const TOKEN_TTL_SECONDS = 3600;
 
+    /** Failed-attempt throttling window and ceiling per source IP (diagnostic F-2). */
+    private const THROTTLE_WINDOW_SECONDS = 300;
+    private const THROTTLE_MAX_FAILURES = 10;
+
     public function __construct(
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokenIssuer,
+        private LoginThrottleInterface $throttle,
     ) {
     }
 
     public function execute(LoginInput $input): LoginOutput
     {
+        $ip = $input->ipAddress;
+
+        // Brute-force throttle: once an IP exceeds the failure ceiling within the
+        // window, reject further attempts until the window rolls off (429).
+        if ($ip !== null) {
+            $since = date('Y-m-d H:i:s', time() - self::THROTTLE_WINDOW_SECONDS);
+            if ($this->throttle->countFailuresSince($ip, $since) >= self::THROTTLE_MAX_FAILURES) {
+                throw new TooManyLoginAttemptsException(self::THROTTLE_WINDOW_SECONDS);
+            }
+        }
+
         $user = $this->users->findByEmail($input->email);
 
-        if ($user === null || !password_verify($input->password, $user->passwordHash)) {
+        // A failed credential check, or a non-active account (deactivated /
+        // not-yet-activated), is rejected with the same generic error so account
+        // status is not disclosed (no enumeration). Both count toward the throttle.
+        if ($user === null || !password_verify($input->password, $user->passwordHash) || $user->status !== 'active') {
+            if ($ip !== null) {
+                $this->throttle->recordFailure($ip);
+            }
+
             throw new InvalidCredentialsException();
         }
 
-        // Only active users may authenticate. A deactivated / not-yet-activated
-        // account must not obtain a token. The same generic error is returned so
-        // account status is not disclosed (no enumeration of disabled accounts).
-        if ($user->status !== 'active') {
-            throw new InvalidCredentialsException();
+        if ($ip !== null) {
+            $this->throttle->clearFailures($ip);
         }
 
         $now = time();

--- a/src/Auth/PdoLoginThrottle.php
+++ b/src/Auth/PdoLoginThrottle.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoLoginThrottle implements LoginThrottleInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function countFailuresSince(string $ipAddress, string $since): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM login_attempts WHERE ip_address = ? AND created_at >= ?',
+            [$ipAddress, $since],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function recordFailure(string $ipAddress): void
+    {
+        $this->query->execute(
+            'INSERT INTO login_attempts (ip_address, created_at) VALUES (?, ?)',
+            [$ipAddress, date('Y-m-d H:i:s')],
+        );
+    }
+
+    public function clearFailures(string $ipAddress): void
+    {
+        $this->query->execute('DELETE FROM login_attempts WHERE ip_address = ?', [$ipAddress]);
+    }
+}

--- a/src/Auth/TooManyLoginAttemptsException.php
+++ b/src/Auth/TooManyLoginAttemptsException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use RuntimeException;
+
+/**
+ * Thrown when an IP exceeds the allowed number of failed login attempts within
+ * the throttling window (security: diagnostic F-2). Maps to HTTP 429.
+ */
+final class TooManyLoginAttemptsException extends RuntimeException
+{
+    public function __construct(public readonly int $retryAfterSeconds)
+    {
+        parent::__construct('Too many failed login attempts. Try again later.');
+    }
+}

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -9,6 +9,8 @@ use NeneInvoice\Auth\InvalidCredentialsException;
 use NeneInvoice\Auth\LoginInput;
 use NeneInvoice\Auth\LoginUseCase;
 use NeneInvoice\Auth\Role;
+use NeneInvoice\Auth\TooManyLoginAttemptsException;
+use NeneInvoice\Tests\Support\InMemoryLoginThrottle;
 use NeneInvoice\User\User;
 use NeneInvoice\User\UserRepositoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +22,7 @@ final class LoginUseCaseTest extends TestCase
     public function test_issues_token_with_identity_claims_on_valid_credentials(): void
     {
         $verifier = new LocalBearerTokenVerifier(self::SECRET);
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier);
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier, new InMemoryLoginThrottle());
 
         $output = $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
 
@@ -32,7 +34,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_wrong_password(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET));
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('admin@example.com', 'wrong'));
@@ -40,7 +42,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_unknown_email(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET));
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('nobody@example.com', 'correct-horse'));
@@ -51,6 +53,7 @@ final class LoginUseCaseTest extends TestCase
         $useCase = new LoginUseCase(
             $this->repositoryWithUser('correct-horse', 'disabled'),
             new LocalBearerTokenVerifier(self::SECRET),
+            new InMemoryLoginThrottle(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
@@ -62,10 +65,63 @@ final class LoginUseCaseTest extends TestCase
         $useCase = new LoginUseCase(
             $this->repositoryWithUser('correct-horse', 'invited'),
             new LocalBearerTokenVerifier(self::SECRET),
+            new InMemoryLoginThrottle(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
+    }
+
+    public function test_throttles_after_too_many_failures_from_one_ip(): void
+    {
+        $throttle = new InMemoryLoginThrottle();
+        for ($i = 0; $i < 10; $i++) {
+            $throttle->recordFailure('203.0.113.7');
+        }
+
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse'),
+            new LocalBearerTokenVerifier(self::SECRET),
+            $throttle,
+        );
+
+        // Even with the correct password, the IP is over the failure ceiling.
+        $this->expectException(TooManyLoginAttemptsException::class);
+        $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.7'));
+    }
+
+    public function test_a_failed_attempt_is_recorded_against_the_ip(): void
+    {
+        $throttle = new InMemoryLoginThrottle();
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse'),
+            new LocalBearerTokenVerifier(self::SECRET),
+            $throttle,
+        );
+
+        try {
+            $useCase->execute(new LoginInput('admin@example.com', 'wrong', '203.0.113.8'));
+        } catch (InvalidCredentialsException) {
+            // expected
+        }
+
+        self::assertSame(1, $throttle->countFailuresSince('203.0.113.8', '1970-01-01 00:00:00'));
+    }
+
+    public function test_successful_login_clears_the_ip_failure_history(): void
+    {
+        $throttle = new InMemoryLoginThrottle();
+        $throttle->recordFailure('203.0.113.9');
+
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse'),
+            new LocalBearerTokenVerifier(self::SECRET),
+            $throttle,
+        );
+
+        $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.9'));
+
+        self::assertSame(0, $throttle->countFailuresSince('203.0.113.9', '1970-01-01 00:00:00'));
     }
 
     private function repositoryWithUser(string $plainPassword, string $status = 'active'): UserRepositoryInterface

--- a/tests/Auth/PdoLoginThrottleTest.php
+++ b/tests/Auth/PdoLoginThrottleTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Auth\PdoLoginThrottle;
+use PHPUnit\Framework\TestCase;
+
+final class PdoLoginThrottleTest extends TestCase
+{
+    private PdoLoginThrottle $throttle;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/login_attempts.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->throttle = new PdoLoginThrottle(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    public function test_counts_only_failures_at_or_after_the_cutoff(): void
+    {
+        $this->throttle->recordFailure('203.0.113.1');
+        $this->throttle->recordFailure('203.0.113.1');
+        $this->throttle->recordFailure('203.0.113.2');
+
+        self::assertSame(2, $this->throttle->countFailuresSince('203.0.113.1', '1970-01-01 00:00:00'));
+        self::assertSame(1, $this->throttle->countFailuresSince('203.0.113.2', '1970-01-01 00:00:00'));
+        self::assertSame(0, $this->throttle->countFailuresSince('203.0.113.1', '2999-01-01 00:00:00'));
+    }
+
+    public function test_clear_removes_only_the_given_ip(): void
+    {
+        $this->throttle->recordFailure('203.0.113.1');
+        $this->throttle->recordFailure('203.0.113.2');
+
+        $this->throttle->clearFailures('203.0.113.1');
+
+        self::assertSame(0, $this->throttle->countFailuresSince('203.0.113.1', '1970-01-01 00:00:00'));
+        self::assertSame(1, $this->throttle->countFailuresSince('203.0.113.2', '1970-01-01 00:00:00'));
+    }
+}

--- a/tests/Support/InMemoryLoginThrottle.php
+++ b/tests/Support/InMemoryLoginThrottle.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Auth\LoginThrottleInterface;
+
+/**
+ * In-memory login throttle for use-case tests. Records failures with the current
+ * timestamp; {@see countFailuresSince()} compares against the given datetime.
+ */
+final class InMemoryLoginThrottle implements LoginThrottleInterface
+{
+    /** @var array<string, list<string>> ip => list of failure datetimes (Y-m-d H:i:s) */
+    private array $failures = [];
+
+    public function countFailuresSince(string $ipAddress, string $since): int
+    {
+        $count = 0;
+        foreach ($this->failures[$ipAddress] ?? [] as $at) {
+            if ($at >= $since) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function recordFailure(string $ipAddress): void
+    {
+        $this->failures[$ipAddress][] = date('Y-m-d H:i:s');
+    }
+
+    public function clearFailures(string $ipAddress): void
+    {
+        unset($this->failures[$ipAddress]);
+    }
+}


### PR DESCRIPTION
## 概要
Closes #189

診断 **F-2 (Medium)**。`/auth/login` に試行制限がなく、オンライン総当たり/クレデンシャルスタッフィングが可能だった（10連続失敗後も正PWで 200）。

## 変更
- **`login_attempts` テーブル**（migration / mysql schema / sqlite schema）。IP 単位で失敗試行を記録。
- **`LoginThrottleInterface` + `PdoLoginThrottle`**。
- **`LoginUseCase`**: ウィンドウ **300s** 内に **10** 回失敗で `TooManyLoginAttemptsException`。資格情報失敗・非アクティブ拒否を記録、成功でクリア。
- **`LoginHandler`**: `REMOTE_ADDR` を抽出し **429 `too-many-requests`** ＋ `Retry-After` を返す。
- terminology に `too-many-requests`、OpenAPI に 429 応答を追加。
- UseCase / Pdo throttle のテスト追加。

### 設計判断
アカウントロックアウト DoS を避けるため、**アカウント単位ではなく IP 単位**の一時スロットル（ウィンドウ経過で自動解除）。リバースプロキシ配下では `REMOTE_ADDR` がプロキシになるため、信頼できる `X-Forwarded-For` 採用は別途デプロイ設定の検討事項。

## 検証
- [x] `composer check` green（263 tests）
- [x] 稼働環境で 11回目→**429** / スロットル中の正PW→**429** / `Retry-After: 300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)