### PR TITLE
feat(audit): 監査ログの操作者をメールアドレスで表示する (#237)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1606,6 +1606,9 @@ components:
           type: integer
         actor_user_id:
           type: [integer, 'null']
+        actor_email:
+          type: [string, 'null']
+          description: Actor's current email, resolved at read time for display.
         organization_id:
           type: [integer, 'null']
         action:

--- a/frontend/src/entities/audit/mapper.ts
+++ b/frontend/src/entities/audit/mapper.ts
@@ -9,6 +9,7 @@ export function toAuditLog(dto: AuditLogDto): AuditLog {
   return {
     id: dto.id,
     actor_user_id: dto.actor_user_id ?? null,
+    actor_email: dto.actor_email ?? null,
     organization_id: dto.organization_id ?? null,
     action: dto.action,
     entity_type: dto.entity_type,

--- a/frontend/src/entities/audit/model.ts
+++ b/frontend/src/entities/audit/model.ts
@@ -2,6 +2,7 @@
 export interface AuditLog {
   id: number
   actor_user_id: number | null
+  actor_email: string | null
   organization_id: number | null
   action: string
   entity_type: string

--- a/frontend/src/features/list-audit-logs/ui/ListAuditLogs.tsx
+++ b/frontend/src/features/list-audit-logs/ui/ListAuditLogs.tsx
@@ -229,7 +229,10 @@ function AuditRow({ log, expanded, onToggle }: AuditRowProps) {
           {log.entity_id !== null ? ` #${String(log.entity_id)}` : ''}
         </td>
         <td data-label={t('admin.audit.col.actor')}>
-          {log.actor_user_id !== null ? `#${String(log.actor_user_id)}` : t('admin.audit.system')}
+          {log.actor_email ??
+            (log.actor_user_id !== null
+              ? `#${String(log.actor_user_id)}`
+              : t('admin.audit.system'))}
         </td>
         <td className="tr" data-label={t('admin.audit.col.detail')}>
           <Button variant="ghost" size="sm" onClick={onToggle} aria-expanded={expanded}>

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -848,6 +848,8 @@ export interface components {
         AuditLog: {
             id: number;
             actor_user_id?: number | null;
+            /** @description Actor's current email, resolved at read time for display. */
+            actor_email?: string | null;
             organization_id?: number | null;
             /** @description e.g. invoice.created, invoice.issued, payment.recorded. */
             action: string;

--- a/src/Audit/AuditLog.php
+++ b/src/Audit/AuditLog.php
@@ -26,6 +26,8 @@ final readonly class AuditLog
         public ?array $after = null,
         public ?int $id = null,
         public ?string $createdAt = null,
+        /** Actor's current email, resolved at read time (null on write / unresolvable). */
+        public ?string $actorEmail = null,
     ) {
     }
 }

--- a/src/Audit/AuditLogResponse.php
+++ b/src/Audit/AuditLogResponse.php
@@ -16,6 +16,7 @@ final class AuditLogResponse
         return [
             'id' => $log->id,
             'actor_user_id' => $log->actorUserId,
+            'actor_email' => $log->actorEmail,
             'organization_id' => $log->organizationId,
             'action' => $log->action,
             'entity_type' => $log->entityType,

--- a/src/Audit/PdoAuditLogRepository.php
+++ b/src/Audit/PdoAuditLogRepository.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterface
 {
-    private const COLUMNS = 'id, actor_user_id, organization_id, action, entity_type, entity_id, before_json, after_json, created_at';
+    private const COLUMNS = 'a.id, a.actor_user_id, a.organization_id, a.action, a.entity_type, a.entity_id, a.before_json, a.after_json, a.created_at';
 
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for read queries
@@ -47,8 +47,13 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
         $params[] = $limit;
         $params[] = $offset;
 
+        // Resolve the actor's current email for display (the stored
+        // actor_user_id is immutable; this lookup is read-time only).
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM audit_logs WHERE ' . $where . ' ORDER BY id DESC LIMIT ? OFFSET ?',
+            'SELECT ' . self::COLUMNS . ', u.email AS actor_email
+             FROM audit_logs a
+             LEFT JOIN users u ON u.id = a.actor_user_id
+             WHERE ' . $where . ' ORDER BY a.id DESC LIMIT ? OFFSET ?',
             $params,
         );
 
@@ -59,7 +64,7 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
     {
         [$where, $params] = $this->buildWhere($filter);
 
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM audit_logs WHERE ' . $where, $params);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS cnt FROM audit_logs a WHERE ' . $where, $params);
 
         return $row !== null ? (int) $row['cnt'] : 0;
     }
@@ -71,31 +76,33 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
      */
     private function buildWhere(AuditLogFilter $filter): array
     {
-        $conditions = ['organization_id = ?'];
+        // Columns are qualified with the `a` (audit_logs) alias because findAll
+        // joins `users` (both tables have organization_id / created_at).
+        $conditions = ['a.organization_id = ?'];
         $params = [$this->orgId->get()];
 
         if ($filter->entityType !== null) {
-            $conditions[] = 'entity_type = ?';
+            $conditions[] = 'a.entity_type = ?';
             $params[] = $filter->entityType;
         }
 
         if ($filter->action !== null) {
-            $conditions[] = 'action = ?';
+            $conditions[] = 'a.action = ?';
             $params[] = $filter->action;
         }
 
         if ($filter->actorUserId !== null) {
-            $conditions[] = 'actor_user_id = ?';
+            $conditions[] = 'a.actor_user_id = ?';
             $params[] = $filter->actorUserId;
         }
 
         if ($filter->createdFrom !== null) {
-            $conditions[] = 'created_at >= ?';
+            $conditions[] = 'a.created_at >= ?';
             $params[] = $filter->createdFrom;
         }
 
         if ($filter->createdTo !== null) {
-            $conditions[] = 'created_at <= ?';
+            $conditions[] = 'a.created_at <= ?';
             $params[] = $filter->createdTo;
         }
 
@@ -140,6 +147,7 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
             after: self::decode(isset($row['after_json']) ? (string) $row['after_json'] : null),
             id: (int) $row['id'],
             createdAt: (string) $row['created_at'],
+            actorEmail: isset($row['actor_email']) ? (string) $row['actor_email'] : null,
         );
     }
 }

--- a/tests/Audit/AuditLogTest.php
+++ b/tests/Audit/AuditLogTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class AuditLogTest extends TestCase
 {
     private PdoAuditLogRepository $repository;
+    private \PDO $pdo;
     /** @var RequestScopedHolder<int> */
     private RequestScopedHolder $holder;
 
@@ -39,9 +40,25 @@ final class AuditLogTest extends TestCase
         self::assertIsString($schema);
         $pdo->exec($schema);
 
+        // findAll LEFT JOINs users to resolve the actor email.
+        $usersSchema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/users.sql');
+        self::assertIsString($usersSchema);
+        $pdo->exec($usersSchema);
+
+        $this->pdo = $pdo;
         $this->holder = new RequestScopedHolder();
         $this->holder->set(1);
         $this->repository = new PdoAuditLogRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
+    }
+
+    private function insertUser(int $id, string $email): void
+    {
+        $this->pdo->exec(sprintf(
+            "INSERT INTO users (id, email, password_hash, role, organization_id, status, created_at, updated_at)
+             VALUES (%d, '%s', 'x', 'admin', 1, 'active', '2026-05-01 00:00:00', '2026-05-01 00:00:00')",
+            $id,
+            $email,
+        ));
     }
 
     public function test_recorder_persists_before_and_after_snapshots(): void
@@ -57,6 +74,21 @@ final class AuditLogTest extends TestCase
         self::assertSame(42, $logs[0]->entityId);
         self::assertSame(['name' => '前'], $logs[0]->before);
         self::assertSame(['name' => '後'], $logs[0]->after);
+    }
+
+    public function test_resolves_actor_email_and_falls_back_to_null(): void
+    {
+        $this->insertUser(7, 'operator@example.com');
+
+        $recorder = new AuditRecorder($this->repository);
+        $recorder->record(7, 1, 'invoice.issued', 'invoice', 5, null, ['status' => 'issued']);
+        // Actor 99 has no users row → email stays null (caller shows #id).
+        $recorder->record(99, 1, 'invoice.created', 'invoice', 6, null, ['status' => 'draft']);
+
+        $logs = $this->repository->findAll(new AuditLogFilter(), 10, 0);
+        // Newest first: actor 99 (no email), then actor 7 (resolved).
+        self::assertNull($logs[0]->actorEmail);
+        self::assertSame('operator@example.com', $logs[1]->actorEmail);
     }
 
     public function test_logs_are_scoped_and_counted_per_organization(): void


### PR DESCRIPTION
## 概要
監査ログの「操作者」が `#1`（ユーザーID）表示で誰か分かりづらかったのを、**メールアドレス表示**に変更。

## Before → After
| 操作者 | Before | After |
| --- | --- | --- |
| 通常 | `#1` | `admin@example.com` |
| 解決不可（退会・他組織 superadmin 等） | `#99` | `#99`（フォールバック維持） |
| actor なし（システム） | システム | システム |

## 変更
- **backend**: `PdoAuditLogRepository.findAll` が `users` を LEFT JOIN し `actor_email` を解決。
  - 保存値 `actor_user_id` は**不変（immutable）**。email は**読み取り時のみ解決**＝監査記録自体は改ざんしない。
  - 列を `a.`（audit_logs）で修飾し `organization_id` / `created_at` の曖昧性を回避。`count` は別名 `a` で対応。
  - `AuditLog.actorEmail`（読み取り専用）/ `AuditLogResponse.actor_email` / OpenAPI `actor_email` を追加。
- **frontend**: 操作者を email 表示（解決不可は `#ID`、actor 無しは「システム」にフォールバック）。

## 会計コンプライアンス
監査証跡の保存値は一切変更せず（追記専用・不変）。email は表示用の読み取り時解決のみ。org スコープは維持。

## 検証
- backend: 294 tests（email 解決とフォールバックの Pdo テスト追加）/ phpstan / cs / OpenAPI / MCP green。
- frontend: type-check / eslint / 140 unit / build green。
- スクショで操作者の email 表示・#ID フォールバックを確認。

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)