### PR TITLE
feat(audit): 送付・DLトークン発行を監査ログに記録する (#222)

### DIFF
--- a/docs/adr/0008-audit-logging.md
+++ b/docs/adr/0008-audit-logging.md
@@ -48,6 +48,14 @@ A dedicated `audit_logs` table records one row per mutating operation:
   snapshots.
 - **All create / update / delete operations** record an entry. Reads are not
   audited. Soft deletes record a `*.deleted` action with the before snapshot.
+- **Non-CRUD state-changing events are also recorded** when they are
+  business-meaningful and compliance-relevant, using the same `{entity}.{verb}`
+  convention with `before = null`:
+  - `invoice.sent` — the invoice PDF was emailed to the client; `after` is the
+    sanitized invoice snapshot (proof of the content that went out).
+  - `invoice.download_token_issued` — a time-limited public download link was
+    generated; `after` carries only the non-secret `expires_at`. The raw token
+    and its SHA-256 hash are **never** written to the audit trail.
 - New domains (quotes, invoices, payments, …) record audit from the start.
 
 ## Consequences

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -188,6 +188,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, CompanySettingsRepositoryInterface::class),
                     self::resolve($c, InvoicePdfGenerator::class),
                     self::resolve($c, MailerInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
                     self::orgHolder($c),
                     (string) (getenv('MAIL_FROM_NAME') ?: 'NeNe Invoice'),
                 ),

--- a/src/Invoice/SendInvoiceEmailHandler.php
+++ b/src/Invoice/SendInvoiceEmailHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,7 +29,7 @@ final readonly class SendInvoiceEmailHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $this->useCase->execute($id);
+        $this->useCase->execute(AuthContext::userId($request), $id);
 
         return $this->psr17->createResponse(204);
     }

--- a/src/Invoice/SendInvoiceEmailUseCase.php
+++ b/src/Invoice/SendInvoiceEmailUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\Client;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettings;
@@ -33,16 +34,19 @@ final readonly class SendInvoiceEmailUseCase
         private CompanySettingsRepositoryInterface $companySettings,
         private InvoicePdfGeneratorInterface $pdfGenerator,
         private MailerInterface $mailer,
+        private AuditRecorderInterface $audit,
         private RequestScopedHolder $orgId,
         private string $fromName,
     ) {
     }
 
     /**
+     * @param int|null $actorUserId authenticated user who triggered the send (null for system)
+     *
      * @throws InvoiceNotFoundException
      * @throws InvoiceEmailException
      */
-    public function execute(int $invoiceId): void
+    public function execute(?int $actorUserId, int $invoiceId): void
     {
         $organizationId = $this->orgId->get();
 
@@ -96,5 +100,18 @@ final readonly class SendInvoiceEmailUseCase
             attachmentName: preg_replace('/[^A-Za-z0-9\-_]/', '_', $invoiceNumber) . '.pdf',
             attachmentMime: 'application/pdf',
         ));
+
+        // Audit (ADR 0008): record the send as an auditable event. `after` is the
+        // sanitized snapshot of the invoice content that was sent (proof of what
+        // went out); `before` is null because no entity state changed.
+        $this->audit->record(
+            $actorUserId,
+            $organizationId,
+            'invoice.sent',
+            'invoice',
+            $invoiceId,
+            null,
+            InvoiceResponse::toArray($invoice, $lines),
+        );
     }
 }

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -29,7 +30,7 @@ final readonly class GenerateDownloadTokenHandler implements RequestHandlerInter
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $result = $this->useCase->execute($id);
+        $result = $this->useCase->execute(AuthContext::userId($request), $id);
 
         return $this->json->create([
             'url'        => '/invoices/download/' . $result['rawToken'],

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 
 use DateTimeImmutable;
 use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 
@@ -24,15 +25,18 @@ final readonly class GenerateDownloadTokenUseCase
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private InvoiceDownloadTokenRepositoryInterface $tokens,
+        private AuditRecorderInterface $audit,
         private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
+     * @param int|null $actorUserId authenticated user who generated the token (null for system)
+     *
      * @return array{rawToken: string, expiresAt: string}
      * @throws InvoiceNotFoundException
      */
-    public function execute(int $invoiceId): array
+    public function execute(?int $actorUserId, int $invoiceId): array
     {
         // The invoice repository is org-scoped (holder), so a foreign invoice
         // is already invisible here.
@@ -57,6 +61,19 @@ final readonly class GenerateDownloadTokenUseCase
             expiresAt: $expiresAt,
             createdAt: $createdAt,
         ));
+
+        // Audit (ADR 0008): issuing a public download link is an auditable event.
+        // `after` carries only the non-secret expiry — the raw token and its hash
+        // are never written to the audit trail.
+        $this->audit->record(
+            $actorUserId,
+            $organizationId,
+            'invoice.download_token_issued',
+            'invoice',
+            $invoiceId,
+            null,
+            ['expires_at' => $expiresAt],
+        );
 
         return ['rawToken' => $rawToken, 'expiresAt' => $expiresAt];
     }

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
@@ -40,6 +41,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 static fn (ContainerInterface $c): GenerateDownloadTokenUseCase => new GenerateDownloadTokenUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
+                    self::resolve($c, AuditRecorderInterface::class),
                     self::orgHolder($c),
                 ),
             )

