### PR TITLE
fix(frontend): 詳細の操作フィードバックをボタン行の外へ — 列ストレッチ崩れを解消 (#266)

### DIFF
--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -84,85 +84,86 @@ export function ViewInvoice({ invoiceId }: ViewInvoiceProps) {
           </Text>
           <div className="flex flex-wrap items-start gap-inline-sm">
             {pdf.canDownload && (
-              <Stack gap="sm">
-                <Button onClick={pdf.download} disabled={pdf.isDownloading}>
-                  {pdf.isDownloading
-                    ? t('admin.invoices.detail.downloadingPdf')
-                    : t('admin.invoices.detail.downloadPdf')}
-                </Button>
-                {pdf.errorMessage !== null && (
-                  <InlineAlert tone="error" message={pdf.errorMessage} />
-                )}
-              </Stack>
+              <Button onClick={pdf.download} disabled={pdf.isDownloading}>
+                {pdf.isDownloading
+                  ? t('admin.invoices.detail.downloadingPdf')
+                  : t('admin.invoices.detail.downloadPdf')}
+              </Button>
             )}
             {isIssued && (
-              <Stack gap="sm">
-                <Button onClick={sendInvoiceEmail} disabled={sendEmail.isPending}>
-                  {sendEmail.isPending
-                    ? t('admin.invoices.detail.sendingEmail')
-                    : t('admin.invoices.detail.sendEmail')}
-                </Button>
-                {sendEmail.isError && (
-                  <div className="max-w-md">
-                    <ActionError
-                      title={t('admin.invoices.detail.emailErrorTitle')}
-                      description={t('admin.invoices.detail.emailErrorBody')}
-                      actions={[
-                        {
-                          label: t('admin.invoices.detail.emailRetry'),
-                          variant: 'solid',
-                          onClick: sendInvoiceEmail,
-                        },
-                        {
-                          label: t('admin.invoices.detail.emailCheckClient'),
-                          variant: 'outline',
-                          onClick: () => {
-                            void navigate(`/clients/${String(invoice.client_id)}/edit`)
-                          },
-                        },
-                      ]}
-                      onClose={() => {
-                        sendEmail.reset()
-                      }}
-                      closeLabel={t('common.actions.close')}
-                    />
-                  </div>
-                )}
-              </Stack>
+              <Button onClick={sendInvoiceEmail} disabled={sendEmail.isPending}>
+                {sendEmail.isPending
+                  ? t('admin.invoices.detail.sendingEmail')
+                  : t('admin.invoices.detail.sendEmail')}
+              </Button>
             )}
             {link.canGenerate && (
-              <Stack gap="sm">
-                <Button onClick={link.generate} disabled={link.isGenerating}>
-                  {link.isGenerating
-                    ? t('admin.invoices.detail.generatingLink')
-                    : t('admin.invoices.detail.generateLink')}
-                </Button>
-                {link.downloadUrl !== null && (
-                  <Stack gap="sm">
-                    <Text variant="muted" className="break-all text-caption">
-                      {`${window.location.origin}${link.downloadUrl}`}
-                    </Text>
-                    <Stack direction="row" gap="sm">
-                      <Button onClick={link.copy}>
-                        {link.copied
-                          ? t('admin.invoices.detail.linkCopied')
-                          : t('admin.invoices.detail.linkCopy')}
-                      </Button>
-                      {link.expiresAt !== null && (
-                        <Text variant="muted">
-                          {t('admin.invoices.detail.linkExpiry', { expiresAt: link.expiresAt })}
-                        </Text>
-                      )}
-                    </Stack>
-                  </Stack>
-                )}
-                {link.errorMessage !== null && (
-                  <InlineAlert tone="error" message={link.errorMessage} />
-                )}
-              </Stack>
+              <Button onClick={link.generate} disabled={link.isGenerating}>
+                {link.isGenerating
+                  ? t('admin.invoices.detail.generatingLink')
+                  : t('admin.invoices.detail.generateLink')}
+              </Button>
             )}
           </div>
         </div>
+
+        {/* Feedback sits outside the button row so a failing action never
+            stretches one button's column (Issue #266). */}
+        {pdf.errorMessage !== null && (
+          <div className="ar-banner">
+            <InlineAlert tone="error" message={pdf.errorMessage} />
+          </div>
+        )}
+        {sendEmail.isError && (
+          <div className="ar-banner">
+            <ActionError
+              title={t('admin.invoices.detail.emailErrorTitle')}
+              description={t('admin.invoices.detail.emailErrorBody')}
+              actions={[
+                {
+                  label: t('admin.invoices.detail.emailRetry'),
+                  variant: 'solid',
+                  onClick: sendInvoiceEmail,
+                },
+                {
+                  label: t('admin.invoices.detail.emailCheckClient'),
+                  variant: 'outline',
+                  onClick: () => {
+                    void navigate(`/clients/${String(invoice.client_id)}/edit`)
+                  },
+                },
+              ]}
+              onClose={() => {
+                sendEmail.reset()
+              }}
+              closeLabel={t('common.actions.close')}
+            />
+          </div>
+        )}
+        {link.downloadUrl !== null && (
+          <Stack gap="sm" className="ar-banner">
+            <Text variant="muted" className="break-all text-caption">
+              {`${window.location.origin}${link.downloadUrl}`}
+            </Text>
+            <Stack direction="row" gap="sm">
+              <Button onClick={link.copy}>
+                {link.copied
+                  ? t('admin.invoices.detail.linkCopied')
+                  : t('admin.invoices.detail.linkCopy')}
+              </Button>
+              {link.expiresAt !== null && (
+                <Text variant="muted">
+                  {t('admin.invoices.detail.linkExpiry', { expiresAt: link.expiresAt })}
+                </Text>
+              )}
+            </Stack>
+          </Stack>
+        )}
+        {link.errorMessage !== null && (
+          <div className="ar-banner">
+            <InlineAlert tone="error" message={link.errorMessage} />
+          </div>
+        )}
         <Stack direction="row" gap="md">
           <Badge tone={invoiceStatusTone[invoice.status]}>
             {t(`admin.invoices.status.${invoice.status}`)}

--- a/frontend/src/features/view-quote/ui/ViewQuote.tsx
+++ b/frontend/src/features/view-quote/ui/ViewQuote.tsx
@@ -53,14 +53,11 @@ export function ViewQuote({ quoteId }: ViewQuoteProps) {
             {quote.quote_number}
           </Text>
           <Stack direction="row" gap="sm" className="flex-wrap justify-end">
-            <Stack gap="sm">
-              <Button onClick={pdf.download} disabled={pdf.isDownloading}>
-                {pdf.isDownloading
-                  ? t('admin.quotes.detail.downloadingPdf')
-                  : t('admin.quotes.detail.downloadPdf')}
-              </Button>
-              {pdf.errorMessage !== null && <InlineAlert tone="error" message={pdf.errorMessage} />}
-            </Stack>
+            <Button onClick={pdf.download} disabled={pdf.isDownloading}>
+              {pdf.isDownloading
+                ? t('admin.quotes.detail.downloadingPdf')
+                : t('admin.quotes.detail.downloadPdf')}
+            </Button>
             {state.canSend && (
               <Button
                 onClick={() => {
@@ -110,6 +107,14 @@ export function ViewQuote({ quoteId }: ViewQuoteProps) {
             )}
           </Stack>
         </div>
+
+        {/* Feedback sits outside the button row (Issue #266). */}
+        {pdf.errorMessage !== null && (
+          <div className="ar-banner">
+            <InlineAlert tone="error" message={pdf.errorMessage} />
+          </div>
+        )}
+
         <Stack direction="row" gap="md">
           <Badge tone={quoteStatusTone[quote.status]}>
             {t(`admin.quotes.status.${quote.status}`)}
@@ -125,7 +130,11 @@ export function ViewQuote({ quoteId }: ViewQuoteProps) {
             </Text>
           )}
         </Stack>
-        {state.actionError !== null && <InlineAlert tone="error" message={state.actionError} />}
+        {state.actionError !== null && (
+          <div className="ar-banner">
+            <InlineAlert tone="error" message={state.actionError} />
+          </div>
+        )}
       </Stack>
 
       <LineItemsTable items={quote.line_items} />

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1146,6 +1146,13 @@
     gap: 0.5rem;
     margin-top: 0.6875rem;
   }
+  /* Full-width feedback banner placed *outside* a button row so a failing
+     action never stretches one button's column (Issue #266). Capped for
+     readability. */
+  .ar-banner {
+    width: 100%;
+    max-width: 640px;
+  }
   .alert-rich .ar-close {
     flex: none;
     width: 1.5rem;


### PR DESCRIPTION
## 概要
請求書/見積詳細のヘッダー操作エリアで、フィードバック（エラー等）をボタンの「列」の内側に入れていたためにレイアウトが崩れる問題を修正する。**Closes #266**。

## 原因
操作ボタンが各々個別の縦 `Stack`（列）になっており、その列の内側に `ActionError`／リンクURL行を入れていた。失敗時にその列だけ縦に伸び、`flex-wrap` 行内で高さが不揃いになり、隣の「クライアント向けリンク生成」が押し下げられて崩れていた。

## 対応
- 操作ボタンは**1つの行**に閉じる。
- フィードバック（PDF/リンクのエラー、メール送信の `ActionError`、リンクURL/コピー行）は**ボタン行の外・直下**に全幅バナー（`.ar-banner`、`max-width: 640px`）として配置。ボタンが何個でも・折り返しても崩れない。
- 同じアンチパターンの見積詳細（`ViewQuote` の PDF エラー・ステータス変更エラー）も同様に修正。
- theme に `.ar-banner` を追加。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（162 passed）`/`vite build` グリーン。
- 実機（dev）でメール送信を失敗させ確認：3ボタンが1行で揃い、`ActionError` がボタン行直下の全幅バナー（≤640px）として表示、リンク生成ボタンが押し下げられない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)