### PR TITLE
feat(invoice,quote): 発行・見積作成に支払サイト/有効期限の既定を適用 (#268)

### DIFF
--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use DateTimeImmutable;
 use LogicException;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
@@ -59,15 +60,28 @@ final readonly class IssueInvoiceUseCase
             throw new InvoiceValidationException('An invoice cannot be issued without line items.');
         }
 
-        if ($input->qualified) {
-            $settings = $this->companySettings->find();
+        $settings = $this->companySettings->find();
 
+        if ($input->qualified) {
             if ($settings === null || $settings->registrationNumber === null) {
                 throw new QualifiedInvoiceIncompleteException('A qualified invoice requires the issuer registration number to be configured in company settings.');
             }
         }
 
         $number = $this->numbers->next(DocumentType::Invoice, (int) date('Y'));
+
+        $issuedAt = date('Y-m-d H:i:s');
+
+        // Due date: explicit input wins, then any pre-set value, else the
+        // company payment-terms default (締め日＋支払サイト) from the issue date.
+        $dueAt = $input->dueAt ?? $invoice->dueAt;
+
+        if ($dueAt === null) {
+            $terms = $settings?->paymentTerms();
+            if ($terms !== null) {
+                $dueAt = $terms->dueDateFrom(new DateTimeImmutable($issuedAt));
+            }
+        }
 
         $this->invoices->update(new Invoice(
             organizationId: $invoice->organizationId,
@@ -79,8 +93,8 @@ final readonly class IssueInvoiceUseCase
             isQualifiedInvoice: $input->qualified,
             quoteId: $invoice->quoteId,
             invoiceNumber: $number,
-            issuedAt: date('Y-m-d H:i:s'),
-            dueAt: $input->dueAt ?? $invoice->dueAt,
+            issuedAt: $issuedAt,
+            dueAt: $dueAt,
             notes: $invoice->notes,
             id: $invoice->id,
             createdAt: $invoice->createdAt,

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
+use DateTimeImmutable;
 use LogicException;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\DocumentSequence\DocumentType;
 use NeneInvoice\LineItem\LineItem;
@@ -32,6 +34,7 @@ final readonly class CreateQuoteUseCase
         private QuoteRepositoryInterface $quotes,
         private LineItemRepositoryInterface $lineItems,
         private ClientRepositoryInterface $clients,
+        private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
         private TaxCalculator $taxCalculator,
         private AuditRecorderInterface $audit,
@@ -72,6 +75,11 @@ final readonly class CreateQuoteUseCase
         $totals = $this->taxCalculator->calculate($input->lines);
         $number = $this->numbers->next(DocumentType::Quote, (int) date('Y'));
 
+        // Validity: explicit input wins, else the company default period (有効期限)
+        // measured from today (the draft's creation date).
+        $validUntil = $input->validUntil
+            ?? $this->companySettings->find()?->quoteValidUntilFrom(new DateTimeImmutable('today'));
+
         $quoteId = $this->quotes->save(new Quote(
             organizationId: $organizationId,
             clientId: $input->clientId,
@@ -80,7 +88,7 @@ final readonly class CreateQuoteUseCase
             subtotalCents: $totals->subtotalCents,
             taxCents: $totals->taxCents,
             totalCents: $totals->totalCents,
-            validUntil: $input->validUntil,
+            validUntil: $validUntil,
             notes: $input->notes,
         ));
 

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -50,6 +50,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                     self::quotes($c),
                     self::resolve($c, LineItemRepositoryInterface::class),
                     self::resolve($c, ClientRepositoryInterface::class),
+                    self::resolve($c, CompanySettingsRepositoryInterface::class),
                     self::resolve($c, DocumentNumberGenerator::class),
                     self::resolve($c, TaxCalculator::class),
                     self::resolve($c, AuditRecorderInterface::class),

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Invoice;
 
+use DateTimeImmutable;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Company\PaymentTerms;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -92,6 +94,36 @@ final class IssueInvoiceUseCaseTest extends TestCase
         self::assertSame('INV-' . date('Y') . '-001', $result->invoice->invoiceNumber);
         self::assertNotNull($result->invoice->issuedAt);
         self::assertSame('invoice.issued', $this->audit->records[0]['action']);
+    }
+
+    public function test_applies_company_payment_terms_default_due_date(): void
+    {
+        // 月末締め翌月末払い (closing/pay null = 末日).
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'Example KK',
+            defaultPaymentMonthOffset: 1,
+        ));
+        $id = $this->draftInvoice();
+
+        $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: false));
+
+        $expected = (new PaymentTerms(null, 1, null))->dueDateFrom(new DateTimeImmutable('today'));
+        self::assertSame($expected, substr((string) $result->invoice->dueAt, 0, 10));
+    }
+
+    public function test_explicit_due_at_overrides_payment_terms_default(): void
+    {
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'Example KK',
+            defaultPaymentMonthOffset: 1,
+        ));
+        $id = $this->draftInvoice();
+
+        $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: false, dueAt: '2026-09-30'));
+
+        self::assertSame('2026-09-30', substr((string) $result->invoice->dueAt, 0, 10));
     }
 
     public function test_issues_non_qualified_invoice_without_registration_number(): void

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Quote;
 
+use DateTimeImmutable;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemInput;
 use NeneInvoice\LineItem\LineItemParent;