--- a/tests/Invoice/SendInvoiceEmailUseCaseTest.php
+++ b/tests/Invoice/SendInvoiceEmailUseCaseTest.php
@@ -18,6 +18,7 @@ use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use NeneInvoice\Tests\Support\RecordingMailer;
 use PHPUnit\Framework\TestCase;
 
@@ -30,6 +31,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
     private InMemoryCompanySettingsRepository $companySettings;
     private InMemoryLineItemRepository $lineItems;
     private RecordingMailer $mailer;
+    private RecordingAuditRecorder $audit;
     private SendInvoiceEmailUseCase $useCase;
 
     protected function setUp(): void
@@ -41,6 +43,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         $this->companySettings = new InMemoryCompanySettingsRepository();
         $this->lineItems       = new InMemoryLineItemRepository();
         $this->mailer          = new RecordingMailer();
+        $this->audit           = new RecordingAuditRecorder();
 
         // Stub PDF generator: returns fixed bytes without calling mPDF.
         $pdfGenerator = new class () implements InvoicePdfGeneratorInterface {
@@ -57,6 +60,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
             $this->companySettings,
             $pdfGenerator,
             $this->mailer,
+            $this->audit,
             $this->holder,
             'NeNe Invoice',
         );
@@ -85,7 +89,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         ));
         $invoiceId = $this->issuedInvoice($clientId);
 
-        $this->useCase->execute($invoiceId);
+        $this->useCase->execute(7, $invoiceId);
 
         self::assertCount(1, $this->mailer->sent);
         $message = $this->mailer->sent[0];
@@ -96,10 +100,51 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         self::assertStringContainsString('INV-2026-001', $message->attachmentName ?? '');
     }
 
+    public function test_records_audit_log_on_send(): void
+    {
+        $clientId  = $this->clients->save(new Client(
+            organizationId: 1,
+            name: 'Buyer',
+            email: 'buyer@example.com',
+        ));
+        $invoiceId = $this->issuedInvoice($clientId);
+
+        $this->useCase->execute(7, $invoiceId);
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame(7, $record['actor_user_id']);
+        self::assertSame(1, $record['organization_id']);
+        self::assertSame('invoice.sent', $record['action']);
+        self::assertSame('invoice', $record['entity_type']);
+        self::assertSame($invoiceId, $record['entity_id']);
+        self::assertNull($record['before']);
+        self::assertIsArray($record['after']);
+        self::assertSame('INV-2026-001', $record['after']['invoice_number']);
+    }
+
+    public function test_does_not_record_audit_when_send_fails(): void
+    {
+        $clientId  = $this->clients->save(new Client(
+            organizationId: 1,
+            name: 'No Email Corp',
+        ));
+        $invoiceId = $this->issuedInvoice($clientId);
+
+        try {
+            $this->useCase->execute(7, $invoiceId);
+            self::fail('Expected InvoiceEmailException');
+        } catch (InvoiceEmailException) {
+            // expected
+        }
+
+        self::assertCount(0, $this->audit->records);
+    }
+
     public function test_throws_not_found_for_unknown_invoice(): void
     {
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute(999);
+        $this->useCase->execute(7, 999);
     }
 
     public function test_throws_when_client_has_no_email(): void
@@ -111,7 +156,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         $invoiceId = $this->issuedInvoice($clientId);
 
         $this->expectException(InvoiceEmailException::class);
-        $this->useCase->execute($invoiceId);
+        $this->useCase->execute(7, $invoiceId);
     }
 
     public function test_throws_when_invoice_is_draft(): void
@@ -131,7 +176,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         ));
 
         $this->expectException(InvoiceEmailException::class);
-        $this->useCase->execute($invoiceId);
+        $this->useCase->execute(7, $invoiceId);
     }
 
     public function test_uses_company_name_from_settings(): void
@@ -147,7 +192,7 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         ));
         $invoiceId = $this->issuedInvoice($clientId);
 
