### PR TITLE
design(frontend): 見積書作成フォームを最終デザイン仕様に合わせる (#239)

### DIFF
--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -1,134 +1,209 @@
+import { useWatch } from 'react-hook-form'
 import { useTranslation } from '@/shared/i18n'
-import { formatTaxRate } from '@/shared/lib/format-money'
-import { Button, Field, Input, MutationError, Select, Stack, Text } from '@/shared/ui'
+import { formatTaxRate, formatYen } from '@/shared/lib/format-money'
+import { computeDocumentTotals } from '@/shared/lib/tax'
+import {
+  Button,
+  Field,
+  FormRow,
+  Input,
+  MutationError,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+} from '@/shared/ui'
 import { useCreateQuote } from '../hooks/use-create-quote'
 
 const TAX_RATES = [1000, 800] as const
 
 const toNumber = (value: string): number => (value === '' ? Number.NaN : Number(value))
 
+/** Trash icon for removing a line (final-spec icon-btn). */
+const trashIcon = (
+  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+    <path d="M3 4h10M6.5 4V2.8h3V4M5 4l.6 9h4.8L11 4" />
+  </svg>
+)
+
+/**
+ * Quote creation form (final design spec, screen 04): client + valid-until card,
+ * line-item editor grid, and notes + live totals, with a right-aligned action.
+ */
 export function CreateQuoteForm() {
   const { t } = useTranslation()
   const { form, lines, clients, clientsLoading, onSubmit, addLine, isPending, errorMessage } =
     useCreateQuote()
   const {
+    control,
     register,
     formState: { errors },
   } = form
 
+  // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
+  const watched = useWatch({ control, name: 'line_items' })
+  const totals = computeDocumentTotals(
+    watched.map((line) => ({
+      quantity: line.quantity,
+      unit_price_cents: line.unit_price_cents,
+      tax_rate_bps: line.tax_rate_bps,
+    })),
+  )
+
   return (
-    <form onSubmit={onSubmit} noValidate>
-      <Stack gap="lg">
-        <Text as="h1" variant="heading-md">
-          {t('admin.quotes.create.title')}
-        </Text>
-
-        <Field
-          id="client_id"
-          label={t('admin.quotes.create.client')}
-          error={errors.client_id ? t('admin.quotes.create.invalid') : undefined}
-        >
-          <Select
-            id="client_id"
-            disabled={clientsLoading}
-            aria-invalid={errors.client_id ? true : undefined}
-            {...register('client_id', { setValueAs: toNumber })}
-          >
-            <option value="">{t('admin.quotes.create.clientPlaceholder')}</option>
-            {clients.map((client) => (
-              <option key={client.id} value={client.id}>
-                {client.name}
-              </option>
-            ))}
-          </Select>
-        </Field>
-
-        {!clientsLoading && clients.length === 0 && (
-          <Text variant="muted">{t('admin.quotes.create.noClients')}</Text>
-        )}
-
+    <div className="content-mid">
+      <form onSubmit={onSubmit} noValidate>
         <Stack gap="md">
-          <Text variant="heading-sm">{t('admin.quotes.create.lineItems')}</Text>
-          {lines.fields.map((field, index) => (
-            <Stack key={field.id} direction="row" gap="sm">
+          <Text as="h1" variant="heading-md">
+            {t('admin.quotes.create.title')}
+          </Text>
+
+          {/* Client + valid-until */}
+          <div className="card">
+            <FormRow>
               <Field
-                id={`line-${index}-description`}
-                label={t('admin.invoices.line.description')}
-                error={
-                  errors.line_items?.[index]?.description
-                    ? t('admin.quotes.create.invalid')
-                    : undefined
-                }
+                id="client_id"
+                label={t('admin.quotes.create.client')}
+                error={errors.client_id ? t('admin.quotes.create.invalid') : undefined}
               >
-                <Input
-                  id={`line-${index}-description`}
-                  {...register(`line_items.${index}.description`)}
-                />
-              </Field>
-              <Field id={`line-${index}-quantity`} label={t('admin.invoices.line.quantity')}>
-                <Input
-                  id={`line-${index}-quantity`}
-                  type="number"
-                  min={1}
-                  {...register(`line_items.${index}.quantity`, { valueAsNumber: true })}
-                />
-              </Field>
-              <Field id={`line-${index}-unit`} label={t('admin.invoices.line.unitPrice')}>
-                <Input
-                  id={`line-${index}-unit`}
-                  type="number"
-                  min={0}
-                  {...register(`line_items.${index}.unit_price_cents`, { valueAsNumber: true })}
-                />
-              </Field>
-              <Field id={`line-${index}-tax`} label={t('admin.invoices.line.taxRate')}>
                 <Select
-                  id={`line-${index}-tax`}
-                  {...register(`line_items.${index}.tax_rate_bps`, { setValueAs: toNumber })}
+                  id="client_id"
+                  disabled={clientsLoading}
+                  aria-invalid={errors.client_id ? true : undefined}
+                  {...register('client_id', { setValueAs: toNumber })}
                 >
-                  {TAX_RATES.map((bps) => (
-                    <option key={bps} value={bps}>
-                      {formatTaxRate(bps)}
+                  <option value="">{t('admin.quotes.create.clientPlaceholder')}</option>
+                  {clients.map((client) => (
+                    <option key={client.id} value={client.id}>
+                      {client.name}
                     </option>
                   ))}
                 </Select>
               </Field>
-              {lines.fields.length > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    lines.remove(index)
-                  }}
-                >
-                  {t('admin.quotes.create.removeLine')}
-                </Button>
-              )}
-            </Stack>
-          ))}
-          <div>
-            <Button variant="ghost" size="sm" onClick={addLine}>
-              {t('admin.quotes.create.addLine')}
+              <Field id="valid_until" label={t('admin.quotes.create.validUntil')}>
+                <Input id="valid_until" type="date" {...register('valid_until')} />
+              </Field>
+            </FormRow>
+            {!clientsLoading && clients.length === 0 && (
+              <Text variant="muted">{t('admin.quotes.create.noClients')}</Text>
+            )}
+          </div>
+
+          {/* Line items */}
+          <div className="card">
+            <div className="section-title">{t('admin.quotes.create.lineItems')}</div>
+            <div className="line-grid">
+              <div className="line-head">
+                <span>{t('admin.invoices.line.description')}</span>
+                <span className="tr">{t('admin.invoices.line.quantity')}</span>
+                <span className="tr">{t('admin.invoices.line.unitPrice')}</span>
+                <span>{t('admin.invoices.line.taxRate')}</span>
+                <span className="tr">{t('admin.invoices.line.lineSubtotal')}</span>
+                <span />
+              </div>
+              {lines.fields.map((field, index) => {
+                const line = watched.at(index)
+                const amount = (line?.quantity || 0) * (line?.unit_price_cents || 0)
+                return (
+                  <div className="line-row" key={field.id}>
+                    <Input
+                      id={`line-${index}-description`}
+                      aria-label={t('admin.invoices.line.description')}
+                      aria-invalid={errors.line_items?.[index]?.description ? true : undefined}
+                      {...register(`line_items.${index}.description`)}
+                    />
+                    <Input
+                      id={`line-${index}-quantity`}
+                      className="num text-right"
+                      type="number"
+                      min={1}
+                      aria-label={t('admin.invoices.line.quantity')}
+                      {...register(`line_items.${index}.quantity`, { valueAsNumber: true })}
+                    />
+                    <Input
+                      id={`line-${index}-unit`}
+                      className="num text-right"
+                      type="number"
+                      min={0}
+                      aria-label={t('admin.invoices.line.unitPrice')}
+                      {...register(`line_items.${index}.unit_price_cents`, { valueAsNumber: true })}
+                    />
+                    <Select
+                      id={`line-${index}-tax`}
+                      aria-label={t('admin.invoices.line.taxRate')}
+                      {...register(`line_items.${index}.tax_rate_bps`, { setValueAs: toNumber })}
+                    >
+                      {TAX_RATES.map((bps) => (
+                        <option key={bps} value={bps}>
+                          {formatTaxRate(bps)}
+                        </option>
+                      ))}
+                    </Select>
+                    <span className="line-amt">{formatYen(amount)}</span>
+                    {lines.fields.length > 1 ? (
+                      <button
+                        type="button"
+                        className="icon-btn"
+                        aria-label={t('admin.quotes.create.removeLine')}
+                        onClick={() => {
+                          lines.remove(index)
+                        }}
+                      >
+                        {trashIcon}
+                      </button>
+                    ) : (
+                      <span />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+            <div className="mt-stack-md">
+              <Button variant="ghost" size="sm" onClick={addLine}>
+                ＋ {t('admin.quotes.create.addLine')}
+              </Button>
+            </div>
+          </div>
+
+          {/* Notes + live totals */}
+          <div className="note-totals-grid">
+            <div className="card">
+              <Field id="notes" label={t('admin.quotes.create.notes')}>
+                <Textarea
+                  id="notes"
+                  rows={4}
+                  placeholder={t('admin.quotes.create.notesPlaceholder')}
+                  {...register('notes')}
+                />
+              </Field>
+            </div>
+            <div className="card">
+              <div className="totals">
+                <div className="totals-row">
+                  <span className="t-label">{t('admin.invoices.detail.subtotal')}</span>
+                  <span className="t-val">{formatYen(totals.subtotal_cents)}</span>
+                </div>
+                <div className="totals-row">
+                  <span className="t-label">{t('admin.invoices.detail.tax')}</span>
+                  <span className="t-val">{formatYen(totals.tax_cents)}</span>
+                </div>
+                <div className="totals-row grand">
+                  <span className="t-label">{t('admin.invoices.detail.total')}</span>
+                  <span className="t-val">{formatYen(totals.total_cents)}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <MutationError message={errorMessage} />
+
+          <div className="form-actions-end">
+            <Button type="submit" disabled={isPending}>
+              {isPending ? t('admin.quotes.create.submitting') : t('admin.quotes.create.submit')}
             </Button>
           </div>
         </Stack>
-
-        <Field id="valid_until" label={t('admin.quotes.create.validUntil')}>
-          <Input id="valid_until" type="date" {...register('valid_until')} />
-        </Field>
-
-        <Field id="notes" label={t('admin.quotes.create.notes')}>
-          <Input id="notes" {...register('notes')} />
-        </Field>
-
-        <MutationError message={errorMessage} />
-
-        <div>
-          <Button type="submit" disabled={isPending}>
-            {isPending ? t('admin.quotes.create.submitting') : t('admin.quotes.create.submit')}
-          </Button>
-        </div>
-      </Stack>
-    </form>
+      </form>
+    </div>
   )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -212,6 +212,7 @@ export const enMessages: MessageCatalog = {
   'admin.quotes.create.removeLine': 'Remove',
   'admin.quotes.create.validUntil': 'Valid until',
   'admin.quotes.create.notes': 'Notes',
+  'admin.quotes.create.notesPlaceholder': 'We look forward to your consideration.',
   'admin.quotes.create.submit': 'Create',
   'admin.quotes.create.submitting': 'Creating…',
   'admin.quotes.create.error': 'Could not create the quote. Check your input.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -214,6 +214,7 @@ export const jaMessages = {
   'admin.quotes.create.removeLine': '削除',
   'admin.quotes.create.validUntil': '有効期限',
   'admin.quotes.create.notes': '備考',
+  'admin.quotes.create.notesPlaceholder': 'ご検討のほどよろしくお願いいたします。',
   'admin.quotes.create.submit': '作成する',
   'admin.quotes.create.submitting': '作成中…',
   'admin.quotes.create.error': '見積書を作成できませんでした。入力内容を確認してください。',


### PR DESCRIPTION
## 概要
見積書作成フォーム（最終デザイン仕様 screen 04）と実装の乖離を解消。請求書フォーム（#236）と同じ手法で、カード分割・明細グリッド・ライブ合計・幅・配置を仕様に一致させた。

## screen 09（請求書）との違いを反映
- **Card1 が `.form-row`**：取引先 select ＋ **有効期限 (date)** の2カラム。
- 追加ボタンは「＋ 行を追加」。

## Before → After
| 項目 | Before | After |
| --- | --- | --- |
| 幅 | 全幅 | `.content.mid`（940px） |
| 構造 | フラット縦積み | カード3分割 |
| 明細 | 各行ラベル重複 | `.line-grid`（ヘッダ行＋金額表示＋削除アイコン） |
| 合計 | なし | ライブ合計（小計/消費税/合計） |
| 備考 | input | textarea |
| アクション | 左寄せ | 右寄せ |

## 変更
- `CreateQuoteForm` を仕様構造に書き換え（請求書で導入済みの `.card`/`.line-grid`/`.totals`/`FormRow`/`Textarea`/`computeDocumentTotals` を再利用）。
- 備考プレースホルダ `admin.quotes.create.notesPlaceholder` を ja/en に追加。

## 会計コンプライアンス
ライブ合計は表示プレビュー（backend の `TaxCalculator` を `tax.ts` で忠実再現済み・per-rate half-up）。確定値は backend が算出。

## 検証
- type-check / eslint / 140 unit / build green。
- e2e: create-quote（3）/ view-quote / list-quotes green。セレクタ（`#client_id` / `#valid_until` / `#line-*` / 見出し / ボタン）維持。
- スクショで取引先＋有効期限の form-row・明細グリッド・ライブ合計（¥495,000）・右寄せを確認。

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)