### PR TITLE
feat(frontend): キーボード明細グリッド Enter ナビ — #257 完了

### DIFF
--- a/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
+++ b/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
@@ -1,5 +1,6 @@
 import { useWatch } from 'react-hook-form'
 import { useTranslation } from '@/shared/i18n'
+import { useLineGridEnter } from '@/shared/keyboard'
 import { formatTaxRate, formatYen } from '@/shared/lib/format-money'
 import { computeDocumentTotals } from '@/shared/lib/tax'
 import { Button, Field, InlineAlert, Input, Select, Stack, Text, Textarea } from '@/shared/ui'
@@ -29,6 +30,7 @@ export function CreateInvoiceForm() {
     register,
     formState: { errors },
   } = form
+  const { gridRef } = useLineGridEnter(lines.fields.length, addLine)
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   // Empty number inputs surface as NaN; computeDocumentTotals coerces those to 0.
@@ -78,7 +80,7 @@ export function CreateInvoiceForm() {
           {/* Line items */}
           <div className="card">
             <div className="section-title">{t('admin.invoices.create.lineItems')}</div>
-            <div className="line-grid">
+            <div className="line-grid" ref={gridRef}>
               <div className="line-head">
                 <span>{t('admin.invoices.line.description')}</span>
                 <span className="tr">{t('admin.invoices.line.quantity')}</span>

--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -1,5 +1,6 @@
 import { useWatch } from 'react-hook-form'
 import { useTranslation } from '@/shared/i18n'
+import { useLineGridEnter } from '@/shared/keyboard'
 import { formatTaxRate, formatYen } from '@/shared/lib/format-money'
 import { computeDocumentTotals } from '@/shared/lib/tax'
 import {
@@ -39,6 +40,7 @@ export function CreateQuoteForm() {
     register,
     formState: { errors },
   } = form
+  const { gridRef } = useLineGridEnter(lines.fields.length, addLine)
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   const watched = useWatch({ control, name: 'line_items' })
@@ -92,7 +94,7 @@ export function CreateQuoteForm() {
           {/* Line items */}
           <div className="card">
             <div className="section-title">{t('admin.quotes.create.lineItems')}</div>
-            <div className="line-grid">
+            <div className="line-grid" ref={gridRef}>
               <div className="line-head">
                 <span>{t('admin.invoices.line.description')}</span>
                 <span className="tr">{t('admin.invoices.line.quantity')}</span>

--- a/frontend/src/shared/keyboard/index.ts
+++ b/frontend/src/shared/keyboard/index.ts
@@ -1,4 +1,5 @@
 export { KeyboardShortcuts } from './KeyboardShortcuts'
 export { KbdHint } from './KbdHint'
 export { isMacPlatform } from './platform'
+export { useLineGridEnter } from './use-line-grid-enter'
 export { useRowCursor } from './use-row-cursor'

--- a/frontend/src/shared/keyboard/use-line-grid-enter.test.tsx
+++ b/frontend/src/shared/keyboard/use-line-grid-enter.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import { useLineGridEnter } from './use-line-grid-enter'
+
+function GridHarness() {
+  const [rows, setRows] = useState([0])
+  const { gridRef } = useLineGridEnter(rows.length, () => {
+    setRows((r) => [...r, r.length])
+  })
+  return (
+    <div className="line-grid" ref={gridRef}>
+      {rows.map((r) => (
+        <div key={r}>
+          <input aria-label={`a${String(r)}`} />
+          <input aria-label={`b${String(r)}`} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+describe('useLineGridEnter', () => {
+  it('moves focus to the next cell on Enter', () => {
+    const { getByLabelText } = render(<GridHarness />)
+    const a0 = getByLabelText('a0')
+    a0.focus()
+
+    fireEvent.keyDown(a0, { key: 'Enter' })
+
+    expect(getByLabelText('b0')).toHaveFocus()
+  })
+
+  it('adds a row and focuses its first cell from the last cell', () => {
+    const { getByLabelText, queryByLabelText } = render(<GridHarness />)
+    const b0 = getByLabelText('b0')
+    b0.focus()
+
+    fireEvent.keyDown(b0, { key: 'Enter' })
+
+    expect(queryByLabelText('a1')).not.toBeNull()
+    expect(getByLabelText('a1')).toHaveFocus()
+  })
+})

--- a/frontend/src/shared/keyboard/use-line-grid-enter.ts
+++ b/frontend/src/shared/keyboard/use-line-grid-enter.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Line-item grid Enter navigation (Issue #257, spec §1-4 — the primary
+ * data-entry shortcut). Enter moves to the next cell; at the last cell it adds a
+ * new row and focuses its first cell, so the hand never leaves the grid. This is
+ * form-local (the global dispatcher's IME guard skips keys inside fields).
+ *
+ * Attach the returned `gridRef` to the grid container. Only `input` and `select`
+ * cells participate; buttons (e.g. remove) keep their native Enter. The keydown
+ * listener is attached natively so the container stays a plain, non-interactive
+ * element (the focusable cells carry the interaction).
+ */
+export function useLineGridEnter(
+  rowCount: number,
+  addRow: () => void,
+): { gridRef: React.RefObject<HTMLDivElement | null> } {
+  const gridRef = useRef<HTMLDivElement | null>(null)
+  const focusIndexRef = useRef<number | null>(null)
+  const addRowRef = useRef(addRow)
+
+  useEffect(() => {
+    addRowRef.current = addRow
+  }, [addRow])
+
+  useEffect(() => {
+    const container = gridRef.current
+    if (container === null) return
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Enter' || !(event.target instanceof HTMLElement)) return
+      const fields = Array.from(container.querySelectorAll<HTMLElement>('input, select'))
+      const index = fields.indexOf(event.target)
+      if (index === -1) return
+
+      // Intercept the browser's implicit form submit on Enter inside a cell.
+      event.preventDefault()
+      const next = fields[index + 1]
+      if (next !== undefined) {
+        next.focus()
+      } else {
+        // Last cell: the new row's first field will append at the current length.
+        focusIndexRef.current = fields.length
+        addRowRef.current()
+      }
+    }
+
+    container.addEventListener('keydown', onKeyDown)
+    return () => {
+      container.removeEventListener('keydown', onKeyDown)
+    }
+  }, [])
+
+  // After a row is added, focus the first cell of the new (last) row.
+  useEffect(() => {
+    const target = focusIndexRef.current
+    if (target === null) return
+    focusIndexRef.current = null
+    const fields = gridRef.current?.querySelectorAll<HTMLElement>('input, select')
+    fields?.[target]?.focus()
+  }, [rowCount])
+
+  return { gridRef }
+}


### PR DESCRIPTION
## 概要
キーボードショートカット実装の最終段（PR4）。明細グリッドの `Enter`（データ入力の主導線）を追加し、#257 のキーマップを完了する。**Closes #257**（PR1 #262・PR2 #263・PR3 #264 に続く完結）。

## 実装
- **`useLineGridEnter` フック**: グリッド内の `input`/`select` で `Enter` → 次セルへ移動。**最終セルで `Enter` → 新規行を追加して新行の先頭セルへフォーカス**（手をグリッドから離さない）。
  - ブラウザの暗黙フォーム送信を `preventDefault` で抑止。
  - remove ボタンは対象外（native Enter を保持）。
  - keydown はネイティブリスナーで購読し、コンテナを非インタラクティブな素の要素に保つ（a11y）。
- 見積作成・請求作成フォームの `.line-grid` に適用。
- フックのユニットテスト（次セル移動／末尾で行追加＋フォーカス）。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（162 passed）`/`vite build` グリーン。
- 実機（dev）で確認：desc→Enter→`quantity`→…→`tax_rate_bps`（末尾）→Enter で **2行目に行追加＋`line_items.1.description` へフォーカス**。

## #257 完了 — 確定キーマップ全実装
| 層 | 実装 |
| --- | --- |
| 1 画面遷移 | `g→d/q/i/c/u/s/a` |
| 2 アクション | `n`（文脈新規）/ `/`（検索フォーカス） |
| 3 フォーム確定 | `⌘/Ctrl+Enter` |
| 4 リスト/グリッド | `j/k` 行カーソル・`Enter`/`o` 行を開く・**明細グリッド `Enter`** |
| ヘルプ | `?` オーバーレイ（ja主/en副・キーキャップ） |

契約 A–E（IMEガード・g前置・プラットフォーム判定）順守。

🤖 Generated with [Claude Code](https://claude.com/claude-code)