### PR TITLE
feat(dashboard): ダッシュボード集計に当月入金額・前月比・売掛金エイジングを追加する (#210)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -94,6 +94,8 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Issuer fields | `legal_name`, `bank_name`, `bank_branch`, `account_type`, `account_number`, `logo_url` | `company_name`, `branch`, `acct_no` |
 | Client fields | `contact_name`, `billing_address` | `contact`, `address` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
+| Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents` | `monthly_received_cents`, `received_this_month`, `mtd_cents` |
+| Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
 the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1198,7 +1198,29 @@ components:
           description: Up to 5 most recent unpaid invoices, newest first.
           items:
             $ref: '#/components/schemas/Invoice'
-      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid]
+        received_this_month_cents:
+          type: integer
+          description: Sum of non-void payments received in the current month (paid_at based), in cents.
+        received_last_month_cents:
+          type: integer
+          description: Sum of non-void payments received in the previous month, in cents (for month-over-month comparison).
+        aging:
+          $ref: '#/components/schemas/ReceivableAging'
+      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid, received_this_month_cents, received_last_month_cents, aging]
+    ReceivableAging:
+      type: object
+      description: Outstanding receivable balance bucketed by overdue age, in cents.
+      properties:
+        current:
+          type: integer
+          description: Not yet due (due_at null or in the future), in cents.
+        overdue_1_30:
+          type: integer
+          description: Overdue by 1–30 days, in cents.
+        overdue_31_plus:
+          type: integer
+          description: Overdue by 31 days or more, in cents.
+      required: [current, overdue_1_30, overdue_31_plus]
     CompanySettings:
       type: object
       description: Issuer (自社) profile. registration_number is `T` + 13 digits.

--- a/src/Dashboard/DashboardSummary.php
+++ b/src/Dashboard/DashboardSummary.php
@@ -12,12 +12,18 @@ use NeneInvoice\Invoice\Invoice;
  */
 final readonly class DashboardSummary
 {
-    /** @param list<Invoice> $recentUnpaid */
+    /**
+     * @param list<Invoice>                                                $recentUnpaid
+     * @param array{current: int, overdue_1_30: int, overdue_31_plus: int} $aging outstanding receivable bucketed by overdue age, in cents
+     */
     public function __construct(
         public int $unpaidCount,
         public int $overdueCount,
         public int $outstandingTotalCents,
         public array $recentUnpaid,
+        public int $receivedThisMonthCents,
+        public int $receivedLastMonthCents,
+        public array $aging,
     ) {
     }
 }

--- a/src/Dashboard/GetDashboardHandler.php
+++ b/src/Dashboard/GetDashboardHandler.php
@@ -51,6 +51,9 @@ final readonly class GetDashboardHandler implements RequestHandlerInterface
             'overdue_count'           => $summary->overdueCount,
             'outstanding_total_cents' => $summary->outstandingTotalCents,
             'recent_unpaid'           => $recentUnpaid,
+            'received_this_month_cents' => $summary->receivedThisMonthCents,
+            'received_last_month_cents' => $summary->receivedLastMonthCents,
+            'aging'                     => $summary->aging,
         ]);
     }
 }

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -23,16 +23,27 @@ final readonly class GetDashboardSummaryUseCase
 
     public function execute(): DashboardSummary
     {
-        $now  = (new DateTimeImmutable())->format('Y-m-d H:i:s');
-        $data = $this->invoices->getDashboardData($now);
+        // All time boundaries follow the application timezone (deploy with
+        // TZ=Asia/Tokyo), consistent with how paid_at / due_at are written.
+        $nowDt = new DateTimeImmutable();
+        $now   = $nowDt->format('Y-m-d H:i:s');
+        $data  = $this->invoices->getDashboardData($now);
 
         $outstandingTotalCents = $this->payments->outstandingTotal();
+
+        $thisMonthStart = $nowDt->format('Y-m-01 00:00:00');
+        $nextMonthStart = $nowDt->modify('first day of next month')->format('Y-m-01 00:00:00');
+        $lastMonthStart = $nowDt->modify('first day of last month')->format('Y-m-01 00:00:00');
+        $thirtyDaysAgo  = $nowDt->modify('-30 days')->format('Y-m-d H:i:s');
 
         return new DashboardSummary(
             unpaidCount: $data['unpaid_count'],
             overdueCount: $data['overdue_count'],
             outstandingTotalCents: $outstandingTotalCents,
             recentUnpaid: $data['recent_unpaid'],
+            receivedThisMonthCents: $this->payments->receivedTotalBetween($thisMonthStart, $nextMonthStart),
+            receivedLastMonthCents: $this->payments->receivedTotalBetween($lastMonthStart, $thisMonthStart),
+            aging: $this->payments->agingBuckets($now, $thirtyDaysAgo),
         );
     }
 }

--- a/src/Payment/PaymentRepositoryInterface.php
+++ b/src/Payment/PaymentRepositoryInterface.php
@@ -51,4 +51,19 @@ interface PaymentRepositoryInterface
      * @return list<array{invoice_number: string, client_name: string, paid_at: string, amount_cents: int, method: string, note: string}>
      */
     public function findValidForExport(): array;
+
+    /**
+     * Sum of non-void payment amounts (cents) with paid_at in [$startInclusive, $endExclusive).
+     * Used for the dashboard's monthly received total. Org-scoped.
+     */
+    public function receivedTotalBetween(string $startInclusive, string $endExclusive): int;
+
+    /**
+     * Outstanding receivable (sum invoice.total_cents - non-void payments, per invoice, floored at 0)
+     * bucketed by overdue age, in cents, across issued / partially_paid invoices. Org-scoped.
+     * Buckets: current (due_at null or >= now), 1–30 days overdue, 31+ days overdue.
+     *
+     * @return array{current: int, overdue_1_30: int, overdue_31_plus: int}
+     */
+    public function agingBuckets(string $now, string $thirtyDaysAgo): array;
 }

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -159,6 +159,46 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         ], $rows);
     }
 
+    public function receivedTotalBetween(string $startInclusive, string $endExclusive): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COALESCE(SUM(amount_cents), 0) AS total
+             FROM payments
+             WHERE organization_id = ? AND is_deleted = 0 AND paid_at >= ? AND paid_at < ?',
+            [$this->orgId->get(), $startInclusive, $endExclusive],
+        );
+
+        return $row !== null ? (int) $row['total'] : 0;
+    }
+
+    public function agingBuckets(string $now, string $thirtyDaysAgo): array
+    {
+        // Per-invoice net outstanding (total - non-void payments), then bucket the
+        // positive remainder by how far past due_at the invoice is.
+        $row = $this->query->fetchOne(
+            'SELECT
+                COALESCE(SUM(CASE WHEN t.due_at IS NULL OR t.due_at >= ? THEN t.net ELSE 0 END), 0) AS current,
+                COALESCE(SUM(CASE WHEN t.due_at < ? AND t.due_at >= ? THEN t.net ELSE 0 END), 0) AS overdue_1_30,
+                COALESCE(SUM(CASE WHEN t.due_at < ? THEN t.net ELSE 0 END), 0) AS overdue_31_plus
+             FROM (
+                SELECT i.id, i.due_at,
+                       i.total_cents - COALESCE(SUM(CASE WHEN p.is_deleted = 0 THEN p.amount_cents ELSE 0 END), 0) AS net
+                FROM invoices i
+                LEFT JOIN payments p ON p.invoice_id = i.id
+                WHERE i.organization_id = ? AND i.is_deleted = 0 AND i.status IN (\'issued\', \'partially_paid\')
+                GROUP BY i.id, i.due_at, i.total_cents
+             ) t
+             WHERE t.net > 0',
+            [$now, $now, $thirtyDaysAgo, $thirtyDaysAgo, $this->orgId->get()],
+        );
+
+        return [
+            'current'         => $row !== null ? (int) $row['current'] : 0,
+            'overdue_1_30'    => $row !== null ? (int) $row['overdue_1_30'] : 0,
+            'overdue_31_plus' => $row !== null ? (int) $row['overdue_31_plus'] : 0,
+        ];
+    }
+
     /** @param array<string, mixed> $row */
     private function mapRow(array $row): Payment
     {

--- a/tests/Dashboard/GetDashboardHandlerTest.php
+++ b/tests/Dashboard/GetDashboardHandlerTest.php
@@ -51,6 +51,9 @@ final class GetDashboardHandlerTest extends TestCase
         self::assertSame(0, $body['overdue_count']);
         self::assertSame(0, $body['outstanding_total_cents']);
         self::assertSame([], $body['recent_unpaid']);
+        self::assertSame(0, $body['received_this_month_cents']);
+        self::assertSame(0, $body['received_last_month_cents']);
+        self::assertSame(['current' => 0, 'overdue_1_30' => 0, 'overdue_31_plus' => 0], $body['aging']);
     }
 
     public function test_returns_correct_counts_with_invoices(): void

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -15,6 +15,8 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 {
     private InMemoryInvoiceRepository $invoices;
 
+    private InMemoryPaymentRepository $payments;
+
     private GetDashboardSummaryUseCase $useCase;
 
     protected function setUp(): void
@@ -22,7 +24,8 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $holder = new \Nene2\Http\RequestScopedHolder();
         $holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($holder);
-        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, new InMemoryPaymentRepository($holder));
+        $this->payments = new InMemoryPaymentRepository($holder);
+        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, $this->payments);
     }
 
     public function test_empty_organization_returns_zeros(): void
@@ -33,6 +36,19 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         self::assertSame(0, $summary->overdueCount);
         self::assertSame(0, $summary->outstandingTotalCents);
         self::assertCount(0, $summary->recentUnpaid);
+        self::assertSame(0, $summary->receivedThisMonthCents);
+        self::assertSame(0, $summary->receivedLastMonthCents);
+        self::assertSame(['current' => 0, 'overdue_1_30' => 0, 'overdue_31_plus' => 0], $summary->aging);
+    }
+
+    public function test_received_this_month_sums_current_month_payments(): void
+    {
+        $thisMonth = date('Y-m-15 12:00:00');
+        $this->payments->save(new \NeneInvoice\Payment\Payment(organizationId: 1, invoiceId: 1, amountCents: 4200, paidAt: $thisMonth));
+
+        $summary = $this->useCase->execute();
+
+        self::assertSame(4200, $summary->receivedThisMonthCents);
     }
 
     public function test_counts_unpaid_invoices(): void

--- a/tests/Payment/ExportPaymentsCsvUseCaseTest.php
+++ b/tests/Payment/ExportPaymentsCsvUseCaseTest.php
@@ -121,6 +121,15 @@ final class ExportPaymentsCsvUseCaseTest extends TestCase
             {
                 return 0;
             }
+            public function receivedTotalBetween(string $startInclusive, string $endExclusive): int
+            {
+                return 0;
+            }
+            /** @return array{current: int, overdue_1_30: int, overdue_31_plus: int} */
+            public function agingBuckets(string $now, string $thirtyDaysAgo): array
+            {
+                return ['current' => 0, 'overdue_1_30' => 0, 'overdue_31_plus' => 0];
+            }
         };
     }
 }

--- a/tests/Payment/PdoPaymentRepositoryTest.php
+++ b/tests/Payment/PdoPaymentRepositoryTest.php
@@ -17,6 +17,7 @@ final class PdoPaymentRepositoryTest extends TestCase
     /** @var RequestScopedHolder<int> */
     private RequestScopedHolder $orgId;
     private PdoPaymentRepository $repository;
+    private \PDO $pdo;
 
     protected function setUp(): void
     {
@@ -34,13 +35,43 @@ final class PdoPaymentRepositoryTest extends TestCase
         $factory = new PdoConnectionFactory($config);
         $pdo = $factory->create();
 
-        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/payments.sql');
-        self::assertIsString($schema);
-        $pdo->exec($schema);
+        foreach (['payments', 'invoices'] as $table) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . "/database/schema/{$table}.sql");
+            self::assertIsString($schema);
+            $pdo->exec($schema);
+        }
 
+        $this->pdo   = $pdo;
         $this->orgId = new RequestScopedHolder();
         $this->orgId->set(1);
         $this->repository = new PdoPaymentRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
+    }
+
+    /** Inserts an invoice row directly (the payment repo cannot create invoices). */
+    private function insertInvoice(
+        int $id,
+        int $organizationId,
+        string $status,
+        int $totalCents,
+        ?string $dueAt,
+    ): void {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO invoices (id, organization_id, client_id, status, is_qualified_invoice, due_at, subtotal_cents, tax_cents, total_cents, is_deleted, created_at, updated_at)
+             VALUES (?, ?, 1, ?, 0, ?, ?, 0, ?, 0, ?, ?)',
+        );
+        $now = '2026-05-29 00:00:00';
+        $stmt->execute([$id, $organizationId, $status, $dueAt, $totalCents, $totalCents, $now, $now]);
+    }
+
+    /** Inserts a payment row directly with an explicit organization (the repo forces org from the holder). */
+    private function insertPayment(int $organizationId, int $invoiceId, int $amountCents, string $paidAt, bool $isDeleted): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
+        );
+        $now = '2026-05-29 00:00:00';
+        $stmt->execute([$organizationId, $invoiceId, $amountCents, $paidAt, $isDeleted ? 1 : 0, $now, $now]);
     }
 
     public function test_saves_and_reads_back_payments_for_invoice(): void
@@ -139,5 +170,55 @@ final class PdoPaymentRepositoryTest extends TestCase
         $voided = $this->repository->findById($id);
         self::assertNotNull($voided);
         self::assertTrue($voided->isDeleted);
+    }
+
+    public function test_received_total_between_sums_non_void_in_range_and_scopes_org(): void
+    {
+        // in range
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 1, amountCents: 1000, paidAt: '2026-05-10 09:00:00'));
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 2, amountCents: 2000, paidAt: '2026-05-31 23:59:59'));
+        // boundary: end is exclusive
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 3, amountCents: 4000, paidAt: '2026-06-01 00:00:00'));
+        // before range
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 4, amountCents: 8000, paidAt: '2026-04-30 23:59:59'));
+        // other org (raw insert: the repo forces organization_id from the holder)
+        $this->insertPayment(2, 5, 9000, '2026-05-15 09:00:00', false);
+        // voided in range
+        $voidId = $this->repository->save(new Payment(organizationId: 1, invoiceId: 6, amountCents: 500, paidAt: '2026-05-20 09:00:00'));
+        $this->repository->markVoided($voidId);
+
+        $total = $this->repository->receivedTotalBetween('2026-05-01 00:00:00', '2026-06-01 00:00:00');
+
+        self::assertSame(3000, $total);
+    }
+
+    public function test_aging_buckets_split_outstanding_by_overdue_age(): void
+    {
+        // now reference for the assertion: 2026-05-31, thirtyDaysAgo: 2026-05-01
+        $now          = '2026-05-31 12:00:00';
+        $thirtyDaysAgo = '2026-05-01 12:00:00';
+
+        // current: not yet due
+        $this->insertInvoice(1, 1, 'issued', 10000, '2026-06-30 00:00:00');
+        // current: no due date
+        $this->insertInvoice(2, 1, 'issued', 5000, null);
+        // 1–30 days overdue (due 2026-05-20, partially paid 2000 → net 6000)
+        $this->insertInvoice(3, 1, 'partially_paid', 8000, '2026-05-20 00:00:00');
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 3, amountCents: 2000, paidAt: '2026-05-21 09:00:00'));
+        // 31+ days overdue
+        $this->insertInvoice(4, 1, 'issued', 7000, '2026-03-31 00:00:00');
+        // excluded: paid invoice
+        $this->insertInvoice(5, 1, 'paid', 9999, '2026-03-01 00:00:00');
+        // excluded: fully covered net = 0
+        $this->insertInvoice(6, 1, 'issued', 3000, '2026-04-01 00:00:00');
+        $this->repository->save(new Payment(organizationId: 1, invoiceId: 6, amountCents: 3000, paidAt: '2026-04-02 09:00:00'));
+        // excluded: other org
+        $this->insertInvoice(7, 2, 'issued', 12000, '2026-03-01 00:00:00');
+
+        $aging = $this->repository->agingBuckets($now, $thirtyDaysAgo);
+
+        self::assertSame(15000, $aging['current']);          // 10000 + 5000
+        self::assertSame(6000, $aging['overdue_1_30']);      // 8000 - 2000
+        self::assertSame(7000, $aging['overdue_31_plus']);
     }
 }

--- a/tests/Support/InMemoryPaymentRepository.php
+++ b/tests/Support/InMemoryPaymentRepository.php
@@ -144,4 +144,30 @@ final class InMemoryPaymentRepository implements PaymentRepositoryInterface
     {
         return [];
     }
+
+    public function receivedTotalBetween(string $startInclusive, string $endExclusive): int
+    {
+        $total = 0;
+
+        foreach ($this->byId as $payment) {
+            if (
+                $payment->organizationId === $this->orgId->get()
+                && !$payment->isDeleted
+                && $payment->paidAt >= $startInclusive
+                && $payment->paidAt < $endExclusive
+            ) {
+                $total += $payment->amountCents;
+            }
+        }
+
+        return $total;
+    }
+
+    /** @return array{current: int, overdue_1_30: int, overdue_31_plus: int} */
+    public function agingBuckets(string $now, string $thirtyDaysAgo): array
+    {
+        // InMemory: invoices are tracked separately, so this fake returns zeros.
+        // The aging join is covered by the Pdo repository integration test.
+        return ['current' => 0, 'overdue_1_30' => 0, 'overdue_31_plus' => 0];
+    }
 }


### PR DESCRIPTION
Closes #210（バックエンド集計部分）

## 概要
ダッシュボードの read モデルを拡張。**スキーマ変更なし**、既存テーブル（`payments.paid_at` / `invoices.due_at` + 入金充当）から派生。

- `DashboardSummary` に `received_this_month_cents` / `received_last_month_cents` / `aging`（`current` / `overdue_1_30` / `overdue_31_plus`）を追加
- `PaymentRepository.receivedTotalBetween`（paid_at 範囲・非void・org スコープ）+ `agingBuckets`（請求ごとの純残高を due_at 経過日数でバケツ分け）
- `GetDashboardSummaryUseCase`: 当月/前月/30日境界を算出
- `GetDashboardHandler`: 新フィールドを JSON（snake_case）で公開
- OpenAPI に `ReceivableAging` スキーマ追加 / 用語レジストリ更新

## コンプライアンス
- integer cents（ADR 0004）、void/draft 除外、入金は `paid_at` 基準
- 月境界はアプリTZ（`TZ=Asia/Tokyo` デプロイ前提）に従う
- `docs/explanation/accounting-compliance.md` 準拠の read 派生（採番/税/PDFには非関与）

## テスト
`composer check` green（PHPUnit 288 / PHPStan lv8 / cs / OpenAPI×2 / MCP）。
Pdo repo（範囲集計・org分離・void除外・エイジング3バケツ）/ UseCase / Handler を追加・更新。ライブ確認済み。

## 関連
フロント消費（4枚目カード＋エイジング棒グラフ）は #209（トップ画面リデザイン）で実装。

## セルフレビュー
- [x] 命名: 用語レジストリと一致（terminology 更新済み）
- [x] 会計コンプラ: integer cents / void除外 / paid_at 基準
- [x] マルチテナント: 全クエリ org スコープ
- [x] テスト: repo/usecase/handler green

🤖 Generated with [Claude Code](https://claude.com/claude-code)