@@ -15,6 +17,7 @@ use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\QuoteStatus;
 use NeneInvoice\Quote\QuoteValidationException;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
@@ -28,6 +31,7 @@ final class CreateQuoteUseCaseTest extends TestCase
     private InMemoryQuoteRepository $quotes;
     private InMemoryLineItemRepository $lineItems;
     private InMemoryClientRepository $clients;
+    private InMemoryCompanySettingsRepository $companySettings;
     private RecordingAuditRecorder $audit;
     private CreateQuoteUseCase $useCase;
     private int $clientId;
@@ -39,6 +43,7 @@ final class CreateQuoteUseCaseTest extends TestCase
         $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->clients = new InMemoryClientRepository($this->holder);
+        $this->companySettings = new InMemoryCompanySettingsRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
         $this->clientId = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
 
@@ -46,11 +51,46 @@ final class CreateQuoteUseCaseTest extends TestCase
             $this->quotes,
             $this->lineItems,
             $this->clients,
+            $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             $this->audit,
             $this->holder,
         );
+    }
+
+    public function test_applies_company_default_validity_when_not_provided(): void
+    {
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'X',
+            defaultQuoteValidityDays: 30,
+        ));
+
+        $result = $this->useCase->execute(1, new CreateQuoteInput(
+            clientId: $this->clientId,
+            lines: [new LineItemInput('X', 1, 1000, 1000)],
+        ));
+
+        $expected = (new DateTimeImmutable('today'))->modify('+30 day')->format('Y-m-d');
+        self::assertSame($expected, substr((string) $result->quote->validUntil, 0, 10));
+    }
+
+    public function test_explicit_valid_until_overrides_company_default(): void
+    {
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'X',
+            defaultQuoteValidityDays: 30,
+        ));
+
+        $result = $this->useCase->execute(1, new CreateQuoteInput(
+            clientId: $this->clientId,
+            lines: [new LineItemInput('X', 1, 1000, 1000)],
+            validUntil: '2026-12-31',
+        ));
+
+        self::assertSame('2026-12-31', substr((string) $result->quote->validUntil, 0, 10));
     }
 
     public function test_creates_quote_with_computed_totals_number_lines_and_audit(): void

--- a/tests/Quote/GenerateQuotePdfUseCaseTest.php
+++ b/tests/Quote/GenerateQuotePdfUseCaseTest.php
@@ -66,6 +66,7 @@ final class GenerateQuotePdfUseCaseTest extends TestCase
             $this->quotes,
             $this->lineItems,
             $this->clients,
+            $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             new RecordingAuditRecorder(),

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -15,6 +15,7 @@ use NeneInvoice\Quote\GetQuoteByIdUseCase;
 use NeneInvoice\Quote\ListQuotesUseCase;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
@@ -49,6 +50,7 @@ final class QuoteQueryUseCasesTest extends TestCase
             $this->quotes,
             $this->lineItems,
             $this->clients,
+            new InMemoryCompanySettingsRepository($this->holder),
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             new RecordingAuditRecorder(),

--- a/tests/Support/InMemoryCompanySettingsRepository.php
+++ b/tests/Support/InMemoryCompanySettingsRepository.php
@@ -53,6 +53,10 @@ final class InMemoryCompanySettingsRepository implements CompanySettingsReposito
             accountType: $settings->accountType,
             accountNumber: $settings->accountNumber,
             logoUrl: $settings->logoUrl,
+            defaultQuoteValidityDays: $settings->defaultQuoteValidityDays,
+            defaultPaymentClosingDay: $settings->defaultPaymentClosingDay,
+            defaultPaymentMonthOffset: $settings->defaultPaymentMonthOffset,
+            defaultPaymentPayDay: $settings->defaultPaymentPayDay,
             createdAt: $settings->createdAt,
             updatedAt: $settings->updatedAt,
         );


### PR DESCRIPTION
## 概要
PR1（#269）で追加した会社の請求/見積既定値を、**発行・作成時に自動適用**する（PR2）。明示指定があればそれを優先。Refs #268。

## 変更点
- **IssueInvoiceUseCase**: 発行時に `due_at` 未指定なら、会社の支払サイト（締め日＋支払サイト）から**発行日基準で支払期日を算出**（既存の CompanySettings 取得を再利用）。
  - → これで発行時に支払期日が記録され、ダッシュボードの **overdue / 売掛エイジングが機能する**（従来 `due_at: null` 固定だった問題の根治に向けた基盤）。
- **CreateQuoteUseCase**: `valid_until` 未指定なら、会社の既定有効期限日数（作成日＋N日）を適用。`CompanySettingsRepository` を注入（`QuoteServiceProvider` 更新）。
- 明示指定（valid_until / due_at）はいずれも既定より優先。

## テスト
- 見積：既定有効期限の自動適用／明示 `valid_until` の上書き。
- 請求：支払サイト既定の自動 due_at 算出／明示 `due_at` の上書き。
- `InMemoryCompanySettingsRepository` が新フィールドを保持するよう修正。

## 検証
- `composer test（318）` / `analyse（0）` / `cs` / `openapi` / `mcp` 全グリーン。

## 後続
- PR3: 会社設定フォーム（4項目）＋発行UIの支払期日表示/上書き＋見積の既定挙動表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)