### PR TITLE
feat(frontend): キーボード第4層 — リスト行カーソル j/k/Enter/o (#257)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode, type SyntheticEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   EMPTY_CLIENT_FILTERS,
   useDeleteClient,
@@ -8,7 +8,7 @@ import {
   type ClientSortField,
 } from '@/entities/client'
 import { useTranslation } from '@/shared/i18n'
-import { KbdHint } from '@/shared/keyboard'
+import { KbdHint, useRowCursor } from '@/shared/keyboard'
 import {
   Button,
   ConfirmDialog,
@@ -28,10 +28,17 @@ const trimmedOrNull = (value: string): string | null => (value.trim() === '' ? n
 /** Client (取引先) list screen with search / sort and per-row delete. */
 export function ListClients() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const view = useListClients()
   const deleteClient = useDeleteClient()
   const [pendingDelete, setPendingDelete] = useState<Client | null>(null)
   const [draft, setDraft] = useState<ClientListFilters>(EMPTY_CLIENT_FILTERS)
+
+  const rows = view.state.kind === 'ready' ? view.state.clients : []
+  const cursor = useRowCursor(rows.length, (index) => {
+    const row = rows[index]
+    if (row !== undefined) void navigate(`/clients/${String(row.id)}/edit`)
+  })
 
   const confirmDelete = (): void => {
     if (pendingDelete === null) return
@@ -129,8 +136,12 @@ export function ListClients() {
               </tr>
             </thead>
             <tbody>
-              {view.state.clients.map((client) => (
-                <tr key={client.id}>
+              {view.state.clients.map((client, index) => (
+                <tr
+                  key={client.id}
+                  data-kbd-row={index}
+                  className={cursor === index ? 'is-cursor' : undefined}
+                >
                   <td data-label={t('admin.clients.col.name')}>{client.name}</td>
                   <td data-label={t('admin.clients.col.contact')}>{client.contact_name ?? '—'}</td>
                   <td data-label={t('admin.clients.col.email')}>{client.email ?? '—'}</td>

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode, type SyntheticEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   EMPTY_INVOICE_FILTERS,
   INVOICE_STATUSES,
@@ -10,7 +10,7 @@ import {
   type InvoiceSortField,
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
-import { KbdHint } from '@/shared/keyboard'
+import { KbdHint, useRowCursor } from '@/shared/keyboard'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -36,11 +36,18 @@ const trimmedOrNull = (value: string): string | null => (value.trim() === '' ? n
 /** Invoice list screen with search / filter / sort. */
 export function ListInvoices() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const view = useListInvoices()
   const exportInvoices = useExportInvoicesCsv()
   const exportPayments = useExportPaymentsCsv()
 
   const [draft, setDraft] = useState<InvoiceListFilters>(EMPTY_INVOICE_FILTERS)
+
+  const rows = view.state.kind === 'ready' ? view.state.invoices : []
+  const cursor = useRowCursor(rows.length, (index) => {
+    const row = rows[index]
+    if (row !== undefined) void navigate(`/invoices/${String(row.id)}`)
+  })
 
   const onSubmit = (event: SyntheticEvent): void => {
     event.preventDefault()
@@ -236,8 +243,12 @@ export function ListInvoices() {
                 </tr>
               </thead>
               <tbody>
-                {view.state.invoices.map((invoice) => (
-                  <tr key={invoice.id}>
+                {view.state.invoices.map((invoice, index) => (
+                  <tr
+                    key={invoice.id}
+                    data-kbd-row={index}
+                    className={cursor === index ? 'is-cursor' : undefined}
+                  >
                     <td data-label={t('admin.invoices.col.number')}>
                       <Link to={`/invoices/${String(invoice.id)}`} className="num text-accent">
                         {invoice.invoice_number ?? '—'}

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode, type SyntheticEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   EMPTY_QUOTE_FILTERS,
   QUOTE_STATUSES,
@@ -9,7 +9,7 @@ import {
   type QuoteStatus,
 } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
-import { KbdHint } from '@/shared/keyboard'
+import { KbdHint, useRowCursor } from '@/shared/keyboard'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -34,8 +34,15 @@ const trimmedOrNull = (value: string): string | null => (value.trim() === '' ? n
 
 export function ListQuotes() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const view = useListQuotes()
   const [draft, setDraft] = useState<QuoteListFilters>(EMPTY_QUOTE_FILTERS)
+
+  const rows = view.state.kind === 'ready' ? view.state.quotes : []
+  const cursor = useRowCursor(rows.length, (index) => {
+    const row = rows[index]
+    if (row !== undefined) void navigate(`/quotes/${String(row.id)}`)
+  })
 
   const onSubmit = (event: SyntheticEvent): void => {
     event.preventDefault()
@@ -188,8 +195,12 @@ export function ListQuotes() {
                 </tr>
               </thead>
               <tbody>
-                {view.state.quotes.map((quote) => (
-                  <tr key={quote.id}>
+                {view.state.quotes.map((quote, index) => (
+                  <tr
+                    key={quote.id}
+                    data-kbd-row={index}
+                    className={cursor === index ? 'is-cursor' : undefined}
+                  >
                     <td data-label={t('admin.quotes.col.number')}>
                       <Link to={`/quotes/${String(quote.id)}`} className="num text-accent">
                         {quote.quote_number}

--- a/frontend/src/features/list-users/ui/ListUsers.tsx
+++ b/frontend/src/features/list-users/ui/ListUsers.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useDeleteUser, type User, type UserRole, type UserStatus } from '@/entities/user'
 import { useTranslation } from '@/shared/i18n'
-import { KbdHint } from '@/shared/keyboard'
+import { KbdHint, useRowCursor } from '@/shared/keyboard'
 import {
   Badge,
   type BadgeTone,
@@ -32,9 +32,16 @@ const STATUS_TONE: Record<UserStatus, BadgeTone> = {
 /** User list screen with per-row delete (confirmed). */
 export function ListUsers() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const state = useListUsers()
   const deleteUser = useDeleteUser()
   const [pendingDelete, setPendingDelete] = useState<User | null>(null)
+
+  const rows = state.kind === 'ready' ? state.users : []
+  const cursor = useRowCursor(rows.length, (index) => {
+    const row = rows[index]
+    if (row !== undefined) void navigate(`/users/${String(row.id)}/edit`)
+  })
 
   const confirmDelete = (): void => {
     if (pendingDelete === null) return
@@ -81,8 +88,12 @@ export function ListUsers() {
               </tr>
             </thead>
             <tbody>
-              {state.users.map((user) => (
-                <tr key={user.id}>
+              {state.users.map((user, index) => (
+                <tr
+                  key={user.id}
+                  data-kbd-row={index}
+                  className={cursor === index ? 'is-cursor' : undefined}
+                >
                   <td data-label={t('admin.users.col.email')}>{user.email}</td>
                   <td data-label={t('admin.users.col.role')}>
                     <Badge tone={ROLE_TONE[user.role]}>{t(`admin.users.role.${user.role}`)}</Badge>

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -3,9 +3,23 @@ import { useLocation } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { KeyboardShortcuts } from './KeyboardShortcuts'
+import { useRowCursor } from './use-row-cursor'
 
 function LocationProbe() {
   return <div data-testid="loc">{useLocation().pathname}</div>
+}
+
+function ListHarness({ onOpen }: { onOpen: (index: number) => void }) {
+  const cursor = useRowCursor(3, onOpen)
+  return (
+    <ul>
+      {[0, 1, 2].map((i) => (
+        <li key={i} data-kbd-row={i} className={cursor === i ? 'is-cursor' : undefined}>
+          row{i}
+        </li>
+      ))}
+    </ul>
+  )
 }
 
 describe('KeyboardShortcuts', () => {
@@ -96,6 +110,26 @@ describe('KeyboardShortcuts', () => {
     await waitFor(() => {
       expect(getByTestId('loc')).toHaveTextContent('/invoices/new')
     })
+  })
+
+  it('moves the row cursor with j/k and opens the cursored row with o', () => {
+    const onOpen = vi.fn()
+    const { container } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <ListHarness onOpen={onOpen} />
+      </>,
+    )
+
+    fireEvent.keyDown(document.body, { key: 'j' })
+    expect(container.querySelector('.is-cursor')).toHaveTextContent('row0')
+    fireEvent.keyDown(document.body, { key: 'j' })
+    expect(container.querySelector('.is-cursor')).toHaveTextContent('row1')
+    fireEvent.keyDown(document.body, { key: 'k' })
+    expect(container.querySelector('.is-cursor')).toHaveTextContent('row0')
+
+    fireEvent.keyDown(document.body, { key: 'o' })
+    expect(onOpen).toHaveBeenCalledWith(0)
   })
 
   it('submits the surrounding form on Ctrl/Cmd+Enter, even from a field', () => {

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { ShortcutsOverlay } from './ShortcutsOverlay'
+import { KBD_LIST_EVENT, type RowCursorAction } from './use-row-cursor'
+
+function emitListAction(action: RowCursorAction): void {
+  document.dispatchEvent(new CustomEvent(KBD_LIST_EVENT, { detail: { action } }))
+}
 
 /** g-prefix sequence timeout (spec §02-D). */
 const G_TIMEOUT_MS = 1200
@@ -34,9 +39,10 @@ function isEditableTarget(target: EventTarget | null): boolean {
 
 /**
  * Global keyboard dispatcher (Issue #257, spec §02 contract A→E). Mounted once
- * inside the authenticated shell — never on the login screen. This phase wires
- * navigation (g-prefix), the ⌘/Ctrl+Enter submit chord, and the `?` overlay;
- * single-key actions and list/grid navigation arrive in later phases.
+ * inside the authenticated shell — never on the login screen. Wires navigation
+ * (g-prefix), the ⌘/Ctrl+Enter submit chord, the `?` overlay, single-key actions
+ * (n / /), and the list row cursor (j / k / o / Enter) via the `kbd:list` event.
+ * The line-item grid Enter is handled form-locally, not here.
  */
 export function KeyboardShortcuts() {
   const navigate = useNavigate()
@@ -147,7 +153,22 @@ export function KeyboardShortcuts() {
         return
       }
 
-      // List/grid navigation (j / k / o / Enter) lands in the next phase.
+      // Layer 4 — list row cursor. A mounted list (useRowCursor) consumes these;
+      // on other screens they are no-ops.
+      if (e.key === 'j' || e.key === 'k') {
+        e.preventDefault()
+        emitListAction(e.key === 'j' ? 'down' : 'up')
+        return
+      }
+      if (e.key === 'o') {
+        emitListAction('open')
+        return
+      }
+      // Enter opens the cursored row only when nothing interactive is focused —
+      // otherwise it must activate the focused control (button/link) normally.
+      if (e.key === 'Enter' && (e.target === document.body || e.target === null)) {
+        emitListAction('open')
+      }
     }
 
     document.addEventListener('keydown', onKeydown)

--- a/frontend/src/shared/keyboard/index.ts
+++ b/frontend/src/shared/keyboard/index.ts
@@ -1,3 +1,4 @@
 export { KeyboardShortcuts } from './KeyboardShortcuts'
 export { KbdHint } from './KbdHint'
 export { isMacPlatform } from './platform'
+export { useRowCursor } from './use-row-cursor'

--- a/frontend/src/shared/keyboard/shortcuts-data.ts
+++ b/frontend/src/shared/keyboard/shortcuts-data.ts
@@ -43,6 +43,28 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     ],
   },
   {
+    ja: 'リスト',
+    en: 'List',
+    rows: [
+      {
+        ja: '次 / 前の行',
+        en: 'Next / Prev row',
+        combos: [
+          { caps: ['j'], join: 'none' },
+          { caps: ['k'], join: 'none' },
+        ],
+      },
+      {
+        ja: '選択行を開く',
+        en: 'Open row',
+        combos: [
+          { caps: ['Enter'], join: 'none' },
+          { caps: ['o'], join: 'none' },
+        ],
+      },
+    ],
+  },
+  {
     ja: 'アクション',
     en: 'Actions',
     rows: [

--- a/frontend/src/shared/keyboard/use-row-cursor.ts
+++ b/frontend/src/shared/keyboard/use-row-cursor.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** Action carried by the global `kbd:list` event from the dispatcher. */
+export type RowCursorAction = 'down' | 'up' | 'open'
+
+/** Custom event name the dispatcher emits for j / k / o / Enter (spec §1-4). */
+export const KBD_LIST_EVENT = 'kbd:list'
+
+/**
+ * List row cursor (Issue #257, 第4層). A list opts in by calling this with its
+ * row count and an open handler; the global {@link KeyboardShortcuts} dispatcher
+ * emits `kbd:list` for j/k/o/Enter, and the cursored row is highlighted with
+ * `.is-cursor` (the caller renders it). Returns the active index, or -1 for none.
+ */
+export function useRowCursor(count: number, onOpen: (index: number) => void): number {
+  const [cursor, setCursor] = useState(-1)
+  const cursorRef = useRef(-1)
+  const onOpenRef = useRef(onOpen)
+
+  useEffect(() => {
+    cursorRef.current = cursor
+  }, [cursor])
+  useEffect(() => {
+    onOpenRef.current = onOpen
+  }, [onOpen])
+
+  // Keep the cursor in range when the row set shrinks (e.g. after filtering).
+  // Adjusting state during render is the React-recommended pattern here.
+  if (cursor >= count) {
+    setCursor(count - 1)
+  }
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const action = (event as CustomEvent<{ action: RowCursorAction }>).detail.action
+      if (action === 'down') {
+        setCursor((c) => Math.min(count - 1, c + 1))
+      } else if (action === 'up') {
+        setCursor((c) => (c <= 0 ? 0 : c - 1))
+      } else if (cursorRef.current >= 0) {
+        onOpenRef.current(cursorRef.current)
+      }
+    }
+    document.addEventListener(KBD_LIST_EVENT, handler)
+    return () => {
+      document.removeEventListener(KBD_LIST_EVENT, handler)
+    }
+  }, [count])
+
+  // Keep the cursored row visible.
+  useEffect(() => {
+    if (cursor < 0) return
+    const el = document.querySelector(`[data-kbd-row="${String(cursor)}"]`)
+    if (el instanceof HTMLElement && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest' })
+    }
+  }, [cursor])
+
+  return cursor
+}

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1324,6 +1324,11 @@
       display: none;
     }
   }
+  /* list row cursor (spec §1-4) — j/k highlight with a ruled accent edge */
+  .data-table tbody tr.is-cursor {
+    background: var(--color-accent-soft);
+    box-shadow: inset 3px 0 0 var(--color-accent);
+  }
 
   /* g… prefix indicator (spec §02-D) — bottom-left while awaiting the 2nd key */
   .kbd-gind {


### PR DESCRIPTION
## 概要
キーボードショートカット実装第3弾（PR3）。第4層のリスト操作（行カーソル）を追加する。Refs #257（PR1 #262・PR2 #263 に続く）。

## 実装
### ディスパッチャ
- `j`/`k`/`o`/`Enter` で `kbd:list` カスタムイベントを発行（j=次行・k=前行・o/Enter=開く）。
- `Enter` は**フォーカスが `body` のときのみ** 行オープンに使う（フォーカス中のボタン/リンクの既定動作を奪わない）。
### `useRowCursor` フック
- 一覧が `kbd:list` を購読し行カーソル（index）を管理。`.is-cursor` でハイライト＋選択行へ `scrollIntoView`、open で当該行を開く。行集合が縮んだらレンダー時にクランプ。
### 適用
- 見積・請求・取引先・ユーザーの4一覧。open 先：請求→`/invoices/:id`、見積→`/quotes/:id`、取引先→`/clients/:id/edit`、ユーザー→`/users/:id/edit`。
### その他
- `?` オーバーレイに「リスト」グループ（次/前の行 `j` `k`・選択行を開く `Enter` `o`）。
- theme：`.data-table tbody tr.is-cursor`（淡い accent 背景＋左罫線強調）。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（160 passed・新規含む8件）`/`vite build` グリーン。
- 実機（dev）で `j`×3 → 3行目ハイライト、`o` → 詳細遷移（/invoices/9）を確認。

| 行カーソル（実機） |
| --- |
| `j/k` で `.is-cursor`（淡い緑背景＋左アクセント罫線）、`o`/`Enter` で行を開く |

## 残り（#257 の最後）
- 明細グリッドの `Enter`（次セル移動／末尾で新規行追加）はフォームローカル実装として別PRで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)