### PR TITLE
design(frontend): 一覧テーブルを最終仕様（.tbl/.tbl-wrap）に合わせる (#241)

### DIFF
--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -8,7 +8,8 @@
 }
 
 @layer components {
-  /* Case C — ruled, dense data table */
+  /* Case C — ruled, dense data table (spec .tbl). The outer box is .table-scroll
+     (spec .tbl-wrap); cells are ruled with vertical hairlines. */
   .data-table {
     width: 100%;
     border-collapse: collapse;
@@ -17,12 +18,12 @@
   .data-table thead th {
     text-align: left;
     font-weight: 600;
-    font-size: var(--text-caption);
+    font-size: 0.625rem; /* 10px — spec dir-c th */
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.05em;
     color: var(--color-fg-muted);
     background: var(--color-surface-overlay);
-    padding: 0.5rem 0.75rem;
+    padding: 0.5625rem 0.5625rem; /* 9px */
     border-bottom: 1px solid var(--color-border-strong);
     white-space: nowrap;
   }
@@ -30,12 +31,25 @@
     text-align: right;
   }
   .data-table tbody td {
-    padding: 0.4375rem 0.75rem;
+    padding: 0.25rem 0.5625rem; /* 4px 9px — spec dir-c row padding (dense) */
     border-bottom: 1px solid var(--color-border);
     vertical-align: middle;
   }
   .data-table tbody td.tr {
     text-align: right;
+  }
+  /* vertical cell ruling (spec: .dir-c .tbl td/th { border-right }) */
+  .data-table th,
+  .data-table td {
+    border-right: 1px solid var(--color-border);
+  }
+  .data-table th:last-child,
+  .data-table td:last-child {
+    border-right: none;
+  }
+  /* the outer .table-scroll box provides the bottom edge */
+  .data-table tbody tr:last-child td {
+    border-bottom: none;
   }
   .data-table tbody tr:nth-child(even) {
     background: var(--color-surface-overlay);
@@ -733,8 +747,13 @@
   .side-backdrop {
     display: none;
   }
+  /* Spec .tbl-wrap: the table sits inside a bordered box (square, no radius). */
   .table-scroll {
     width: 100%;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
   }
 
   /* ============================================================


### PR DESCRIPTION
## 概要
見積・請求・取引先・監査ログの一覧テーブルが最終デザイン仕様（案C `.tbl`/`.tbl-wrap`）と異なっていたのを修正。共有の `.data-table` / `.table-scroll` を直し、**全テーブルに一括反映**。

## Before → After
| 項目 | Before | After（仕様準拠） |
| --- | --- | --- |
| 外枠 | 無し（テーブルが裸） | **枠付きボックス**（`.tbl-wrap`: border＋surface背景） |
| 縦罫線 | 無し | **列間の縦罫線**（dir-c ruled グリッド、最終列除く） |
| ヘッダ | caption(11px)/.04em | **10px・uppercase・.05em** |
| 行パディング | 7px/12px | **4px/9px（高密度）** |
| 最終行 | border-bottom あり | 外枠があるため除去 |
| zebra（偶数行） | あり | あり（維持） |

## 反映範囲
共有クラスのため、**取引先 / 見積 / 請求 / ユーザー / 監査ログの一覧**＋**明細テーブル（請求/見積詳細）**＋**入金テーブル**すべてに反映。

## モバイル
カード化は維持（td の縦罫線はモバイルで解除＝既存ルール）。カード群は外枠ボックス内に表示。

## 検証
- type-check / eslint / 140 unit / build green。
- e2e: list-invoices / list-users green（スタイル変更のみ・セレクタ不変）。
- スクショで desktop（外枠＋縦罫線グリッド＋zebra）・mobile（カードが枠内）を確認。

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)