### PR TITLE
fix(frontend): 公開DLリンクを dev で API へプロキシしログイン画面化を解消する (#255)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,13 @@ export default defineConfig(({ command, mode }) => {
         '/auth': { target, changeOrigin: true },
         '/admin': { target, changeOrigin: true },
         '/health': { target, changeOrigin: true },
+        // Public, unauthenticated PDF download (client-facing token link). It
+        // lives under the SPA's /invoices namespace, so it must be proxied to
+        // the API explicitly — otherwise Vite serves the SPA shell and the link
+        // bounces to the login screen. The prefix is narrow enough that SPA
+        // routes (/invoices, /invoices/:id) are unaffected. Prod routes this via
+        // .htaccess → index.php, so this is a dev-only concern.
+        '/invoices/download': { target, changeOrigin: true },
       },
     },
   }


### PR DESCRIPTION
## 概要
請求書詳細の「クライアント向けリンク」（`/invoices/download/{token}`）にアクセスするとログイン画面が表示される dev 限定バグを修正する。

## 原因
- バックエンドの `GET /invoices/download/{token}` は無認証の公開ルートとして正しく登録済み。
- だが Vite dev プロキシ（`frontend/vite.config.ts`）は `/auth` `/admin` `/health` のみ転送し、公開DLパス `/invoices/download/*` を転送していなかった。
- そのため SPA オリジン（Vite :5185）でリンクを開くと Vite が SPA シェルを返し、React Router のキャッチオール→認証ゲート→ログイン画面になっていた。
- 本番（Tier A）は `.htaccess` が非ファイルを `index.php` に回すため公開ルートに届く＝問題なし。dev 限定。

## 対応
- Vite プロキシに `/invoices/download` プレフィックスを追加し API（:8510）へ転送。`/invoices` `/invoices/:id` 等の SPA ルートは前方一致しないため影響なし。

## 検証（dev サーバ実機）
| パス | 修正前 | 修正後 |
| --- | --- | --- |
| `:5185/invoices/download/faketoken` | `200 text/html`（SPAシェル＝ログイン化） | `404 application/problem+json`（API公開ハンドラへ転送。有効トークンならPDF） |
| `:5185/invoices` | `200 text/html` | `200 text/html`（SPAのまま・影響なし） |

`prettier --check` / `tsc --noEmit` パス。

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)