### PR TITLE
fix(pdf): 請求書・見積書PDFの日本語文字化けを修正する (#245)

### DIFF
--- a/src/Invoice/Pdf/InvoicePdfGenerator.php
+++ b/src/Invoice/Pdf/InvoicePdfGenerator.php
@@ -141,13 +141,22 @@ final readonly class InvoicePdfGenerator implements InvoicePdfGeneratorInterface
             ? '<p class="notes"><strong>備考</strong><br>' . nl2br($esc($notes)) . '</p>'
             : '';
 
+        // Heredoc does not interpolate static calls ({self::yen(...)}), so the
+        // amounts are formatted into plain variables first.
+        $subtotalYen = self::yen($subtotalCents);
+        $taxTotalYen = self::yen($taxCents);
+        $totalYen    = self::yen($totalCents);
+
         return <<<HTML
 <!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
 <style>
-body { font-family: sans-serif; font-size: 10pt; color: #111; }
+/* Do NOT set a non-CJK font-family (e.g. sans-serif): it overrides mPDF's
+   mode=ja Japanese font and renders all 日本語 as tofu (□). Leave it unset so
+   the CJK-capable default applies. */
+body { font-size: 10pt; color: #111; }
 h1 { font-size: 22pt; text-align: center; margin: 0 0 4mm; border-bottom: 1pt solid #333; padding-bottom: 2mm; }
 .header-meta { text-align: right; font-size: 9pt; margin-bottom: 5mm; }
 .parties { width: 100%; border-collapse: collapse; margin-bottom: 5mm; }
@@ -208,9 +217,9 @@ h1 { font-size: 22pt; text-align: center; margin: 0 0 4mm; border-bottom: 1pt so
 </table>
 <table class="summary">
   {$breakdownRows}
-  <tr><td>小計</td><td class="tr">{self::yen($subtotalCents)}</td></tr>
-  <tr><td>消費税合計</td><td class="tr">{self::yen($taxCents)}</td></tr>
-  <tr class="total-row"><td>ご請求金額</td><td class="tr">{self::yen($totalCents)}</td></tr>
+  <tr><td>小計</td><td class="tr">{$subtotalYen}</td></tr>
+  <tr><td>消費税合計</td><td class="tr">{$taxTotalYen}</td></tr>
+  <tr class="total-row"><td>ご請求金額</td><td class="tr">{$totalYen}</td></tr>
 </table>
 {$bankHtml}
 {$notesHtml}

--- a/src/Quote/Pdf/QuotePdfGenerator.php
+++ b/src/Quote/Pdf/QuotePdfGenerator.php
@@ -137,13 +137,22 @@ final readonly class QuotePdfGenerator
             ? '<p class="notes"><strong>備考</strong><br>' . nl2br($esc($notes)) . '</p>'
             : '';
 
+        // Heredoc does not interpolate static calls ({self::yen(...)}), so the
+        // amounts are formatted into plain variables first.
+        $subtotalYen = self::yen($subtotalCents);
+        $taxTotalYen = self::yen($taxCents);
+        $totalYen    = self::yen($totalCents);
+
         return <<<HTML
 <!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
 <style>
-body { font-family: sans-serif; font-size: 10pt; color: #111; }
+/* Do NOT set a non-CJK font-family (e.g. sans-serif): it overrides mPDF's
+   mode=ja Japanese font and renders all 日本語 as tofu (□). Leave it unset so
+   the CJK-capable default applies. */
+body { font-size: 10pt; color: #111; }
 h1 { font-size: 22pt; text-align: center; margin: 0 0 4mm; border-bottom: 1pt solid #333; padding-bottom: 2mm; }
 .header-meta { text-align: right; font-size: 9pt; margin-bottom: 5mm; }
 .parties { width: 100%; border-collapse: collapse; margin-bottom: 5mm; }
@@ -204,9 +213,9 @@ h1 { font-size: 22pt; text-align: center; margin: 0 0 4mm; border-bottom: 1pt so
 </table>
 <table class="summary">
   {$breakdownRows}
-  <tr><td>小計</td><td class="tr">{self::yen($subtotalCents)}</td></tr>
-  <tr><td>消費税合計</td><td class="tr">{self::yen($taxCents)}</td></tr>
-  <tr class="total-row"><td>お見積金額</td><td class="tr">{self::yen($totalCents)}</td></tr>
+  <tr><td>小計</td><td class="tr">{$subtotalYen}</td></tr>
+  <tr><td>消費税合計</td><td class="tr">{$taxTotalYen}</td></tr>
+  <tr class="total-row"><td>お見積金額</td><td class="tr">{$totalYen}</td></tr>
 </table>
 {$bankHtml}
 {$notesHtml}

--- a/tests/Invoice/Pdf/InvoicePdfGeneratorTest.php
+++ b/tests/Invoice/Pdf/InvoicePdfGeneratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice\Pdf;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\InvoiceWithLines;
+use NeneInvoice\Invoice\Pdf\InvoicePdfData;
+use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use PHPUnit\Framework\TestCase;
+
+final class InvoicePdfGeneratorTest extends TestCase
+{
+    public function test_renders_japanese_with_a_cjk_font_not_dejavu(): void
+    {
+        $invoice = new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 300000,
+            taxCents: 30000,
+            totalCents: 330000,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-01',
+            dueAt: '2026-05-31',
+        );
+        $lines = [
+            new LineItem(LineItemParent::Invoice, 1, 'Webサイト制作（基本プラン）', 1, 300000, 1000),
+        ];
+        $data = new InvoicePdfData(
+            new InvoiceWithLines($invoice, $lines, 330000),
+            new CompanySettings(organizationId: 1, legalName: '株式会社ネネ商会'),
+            new Client(organizationId: 1, name: '株式会社サンプル製作所'),
+        );
+
+        $pdf = (new InvoicePdfGenerator(new TaxCalculator()))->generate($data);
+
+        self::assertStringStartsWith('%PDF', $pdf);
+        // Regression guard: Japanese must embed a CJK font (mode=ja), never the
+        // non-CJK DejaVu — which would render every 日本語 character as tofu (□).
+        self::assertStringContainsString('Sun-ExtA', $pdf);
+        self::assertStringNotContainsString('DejaVu', $pdf);
+    }
+}

--- a/tests/Quote/Pdf/QuotePdfGeneratorTest.php
+++ b/tests/Quote/Pdf/QuotePdfGeneratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote\Pdf;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Quote\Pdf\QuotePdfData;
+use NeneInvoice\Quote\Pdf\QuotePdfGenerator;
+use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Quote\QuoteWithLines;
+use PHPUnit\Framework\TestCase;
+
+final class QuotePdfGeneratorTest extends TestCase
+{
+    public function test_renders_japanese_with_a_cjk_font_not_dejavu(): void
+    {
+        $quote = new Quote(
+            organizationId: 1,
+            clientId: 1,
+            quoteNumber: 'EST-2026-001',
+            status: QuoteStatus::Sent,
+            subtotalCents: 450000,
+            taxCents: 45000,
+            totalCents: 495000,
+            issuedAt: '2026-05-01',
+            validUntil: '2026-06-30',
+        );
+        $lines = [
+            new LineItem(LineItemParent::Quote, 1, '保守費用（月額）', 3, 50000, 1000),
+        ];
+        $data = new QuotePdfData(
+            new QuoteWithLines($quote, $lines),
+            new CompanySettings(organizationId: 1, legalName: '株式会社ネネ商会'),
+            new Client(organizationId: 1, name: '株式会社サンプル製作所'),
+        );
+
+        $pdf = (new QuotePdfGenerator(new TaxCalculator()))->generate($data);
+
+        self::assertStringStartsWith('%PDF', $pdf);
+        // Regression guard: Japanese must embed a CJK font (mode=ja), never the
+        // non-CJK DejaVu — which would render every 日本語 character as tofu (□).
+        self::assertStringContainsString('Sun-ExtA', $pdf);
+        self::assertStringNotContainsString('DejaVu', $pdf);
+    }
+}


### PR DESCRIPTION
## 概要
ダウンロードしたPDFの日本語が文字化けする件を調査・修正。原因は2件あり、**1件目（文字化け）が2件目（合計のリテラル表示）を隠していた**。

## バグ1: 日本語が全て豆腐（□）
- **原因**: PDF用CSS `body { font-family: sans-serif }` が mPDF の `mode => 'ja'` 日本語フォントを上書きし、日本語グリフを持たない **DejaVuSansCondensed** を強制していた。
- **修正**: `font-family` 指定を除去し、`mode=ja` の CJK フォント（Sun-ExtA）を使わせる。再発防止コメントを追加。
- 生成PDFを目視確認 → 漢字・ひらがな・カタカナすべて正常表示。

## バグ2: 合計が `{self::yen(495000)}` のリテラル表示
- **原因**: heredoc は静的メソッド呼び出し `{self::yen(...)}` を**展開しない**（`{$var}` のみ）。そのため 小計／消費税合計／**ご請求金額（お見積金額）** がコードのまま表示されていた。
- **修正**: 金額を変数に整形してから `{$var}` で補間。
- 文字化けで読めなかったため気づかれていなかった既存バグ。**請求書の最重要項目（合計金額）が壊れていた**ため重要度高。

## Before / After（合計欄）
| | Before | After |
| --- | --- | --- |
| ご請求金額 | `{self::yen(495000)}` | **¥495,000** |

## 会計コンプライアンス
内容・税計算・採番は不変。文字化け／合計の壊れた適格請求書はむしろ非準拠であり、本修正はその正常化（accounting-compliance への内容変更なし）。

## 検証
- `InvoicePdfGeneratorTest` / `QuotePdfGeneratorTest` を追加：日本語が **CJK フォントで埋め込まれ DejaVu でない**ことを検証（回帰ガード）。
- 実テンプレートで生成したPDFを目視確認（日本語・合計とも正常）。
- backend 298 tests / phpstan / cs / OpenAPI / MCP green。

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)