### PR TITLE
docs(security): セキュリティ診断レポートと再現ハーネスを追加する (#191)

### DIFF
--- a/docs/security/2026-05-31-assessment-round1.md
+++ b/docs/security/2026-05-31-assessment-round1.md
@@ -1,0 +1,184 @@
+# NeNe Invoice — セキュリティ診断レポート
+
+- **対象**: NeNe Invoice API（自己ホスト型 見積・請求・入金管理 / NENE2 PHP 8.4 + MySQL）
+- **実施日**: 2026-05-31
+- **手法**: 認可されたブラックボックス + グレーボックス手動診断（自己所有アプリ・ローカル Docker）
+- **対象環境**: ローカル Docker（`app` = php:8.4-apache, `db` = mysql:8.0）。`http://localhost:18090`、MySQL `13309`
+- **テナント構成**: `TENANT_RESOLUTION=single`, `ORG_SLUG=org-a`（解決 org = org-a/id 1）
+- **シードデータ**: org-a(1) / org-b(2)、ユーザ admin/member/viewer/superadmin、各 org に client・invoice・company_settings
+
+> ⚠️ 本診断は**自分のアプリ・隔離されたローカル環境**に対する正当なセキュリティ検証です。破壊的操作（DB ドロップ等）は実行せず、到達性・分離・検証ロジックの確認に留めています。
+
+---
+
+## エグゼクティブサマリ
+
+アプリケーション層（認証・**マルチテナント分離**・認可・入力検証・インジェクション耐性・業務ロジック）は**非常に堅牢**で、試行した攻撃はすべて防御されました。特に組織間のデータ分離は SQL レベルで一貫して強制されており、IDOR / クロステナント漏洩は確認できませんでした。
+
+一方、**デプロイ/運用面**で対処すべき項目が 1 件（High）、認証ハードニングで 1 件（Medium）、情報開示等の軽微な項目が数件あります。
+
+| # | 深刻度 | 項目 | 状態 |
+|---|--------|------|------|
+| F-1 | **High（条件付き）** | `install.php` が Web ルートに到達可能（マーカー消失時に無認証セットアップ可能） | 要対処 |
+| F-2 | **Medium** | `/auth/login` にレート制限・アカウントロックアウトなし（総当たり可能） | 要対処 |
+| F-3 | Low / Info | バージョン情報の開示（`Server` / `X-Powered-By`） | 推奨 |
+| F-4 | Low / Info | 対称鍵 JWT・単一シークレットで人/サービス両トークンに署名・失効不可 | 設計上の留意 |
+| F-5 | Info | HSTS ヘッダなし（TLS 終端構成依存） | 推奨 |
+| F-6 | Info | Problem Details の `type` ベース host 不一致（`nene2.dev` 混在） | 軽微 |
+
+---
+
+## 検出された問題（Findings）
+
+### F-1 [High（条件付き）] `install.php` が Web ルートに到達可能
+
+**状況**: `public_html/install.php`（13KB の Web インストーラ）がデプロイ後も配信され、`GET /install.php` が **HTTP 200** でセットアップ画面を返す。
+
+```
+GET /install.php  -> HTTP 200（DB設定フォームを表示）
+<b>Warning</b>: mkdir(): File exists in <b>/var/www/html/public_html/install.php</b> on line <b>53</b>
+```
+
+**分析**:
+- インストーラは `var/.installed` マーカーの存在で再実行を拒否する設計（マーカーあり → 「インストール済みです。install.php を削除してください。」で `exit`）。
+- しかし防御は **マーカーファイル + 手動削除の案内のみ**。マーカーが**不在**の場合（DB を直接シード/リストアしたデプロイ、コンテナ再デプロイで `var/` が ephemeral かつ DB は永続、git ベース配備でインストーラ未実行など）、インストーラは「未インストール」と判断し**起動状態**になる。
+- 起動状態では、無認証の攻撃者が:
+  - **step=1**: `file_put_contents(ENV_FILE, …)` で `.env` を上書き → DB 接続先を攻撃者の DB に向ける（= 認証バイパス／全データ差し替え）。
+  - **step=2**: 任意の組織・**管理者ユーザを新規作成**（`INSERT INTO users … role=admin`）。
+  → **完全乗っ取り**に至る。
+- 併せて、`install.php` 単体で **PHP warning が表示**され（display_errors が有効）、絶対パス `/var/www/html/public_html/install.php` を開示。
+
+**影響**: マーカー不在のデプロイ条件下で、無認証の `.env` 改ざん + 管理者作成によるフルテイクオーバー。マーカーは `var/`（多くの構成で ephemeral/gitignore）に置かれるため、DB が永続するコンテナ再デプロイで**容易に再露出**しうる。
+
+**推奨**:
+1. **配備物の Web ルートからインストーラを除外**（リリース ZIP に含めない／別ディレクトリ）。または初回起動後に**自動削除**。
+2. マーカーに依存せず、**DB に既存 org/user が存在する場合はセットアップを拒否**する二重ガードを追加。
+3. インストーラの `.env` 書き込み・管理者作成を、ワンタイムトークン or ループバック限定にする。
+4. `display_errors=Off` をインストーラにも適用（パス開示の抑止）。
+
+---
+
+### F-2 [Medium] `/auth/login` にレート制限・アカウントロックアウトなし
+
+**状況**: 同一アカウントへ連続して誤パスワードでログインしても制限・遅延・ロックが一切かからない。
+
+```
+10連続 失敗ログイン -> 401 401 401 401 401 401 401 401 401 401
+直後に正パスワード   -> HTTP 200（ロックされていない）
+```
+
+`src/Auth/LoginHandler.php`（48行）は `InvalidCredentialsException` を 401 に変換するのみで、試行回数の記録・スロットリング・CAPTCHA・指数バックオフ等は未実装。
+
+**影響**: オンライン総当たり / クレデンシャルスタッフィングが可能。`password_hash`（bcrypt cost 12）でハッシュ自体は強いが、弱いパスワードは時間をかければ突破されうる。
+
+**推奨**: IP / アカウント単位のレート制限（例: 5 回/分でバックオフ、N 回でロック or 一時遅延）、失敗試行の監査ログ記録、必要に応じ CAPTCHA。ミドルウェア（`/auth/login` 前段）での実装が望ましい。
+
+**補足（良好点）**: ユーザ列挙は不可。存在しないユーザも誤パスワードも一様に `invalid-credentials` を返す。
+
+---
+
+### F-3 [Low / Info] バージョン情報の開示
+
+```
+Server: Apache/2.4.67 (Debian)
+X-Powered-By: PHP/8.4.21
+```
+
+既知脆弱性の標的選定を容易にする。`ServerTokens Prod` / `ServerSignature Off`、`expose_php=Off` で抑止を推奨。
+
+### F-4 [Low / Info] 対称鍵 JWT / 単一シークレット / 失効不可
+
+- 人間トークンとサービストークン（`/api/*`）が**同一の `NENE2_LOCAL_JWT_SECRET`（HMAC-SHA256）**で署名される。
+- 検証で署名鍵を知っていれば任意クレームのトークンを生成可能 — 本診断でも、鍵を用いて `org=2, scopes=[…]` のサービストークンを偽造し `/api/invoices` が 200 を返すことを確認（= 鍵漏洩時はクロス組織のサービスアクセスを含むフル侵害）。
+- `jti`/失効リスト/ローテーションがなく、ログアウト/失効 API もない（ステートレス）。盗まれたトークンは `exp`（1 時間）まで有効で取り消せない。
+
+**推奨**: シークレットの厳格な管理（F-1 の `.env` 露出と複合するとクリティカル）、人/サービスで鍵分離 or 鍵 ID(`kid`) によるローテーション、機微操作向けの短い有効期限、必要に応じ失効リスト。
+
+### F-5 [Info] HSTS ヘッダなし
+`Strict-Transport-Security` 不在。TLS をリバースプロキシで終端する構成なら、そのプロキシ側で付与を推奨。
+
+### F-6 [Info] Problem Details `type` の host 不一致
+404 応答が `https://nene2.dev/problems/not-found`（フレームワーク既定）を返し、アプリの `https://nene-invoice.dev/problems/...` と混在。情報漏洩ではないが一貫性のため統一を推奨。
+
+---
+
+## 検証済み（堅牢と確認できた防御）
+
+### マルチテナント分離（ADR 0006）— **完全**
+SQL レベルで `organization_id` が強制され、組織間アクセスはすべて遮断:
+
+| 攻撃 | 結果 |
+|---|---|
+| admin-a が org-B の `GET /admin/invoices/2` | **404** `invoice-not-found` |
+| admin-a が org-B の `GET /admin/clients/2` | **404** |
+| admin-a が org-B の `GET /admin/users/3` / `DELETE` | **404** |
+| admin-a が org-B の `GET /admin/invoices/2/payments` | **404** |
+| 一覧（clients / invoices） | 自組織のみ返却（各 1 件） |
+| admin-B のトークンで org-a アプリへ | **403** `organization-mismatch`（OrgGuard） |
+| client 作成時に `organization_id:2` / `id:999` を注入 | **org=1 に強制**（mass-assignment 無効、DB 確認済み） |
+
+### 認証（JWT）— **堅牢**
+| 攻撃 | 結果 |
+|---|---|
+| トークンなし / 不正文字列 | **401** |
+| 署名改ざん | **401** |
+| `alg=none` で superadmin 偽造 | **401** |
+| 誤シークレット署名 | **401** |
+| 有効署名だが期限切れ | **401** |
+
+### 認可 / 権限昇格 — **堅牢**
+- member → `POST /admin/users` **403**、`GET /admin/audit-logs` **403**
+- viewer → `POST /admin/clients`（書込）**403**（read は 200）
+- admin → `GET /admin/organizations` **403**（superadmin 専用）、superadmin → **200**
+- admin が `role=superadmin` のユーザ作成 → **403/422** `role-not-assignable`
+- 自分自身の削除 → **409** `cannot-delete-self`
+- ロールモデル（member=請求オペレータ／viewer=読取専用）が一貫して強制
+
+### サービス API（`/api/*`）— **堅牢**
+- 人間トークン（scopes なし）→ **403** `insufficient-scope`
+- トークンなし → **401**
+
+### インジェクション — **堅牢**（全て PDO プリペアド）
+- ログイン email に `' OR '1'='1` → **401**（バイパスなし）
+- client 名に `'; DROP TABLE users;--` → 文字列として保存、`users` テーブル健在（DROP 不発）
+- `?limit` への UNION 注入 → int キャストで無効化
+
+### 入力検証 / 業務ロジック — **堅牢**
+- 負の入金額 → **422** `validation-failed`
+- 残高超過入金 → **422** `payment-exceeds-outstanding`
+- 整数オーバーフロー額 → **422**（クラッシュなし）
+- 発行済み請求書の再発行 → **422**
+- 深いネスト JSON（5000 段）→ **422**（json_decode depth で安全に拒否）
+
+### エラーハンドリング / ヘッダ / その他 — **良好**
+- `APP_DEBUG=false`：不正 JSON・404・型不一致いずれもクリーンな Problem Details、**スタックトレース/パス漏洩なし**（インストーラを除く）
+- セキュリティヘッダ: `Content-Security-Policy: default-src 'self'` / `X-Frame-Options: SAMEORIGIN` / `X-Content-Type-Options: nosniff` / `Referrer-Policy` / `Permissions-Policy`
+- CORS: 不正 Origin を反映しない（`Access-Control-Allow-Origin` 非出力）
+- 公開ダウンロードトークン: 32 byte 乱数・SHA-256 ハッシュ保管・推測不可、未定義トークンは **404**、クロス組織の発行は **404**
+- HTTP メソッド: 未定義メソッドは **405**、`TRACE` **405**（XST 不可）、`.env`/`.git`/`composer.json` は **404**
+
+---
+
+## 再現環境（参考）
+
+```
+docs/security/harness/
+├── Dockerfile           # php:8.4-apache + pdo_mysql + rewrite
+├── docker-compose.yml   # app:18090 / db:13309（既存コンテナと非衝突）
+├── .env.app.example     # mysql 接続 + ORG_SLUG=org-a の雛形（実体は .gitignore）
+└── seed.sql             # 2 組織・5 ユーザ・client/invoice/company_settings
+```
+
+起動: `cd docs/security/harness && docker compose up -d --build` ／ 解体: `docker compose -p nene-invoice-sectest down -v`
+
+> 実シークレット（.env.app）・取得トークンは .gitignore 済み（非コミット）。コミットされる値はテスト専用の使い捨て。
+
+---
+
+## 結論と優先対応
+
+アプリケーションのコア（テナント分離・認証認可・検証・インジェクション耐性）は**設計通り堅牢**で、既存のユニット/E2E テスト群と整合する高い品質。残課題は主に**デプロイ/運用の固め**:
+
+1. **最優先 F-1**: インストーラを配備 Web ルートから除外 or 自動削除し、DB 既存データによる二重ガードを追加。
+2. **次点 F-2**: ログインのレート制限/ロックアウトを実装。
+3. **推奨 F-3〜F-6**: バージョン秘匿、JWT 鍵運用・有効期限見直し、HSTS、Problem Details host 統一。

--- a/docs/security/2026-05-31-assessment-round2.md
+++ b/docs/security/2026-05-31-assessment-round2.md
@@ -1,0 +1,169 @@
+# NeNe Invoice — セキュリティ診断レポート（第2ラウンド / 深掘り）
+
+- **対象**: NeNe Invoice API（NENE2 PHP 8.4 + MySQL）
+- **実施日**: 2026-05-31
+- **位置づけ**: 第1ラウンド（`security-assessment-2026-05-31.md`）で OWASP 主要カテゴリを網羅。本ラウンドは**より深く・創造的な攻撃面**（JWT 検証の内部挙動・型混同・業務/会計ロジック・サービストークン・PDF・パス細工・状態管理）を狙い、コード解析と実地攻撃を併用。
+- **環境**: 同一ローカル Docker（`http://localhost:18090`、MySQL `13309`、org-a/org-b 2 組織シード）
+
+> ⚠️ 認可された自己所有アプリ・隔離環境での検証。破壊的操作は行わず、到達性・分離・ロジックの確認に限定。
+
+---
+
+## エグゼクティブサマリ
+
+第1ラウンドで確認した**コア防御（テナント分離・認証・認可・インジェクション耐性・価格改ざん）は深掘りでも一切破れず**、サービストークンのテナント/スコープ分離、PDF のクロス組織遮断・出力エスケープ、パス細工耐性なども堅牢でした。
+
+一方、**状態管理と会計ロジックの整合性**に新たな指摘が複数見つかりました（直接の権限奪取には至らないが、会計データの正確性・アカウント無効化の実効性に関わる）。
+
+| # | 深刻度 | 項目 |
+|---|--------|------|
+| R2-1 | **Medium** | ログインが利用者 `status` を無視 → 無効化/招待中ユーザもログイン・操作可能 |
+| R2-2 | **Medium** | 承認済み見積を**何度でも請求書に変換可能** → 請求書の重複生成（会計整合性） |
+| R2-3 | Low–Medium | 管理API の入金記録が**冪等でない**（`idempotency_key` を無視）→ 再送で二重計上 |
+| R2-4 | Low–Medium | 不正な `paid_at` で **HTTP 500**（未処理例外 / 入力検証漏れ。トレース漏洩はなし） |
+| R2-5 | Low | 入金日 `paid_at` の**バックデート/未来日**が無制限（1990/2999 を受理） |
+| R2-6 | Info / Hardening | JWT verifier: `exp` 欠落/非整数で**無期限化**、OrgGuard が `org=null` を role 無確認で superadmin 扱い（いずれも secret 依存） |
+| R2-7 | Info | API が生 HTML を保存・JSON でそのまま返却（PDF/React は出力時にエスケープ済 → 現状悪用不可） |
+
+---
+
+## 検出された問題（Findings）
+
+### R2-1 [Medium] ログインが利用者 `status` を検証しない
+
+`status` を `disabled` / `invited` に設定したユーザでもログインが成功し、発行トークンが**実際に通る**ことを確認:
+
+```
+disabled@a.test でログイン -> token 発行
+  そのトークンで GET /admin/me       -> 200
+  そのトークンで GET /admin/invoices -> 200   ← 無効化が無意味
+invited@a.test  でログイン -> token 発行（同様）
+```
+
+`src/Auth/LoginUseCase.php` は資格情報（`password_verify`）のみ検証し、`status === 'active'` のチェックがない。加えて JWT はステートレスのため、**無効化操作は既発行トークンを失効させない**（`exp`=1h まで有効）。
+
+**影響**: 退職者・停止アカウント・未アクティベートの招待ユーザが認証・操作を継続できる。
+**推奨**: ログイン時に `status === 'active'` を必須化（非アクティブは `invalid-credentials` 相当で拒否）。重要操作では DB の現行ステータス/失効リストを参照する設計を検討。
+
+### R2-2 [Medium] 承認済み見積を複数回 請求書化できる（重複請求書）
+
+同一見積を 3 回変換すると **3 件の請求書が生成**され、見積は `accepted` のまま再変換可能:
+
+```
+POST /admin/quotes/1/convert ×3 -> 201 / 201 / 201
+invoices(quote_id=1): id 6,7,8（いずれも draft, total 5500）
+quotes(1).status = accepted（変換後も不変）
+```
+
+発行（issue）には「発行済みは再発行不可（422）」のガードがあるのに対し、**変換（convert）には重複防止ガードがない**。生成物は draft（未採番）だが、二重に issue されれば**重複請求・採番浪費・会計記録の重複**に直結する。会計コンプライアンス（`docs/explanation/accounting-compliance.md`）を重視する本製品では要対処。
+
+**推奨**: 変換は 1 回限りにする（変換成立で見積を `converted` 等の終端状態へ遷移、または `quote_id` に紐づく invoice 存在時は再変換を拒否）。
+
+### R2-3 [Low–Medium] 管理API の入金記録が冪等でない
+
+`src/Payment/RecordPaymentUseCase.php` は `idempotencyKey` による重複排除を実装しているが、**管理ハンドラ `RecordPaymentHandler` は body の `idempotency_key` を読まずに `RecordPaymentInput(...)` を生成**（第5引数 null 既定）。一方サービスAPI `RecordServicePaymentHandler` は `idempotency_key` を必須にしている。
+
+```
+admin: POST /admin/invoices/1/payments {amount_cents:500, idempotency_key:"same"} ×3
+  -> payments 3 → 6（+3 すべて作成、DB の idempotency_key は全て NULL）
+```
+
+**影響**: ネットワーク再送・二重送信で**入金が二重計上**され、請求書の入金状態・会計残高が破綻しうる（フロントの確認ダイアログは緩和に留まる）。
+**推奨**: 管理ハンドラでも `idempotency_key`（または `Idempotency-Key` ヘッダ）を受理し UseCase の重複排除へ渡す。
+
+### R2-4 [Low–Medium] 不正な `paid_at` で HTTP 500
+
+```
+POST /admin/invoices/1/payments {amount_cents:100, paid_at:"not-a-date"} -> 500
+```
+
+不正日付文字列が検証されずに処理され、未処理例外として 500 になる（応答本文はクリーンな Problem Details で**スタックトレース/パスの漏洩はなし**＝ APP_DEBUG=false は適切に機能）。検証漏れ・堅牢性の問題。
+**推奨**: `paid_at` を入力検証（ISO 日付パース失敗は 422 validation-failed）。
+
+### R2-5 [Low] 入金日のバックデート/未来日が無制限
+
+```
+paid_at = 1990-01-01 -> 201（受理）
+paid_at = 2999-12-31 -> 201（受理）
+```
+
+過去・未来の任意日付を受理。正当な遡及記録もあるが、税務/会計の期間整合の観点では妥当範囲のガード（例: 請求書発行日〜現在＋猶予）を推奨。
+
+### R2-6 [Info / Hardening] JWT verifier の堅牢性（secret 依存）
+
+HMAC シークレットを用いた検証で以下を確認（いずれも**鍵を知らないと悪用不可**＝第1ラウンド F-4 を増幅する多層防御課題）:
+
+| 細工（正しい署名）| 結果 | 含意 |
+|---|---|---|
+| `exp` クレーム無し | **200** | `exp` 不在時は期限チェックをスキップ → **無期限トークン** |
+| `exp` が文字列/浮動小数 | **200** | `is_int($exp)` 条件のため非整数 exp は期限チェックを回避 |
+| `org:null` + `role:admin` | **200** | OrgGuard は `org===null` を**役割無確認で superadmin 扱い**し org チェックを免除 |
+| `org:"1"`（文字列）| **403** | `is_int` で正しく拒否（堅牢） |
+| `alg:"NONE"` / `"hs256"` | **401** | 大小/別名は厳格拒否（堅牢） |
+
+**推奨**: verifier は `exp` を**必須かつ整数**として検証（欠落/非整数は無効扱い）。OrgGuard の superadmin 免除は `org===null` だけでなく `role==='superadmin'` も確認。鍵は人間/サービスで分離・ローテーション可能に（F-4）。
+
+### R2-7 [Info] API が生 HTML を保存・返却
+
+`name = "<script>alert(1)</script>"` が**生のまま保存・JSON 応答にも生で出現**。ただし:
+- **PDF 出力**: 生成 PDF に生の `<script>` / `<b>` は**含まれず（エスケープ済）**を確認（`application/pdf`, 31KB）。
+- フロント（React）は描画時に自動エスケープ。
+
+→ 現行の描画経路では悪用不可。JSON API として「保存は生・出力でエスケープ」は許容方針だが、**将来 CSV/Excel エクスポートや別レンダラを追加する際は数式/HTML インジェクションに注意**（`=cmd|...` 等）。
+
+---
+
+## 第2ラウンドで再確認した堅牢性
+
+| 攻撃面 | 結果 |
+|---|---|
+| サービストークンのテナント分離 | read:invoices(org1) → `/api/invoices/2` **404**、`/api/clients/2` **404** |
+| サービストークンのスコープ | read のみで `POST payment`（write必要）**403**、空/ワイルドカード scope **403** |
+| PDF クロス組織 | admin-a → `/admin/invoices/2/pdf` **404**、自org **200** |
+| PDF 出力エスケープ | `<script>`/`<b>` を生で含まず（HTML インジェクション不可） |
+| パス/ルート細工 | 大文字 **404** / 末尾スラッシュ **404** / `..`・二重符号化 **404/403** / DL token トラバーサル **404** |
+| `X-Original-URL` で capability 迂回 | **403**（実パスで判定、迂回不可） |
+| 価格改ざん | クライアント `total_cents` 無視・サーバ再計算（110000）、税率 5000bps **422**、負数量/単価 **422** |
+| 他orgの client 参照で請求書作成 | **422** |
+| ページング | `limit` は **100 に丸め**、負/0/巨大値も安全、HPP（`?limit=1&limit=999999`）→ 100 |
+| 重複 JSON キー | 安全（422） |
+| 型ジャグリング | email/password/name を配列/真偽/オブジェクトに → **422** |
+| DoS 耐性 | 100K 文字入力・長大 registration_number → 401/422（ReDoS/ハングなし） |
+| エラー処理 | 500 でも Problem Details のみ・**トレース/パス漏洩なし**（APP_DEBUG=false） |
+
+---
+
+## 総括
+
+第2ラウンドの深掘りでも、**機密性に関わるコア防御（テナント分離・認証・認可・インジェクション・価格改ざん）は突破不能**であることを再確認しました。新規指摘は主に **(a) アカウント無効化の実効性（R2-1）** と **(b) 会計データの整合性（R2-2 二重変換 / R2-3 入金冪等性 / R2-4,5 日付検証）** に集約されます。会計コンプライアンスを最重要とする本製品の性格上、**R2-1・R2-2 を優先**し、R2-3〜R2-5、ハードニングの R2-6 を順次対処することを推奨します。
+
+### 優先度順 対応サマリ（第1+第2ラウンド統合）
+1. **High** F-1: インストーラの Web ルート露出（配備除外/自動削除＋DB 既存データガード）
+2. **Medium** R2-1: ログイン `status` 検証 / R2-2: 見積二重変換防止 / F-2: ログインのレート制限
+3. **Low–Medium** R2-3: 入金冪等性 / R2-4: `paid_at` 検証（500→422） / R2-5: 日付範囲ガード
+4. **Info/Hardening** R2-6: JWT verifier（exp 必須・OrgGuard role 確認）/ F-3〜F-6: バージョン秘匿・鍵運用・HSTS 等
+
+---
+
+## 対応状況（Remediation, 2026-05-31）
+
+診断で確認したアプリ層の指摘はすべて修正 PR を作成・マージ済み（main）。
+
+| 指摘 | 深刻度 | 状態 | PR |
+|---|---|---|---|
+| F-1 install.php 露出 | High | ✅ 修正（DB 既存データガード追加） | #186 |
+| F-2 ログイン レート制限なし | Medium | ✅ 修正（IP 単位スロットル・429/Retry-After） | #190 |
+| R2-1 ログイン status 無視 | Medium | ✅ 修正（active 必須化） | #178 |
+| R2-2 見積の二重変換 | Medium | ✅ 修正（1見積=1請求書ガード） | #180 |
+| R2-3 入金の冪等性欠如 | Low–Med | ✅ 修正（admin で idempotency_key 受理） | #182 |
+| R2-4 不正 paid_at → 500 | Low–Med | ✅ 修正（422 検証） | #182 |
+| R2-5 paid_at 未来日 | Low | ✅ 修正（未来日拒否） | #182 |
+| R2-6 OrgGuard null-org | Info/Hard | ✅ 修正（superadmin role 必須化） | #184 |
+| F-3 バージョン開示 | Low | ✅ 修正（X-Powered-By 除去） | #188 |
+| F-5 HSTS | Info | ✅ 部分対応（.htaccess best-effort、TLS 終端は proxy 責務） | #188 |
+
+### フレームワーク/デプロイ層（アプリ修正対象外・文書化のみ）
+- **F-4 / R2-6（JWT verifier）**: `exp` 必須化・人/サービス鍵分離・失効リストは vendor (nene2 `LocalBearerTokenVerifier`) とインフラの責務。OrgGuard 側の多層防御は #184 で強化済み。
+- **F-6 Problem Details host**: 404 の `nene2.dev` はフレームワーク既定（vendor）。
+- **R2-7 生 HTML 保存**: PDF/React とも出力時にエスケープ済で悪用不可（現状変更不要）。
+- **Server ヘッダ秘匿・TLS HSTS**: web サーバ/リバースプロキシ設定。

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,37 @@
+# セキュリティ診断履歴
+
+NeNe Invoice に対して実施したセキュリティ診断（認可された自己診断）の記録です。
+
+## 診断レポート
+
+| 日付 | レポート | 概要 |
+| --- | --- | --- |
+| 2026-05-31 | [Round 1](2026-05-31-assessment-round1.md) | OWASP 主要カテゴリ網羅（認証・テナント分離・認可・インジェクション・ヘッダ等） |
+| 2026-05-31 | [Round 2](2026-05-31-assessment-round2.md) | 深掘り（JWT 検証内部・型混同・会計ロジック・サービストークン・PDF・状態管理）＋対応状況 |
+
+各レポートは Finding（深刻度／証拠／推奨）、検証済みの堅牢性、Remediation（対応 PR）を含みます。Round 2 末尾の対応状況表に、各指摘の修正 PR（#178〜#190）を記載しています。
+
+## 再現ハーネス
+
+[`harness/`](harness/) に、診断に使ったローカル再現環境（Docker）と道具を収めています。バックエンドをスタブせず**実アプリを起動して**叩くための最小構成です。
+
+> ⚠️ 認可された自己所有アプリ・隔離環境での検証専用。第三者システムへの無断使用は禁止。
+
+### 実行方法
+
+```bash
+cd docs/security/harness
+cp .env.app.example .env.app
+# .env.app の NENE2_LOCAL_JWT_SECRET を生成して設定:
+#   php -r "echo bin2hex(random_bytes(32));"
+docker compose up -d --build      # app:18090 / db:13309（既存コンテナと非衝突ポート）
+
+# 動作確認
+curl -s localhost:18090/health
+
+# 解体
+docker compose -p nene-invoice-sectest down -v
+```
+
+- `mint.php` は HMAC シークレットを使った JWT 生成ツール（alg/exp/org クレームの検証用）。
+- 秘密情報（`.env.app` 実体・取得トークン・ログ）は `.gitignore` 済みでコミットしません。

--- a/docs/security/harness/.env.app.example
+++ b/docs/security/harness/.env.app.example
@@ -1,0 +1,15 @@
+APP_ENV=local
+APP_DEBUG=false
+APP_NAME="NeNe Invoice"
+PROBLEM_DETAILS_BASE_URL=https://nene-invoice.dev/problems/
+TENANT_RESOLUTION=single
+ORG_SLUG=org-a
+BASE_DOMAIN=localhost
+NENE2_LOCAL_JWT_SECRET=__GENERATE_ME__  # php -r "echo bin2hex(random_bytes(32));"
+DB_ADAPTER=mysql
+DB_NAME=nene_invoice
+DB_HOST=db
+DB_PORT=3306
+DB_USER=nene
+DB_PASSWORD=nene_pw
+DB_CHARSET=utf8mb4

--- a/docs/security/harness/.gitignore
+++ b/docs/security/harness/.gitignore
@@ -1,0 +1,6 @@
+# Local-only secrets and run artifacts — never commit.
+.env.app
+tokens.env
+pr.env
+*.log
+test-results/

--- a/docs/security/harness/Dockerfile
+++ b/docs/security/harness/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:8.4-apache
+RUN docker-php-ext-install pdo_mysql >/dev/null 2>&1 && a2enmod rewrite
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+ && sed -ri -e 's!AllowOverride None!AllowOverride All!g' /etc/apache2/apache2.conf

--- a/docs/security/harness/README.md
+++ b/docs/security/harness/README.md
@@ -1,0 +1,47 @@
+# セキュリティ診断 再現ハーネス
+
+実アプリ（PHP 8.4 + MySQL）をローカル Docker で起動し、セキュリティ検証を行うための最小構成。
+2 組織・複数ロールのユーザをシードし、テナント分離・認可・認証・業務ロジックを実地で叩けます。
+
+> ⚠️ 認可された自己所有アプリ・隔離環境での検証専用。シークレット類は使い捨て。
+
+## 構成
+
+| ファイル | 役割 |
+| --- | --- |
+| `Dockerfile` | `php:8.4-apache` + `pdo_mysql` + rewrite、docroot=`public_html` |
+| `docker-compose.yml` | `app`(:18090) と `db`(:13309)。リポジトリをマウントし `.env.app` を上書き |
+| `seed.sql` | 2 組織 / admin・member・viewer・superadmin / client・invoice・company_settings |
+| `.env.app.example` | アプリ設定の雛形（**JWT シークレットは要生成**） |
+| `mint.php` | HMAC 署名の JWT 生成（`php mint.php '<payload-json>' '<secret>'`） |
+
+シードユーザのパスワードはいずれも `Passw0rd!23`（テスト専用）。
+
+## 起動
+
+```bash
+cp .env.app.example .env.app
+php -r "echo bin2hex(random_bytes(32));"   # → .env.app の NENE2_LOCAL_JWT_SECRET に設定
+docker compose up -d --build
+curl -s localhost:18090/health
+```
+
+## 例: ログインしてトークン取得
+
+```bash
+curl -s -X POST localhost:18090/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin-a@a.test","password":"Passw0rd!23"}'
+```
+
+## 解体
+
+```bash
+docker compose -p nene-invoice-sectest down -v
+```
+
+## 注意
+
+- `docker-compose.yml` / `seed.sql` 内の DB パスワード等は**ローカル使い捨て**。本番値ではありません。
+- `.env.app`（実シークレット）・`tokens.env`・`*.log` は `.gitignore` 済み。
+- ポート 18090 / 13309 は診断時の空きポート。衝突する場合は compose を調整してください。

--- a/docs/security/harness/docker-compose.yml
+++ b/docs/security/harness/docker-compose.yml
@@ -1,0 +1,29 @@
+name: nene-invoice-sectest
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpw
+      MYSQL_DATABASE: nene_invoice
+      MYSQL_USER: nene
+      MYSQL_PASSWORD: nene_pw
+    ports: ["13309:3306"]
+    volumes:
+      - ../../../database/schema/mysql/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./seed.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-prootpw"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports: ["18090:80"]
+    volumes:
+      - ../../..:/var/www/html
+      - ./.env.app:/var/www/html/.env:ro
+    depends_on:
+      db:
+        condition: service_healthy

--- a/docs/security/harness/mint.php
+++ b/docs/security/harness/mint.php
@@ -1,0 +1,10 @@
+<?php
+// usage: php mint.php '<payload-json>' '<secret>'  [optional: '<header-json>']
+$payload = $argv[1];
+$secret  = $argv[2];
+$headerJson = $argv[3] ?? '{"typ":"JWT","alg":"HS256"}';
+$b64 = static fn(string $s): string => rtrim(strtr(base64_encode($s), '+/', '-_'), '=');
+$h = $b64($headerJson);
+$p = $b64($payload);
+$sig = $b64(hash_hmac('sha256', "$h.$p", $secret, true));
+echo "$h.$p.$sig";

--- a/docs/security/harness/seed.sql
+++ b/docs/security/harness/seed.sql
@@ -1,0 +1,20 @@
+USE nene_invoice;
+SET @now = '2026-05-31 00:00:00';
+INSERT INTO organizations (id,name,slug,plan,is_active,created_at,updated_at) VALUES
+ (1,'Org A','org-a','free',1,@now,@now),
+ (2,'Org B','org-b','free',1,@now,@now);
+INSERT INTO users (id,email,password_hash,role,organization_id,status,created_at,updated_at) VALUES
+ (1,'admin-a@a.test','$2y$12$kJCvSpCNb0BlWYERWSoRBuqGOjY3jYaEJyjtz.CiwyKyrTIoyRWlu','admin',1,'active',@now,@now),
+ (2,'member-a@a.test','$2y$12$kJCvSpCNb0BlWYERWSoRBuqGOjY3jYaEJyjtz.CiwyKyrTIoyRWlu','member',1,'active',@now,@now),
+ (3,'admin-b@b.test','$2y$12$kJCvSpCNb0BlWYERWSoRBuqGOjY3jYaEJyjtz.CiwyKyrTIoyRWlu','admin',2,'active',@now,@now),
+ (4,'root@root.test','$2y$12$kJCvSpCNb0BlWYERWSoRBuqGOjY3jYaEJyjtz.CiwyKyrTIoyRWlu','superadmin',NULL,'active',@now,@now),
+ (5,'viewer-a@a.test','$2y$12$kJCvSpCNb0BlWYERWSoRBuqGOjY3jYaEJyjtz.CiwyKyrTIoyRWlu','viewer',1,'active',@now,@now);
+INSERT INTO clients (id,organization_id,name,contact_name,email,created_at,updated_at) VALUES
+ (1,1,'Client A1','Taro','c1@a.test',@now,@now),
+ (2,2,'Client B1 SECRET','Hanako','c1@b.test',@now,@now);
+INSERT INTO company_settings (id,organization_id,legal_name,registration_number,created_at,updated_at) VALUES
+ (1,1,'Org A KK','T1234567890123',@now,@now),
+ (2,2,'Org B KK','T9999999999999',@now,@now);
+INSERT INTO invoices (id,organization_id,client_id,status,invoice_number,is_qualified_invoice,subtotal_cents,tax_cents,total_cents,issued_at,created_at,updated_at) VALUES
+ (1,1,1,'issued','INV-2026-001',0,100000,10000,110000,@now,@now,@now),
+ (2,2,2,'issued','INV-2026-001',0,200000,20000,220000,@now,@now,@now);


### PR DESCRIPTION
## 概要
Closes #191

2026-05-31 に実施した認可済みセキュリティ診断（第1/第2ラウンド）を**履歴**として `docs/security/` に記録。

## 追加内容
- `docs/security/README.md` — 索引（レポート一覧・実行方法）
- `docs/security/2026-05-31-assessment-round1.md` / `-round2.md` — 診断レポート（Finding・検証済み堅牢性・Remediation 表 #178〜#190）
- `docs/security/harness/` — 再現用 Docker 構成・`seed.sql`・`mint.php`（JWT 生成）・`.env.app.example`・README

## セキュリティ配慮
- **実 JWT シークレットは `.env.app.example` でプレースホルダ化**（`__GENERATE_ME__`）。
- `.env.app`（実体）・`tokens.env`・`*.log` は `harness/.gitignore` で除外。
- 実シークレット/実トークン文字列がコミットに含まれないことを確認済み。
- compose 内のローカル DB パスワードは使い捨て（README に明記）。

## 検証
- [x] `docker compose config` が新パスで解決
- [x] 実シークレット/トークンの混入なし（grep 確認）
- [x] `composer check` green（docs は cs/phpstan 対象外、263 tests 回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)