### PR TITLE
feat(company): 請求支払サイト・見積有効期限の既定値 — backend基盤 (#268)

### DIFF
--- a/database/migrations/20260605000000_add_billing_defaults_to_company_settings.php
+++ b/database/migrations/20260605000000_add_billing_defaults_to_company_settings.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Company-level billing defaults (Issue #268): default quote validity period and
+ * the invoice payment-terms model (締め日 + 支払サイト). All nullable — existing
+ * organizations keep "no default" behaviour. `month_offset` doubles as the
+ * presence flag for the payment-terms default (null = not configured); a null
+ * `closing_day` / `pay_day` means 末日 (month-end) when terms are configured.
+ */
+final class AddBillingDefaultsToCompanySettings extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('company_settings')
+            ->addColumn('default_quote_validity_days', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('default_payment_closing_day', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('default_payment_month_offset', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('default_payment_pay_day', 'integer', ['null' => true, 'default' => null])
+            ->update();
+    }
+}

--- a/database/schema/company_settings.sql
+++ b/database/schema/company_settings.sql
@@ -13,6 +13,10 @@ CREATE TABLE IF NOT EXISTS company_settings (
     account_type VARCHAR(32) NULL DEFAULT NULL,
     account_number VARCHAR(64) NULL DEFAULT NULL,
     logo_url VARCHAR(1024) NULL DEFAULT NULL,
+    default_quote_validity_days INTEGER NULL DEFAULT NULL,
+    default_payment_closing_day INTEGER NULL DEFAULT NULL,
+    default_payment_month_offset INTEGER NULL DEFAULT NULL,
+    default_payment_pay_day INTEGER NULL DEFAULT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL
 );

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -61,6 +61,10 @@ CREATE TABLE IF NOT EXISTS `company_settings` (
     `account_type`        VARCHAR(32)   DEFAULT NULL,
     `account_number`      VARCHAR(64)   DEFAULT NULL,
     `logo_url`            VARCHAR(1024) DEFAULT NULL,
+    `default_quote_validity_days`  INT  DEFAULT NULL,
+    `default_payment_closing_day`  INT  DEFAULT NULL,
+    `default_payment_month_offset` INT  DEFAULT NULL,
+    `default_payment_pay_day`      INT  DEFAULT NULL,
     `created_at`          DATETIME      NOT NULL,
     `updated_at`          DATETIME      NOT NULL,
     UNIQUE KEY `uniq_company_settings_organization_id` (`organization_id`)

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -92,6 +92,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Numbers | `quote_number`, `invoice_number` | `number`, `quote_no` |
 | Timestamps | `issued_at`, `due_at`, `paid_at`, `valid_until`, `deleted_at` | `issue_date`, `due_date`, `paidAt` |
 | Issuer fields | `legal_name`, `bank_name`, `bank_branch`, `account_type`, `account_number`, `logo_url` | `company_name`, `branch`, `acct_no` |
+| Billing defaults (issuer) | `default_quote_validity_days`, `default_payment_closing_day`, `default_payment_month_offset`, `default_payment_pay_day` | `quote_validity`, `closing_day`, `payment_site`, `pay_day`, `net_days` |
 | Client fields | `contact_name`, `billing_address` | `contact`, `address` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents` | `monthly_received_cents`, `received_this_month`, `mtd_cents` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1360,6 +1360,24 @@ components:
           type: [string, 'null']
         logo_url:
           type: [string, 'null']
+        default_quote_validity_days:
+          type: [integer, 'null']
+          description: Default quote validity period in days (有効期限). null = no default.
+        default_payment_closing_day:
+          type: [integer, 'null']
+          minimum: 1
+          maximum: 31
+          description: Payment closing day (締め日) 1–31; null = month-end (末日) when terms are configured.
+        default_payment_month_offset:
+          type: [integer, 'null']
+          minimum: 0
+          maximum: 12
+          description: Payment month offset (支払月) — 0=当月, 1=翌月 … null = no payment-terms default.
+        default_payment_pay_day:
+          type: [integer, 'null']
+          minimum: 1
+          maximum: 31
+          description: Payment day (支払日) 1–31; null = month-end (末日) when terms are configured.
         created_at:
           type: [string, 'null']
         updated_at:
@@ -1388,6 +1406,26 @@ components:
           type: [string, 'null']
         logo_url:
           type: [string, 'null']
+        default_quote_validity_days:
+          type: [integer, 'null']
+          minimum: 1
+          maximum: 3650
+          description: Default quote validity period in days (有効期限). null = no default.
+        default_payment_closing_day:
+          type: [integer, 'null']
+          minimum: 1
+          maximum: 31
+          description: Payment closing day (締め日) 1–31; null = month-end (末日) when terms are configured.
+        default_payment_month_offset:
+          type: [integer, 'null']
+          minimum: 0
+          maximum: 12
+          description: Payment month offset (支払月) — 0=当月, 1=翌月 … null = no payment-terms default.
+        default_payment_pay_day:
+          type: [integer, 'null']
+          minimum: 1
+          maximum: 31
+          description: Payment day (支払日) 1–31; null = month-end (末日) when terms are configured.
       required: [legal_name]
     Client:
       type: object

--- a/src/Company/CompanySettings.php
+++ b/src/Company/CompanySettings.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
+use DateTimeImmutable;
+
 /**
  * Issuer (自社) profile for one organization — the supplier side of a qualified
  * invoice. One record per organization.
@@ -12,6 +14,11 @@ namespace NeneInvoice\Company;
  * (登録番号, `T` + 13 digits). It may be null until the operator registers; an
  * invoice can only be marked qualified when it is present (enforced later, at
  * invoice level — see accounting-compliance.md).
+ *
+ * Billing defaults (Issue #268) are all nullable — "no default" by default.
+ * `defaultQuoteValidityDays` drives the quote 有効期限. The three payment fields
+ * form the 締め日 ＋ 支払サイト model; `defaultPaymentMonthOffset` is the presence
+ * flag (null = no payment-terms default), while null closing/pay day = 末日.
  */
 final readonly class CompanySettings
 {
@@ -27,8 +34,36 @@ final readonly class CompanySettings
         public ?string $accountType = null,
         public ?string $accountNumber = null,
         public ?string $logoUrl = null,
+        public ?int $defaultQuoteValidityDays = null,
+        public ?int $defaultPaymentClosingDay = null,
+        public ?int $defaultPaymentMonthOffset = null,
+        public ?int $defaultPaymentPayDay = null,
         public ?string $createdAt = null,
         public ?string $updatedAt = null,
     ) {
+    }
+
+    /** The configured payment terms, or null when no default is set. */
+    public function paymentTerms(): ?PaymentTerms
+    {
+        if ($this->defaultPaymentMonthOffset === null) {
+            return null;
+        }
+
+        return new PaymentTerms(
+            $this->defaultPaymentClosingDay,
+            $this->defaultPaymentMonthOffset,
+            $this->defaultPaymentPayDay,
+        );
+    }
+
+    /** Default quote validity end date (`Y-m-d`) from an issue date, or null. */
+    public function quoteValidUntilFrom(DateTimeImmutable $issueDate): ?string
+    {
+        if ($this->defaultQuoteValidityDays === null) {
+            return null;
+        }
+
+        return $issueDate->modify('+' . $this->defaultQuoteValidityDays . ' day')->format('Y-m-d');
     }
 }

--- a/src/Company/CompanySettingsResponse.php
+++ b/src/Company/CompanySettingsResponse.php
@@ -24,6 +24,10 @@ final class CompanySettingsResponse
             'account_type' => $settings->accountType,
             'account_number' => $settings->accountNumber,
             'logo_url' => $settings->logoUrl,
+            'default_quote_validity_days' => $settings->defaultQuoteValidityDays,
+            'default_payment_closing_day' => $settings->defaultPaymentClosingDay,
+            'default_payment_month_offset' => $settings->defaultPaymentMonthOffset,
+            'default_payment_pay_day' => $settings->defaultPaymentPayDay,
             'created_at' => $settings->createdAt,
             'updated_at' => $settings->updatedAt,
         ];

--- a/src/Company/PaymentTerms.php
+++ b/src/Company/PaymentTerms.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+use DateTimeImmutable;
+
+/**
+ * Japanese closing-date + payment-site (締め日 ＋ 支払サイト) model for invoice
+ * payment due dates (Issue #268, design B).
+ *
+ * - `closingDay` 1–31, or null for 末日 (month-end) closing.
+ * - `monthOffset` 0 = 当月, 1 = 翌月, 2 = 翌々月 … months after the closing month.
+ * - `payDay` 1–31, or null for 末日 (month-end) payment.
+ *
+ * Example: 月末締め翌月末払い → (null, 1, null). 20日締め翌月10日払い → (20, 1, 10).
+ *
+ * The number of days itself is a business/contract choice; for 下請 / フリーランス
+ * relationships the law caps it at 60 days from 受領 — see accounting-compliance.md.
+ */
+final readonly class PaymentTerms
+{
+    public function __construct(
+        public ?int $closingDay,
+        public int $monthOffset,
+        public ?int $payDay,
+    ) {
+    }
+
+    /**
+     * Computes the payment due date for an invoice issued on $issueDate.
+     * Returns a `Y-m-d` string. Month-end days are clamped per target month.
+     */
+    public function dueDateFrom(DateTimeImmutable $issueDate): string
+    {
+        $issueDay = (int) $issueDate->format('j');
+        $issueLastDom = (int) $issueDate->format('t');
+        $monthStart = $issueDate->modify('first day of this month')->setTime(0, 0, 0);
+
+        // Closing day within the issue month (末日 when null), clamped to length.
+        $closingDom = min($this->closingDay ?? $issueLastDom, $issueLastDom);
+
+        // An invoice dated after the closing day rolls into the next cycle.
+        $closingMonth = $issueDay > $closingDom ? $monthStart->modify('+1 month') : $monthStart;
+
+        $payMonth = $closingMonth->modify('+' . $this->monthOffset . ' month');
+        $payLastDom = (int) $payMonth->format('t');
+        $payDom = min($this->payDay ?? $payLastDom, $payLastDom);
+
+        return $payMonth->modify('+' . ($payDom - 1) . ' day')->format('Y-m-d');
+    }
+}

--- a/src/Company/PdoCompanySettingsRepository.php
+++ b/src/Company/PdoCompanySettingsRepository.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoCompanySettingsRepository implements CompanySettingsRepositoryInterface
 {
-    private const COLUMNS = 'organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at';
+    private const COLUMNS = 'organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, default_quote_validity_days, default_payment_closing_day, default_payment_month_offset, default_payment_pay_day, created_at, updated_at';
 
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
@@ -39,7 +39,7 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
 
         if ($exists) {
             $this->query->execute(
-                'UPDATE company_settings SET legal_name = ?, address = ?, phone = ?, email = ?, registration_number = ?, bank_name = ?, bank_branch = ?, account_type = ?, account_number = ?, logo_url = ?, updated_at = ? WHERE organization_id = ?',
+                'UPDATE company_settings SET legal_name = ?, address = ?, phone = ?, email = ?, registration_number = ?, bank_name = ?, bank_branch = ?, account_type = ?, account_number = ?, logo_url = ?, default_quote_validity_days = ?, default_payment_closing_day = ?, default_payment_month_offset = ?, default_payment_pay_day = ?, updated_at = ? WHERE organization_id = ?',
                 [
                     $settings->legalName,
                     $settings->address,
@@ -51,6 +51,10 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
                     $settings->accountType,
                     $settings->accountNumber,
                     $settings->logoUrl,
+                    $settings->defaultQuoteValidityDays,
+                    $settings->defaultPaymentClosingDay,
+                    $settings->defaultPaymentMonthOffset,
+                    $settings->defaultPaymentPayDay,
                     $now,
                     $organizationId,
                 ],
@@ -60,8 +64,8 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
         }
 
         $this->query->execute(
-            'INSERT INTO company_settings (organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO company_settings (organization_id, legal_name, address, phone, email, registration_number, bank_name, bank_branch, account_type, account_number, logo_url, default_quote_validity_days, default_payment_closing_day, default_payment_month_offset, default_payment_pay_day, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $organizationId,
                 $settings->legalName,
@@ -74,6 +78,10 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
                 $settings->accountType,
                 $settings->accountNumber,
                 $settings->logoUrl,
+                $settings->defaultQuoteValidityDays,
+                $settings->defaultPaymentClosingDay,
+                $settings->defaultPaymentMonthOffset,
+                $settings->defaultPaymentPayDay,
                 $now,
                 $now,
             ],
@@ -95,6 +103,10 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
             accountType: $this->nullableString($row['account_type'] ?? null),
             accountNumber: $this->nullableString($row['account_number'] ?? null),
             logoUrl: $this->nullableString($row['logo_url'] ?? null),
+            defaultQuoteValidityDays: $this->nullableInt($row['default_quote_validity_days'] ?? null),
+            defaultPaymentClosingDay: $this->nullableInt($row['default_payment_closing_day'] ?? null),
+            defaultPaymentMonthOffset: $this->nullableInt($row['default_payment_month_offset'] ?? null),
+            defaultPaymentPayDay: $this->nullableInt($row['default_payment_pay_day'] ?? null),
             createdAt: (string) $row['created_at'],
             updatedAt: (string) $row['updated_at'],
         );
@@ -103,5 +115,10 @@ final readonly class PdoCompanySettingsRepository implements CompanySettingsRepo
     private function nullableString(mixed $value): ?string
     {
         return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function nullableInt(mixed $value): ?int
+    {
+        return $value === null || $value === '' ? null : (int) $value;
     }
 }

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -38,6 +38,12 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
             return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"legal_name" is required.');
         }
 
+        $rangeError = $this->validateBillingDefaults($decoded);
+
+        if ($rangeError !== null) {
+            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $rangeError);
+        }
+
         $settings = $this->useCase->execute(AuthContext::userId($request), new UpdateCompanySettingsInput(
             legalName: $legalName,
             address: $this->optional($decoded, 'address'),
@@ -49,6 +55,10 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
             accountType: $this->optional($decoded, 'account_type'),
             accountNumber: $this->optional($decoded, 'account_number'),
             logoUrl: $this->optional($decoded, 'logo_url'),
+            defaultQuoteValidityDays: $this->optionalInt($decoded, 'default_quote_validity_days'),
+            defaultPaymentClosingDay: $this->optionalInt($decoded, 'default_payment_closing_day'),
+            defaultPaymentMonthOffset: $this->optionalInt($decoded, 'default_payment_month_offset'),
+            defaultPaymentPayDay: $this->optionalInt($decoded, 'default_payment_pay_day'),
         ));
 
         return $this->json->create(CompanySettingsResponse::toArray($settings));
@@ -60,5 +70,46 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
         $value = $body[$key] ?? null;
 
         return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /** @param array<string, mixed> $body */
+    private function optionalInt(array $body, string $key): ?int
+    {
+        $value = $body[$key] ?? null;
+
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * Validates the billing-default integers (Issue #268). Returns an error
+     * message, or null when all are absent / null / valid.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function validateBillingDefaults(array $body): ?string
+    {
+        if (!$this->isNullOrIntInRange($body['default_quote_validity_days'] ?? null, 1, 3650)) {
+            return '"default_quote_validity_days" must be an integer between 1 and 3650.';
+        }
+        if (!$this->isNullOrIntInRange($body['default_payment_closing_day'] ?? null, 1, 31)) {
+            return '"default_payment_closing_day" must be an integer between 1 and 31.';
+        }
+        if (!$this->isNullOrIntInRange($body['default_payment_month_offset'] ?? null, 0, 12)) {
+            return '"default_payment_month_offset" must be an integer between 0 and 12.';
+        }
+        if (!$this->isNullOrIntInRange($body['default_payment_pay_day'] ?? null, 1, 31)) {
+            return '"default_payment_pay_day" must be an integer between 1 and 31.';
+        }
+
+        return null;
+    }
+
+    private function isNullOrIntInRange(mixed $value, int $min, int $max): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        return is_int($value) && $value >= $min && $value <= $max;
     }
 }

--- a/src/Company/UpdateCompanySettingsInput.php
+++ b/src/Company/UpdateCompanySettingsInput.php
@@ -17,6 +17,10 @@ final readonly class UpdateCompanySettingsInput
         public ?string $accountType = null,
         public ?string $accountNumber = null,
         public ?string $logoUrl = null,
+        public ?int $defaultQuoteValidityDays = null,
+        public ?int $defaultPaymentClosingDay = null,
+        public ?int $defaultPaymentMonthOffset = null,
+        public ?int $defaultPaymentPayDay = null,
     ) {
     }
 }

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -47,6 +47,10 @@ final readonly class UpdateCompanySettingsUseCase
             accountType: $input->accountType,
             accountNumber: $input->accountNumber,
             logoUrl: $input->logoUrl,
+            defaultQuoteValidityDays: $input->defaultQuoteValidityDays,
+            defaultPaymentClosingDay: $input->defaultPaymentClosingDay,
+            defaultPaymentMonthOffset: $input->defaultPaymentMonthOffset,
+            defaultPaymentPayDay: $input->defaultPaymentPayDay,
         ));
 
         $saved = $this->repository->find();

--- a/tests/Company/PaymentTermsTest.php
+++ b/tests/Company/PaymentTermsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Company;
+
+use DateTimeImmutable;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Company\PaymentTerms;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentTermsTest extends TestCase
+{
+    private function due(?int $closing, int $offset, ?int $pay, string $issue): string
+    {
+        return (new PaymentTerms($closing, $offset, $pay))->dueDateFrom(new DateTimeImmutable($issue));
+    }
+
+    public function test_month_end_close_next_month_end_pay(): void
+    {
+        // 月末締め翌月末払い
+        self::assertSame('2026-05-31', $this->due(null, 1, null, '2026-04-15'));
+        self::assertSame('2026-05-31', $this->due(null, 1, null, '2026-04-30'));
+    }
+
+    public function test_day20_close_rolls_to_next_cycle_after_closing(): void
+    {
+        // 20日締め翌月末払い。発行が締め日以前は当月締め、超過は翌月締め。
+        self::assertSame('2026-05-31', $this->due(20, 1, null, '2026-04-10')); // 4/20締→5月末
+        self::assertSame('2026-06-30', $this->due(20, 1, null, '2026-04-25')); // 5/20締→6月末
+    }
+
+    public function test_specific_pay_day(): void
+    {
+        // 20日締め翌月10日払い
+        self::assertSame('2026-05-10', $this->due(20, 1, 10, '2026-04-10'));
+    }
+
+    public function test_pay_day_is_clamped_to_short_month(): void
+    {
+        // 末日払いが2月にかかる場合は28/29日へクランプ
+        self::assertSame('2026-02-28', $this->due(null, 0, 31, '2026-02-10'));
+        self::assertSame('2024-02-29', $this->due(null, 0, 31, '2024-02-05')); // うるう年
+    }
+
+    public function test_two_month_offset(): void
+    {
+        // 月末締め翌々月末払い
+        self::assertSame('2026-06-30', $this->due(null, 2, null, '2026-04-15'));
+    }
+
+    public function test_company_settings_helpers(): void
+    {
+        $settings = new CompanySettings(
+            organizationId: 1,
+            legalName: 'X',
+            defaultQuoteValidityDays: 30,
+            defaultPaymentClosingDay: null,
+            defaultPaymentMonthOffset: 1,
+            defaultPaymentPayDay: null,
+        );
+
+        $terms = $settings->paymentTerms();
+        self::assertNotNull($terms);
+        self::assertSame('2026-05-31', $terms->dueDateFrom(new DateTimeImmutable('2026-04-15')));
+        self::assertSame('2026-05-15', $settings->quoteValidUntilFrom(new DateTimeImmutable('2026-04-15')));
+    }
+
+    public function test_no_defaults_return_null(): void
+    {
+        $settings = new CompanySettings(organizationId: 1, legalName: 'X');
+        self::assertNull($settings->paymentTerms());
+        self::assertNull($settings->quoteValidUntilFrom(new DateTimeImmutable('2026-04-15')));
+    }
+}

--- a/tests/Company/PdoCompanySettingsRepositoryTest.php
+++ b/tests/Company/PdoCompanySettingsRepositoryTest.php
@@ -66,6 +66,10 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
             bankBranch: '渋谷支店',
             accountType: '普通',
             accountNumber: '1234567',
+            defaultQuoteValidityDays: 30,
+            defaultPaymentClosingDay: 20,
+            defaultPaymentMonthOffset: 1,
+            defaultPaymentPayDay: null,
         );
 
         $this->repo->save($settings);
@@ -76,6 +80,11 @@ final class PdoCompanySettingsRepositoryTest extends TestCase
         self::assertSame('T1234567890123', $found->registrationNumber);
         self::assertSame('テスト銀行', $found->bankName);
         self::assertSame('1234567', $found->accountNumber);
+        // Billing defaults round-trip, including null pay-day = 末日 (Issue #268).
+        self::assertSame(30, $found->defaultQuoteValidityDays);
+        self::assertSame(20, $found->defaultPaymentClosingDay);
+        self::assertSame(1, $found->defaultPaymentMonthOffset);
+        self::assertNull($found->defaultPaymentPayDay);
     }
 
     public function test_save_updates_existing_record(): void


### PR DESCRIPTION
## 概要
見積の有効期限・請求の支払期日を**会社ごとの既定値**として持たせる機能の **PR1（バックエンド基盤）**。支払サイトは **B案＝締め日＋支払サイト**（日本実務寄り）。本PRは**設定の保存と算出ロジックのみ**で、発行/見積への自動適用は後続PR。Refs #268。

## 背景
支払期日・有効期限は会社/契約ごとに異なる業務ルール（法定の固定日数ではない）。ただし**下請法・フリーランス新法では受領後60日が上限**。現状は手入力（既定なし）で、請求の発行UIは `due_at: null` 固定で期日を取得していなかった。

## 変更点
- **DB**: `company_settings` に4カラム追加（全 nullable・後方互換）：`default_quote_validity_days` / `default_payment_closing_day` / `default_payment_month_offset` / `default_payment_pay_day`。マイグレーション＋SQLite/MySQL schema。
- **PaymentTerms 値オブジェクト**: 締め日（null=末日）＋支払月オフセット（0=当月…）＋支払日（null=末日）から、**発行日基準で支払期日を算出**。締め日ロール・月末クランプ対応。
- **CompanySettings**: 4フィールド＋ `paymentTerms()` / `quoteValidUntilFrom()` ヘルパー（`month_offset=null` を「支払サイト既定なし」の存在フラグに）。
- Response / UpdateInput / UseCase / Pdo リポジトリ拡張。Handler で範囲バリデーション（締め日/支払日 1–31、支払月 0–12、有効期限 1–3650）。
- **OpenAPI**（CompanySettings / UpdateCompanySettingsRequest）、**用語レジストリ**に登録。

## 算出仕様（例）
| 設定 | closing/offset/pay | 発行 2026-04-15 → 期日 |
| --- | --- | --- |
| 月末締め翌月末払い | null / 1 / null | 2026-05-31 |
| 20日締め翌月末払い（発行25日） | 20 / 1 / null | 2026-06-30（翌月締めにロール） |
| 20日締め翌月10日払い | 20 / 1 / 10 | 2026-05-10 |
| 末締め当月末（2月） | null / 0 / 31 | 2026-02-28（クランプ） |

## 検証
- `composer test（314）` / `analyse（PHPStan 0）` / `cs` / `openapi` / `mcp` 全グリーン。
- PaymentTerms のエッジケース（締めロール・うるう年クランプ・翌々月）＋永続化ラウンドトリップをテスト。

## 後続
- PR2: 発行（`due_at`）・見積作成（`valid_until`）への既定適用。
- PR3: 会社設定フォーム＋発行UIの支払期日表示/上書き（`due_at: null` 固定の解消）。

法的上限（60日）の最終判断は税理士確認推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)