### PR TITLE
feat(frontend): 言語切り替えUI（日本語/English）を追加する (#233)

### DIFF
--- a/frontend/e2e/language-switcher.spec.ts
+++ b/frontend/e2e/language-switcher.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+import { login } from './helpers/auth'
+
+test.describe('Language switcher', () => {
+  test('switches the UI language and persists the choice', async ({ page }) => {
+    await login(page)
+
+    // Default is Japanese: the sidebar shows 取引先.
+    const side = page.locator('.side')
+    await expect(side.getByRole('link', { name: '取引先' })).toBeVisible()
+
+    // Switch to English from the sidebar account menu.
+    await side.getByRole('button', { name: 'English' }).click()
+    await expect(side.getByRole('link', { name: 'Clients' })).toBeVisible()
+    await expect(side.getByRole('link', { name: '取引先' })).toHaveCount(0)
+
+    // The choice persists across a reload (localStorage). A reload clears the
+    // in-memory token, so we land on the login screen — now in English.
+    await page.reload()
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+  })
+})

--- a/frontend/src/features/account-menu/ui/AccountMenu.tsx
+++ b/frontend/src/features/account-menu/ui/AccountMenu.tsx
@@ -1,18 +1,49 @@
-import { useTranslation } from '@/shared/i18n'
+import { LOCALES, useTranslation } from '@/shared/i18n'
+import { cn } from '@/shared/lib/cn'
 import { useAccountMenu } from '../hooks/use-account-menu'
 
-/** Sidebar account summary + sign-out, themed for the deep-green chrome. */
+/** Sidebar account summary + language switch + sign-out, themed for the chrome. */
 export function AccountMenu() {
-  const { t } = useTranslation()
+  const { t, locale, setLocale } = useTranslation()
   const { email, onSignOut } = useAccountMenu()
 
   return (
-    <div className="flex flex-col gap-stack-xs">
+    <div className="flex flex-col gap-stack-sm">
       {email !== null && (
         <span className="truncate text-caption text-side-fg-muted" title={email}>
           {t('admin.account.signedInAs', { email })}
         </span>
       )}
+
+      <div
+        className="flex border border-side-border"
+        role="group"
+        aria-label={t('common.locale.label')}
+      >
+        {LOCALES.map((loc) => {
+          const active = locale === loc.id
+          return (
+            <button
+              key={loc.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => {
+                setLocale(loc.id)
+              }}
+              className={cn(
+                'flex-1 px-inline-sm py-stack-xs text-caption transition-colors',
+                'focus-visible:outline-2 focus-visible:outline-focus-ring',
+                active
+                  ? 'bg-side-active font-medium text-side-fg'
+                  : 'text-side-fg-muted hover:bg-side-active/60 hover:text-side-fg',
+              )}
+            >
+              {t(loc.labelKey)}
+            </button>
+          )
+        })}
+      </div>
+
       <button
         type="button"
         onClick={onSignOut}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -6,6 +6,7 @@ export const enMessages: MessageCatalog = {
   'common.actions.retry': 'Retry',
   'common.actions.signOut': 'Sign out',
   'common.error.generic': 'Something went wrong.',
+  'common.locale.label': 'Language',
   'common.locale.ja': '日本語',
   'common.locale.en': 'English',
   'common.pagination.prev': 'Previous',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -7,6 +7,7 @@ export const jaMessages = {
   'common.actions.retry': '再試行',
   'common.actions.signOut': 'ログアウト',
   'common.error.generic': 'エラーが発生しました。',
+  'common.locale.label': '言語',
   'common.locale.ja': '日本語',
   'common.locale.en': 'English',
   'common.pagination.prev': '前のページ',


### PR DESCRIPTION
## 概要
i18n 基盤（`ja.ts`/`en.ts` メッセージ一覧、`setLocale`、localStorage 永続化 `nene-locale`、`LOCALES`、用語レジストリ）は完備だが、**ユーザーが言語を切り替えるUIが無かった**ため追加。

## 変更
- サイドバー下部の AccountMenu に **日本語 / English のセグメント切替**を追加（`useTranslation` の `locale`/`setLocale`、`LOCALES` を使用）。
- 選択は localStorage に永続化（既存 `setLocale` が対応済み）。モバイルは「メニュー」ドロワー内の AccountMenu から到達可能。
- aria-label 用に `common.locale.label`（言語 / Language）を ja・en に追加。

## 確認（質問への回答）
- **対応言語**: 日本語・英語の2つ（`SupportedLocale = 'ja' | 'en'`）。他言語なし。
- **メッセージ一覧管理**: 全画面文言が `ja.ts`/`en.ts` 経由（`t()`）で管理済み → 切替が即時反映。
- **用語レジストリ**: `docs/explanation/terminology.md`（binding・タイポ厳禁）が単一の真実として存在済み。

## 検証
- 「English」押下でナビ・見出し・統計・パネル・ボタン・アカウントメニューまで全文言が即英語化（スクショ確認）。
- e2e: ja⇔en 切替＋リロード後の永続化（en のログイン画面表示）を検証。
- type-check / eslint / 135 unit / build / e2e green。

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)