-        $this->useCase->execute($invoiceId);
+        $this->useCase->execute(7, $invoiceId);
 
         $message = $this->mailer->sent[0];
         self::assertStringContainsString('テスト商会', $message->subject);

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenHandler;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 
@@ -43,7 +44,7 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
         ));
 
         $this->handler = new GenerateDownloadTokenHandler(
-            new GenerateDownloadTokenUseCase($this->invoices, $tokens, $this->holder),
+            new GenerateDownloadTokenUseCase($this->invoices, $tokens, new RecordingAuditRecorder(), $this->holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
         );
     }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
@@ -11,6 +11,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
 
 final class GenerateDownloadTokenUseCaseTest extends TestCase
@@ -21,6 +22,8 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
 
     private GenerateDownloadTokenUseCase $useCase;
 
+    private RecordingAuditRecorder $audit;
+
     /** @var RequestScopedHolder<int> */
     private RequestScopedHolder $holder;
 
@@ -30,14 +33,15 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
         $this->holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->tokens   = new InMemoryInvoiceDownloadTokenRepository();
-        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->holder);
+        $this->audit    = new RecordingAuditRecorder();
+        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->audit, $this->holder);
     }
 
     public function test_generates_token_for_invoice_in_org(): void
     {
         $id = $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 100, totalCents: 1100));
 
-        $result = $this->useCase->execute($id);
+        $result = $this->useCase->execute(7, $id);
 
         self::assertNotEmpty($result['rawToken']);
         self::assertNotEmpty($result['expiresAt']);
@@ -48,19 +52,41 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
         self::assertSame($id, $stored->invoiceId);
     }
 
+    public function test_records_audit_log_without_leaking_token(): void
+    {
+        $id = $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 100, totalCents: 1100));
+
+        $result = $this->useCase->execute(7, $id);
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame(7, $record['actor_user_id']);
+        self::assertSame(1, $record['organization_id']);
+        self::assertSame('invoice.download_token_issued', $record['action']);
+        self::assertSame('invoice', $record['entity_type']);
+        self::assertSame($id, $record['entity_id']);
+        self::assertNull($record['before']);
+        self::assertSame(['expires_at' => $result['expiresAt']], $record['after']);
+
+        // The raw token and its hash must never reach the audit trail.
+        $encoded = json_encode($record, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString($result['rawToken'], $encoded);
+        self::assertStringNotContainsString(hash('sha256', $result['rawToken']), $encoded);
+    }
+
     public function test_throws_for_wrong_org(): void
     {
         // Invoice belongs to org 2; the holder resolves org 1, so it is invisible.
         $id = $this->invoices->save(new Invoice(organizationId: 2, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
 
         $this->expectException(InvoiceNotFoundException::class);
-        $this->useCase->execute($id);
+        $this->useCase->execute(7, $id);
     }
 
     public function test_raw_token_is_url_safe_base64(): void
     {
         $id     = $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000));
-        $result = $this->useCase->execute($id);
+        $result = $this->useCase->execute(7, $id);
 
         self::assertMatchesRegularExpression('/^[A-Za-z0-9\-_]+$/', $result['rawToken']);
     }


### PR DESCRIPTION
## 概要
ADR 0008「全ての mutating 操作を before/after 付きで監査記録する」の**抜け2件**を埋める。調査の結果、状態を変える操作のうち以下が `AuditRecorder` を呼んでいなかった。

| UseCase | 追加した action | before / after |
| --- | --- | --- |
| `SendInvoiceEmailUseCase` | `invoice.sent` | before=null / after=送付時点の invoice スナップショット（送付内容の証跡） |
| `GenerateDownloadTokenUseCase` | `invoice.download_token_issued` | before=null / after=`{expires_at}` のみ |

## 設計判断
- **entity_type は既存の `invoice` に統一**（新規ドメインエンティティを増やさない）。
- action 命名は `{entity}.{verb}` 規約準拠。action 文字列は用語レジストリ個別登録対象外（既存 `invoice.issued` 等も未登録）。
- **秘密情報を残さない**: DLトークンの raw token / SHA-256 hash は監査ログに一切書かない（テストで検証）。
- actorUserId は Handler から `AuthContext::userId()` で渡す（既存 UseCase と同パターン）。
- ADR 0008 に「非CRUD の auditable event も記録する」方針を追記。

## テスト
- `invoice.sent` の記録内容・失敗時に記録されないことを検証。
- `invoice.download_token_issued` の記録内容 + **token/hash が混入しない**ことを検証。
- 全体: 291 tests green / phpstan clean / php-cs-fixer clean / OpenAPI・MCP valid。

## コンプライアンス自己レビュー
`docs/review/compliance.md` 準拠。会計・税務コンプライアンス `docs/explanation/accounting-compliance.md` §8（監査証跡）に沿い、送付・公開リンク発行という証跡上重要な操作を追跡対象に含めた。

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)