### PR TITLE
design(frontend): モバイルのテーブルをカード積み上げ表示にする（横スクロール解消）(#214)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -67,11 +67,13 @@ export function ListClients() {
             <tbody>
               {state.clients.map((client) => (
                 <tr key={client.id}>
-                  <td>{client.name}</td>
-                  <td>{client.contact_name ?? '—'}</td>
-                  <td>{client.email ?? '—'}</td>
-                  <td className="num">{client.registration_number ?? '—'}</td>
-                  <td className="tr">
+                  <td data-label={t('admin.clients.col.name')}>{client.name}</td>
+                  <td data-label={t('admin.clients.col.contact')}>{client.contact_name ?? '—'}</td>
+                  <td data-label={t('admin.clients.col.email')}>{client.email ?? '—'}</td>
+                  <td className="num" data-label={t('admin.clients.col.registration')}>
+                    {client.registration_number ?? '—'}
+                  </td>
+                  <td className="tr" data-label={t('admin.clients.col.actions')}>
                     <Stack direction="row" gap="sm" className="justify-end">
                       <Link
                         to={`/clients/${String(client.id)}/edit`}

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -79,12 +79,12 @@ export function ListInvoices() {
               <tbody>
                 {state.invoices.map((invoice) => (
                   <tr key={invoice.id}>
-                    <td>
+                    <td data-label={t('admin.invoices.col.number')}>
                       <Link to={`/invoices/${String(invoice.id)}`} className="num text-accent">
                         {invoice.invoice_number ?? '—'}
                       </Link>
                     </td>
-                    <td>
+                    <td data-label={t('admin.invoices.col.status')}>
                       <span className="flex items-center gap-inline-xs">
                         <Badge tone={invoiceStatusTone[invoice.status]}>
                           {t(`admin.invoices.status.${invoice.status}`)}
@@ -94,9 +94,13 @@ export function ListInvoices() {
                         )}
                       </span>
                     </td>
-                    <td className="num">{invoice.client_id}</td>
-                    <td className="tr num">{formatYen(invoice.total_cents)}</td>
-                    <td className="tr num">
+                    <td className="num" data-label={t('admin.invoices.col.client')}>
+                      {invoice.client_id}
+                    </td>
+                    <td className="tr num" data-label={t('admin.invoices.col.total')}>
+                      {formatYen(invoice.total_cents)}
+                    </td>
+                    <td className="tr num" data-label={t('admin.invoices.col.outstanding')}>
                       {invoice.outstanding_cents === null
                         ? '—'
                         : formatYen(invoice.outstanding_cents)}

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -47,18 +47,22 @@ export function ListQuotes() {
               <tbody>
                 {state.quotes.map((quote) => (
                   <tr key={quote.id}>
-                    <td>
+                    <td data-label={t('admin.quotes.col.number')}>
                       <Link to={`/quotes/${String(quote.id)}`} className="num text-accent">
                         {quote.quote_number}
                       </Link>
                     </td>
-                    <td>
+                    <td data-label={t('admin.quotes.col.status')}>
                       <Badge tone={quoteStatusTone[quote.status]}>
                         {t(`admin.quotes.status.${quote.status}`)}
                       </Badge>
                     </td>
-                    <td className="num">{quote.client_id}</td>
-                    <td className="tr num">{formatYen(quote.total_cents)}</td>
+                    <td className="num" data-label={t('admin.quotes.col.client')}>
+                      {quote.client_id}
+                    </td>
+                    <td className="tr num" data-label={t('admin.quotes.col.total')}>
+                      {formatYen(quote.total_cents)}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/features/list-users/ui/ListUsers.tsx
+++ b/frontend/src/features/list-users/ui/ListUsers.tsx
@@ -80,16 +80,16 @@ export function ListUsers() {
             <tbody>
               {state.users.map((user) => (
                 <tr key={user.id}>
-                  <td>{user.email}</td>
-                  <td>
+                  <td data-label={t('admin.users.col.email')}>{user.email}</td>
+                  <td data-label={t('admin.users.col.role')}>
                     <Badge tone={ROLE_TONE[user.role]}>{t(`admin.users.role.${user.role}`)}</Badge>
                   </td>
-                  <td>
+                  <td data-label={t('admin.users.col.status')}>
                     <Badge tone={STATUS_TONE[user.status]}>
                       {t(`admin.users.status.${user.status}`)}
                     </Badge>
                   </td>
-                  <td className="tr">
+                  <td className="tr" data-label={t('admin.users.col.actions')}>
                     <Stack direction="row" gap="sm" className="justify-end">
                       <Link to={`/users/${String(user.id)}/edit`} className="text-body text-accent">
                         {t('admin.users.editButton')}

--- a/frontend/src/features/manage-payments/ui/ManagePayments.tsx
+++ b/frontend/src/features/manage-payments/ui/ManagePayments.tsx
@@ -72,12 +72,16 @@ export function ManagePayments({ invoiceId }: ManagePaymentsProps) {
             <tbody>
               {payments.map((payment) => (
                 <tr key={payment.id}>
-                  <td className="num">{payment.paid_at}</td>
-                  <td>
+                  <td className="num" data-label={t('admin.payments.col.paidAt')}>
+                    {payment.paid_at}
+                  </td>
+                  <td data-label={t('admin.payments.col.method')}>
                     {payment.method === null ? '—' : t(`admin.payments.method.${payment.method}`)}
                   </td>
-                  <td>{payment.note ?? '—'}</td>
-                  <td className="tr num">{formatYen(payment.amount_cents)}</td>
+                  <td data-label={t('admin.payments.col.note')}>{payment.note ?? '—'}</td>
+                  <td className="tr num" data-label={t('admin.payments.col.amount')}>
+                    {formatYen(payment.amount_cents)}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/shared/ui/components/LineItemsTable.tsx
+++ b/frontend/src/shared/ui/components/LineItemsTable.tsx
@@ -32,11 +32,19 @@ export function LineItemsTable({ items }: { items: LineItemRow[] }) {
         <tbody>
           {items.map((line, index) => (
             <tr key={index}>
-              <td>{line.description}</td>
-              <td className="tr num">{line.quantity}</td>
-              <td className="tr num">{formatYen(line.unit_price_cents)}</td>
-              <td className="tr num">{formatTaxRate(line.tax_rate_bps)}</td>
-              <td className="tr num">{formatYen(line.line_subtotal_cents)}</td>
+              <td data-label={t('admin.invoices.line.description')}>{line.description}</td>
+              <td className="tr num" data-label={t('admin.invoices.line.quantity')}>
+                {line.quantity}
+              </td>
+              <td className="tr num" data-label={t('admin.invoices.line.unitPrice')}>
+                {formatYen(line.unit_price_cents)}
+              </td>
+              <td className="tr num" data-label={t('admin.invoices.line.taxRate')}>
+                {formatTaxRate(line.tax_rate_bps)}
+              </td>
+              <td className="tr num" data-label={t('admin.invoices.line.lineSubtotal')}>
+                {formatYen(line.line_subtotal_cents)}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -404,12 +404,64 @@
     .stat-num {
       font-size: 1.375rem;
     }
+    /* tables → stacked cards (no horizontal scroll) — each <td> needs data-label */
     .table-scroll {
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
+      overflow: visible;
     }
-    .table-scroll .data-table {
-      min-width: 600px;
+    .data-table {
+      display: block;
+      min-width: 0;
+    }
+    .data-table thead {
+      display: none;
+    }
+    .data-table tbody {
+      display: block;
+      width: 100%;
+    }
+    .data-table tbody tr {
+      display: block;
+      padding: 0.6875rem 0.875rem;
+      border-bottom: 1px solid var(--color-border-strong);
+    }
+    .data-table tbody tr:nth-child(even),
+    .data-table tbody tr:hover {
+      background: transparent;
+    }
+    .data-table tbody tr:last-child {
+      border-bottom: none;
+    }
+    .data-table td {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      padding: 0.3125rem 0;
+      text-align: left;
+      white-space: normal;
+      border: none !important;
+      border-bottom: 1px solid var(--color-border) !important;
+    }
+    .data-table td:last-child {
+      border-bottom: none !important;
+    }
+    .data-table td::before {
+      content: attr(data-label);
+      width: 6.5em;
+      flex: none;
+      font-size: var(--text-caption);
+      font-weight: 600;
+      color: var(--color-fg-muted);
+      text-align: left;
+    }
+    .data-table td:not([data-label]) {
+      display: none;
+    }
+    .data-table td.tr {
+      text-align: left;
+    }
+    .data-table td:first-child {
+      font-weight: 600;
+      color: var(--color-fg);
     }
     .auth-card {
       width: 100%;


### PR DESCRIPTION
Closes #214

## 概要
モバイル（≤760px）でテーブルに横スクロールバーが出る問題を、指示書 v2 に沿って **カード積み上げ表示**へ変更して解消。

## 変更
- `index.css`（@media ≤760px）: `.data-table` を block 化・`thead` 非表示・各 `tr` をカード（パディング+下罫線）・各 `td` を「ラベル＋値」行へ。ラベルは `td::before { content: attr(data-label) }`。ゼブラ/ホバー無効、数値セル左寄せ、先頭セル太字
- 横スクロール（`.table-scroll` の `overflow-x`/`min-width`）を廃止（`overflow: visible`）
- 各テーブルの `<td>` に `data-label` を付与（請求書/見積/取引先/ユーザー一覧・明細・入金）

## 確認（スクショ）
- 375px: 請求書一覧・請求書詳細（明細/入金）が横スクロールせずカード表示
- tsc 0 / vitest 127 / e2e 49 / lint・knip・prettier クリーン

## 関連
#213（モバイル対応）の改善。指示書 `/tmp/NeNe-Invoice-redesign_mobile_02/`

## 備考
作成フォームの明細入力行（Stack row）はモバイルで詰まるが横スクロールは出ない。必要なら別途縦積み化を検討（Stack の flex-row を CSS で覆すには別レイヤ対応が要るため本PRでは未対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)