### PR TITLE
feat(frontend): キーボード第2層 — n(文脈新規)/検索フォーカス＋インラインヒント (#257)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -8,6 +8,7 @@ import {
   type ClientSortField,
 } from '@/entities/client'
 import { useTranslation } from '@/shared/i18n'
+import { KbdHint } from '@/shared/keyboard'
 import {
   Button,
   ConfirmDialog,
@@ -76,14 +77,16 @@ export function ListClients() {
         </Text>
         <LinkButton to="/clients/new" size="sm">
           {t('admin.clients.newButton')}
+          <KbdHint>n</KbdHint>
         </LinkButton>
       </div>
 
       <form onSubmit={onSubmit}>
         <div className="flex flex-wrap items-end gap-inline-sm">
-          <Field id="client-q" label={t('admin.clients.filter.search')}>
+          <Field id="client-q" label={t('admin.clients.filter.search')} hint={<KbdHint>/</KbdHint>}>
             <Input
               id="client-q"
+              data-kbd="search"
               className="w-72"
               value={draft.q ?? ''}
               placeholder={t('admin.clients.filter.searchPlaceholder')}

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -10,6 +10,7 @@ import {
   type InvoiceSortField,
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
+import { KbdHint } from '@/shared/keyboard'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -97,6 +98,7 @@ export function ListInvoices() {
           </Button>
           <LinkButton to="/invoices/new" size="sm">
             {t('admin.invoices.newButton')}
+            <KbdHint>n</KbdHint>
           </LinkButton>
         </Stack>
       </div>
@@ -110,9 +112,10 @@ export function ListInvoices() {
       <form onSubmit={onSubmit}>
         <Stack gap="sm">
           <div className="audit-filters">
-            <Field id="inv-q" label={t('admin.invoices.filter.search')}>
+            <Field id="inv-q" label={t('admin.invoices.filter.search')} hint={<KbdHint>/</KbdHint>}>
               <Input
                 id="inv-q"
+                data-kbd="search"
                 value={draft.q ?? ''}
                 placeholder={t('admin.invoices.filter.searchPlaceholder')}
                 onChange={(e) => {

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -9,6 +9,7 @@ import {
   type QuoteStatus,
 } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
+import { KbdHint } from '@/shared/keyboard'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -71,15 +72,17 @@ export function ListQuotes() {
         </Text>
         <LinkButton to="/quotes/new" size="sm">
           {t('admin.quotes.newButton')}
+          <KbdHint>n</KbdHint>
         </LinkButton>
       </div>
 
       <form onSubmit={onSubmit}>
         <Stack gap="sm">
           <div className="audit-filters">
-            <Field id="q-q" label={t('admin.quotes.filter.search')}>
+            <Field id="q-q" label={t('admin.quotes.filter.search')} hint={<KbdHint>/</KbdHint>}>
               <Input
                 id="q-q"
+                data-kbd="search"
                 value={draft.q ?? ''}
                 placeholder={t('admin.quotes.filter.searchPlaceholder')}
                 onChange={(e) => {

--- a/frontend/src/features/list-users/ui/ListUsers.tsx
+++ b/frontend/src/features/list-users/ui/ListUsers.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useDeleteUser, type User, type UserRole, type UserStatus } from '@/entities/user'
 import { useTranslation } from '@/shared/i18n'
+import { KbdHint } from '@/shared/keyboard'
 import {
   Badge,
   type BadgeTone,
@@ -52,6 +53,7 @@ export function ListUsers() {
         </Text>
         <LinkButton to="/users/new" size="sm">
           {t('admin.users.newButton')}
+          <KbdHint>n</KbdHint>
         </LinkButton>
       </div>
 

--- a/frontend/src/shared/keyboard/KbdHint.tsx
+++ b/frontend/src/shared/keyboard/KbdHint.tsx
@@ -1,0 +1,12 @@
+/**
+ * Inline keycap hint (Issue #257, spec §04). A small, muted `.kbd` shown next
+ * to the two most-frequent affordances only — search (`/`) and new (`n`). It is
+ * decorative (`aria-hidden`) and hides on touch devices via `.kbd-hint`.
+ */
+export function KbdHint({ children }: { children: string }) {
+  return (
+    <kbd className="kbd kbd-hint" aria-hidden="true">
+      {children}
+    </kbd>
+  )
+}

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -65,6 +65,39 @@ describe('KeyboardShortcuts', () => {
     expect(getByTestId('loc')).toHaveTextContent('/')
   })
 
+  it('focuses the list search box on /', () => {
+    const { getByRole } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <input data-kbd="search" aria-label="search" />
+      </>,
+    )
+
+    fireEvent.keyDown(document.body, { key: '/' })
+
+    expect(getByRole('textbox')).toHaveFocus()
+  })
+
+  it('opens the contextual new form on n (invoices → /invoices/new)', async () => {
+    const { getByTestId } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <LocationProbe />
+      </>,
+    )
+
+    fireEvent.keyDown(document.body, { key: 'g' })
+    fireEvent.keyDown(document.body, { key: 'i' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/invoices')
+    })
+
+    fireEvent.keyDown(document.body, { key: 'n' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/invoices/new')
+    })
+  })
+
   it('submits the surrounding form on Ctrl/Cmd+Enter, even from a field', () => {
     const onSubmit = vi.fn((e: { preventDefault: () => void }) => {
       e.preventDefault()

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { ShortcutsOverlay } from './ShortcutsOverlay'
 
 /** g-prefix sequence timeout (spec §02-D). */
@@ -14,6 +14,14 @@ const GOTO: Record<string, string> = {
   u: '/users',
   s: '/settings',
   a: '/audit-logs',
+}
+
+/** Layer 2 — `n` (new) resolves by the current list route (spec §06). */
+const NEW_ROUTE: Record<string, string> = {
+  '/quotes': '/quotes/new',
+  '/invoices': '/invoices/new',
+  '/clients': '/clients/new',
+  '/users': '/users/new',
 }
 
 /** True when focus sits in an editable control — single keys must not fire. */
@@ -32,6 +40,7 @@ function isEditableTarget(target: EventTarget | null): boolean {
  */
 export function KeyboardShortcuts() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [pendingG, setPendingG] = useState(false)
 
@@ -39,6 +48,7 @@ export function KeyboardShortcuts() {
   // values without re-binding on every keystroke.
   const overlayRef = useRef(false)
   const pendingRef = useRef(false)
+  const pathRef = useRef(location.pathname)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
@@ -47,6 +57,9 @@ export function KeyboardShortcuts() {
   useEffect(() => {
     pendingRef.current = pendingG
   }, [pendingG])
+  useEffect(() => {
+    pathRef.current = location.pathname
+  }, [location.pathname])
 
   useEffect(() => {
     const clearPending = (): void => {
@@ -114,7 +127,27 @@ export function KeyboardShortcuts() {
         return
       }
 
-      // Single-key actions (n / / / e / j / k / o) land in later phases.
+      // Layer 2 — focus the list search box (`/`).
+      if (e.key === '/') {
+        const search = document.querySelector('[data-kbd="search"]')
+        if (search instanceof HTMLElement) {
+          e.preventDefault()
+          search.focus()
+        }
+        return
+      }
+
+      // Layer 2 — context-sensitive new (`n`), resolved by the current route.
+      if (e.key === 'n') {
+        const dest = NEW_ROUTE[pathRef.current]
+        if (dest !== undefined) {
+          e.preventDefault()
+          void navigate(dest)
+        }
+        return
+      }
+
+      // List/grid navigation (j / k / o / Enter) lands in the next phase.
     }
 
     document.addEventListener('keydown', onKeydown)

--- a/frontend/src/shared/keyboard/index.ts
+++ b/frontend/src/shared/keyboard/index.ts
@@ -1,2 +1,3 @@
 export { KeyboardShortcuts } from './KeyboardShortcuts'
+export { KbdHint } from './KbdHint'
 export { isMacPlatform } from './platform'

--- a/frontend/src/shared/keyboard/shortcuts-data.ts
+++ b/frontend/src/shared/keyboard/shortcuts-data.ts
@@ -43,6 +43,14 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
+    ja: 'アクション',
+    en: 'Actions',
+    rows: [
+      { ja: '新規作成', en: 'New', combos: [{ caps: ['n'], join: 'none' }] },
+      { ja: '検索にフォーカス', en: 'Focus search', combos: [{ caps: ['/'], join: 'none' }] },
+    ],
+  },
+  {
     ja: 'フォーム',
     en: 'Form',
     rows: [

--- a/frontend/src/shared/ui/components/Field.tsx
+++ b/frontend/src/shared/ui/components/Field.tsx
@@ -6,6 +6,8 @@ export interface FieldProps {
   id: string
   label: string
   error?: string | undefined
+  /** Optional trailing adornment beside the label (e.g. a keyboard hint). */
+  hint?: ReactNode
   children: ReactNode
 }
 
@@ -21,7 +23,7 @@ type AriaControlProps = {
  * `aria-invalid` (red border via the primitives) and linked to the message,
  * which renders as `.err-text` directly beneath the field.
  */
-export function Field({ id, label, error, children }: FieldProps) {
+export function Field({ id, label, error, hint, children }: FieldProps) {
   const errorId = `${id}-error`
   const control =
     error !== undefined && isValidElement<AriaControlProps>(children)
@@ -33,8 +35,9 @@ export function Field({ id, label, error, children }: FieldProps) {
 
   return (
     <Stack gap="sm">
-      <label htmlFor={id} className="text-body text-fg-muted">
+      <label htmlFor={id} className="flex items-center gap-inline-xs text-body text-fg-muted">
         {label}
+        {hint}
       </label>
       {control}
       {error !== undefined && (

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1309,6 +1309,21 @@
   .kbd.wide {
     padding: 0 9px;
   }
+  /* inline hint keycap (spec §04) — smaller, muted, hidden on touch */
+  .kbd-hint {
+    height: 18px;
+    min-width: 18px;
+    padding: 0 5px;
+    font-size: 10.5px;
+    border-bottom-width: 1px;
+    box-shadow: none;
+    color: var(--color-fg-muted);
+  }
+  @media (hover: none) {
+    .kbd-hint {
+      display: none;
+    }
+  }
 
   /* g… prefix indicator (spec §02-D) — bottom-left while awaiting the 2nd key */
   .kbd-gind {


### PR DESCRIPTION
## 概要
キーボードショートカット実装第2弾（PR2）。第2層の単キーアクションと、最頻操作のインラインヒントを追加する。Refs #257（PR1 #262 に続く）。

## 実装
### 第2層 単キーアクション（IMEガード下）
- **n** → 現在の一覧ルートに応じた新規作成（`/quotes`→`/quotes/new` 等。`/invoices`・`/clients`・`/users` も）
- **/** → 一覧の検索ボックス（`[data-kbd="search"]`）へフォーカス（`preventDefault` で `/` を入力しない）
### `?` オーバーレイ
- 「アクション」グループ（新規作成 `n` / 検索にフォーカス `/`）を追加。
### インラインヒント（spec §04 ハイブリッド）
- 検索フィールドに `/`、新規ボタンに `n` の小さなキーキャップ（`KbdHint`：`aria-hidden`、`@media (hover:none)` でタッチ端末は非表示）。一覧4画面（見積・請求・取引先・ユーザー）に適用。
- `Field` に `hint` プロップ（ラベル右の付随要素）を追加。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（159 passed・新規含む7件）`/`vite build` グリーン。
- 実機（dev）で `g→i` 遷移・`/` 検索フォーカス（`data-kbd=search` にフォーカス確認）・`n` 新規・ヒント表示を目視確認。

| 一覧のインラインヒント（実機） |
| --- |
| `Search /`（検索ラベル横）・`New invoice n`（新規ボタン内）|

## 後続
- PR3: 第4層 `j/k` 行カーソル・`Enter`/`o` 行を開く・明細グリッド `Enter`（次セル/末尾で新規行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)