### PR TITLE
feat(frontend): エラー型2化 第2弾 — 発行・入金記録（軽量型2＋成功トースト） (#258)

### DIFF
--- a/frontend/e2e/issue-invoice.spec.ts
+++ b/frontend/e2e/issue-invoice.spec.ts
@@ -55,7 +55,9 @@ test.describe('Issue invoice', () => {
     await page.getByRole('dialog').getByRole('button', { name: '発行する（適格請求書）' }).click()
 
     await expect(
-      page.getByText('発行できませんでした。会社情報の登録番号を確認してください。'),
+      page.getByText('発行できませんでした。会社情報の登録番号をご確認ください。'),
     ).toBeVisible()
+    // 型2 recovery affordance: a link to the company settings.
+    await expect(page.getByRole('button', { name: '会社設定を開く →' })).toBeVisible()
   })
 })

--- a/frontend/src/features/issue-invoice/hooks/use-issue-invoice.ts
+++ b/frontend/src/features/issue-invoice/hooks/use-issue-invoice.ts
@@ -4,6 +4,7 @@ import {
   type InvoiceId,
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
+import { useToast } from '@/shared/ui'
 
 export interface UseIssueInvoice {
   /** Only draft invoices can be issued; the action hides otherwise. */
@@ -19,13 +20,28 @@ export interface UseIssueInvoice {
  */
 export function useIssueInvoice(invoiceId: InvoiceId): UseIssueInvoice {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   const invoice = useInvoice(invoiceId)
   const mutation = useIssueInvoiceMutation()
 
   return {
     canIssue: invoice.data?.status === 'draft',
     issue: () => {
-      mutation.mutate({ id: invoiceId, qualified: true, due_at: null })
+      mutation.mutate(
+        { id: invoiceId, qualified: true, due_at: null },
+        {
+          onSuccess: (issued) => {
+            showToast({
+              tone: 'ok',
+              title: t('admin.invoices.issue.successTitle'),
+              description:
+                issued.invoice_number !== null
+                  ? t('admin.invoices.issue.successBody', { number: issued.invoice_number })
+                  : t('admin.invoices.issue.successBodyNoNumber'),
+            })
+          },
+        },
+      )
     },
     isPending: mutation.isPending,
     errorMessage: mutation.isError ? t('admin.invoices.issue.error') : null,

--- a/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
+++ b/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import type { InvoiceId } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
-import { Button, ConfirmDialog, MutationError, Stack } from '@/shared/ui'
+import { Button, ConfirmDialog, InlineAlert, Stack } from '@/shared/ui'
 import { useIssueInvoice } from '../hooks/use-issue-invoice'
 
 export interface IssueInvoiceProps {
@@ -12,6 +13,7 @@ export interface IssueInvoiceProps {
  * (allocates the INV number and locks the document), so it is confirmed. */
 export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const { canIssue, issue, isPending, errorMessage } = useIssueInvoice(invoiceId)
   const [confirming, setConfirming] = useState(false)
 
@@ -36,7 +38,20 @@ export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
           {isPending ? t('admin.invoices.issue.submitting') : t('admin.invoices.issue.action')}
         </Button>
       </div>
-      <MutationError message={errorMessage} />
+      {errorMessage !== null && (
+        <div className="max-w-xl">
+          <InlineAlert
+            tone="error"
+            message={errorMessage}
+            recover={{
+              label: t('admin.invoices.issue.recover'),
+              onClick: () => {
+                void navigate('/settings')
+              },
+            }}
+          />
+        </div>
+      )}
       {confirming && (
         <ConfirmDialog
           title={t('admin.invoices.issue.confirmTitle')}

--- a/frontend/src/features/manage-payments/hooks/use-manage-payments.ts
+++ b/frontend/src/features/manage-payments/hooks/use-manage-payments.ts
@@ -8,6 +8,7 @@ import { invoiceKeys, useInvoice, type InvoiceId } from '@/entities/invoice'
 import { usePaymentList, useRecordPayment, type Payment } from '@/entities/payment'
 import { useTranslation } from '@/shared/i18n'
 import { formatYen } from '@/shared/lib/format-money'
+import { useToast } from '@/shared/ui'
 
 export const PAYMENT_METHODS = ['bank_transfer', 'cash', 'other'] as const
 
@@ -41,6 +42,7 @@ export interface UseManagePayments {
 
 export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   const queryClient = useQueryClient()
   const invoice = useInvoice(invoiceId)
   const payments = usePaymentList(invoiceId)
@@ -75,6 +77,13 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
           form.reset({ amount_cents: 0, method: '', note: '' })
           void queryClient.invalidateQueries({ queryKey: invoiceKeys.detail(invoiceId) })
           void queryClient.invalidateQueries({ queryKey: invoiceKeys.lists() })
+          showToast({
+            tone: 'ok',
+            title: t('admin.payments.record.successTitle'),
+            description: t('admin.payments.record.successBody', {
+              amount: formatYen(values.amount_cents),
+            }),
+          })
         },
       },
     )
@@ -87,6 +96,17 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
   const confirmTitle = t('admin.payments.record.confirmTitle', {
     amount: formatYen(pending?.amount_cents ?? 0),
   })
+
+  // A 422 means the amount was rejected (most often over-payment); surface the
+  // remaining balance when we know it. Other failures (network, 5xx) stay
+  // generic so we never claim a cause we can't confirm.
+  const outstandingCents = invoice.data?.outstanding_cents ?? null
+  const errorMessage =
+    record.error !== null
+      ? record.error.status === 422 && outstandingCents !== null
+        ? t('admin.payments.record.errorOverpay', { balance: formatYen(outstandingCents) })
+        : t('admin.payments.record.error')
+      : null
 
   return {
     visible: status !== undefined && status !== 'draft',
@@ -104,6 +124,6 @@ export function useManagePayments(invoiceId: InvoiceId): UseManagePayments {
     onConfirm,
     onCancel,
     isRecording: record.isPending,
-    errorMessage: record.isError ? t('admin.payments.record.error') : null,
+    errorMessage,
   }
 }

--- a/frontend/src/features/manage-payments/ui/ManagePayments.tsx
+++ b/frontend/src/features/manage-payments/ui/ManagePayments.tsx
@@ -6,9 +6,9 @@ import {
   ConfirmDialog,
   EmptyState,
   Field,
+  InlineAlert,
   Input,
   LoadingState,
-  MutationError,
   Select,
   Stack,
   Text,
@@ -126,7 +126,7 @@ export function ManagePayments({ invoiceId }: ManagePaymentsProps) {
                 <Input id="payment-note" {...register('note')} />
               </Field>
             </Stack>
-            <MutationError message={errorMessage} />
+            {errorMessage !== null && <InlineAlert tone="error" message={errorMessage} />}
             <div>
               <Button type="submit" disabled={isRecording}>
                 {isRecording

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -318,7 +318,11 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.issue.action': 'Issue (qualified invoice)',
   'admin.invoices.issue.submitting': 'Issuing…',
   'admin.invoices.issue.error':
-    'Could not issue. Check the registration number in company settings.',
+    'Could not issue. Please check the registration number in company settings.',
+  'admin.invoices.issue.recover': 'Open company settings →',
+  'admin.invoices.issue.successTitle': 'Issued',
+  'admin.invoices.issue.successBody': '{{number}} has been issued.',
+  'admin.invoices.issue.successBodyNoNumber': 'The invoice has been issued.',
   'admin.invoices.issue.confirmTitle': 'Issue this invoice?',
   'admin.invoices.issue.confirmMessage':
     'Issuing allocates the invoice number and locks the contents (no further edits).',
@@ -343,8 +347,11 @@ export const enMessages: MessageCatalog = {
   'admin.payments.record.confirmTitle': 'Record {{amount}} as a payment?',
   'admin.payments.record.confirmMessage':
     'Recording will update the payment status of the invoice.',
-  'admin.payments.record.error':
-    'Could not record the payment. Check the amount (no over-payment).',
+  'admin.payments.record.error': 'Could not record the payment. Please check your input.',
+  'admin.payments.record.errorOverpay':
+    'Could not record the payment. The amount exceeds the balance ({{balance}}).',
+  'admin.payments.record.successTitle': 'Payment recorded',
+  'admin.payments.record.successBody': 'Recorded {{amount}}.',
   'admin.payments.record.invalid': 'Enter a valid amount.',
   'admin.dashboard.title': 'Dashboard',
   'admin.dashboard.loading': 'Loading…',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -319,7 +319,11 @@ export const jaMessages = {
   'admin.invoices.create.invalid': '入力内容に誤りがあります。',
   'admin.invoices.issue.action': '発行する（適格請求書）',
   'admin.invoices.issue.submitting': '発行中…',
-  'admin.invoices.issue.error': '発行できませんでした。会社情報の登録番号を確認してください。',
+  'admin.invoices.issue.error': '発行できませんでした。会社情報の登録番号をご確認ください。',
+  'admin.invoices.issue.recover': '会社設定を開く →',
+  'admin.invoices.issue.successTitle': '発行しました',
+  'admin.invoices.issue.successBody': '{{number}} を発行しました。',
+  'admin.invoices.issue.successBodyNoNumber': '請求書を発行しました。',
   'admin.invoices.issue.confirmTitle': '請求書を発行しますか？',
   'admin.invoices.issue.confirmMessage':
     '発行すると番号が採番され、内容は確定（変更不可）になります。',
@@ -343,8 +347,11 @@ export const jaMessages = {
   'admin.payments.record.submitting': '記録中…',
   'admin.payments.record.confirmTitle': '{{amount}} を入金として記録しますか？',
   'admin.payments.record.confirmMessage': '記録すると請求書の入金状態が更新されます。',
-  'admin.payments.record.error':
-    '入金を記録できませんでした。金額（過入金でないか）を確認してください。',
+  'admin.payments.record.error': '入金を記録できませんでした。入力内容をご確認ください。',
+  'admin.payments.record.errorOverpay':
+    '入金を記録できませんでした。金額が残高（{{balance}}）を超えています。',
+  'admin.payments.record.successTitle': '入金を記録しました',
+  'admin.payments.record.successBody': '{{amount}} を記録しました。',
   'admin.payments.record.invalid': '金額を正しく入力してください。',
   'admin.dashboard.title': 'ダッシュボード',
   'admin.dashboard.loading': '読み込み中…',

--- a/frontend/src/shared/ui/components/InlineAlert.test.tsx
+++ b/frontend/src/shared/ui/components/InlineAlert.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { InlineAlert } from './InlineAlert'
+
+describe('InlineAlert', () => {
+  it('uses role="alert" for errors and shows the message', () => {
+    const { getByRole } = render(<InlineAlert tone="error" message="Could not issue." />)
+    expect(getByRole('alert')).toHaveTextContent('Could not issue.')
+  })
+
+  it('uses role="status" for success and info tones', () => {
+    const { getByRole, rerender } = render(<InlineAlert tone="success" message="Saved." />)
+    expect(getByRole('status')).toHaveTextContent('Saved.')
+
+    rerender(<InlineAlert tone="info" message="Heads up." />)
+    expect(getByRole('status')).toHaveTextContent('Heads up.')
+  })
+
+  it('renders a recover link that invokes its handler', async () => {
+    const user = userEvent.setup()
+    const onRecover = vi.fn()
+
+    const { getByRole } = render(
+      <InlineAlert
+        tone="error"
+        message="Could not issue."
+        recover={{ label: 'Open company settings', onClick: onRecover }}
+      />,
+    )
+
+    await user.click(getByRole('button', { name: 'Open company settings' }))
+    expect(onRecover).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/shared/ui/components/InlineAlert.tsx
+++ b/frontend/src/shared/ui/components/InlineAlert.tsx
@@ -1,0 +1,94 @@
+/**
+ * Lightweight inline notice (Issue #258). The single-line counterpart of
+ * {@link ActionError}: used for 型2 action errors whose cause is singular
+ * (e.g. issue rejected, overpayment) and for inline success/info notices.
+ *
+ * An optional `recover` renders a "next step" link below the notice — the same
+ * recovery affordance as 型2, without the full title/body card. Errors use
+ * role="alert"; success/info use role="status". Meaning is icon + text.
+ */
+
+export type InlineAlertTone = 'error' | 'success' | 'info'
+
+export interface InlineAlertRecover {
+  label: string
+  onClick: () => void
+}
+
+export interface InlineAlertProps {
+  tone: InlineAlertTone
+  message: string
+  recover?: InlineAlertRecover
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 1.8L15 14.5H1z" />
+      <path d="M8 6.4v3.4M8 11.6v.1" />
+    </svg>
+  )
+}
+
+function SuccessIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3.5 8.5l3 3 6-6.5" />
+    </svg>
+  )
+}
+
+function InfoIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="6.3" />
+      <path d="M8 7.4v3.4M8 5.2v.1" />
+    </svg>
+  )
+}
+
+function ToneIcon({ tone }: { tone: InlineAlertTone }) {
+  if (tone === 'success') return <SuccessIcon />
+  if (tone === 'info') return <InfoIcon />
+  return <ErrorIcon />
+}
+
+export function InlineAlert({ tone, message, recover }: InlineAlertProps) {
+  return (
+    <div>
+      <div className={`alert ${tone}`} role={tone === 'error' ? 'alert' : 'status'}>
+        <ToneIcon tone={tone} />
+        <span>{message}</span>
+      </div>
+      {recover !== undefined && (
+        <button type="button" className="recover-link" onClick={recover.onClick}>
+          {recover.label}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -25,6 +25,12 @@ export {
   type ActionErrorProps,
   type ActionErrorAction,
 } from './components/ActionError'
+export {
+  InlineAlert,
+  type InlineAlertProps,
+  type InlineAlertTone,
+  type InlineAlertRecover,
+} from './components/InlineAlert'
 export { LineItemsTable, TotalRow } from './components/LineItemsTable'
 export { ToastProvider } from './toast/ToastProvider'
 export { useToast } from './toast/context'

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1054,6 +1054,55 @@
     font-weight: 500;
   }
 
+  /* 型2 (lightweight) / inline notices — single-line .alert + recover link.
+     Used when the cause is singular (e.g. issue rejected, overpayment). */
+  .alert {
+    display: flex;
+    gap: 0.5625rem;
+    align-items: flex-start;
+    padding: 0.6875rem 0.875rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border: 1px solid;
+  }
+  .alert svg {
+    flex: none;
+    width: 16px;
+    height: 16px;
+    margin-top: 1px;
+  }
+  .alert.error {
+    background: var(--color-danger-soft);
+    color: var(--color-danger);
+    border-color: color-mix(in oklch, var(--color-danger) 30%, transparent);
+  }
+  .alert.success {
+    background: var(--color-success-soft);
+    color: var(--color-success);
+    border-color: color-mix(in oklch, var(--color-success) 30%, transparent);
+  }
+  .alert.info {
+    background: var(--color-info-soft);
+    color: var(--color-info);
+    border-color: color-mix(in oklch, var(--color-info) 30%, transparent);
+  }
+  .recover-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-danger);
+    cursor: pointer;
+  }
+  .recover-link:hover {
+    text-decoration: underline;
+  }
+
   /* 型2 — action error (operation attempted but not completed) */
   .alert-rich {
     display: flex;


### PR DESCRIPTION
## 概要
エラー表示3型システムの適用第2弾（PR2）。原因が単一に絞れる型2は**軽量形**（単行 `.alert` ＋ recover link）で表示する。Refs #258（PR1 #259 に続く）。

## 変更点
- **theme**: 指示書の単行 `.alert`（error/success/info）と `.recover-link` を移植（トークン名読み替え・角丸ゼロ）。
- **InlineAlert**: 軽量型2／インライン通知コンポーネント。error は `role="alert"`、success/info は `role="status"`。アイコン＋テキスト（色のみに依存しない）。任意で recover link を下に表示。
- **発行（issue-invoice）**:
  - 失敗 → `InlineAlert`「発行できませんでした。会社情報の登録番号をご確認ください。」＋ recover「会社設定を開く →」（`/settings` へ遷移）。
  - 成功 → 型3トースト「発行しました／{番号} を発行しました」。
- **入金記録（manage-payments）**:
  - 失敗 → `InlineAlert`。**422 かつ残高既知のときのみ**「金額が残高（¥…）を超えています」。通信/5xx 等は汎用文言で**原因を断定しない**（文言3原則②）。
  - 成功 → 型3トースト「入金を記録しました／¥… を記録しました」。
- **i18n**: `issue.recover`/`successTitle`/`successBody(NoNumber)`、`payments.record.errorOverpay`/`successTitle`/`successBody` を ja/en 追加。`issue.error` を敬体に統一。
- **テスト**: `InlineAlert`（role 出し分け・recover link）。

## 検証
- `type-check` / `lint` / `prettier` / `knip` / `vitest（152 passed）` / `vite build` すべてグリーン。

## 残り
- PR3: 型1整備 — 取引先作成・明細・ログイン（欄直下 err-text／ログイン上部サマリ）、`MutationError` 全廃。

🤖 Generated with [Claude Code](https://claude.com/claude-code)