### PR TITLE
feat(dashboard): 請求発行額（今月＋前月比）と月次推移グラフ (#272)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -95,7 +95,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Billing defaults (issuer) | `default_quote_validity_days`, `default_payment_closing_day`, `default_payment_month_offset`, `default_payment_pay_day` | `quote_validity`, `closing_day`, `payment_site`, `pay_day`, `net_days` |
 | Client fields | `contact_name`, `billing_address` | `contact`, `address` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
-| Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents` | `monthly_received_cents`, `received_this_month`, `mtd_cents` |
+| Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1319,7 +1319,32 @@ components:
           description: Sum of non-void payments received in the previous month, in cents (for month-over-month comparison).
         aging:
           $ref: '#/components/schemas/ReceivableAging'
-      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid, received_this_month_cents, received_last_month_cents, aging]
+        billed_this_month_cents:
+          type: integer
+          description: Total of invoices issued in the current month (issued_at based), in cents.
+        billed_last_month_cents:
+          type: integer
+          description: Total of invoices issued in the previous month, in cents (for month-over-month comparison).
+        monthly_billed:
+          type: array
+          description: Issued-invoice totals for the last 6 calendar months, oldest first.
+          items:
+            $ref: '#/components/schemas/MonthlyBilled'
+      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid, received_this_month_cents, received_last_month_cents, aging, billed_this_month_cents, billed_last_month_cents, monthly_billed]
+    MonthlyBilled:
+      type: object
+      description: Issued-invoice total for one calendar month.
+      properties:
+        month:
+          type: string
+          description: Calendar month, `YYYY-MM`.
+        billed_cents:
+          type: integer
+          description: Total of invoices issued in this month, in cents.
+        count:
+          type: integer
+          description: Number of invoices issued in this month.
+      required: [month, billed_cents, count]
     ReceivableAging:
       type: object
       description: Outstanding receivable balance bucketed by overdue age, in cents.

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -33,6 +33,12 @@ test.describe('Dashboard', () => {
         received_this_month_cents: 80000,
         received_last_month_cents: 50000,
         aging: { current: 100000, overdue_1_30: 100000, overdue_31_plus: 50000 },
+        billed_this_month_cents: 330000,
+        billed_last_month_cents: 210000,
+        monthly_billed: [
+          { month: '2026-05', billed_cents: 210000, count: 3 },
+          { month: '2026-06', billed_cents: 330000, count: 4 },
+        ],
       },
     })
 

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -27,6 +27,9 @@ const EMPTY_DASHBOARD = {
   received_this_month_cents: 0,
   received_last_month_cents: 0,
   aging: { current: 0, overdue_1_30: 0, overdue_31_plus: 0 },
+  billed_this_month_cents: 0,
+  billed_last_month_cents: 0,
+  monthly_billed: [],
 }
 
 /**

--- a/frontend/src/entities/dashboard/index.ts
+++ b/frontend/src/entities/dashboard/index.ts
@@ -1,2 +1,2 @@
-export type { DashboardSummary, ReceivableAging } from './model'
+export type { DashboardSummary, MonthlyBilled, ReceivableAging } from './model'
 export { useDashboard } from './queries'

--- a/frontend/src/entities/dashboard/mapper.test.ts
+++ b/frontend/src/entities/dashboard/mapper.test.ts
@@ -13,6 +13,12 @@ describe('toDashboardSummary', () => {
       received_this_month_cents: 42000,
       received_last_month_cents: 31000,
       aging: { current: 120000, overdue_1_30: 80000, overdue_31_plus: 50000 },
+      billed_this_month_cents: 330000,
+      billed_last_month_cents: 210000,
+      monthly_billed: [
+        { month: '2026-05', billed_cents: 210000, count: 3 },
+        { month: '2026-06', billed_cents: 330000, count: 4 },
+      ],
     }
 
     const summary = toDashboardSummary(dto)
@@ -24,6 +30,10 @@ describe('toDashboardSummary', () => {
     expect(summary.received_this_month_cents).toBe(42000)
     expect(summary.received_last_month_cents).toBe(31000)
     expect(summary.aging).toEqual({ current: 120000, overdue_1_30: 80000, overdue_31_plus: 50000 })
+    expect(summary.billed_this_month_cents).toBe(330000)
+    expect(summary.billed_last_month_cents).toBe(210000)
+    expect(summary.monthly_billed).toHaveLength(2)
+    expect(summary.monthly_billed[1]).toEqual({ month: '2026-06', billed_cents: 330000, count: 4 })
   })
 
   it('handles an empty recent-unpaid list', () => {
@@ -35,6 +45,9 @@ describe('toDashboardSummary', () => {
       received_this_month_cents: 0,
       received_last_month_cents: 0,
       aging: { current: 0, overdue_1_30: 0, overdue_31_plus: 0 },
+      billed_this_month_cents: 0,
+      billed_last_month_cents: 0,
+      monthly_billed: [],
     })
     expect(summary.recent_unpaid).toEqual([])
   })

--- a/frontend/src/entities/dashboard/mapper.ts
+++ b/frontend/src/entities/dashboard/mapper.ts
@@ -15,5 +15,12 @@ export function toDashboardSummary(dto: DashboardSummaryDto): DashboardSummary {
       overdue_1_30: dto.aging.overdue_1_30,
       overdue_31_plus: dto.aging.overdue_31_plus,
     },
+    billed_this_month_cents: dto.billed_this_month_cents,
+    billed_last_month_cents: dto.billed_last_month_cents,
+    monthly_billed: dto.monthly_billed.map((m) => ({
+      month: m.month,
+      billed_cents: m.billed_cents,
+      count: m.count,
+    })),
   }
 }

--- a/frontend/src/entities/dashboard/model.ts
+++ b/frontend/src/entities/dashboard/model.ts
@@ -7,6 +7,13 @@ export interface ReceivableAging {
   overdue_31_plus: number
 }
 
+/** Issued-invoice total for one calendar month (Issue #272). */
+export interface MonthlyBilled {
+  month: string
+  billed_cents: number
+  count: number
+}
+
 export interface DashboardSummary {
   unpaid_count: number
   overdue_count: number
@@ -15,4 +22,7 @@ export interface DashboardSummary {
   received_this_month_cents: number
   received_last_month_cents: number
   aging: ReceivableAging
+  billed_this_month_cents: number
+  billed_last_month_cents: number
+  monthly_billed: MonthlyBilled[]
 }

--- a/frontend/src/features/view-dashboard/hooks/use-view-dashboard.test.ts
+++ b/frontend/src/features/view-dashboard/hooks/use-view-dashboard.test.ts
@@ -32,6 +32,9 @@ describe('useViewDashboard', () => {
           received_this_month_cents: 0,
           received_last_month_cents: 0,
           aging: { current: 0, overdue_1_30: 0, overdue_31_plus: 0 },
+          billed_this_month_cents: 0,
+          billed_last_month_cents: 0,
+          monthly_billed: [],
         }),
       ),
     )

--- a/frontend/src/features/view-dashboard/hooks/use-view-dashboard.ts
+++ b/frontend/src/features/view-dashboard/hooks/use-view-dashboard.ts
@@ -1,4 +1,9 @@
-import { useDashboard, type DashboardSummary, type ReceivableAging } from '@/entities/dashboard'
+import {
+  useDashboard,
+  type DashboardSummary,
+  type MonthlyBilled,
+  type ReceivableAging,
+} from '@/entities/dashboard'
 import type { Invoice } from '@/entities/invoice'
 
 export type ViewDashboardState =
@@ -13,6 +18,9 @@ export type ViewDashboardState =
       receivedThisMonthCents: number
       receivedLastMonthCents: number
       aging: ReceivableAging
+      billedThisMonthCents: number
+      billedLastMonthCents: number
+      monthlyBilled: MonthlyBilled[]
     }
 
 export function useViewDashboard(): ViewDashboardState {
@@ -39,5 +47,8 @@ export function useViewDashboard(): ViewDashboardState {
     receivedThisMonthCents: data.received_this_month_cents,
     receivedLastMonthCents: data.received_last_month_cents,
     aging: data.aging,
+    billedThisMonthCents: data.billed_this_month_cents,
+    billedLastMonthCents: data.billed_last_month_cents,
+    monthlyBilled: data.monthly_billed,
   }
 }

--- a/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
+++ b/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import type { MonthlyBilled } from '@/entities/dashboard'
 import { invoiceStatusTone } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
 import { formatYen } from '@/shared/lib/format-money'
@@ -41,6 +42,18 @@ export function ViewDashboard() {
     momDir = pct >= 0 ? 'up' : 'down'
   }
 
+  // Same month-over-month, for invoices issued (billed) this month.
+  const billedLast = state.billedLastMonthCents
+  let billedMomText: string | undefined
+  let billedMomDir: 'up' | 'down' | undefined
+  if (billedLast > 0) {
+    const pct = Math.round(((state.billedThisMonthCents - billedLast) / billedLast) * 100)
+    billedMomText = t('admin.dashboard.momChange', {
+      change: `${pct > 0 ? '+' : ''}${String(pct)}%`,
+    })
+    billedMomDir = pct >= 0 ? 'up' : 'down'
+  }
+
   const aging = state.aging
   const agingTotal = aging.current + aging.overdue_1_30 + aging.overdue_31_plus
   const pct = (n: number): number => (agingTotal > 0 ? Math.round((n / agingTotal) * 100) : 0)
@@ -75,6 +88,12 @@ export function ViewDashboard() {
           tone="c-danger"
         />
         <StatCard
+          label={t('admin.dashboard.billedThisMonth')}
+          value={formatYen(state.billedThisMonthCents)}
+          foot={billedMomText}
+          footClass={billedMomDir}
+        />
+        <StatCard
           label={t('admin.dashboard.receivedThisMonth')}
           value={formatYen(state.receivedThisMonthCents)}
           foot={momText}
@@ -85,6 +104,15 @@ export function ViewDashboard() {
           value={formatYen(state.outstandingTotalCents)}
           foot={t('admin.dashboard.invoiceCount', { count: state.unpaidCount })}
         />
+      </div>
+
+      <div className="panel">
+        <div className="panel-head">
+          <h3>{t('admin.dashboard.billedTrend')}</h3>
+        </div>
+        <div className="panel-body">
+          <BilledTrend months={state.monthlyBilled} locale={locale} />
+        </div>
       </div>
 
       <div className="dash-grid">
@@ -167,6 +195,33 @@ export function ViewDashboard() {
         </div>
       </div>
     </Stack>
+  )
+}
+
+/** (B) Monthly issued-invoice trend — simple CSS bar chart (no chart lib). */
+function BilledTrend({ months, locale }: { months: MonthlyBilled[]; locale: string }) {
+  const max = Math.max(1, ...months.map((m) => m.billed_cents))
+  const monthLabel = (ym: string): string =>
+    new Date(`${ym}-01T00:00:00`).toLocaleDateString(locale === 'ja' ? 'ja-JP' : 'en-US', {
+      month: 'short',
+    })
+
+  return (
+    <div className="bar-chart">
+      {months.map((m) => (
+        <div className="bar-col" key={m.month}>
+          <span className="bar-cap num">{formatYen(m.billed_cents)}</span>
+          <div className="bar-track">
+            <div
+              className="bar"
+              style={{ height: `${String(Math.round((m.billed_cents / max) * 100))}%` }}
+              title={formatYen(m.billed_cents)}
+            />
+          </div>
+          <span className="bar-label">{monthLabel(m.month)}</span>
+        </div>
+      ))}
+    </div>
   )
 }
 

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -689,6 +689,21 @@ export interface components {
             /** @description Sum of non-void payments received in the previous month, in cents (for month-over-month comparison). */
             received_last_month_cents: number;
             aging: components["schemas"]["ReceivableAging"];
+            /** @description Total of invoices issued in the current month (issued_at based), in cents. */
+            billed_this_month_cents: number;
+            /** @description Total of invoices issued in the previous month, in cents (for month-over-month comparison). */
+            billed_last_month_cents: number;
+            /** @description Issued-invoice totals for the last 6 calendar months, oldest first. */
+            monthly_billed: components["schemas"]["MonthlyBilled"][];
+        };
+        /** @description Issued-invoice total for one calendar month. */
+        MonthlyBilled: {
+            /** @description Calendar month, `YYYY-MM`. */
+            month: string;
+            /** @description Total of invoices issued in this month, in cents. */
+            billed_cents: number;
+            /** @description Number of invoices issued in this month. */
+            count: number;
         };
         /** @description Outstanding receivable balance bucketed by overdue age, in cents. */
         ReceivableAging: {

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -372,6 +372,8 @@ export const enMessages: MessageCatalog = {
   'admin.dashboard.invoiceCount': '{{count}} invoices',
   'admin.dashboard.due': 'Due {{date}}',
   'admin.dashboard.receivedThisMonth': 'Received this month',
+  'admin.dashboard.billedThisMonth': 'Billed this month',
+  'admin.dashboard.billedTrend': 'Billing trend',
   'admin.dashboard.momChange': 'MoM {{change}}',
   'admin.dashboard.aging': 'Receivable aging',
   'admin.dashboard.agingCurrent': 'Current',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -374,6 +374,8 @@ export const jaMessages = {
   'admin.dashboard.invoiceCount': '{{count}} 件の請求書',
   'admin.dashboard.due': '期限 {{date}}',
   'admin.dashboard.receivedThisMonth': '当月入金額',
+  'admin.dashboard.billedThisMonth': '当月請求発行額',
+  'admin.dashboard.billedTrend': '請求発行額の推移',
   'admin.dashboard.momChange': '前月比 {{change}}',
   'admin.dashboard.aging': '売掛金エイジング',
   'admin.dashboard.agingCurrent': '期限内',

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -377,6 +377,44 @@
     background: var(--color-danger);
   }
 
+  /* Monthly billed trend — vertical CSS bar chart (Issue #272) */
+  .bar-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+  }
+  .bar-col {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+  }
+  .bar-cap {
+    font-size: 0.625rem;
+    color: var(--color-fg-muted);
+    white-space: nowrap;
+  }
+  .bar-track {
+    width: 100%;
+    height: 120px;
+    display: flex;
+    align-items: flex-end;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .bar-track .bar {
+    width: 62%;
+    margin: 0 auto;
+    min-height: 1px;
+    background: var(--color-accent);
+  }
+  .bar-label {
+    font-size: 0.625rem;
+    font-weight: 600;
+    color: var(--color-fg-muted);
+  }
+
   /* Case C — panel (titled content box) */
   .panel {
     background: var(--color-surface-raised);

--- a/frontend/tests/msw/handlers.ts
+++ b/frontend/tests/msw/handlers.ts
@@ -19,6 +19,9 @@ export const handlers = [
       received_this_month_cents: 0,
       received_last_month_cents: 0,
       aging: { current: 0, overdue_1_30: 0, overdue_31_plus: 0 },
+      billed_this_month_cents: 0,
+      billed_last_month_cents: 0,
+      monthly_billed: [],
     }),
   ),
 

--- a/src/Dashboard/DashboardSummary.php
+++ b/src/Dashboard/DashboardSummary.php
@@ -15,6 +15,7 @@ final readonly class DashboardSummary
     /**
      * @param list<Invoice>                                                $recentUnpaid
      * @param array{current: int, overdue_1_30: int, overdue_31_plus: int} $aging outstanding receivable bucketed by overdue age, in cents
+     * @param list<array{month: string, billed_cents: int, count: int}>    $monthlyBilled issued-invoice totals per month (oldest→newest, Issue #272)
      */
     public function __construct(
         public int $unpaidCount,
@@ -24,6 +25,9 @@ final readonly class DashboardSummary
         public int $receivedThisMonthCents,
         public int $receivedLastMonthCents,
         public array $aging,
+        public int $billedThisMonthCents,
+        public int $billedLastMonthCents,
+        public array $monthlyBilled,
     ) {
     }
 }

--- a/src/Dashboard/GetDashboardHandler.php
+++ b/src/Dashboard/GetDashboardHandler.php
@@ -54,6 +54,9 @@ final readonly class GetDashboardHandler implements RequestHandlerInterface
             'received_this_month_cents' => $summary->receivedThisMonthCents,
             'received_last_month_cents' => $summary->receivedLastMonthCents,
             'aging'                     => $summary->aging,
+            'billed_this_month_cents'   => $summary->billedThisMonthCents,
+            'billed_last_month_cents'   => $summary->billedLastMonthCents,
+            'monthly_billed'            => $summary->monthlyBilled,
         ]);
     }
 }

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -36,6 +36,9 @@ final readonly class GetDashboardSummaryUseCase
         $lastMonthStart = $nowDt->modify('first day of last month')->format('Y-m-01 00:00:00');
         $thirtyDaysAgo  = $nowDt->modify('-30 days')->format('Y-m-d H:i:s');
 
+        $billedThisMonth = $this->invoices->billedTotalBetween($thisMonthStart, $nextMonthStart);
+        $billedLastMonth = $this->invoices->billedTotalBetween($lastMonthStart, $thisMonthStart);
+
         return new DashboardSummary(
             unpaidCount: $data['unpaid_count'],
             overdueCount: $data['overdue_count'],
@@ -44,6 +47,37 @@ final readonly class GetDashboardSummaryUseCase
             receivedThisMonthCents: $this->payments->receivedTotalBetween($thisMonthStart, $nextMonthStart),
             receivedLastMonthCents: $this->payments->receivedTotalBetween($lastMonthStart, $thisMonthStart),
             aging: $this->payments->agingBuckets($now, $thirtyDaysAgo),
+            billedThisMonthCents: $billedThisMonth['cents'],
+            billedLastMonthCents: $billedLastMonth['cents'],
+            monthlyBilled: $this->monthlyBilled($nowDt),
         );
+    }
+
+    /**
+     * Issued-invoice totals for the last 6 calendar months (oldest→newest).
+     *
+     * @return list<array{month: string, billed_cents: int, count: int}>
+     */
+    private function monthlyBilled(DateTimeImmutable $nowDt): array
+    {
+        $firstOfThisMonth = $nowDt->modify('first day of this month')->setTime(0, 0, 0);
+        $months = [];
+
+        for ($k = 5; $k >= 0; --$k) {
+            $start  = $firstOfThisMonth->modify("-{$k} month");
+            $end    = $start->modify('+1 month');
+            $bucket = $this->invoices->billedTotalBetween(
+                $start->format('Y-m-d H:i:s'),
+                $end->format('Y-m-d H:i:s'),
+            );
+
+            $months[] = [
+                'month'        => $start->format('Y-m'),
+                'billed_cents' => $bucket['cents'],
+                'count'        => $bucket['count'],
+            ];
+        }
+
+        return $months;
     }
 }

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -46,6 +46,14 @@ interface InvoiceRepositoryInterface
      */
     public function getDashboardData(string $now): array;
 
+    /**
+     * Total (cents) and count of invoices *issued* within [start, end) — the
+     * billing-issuance metric (drafts are excluded; bucketed by `issued_at`).
+     *
+     * @return array{cents: int, count: int}
+     */
+    public function billedTotalBetween(string $startInclusive, string $endExclusive): array;
+
     public function save(Invoice $invoice): int;
 
     /** @throws InvoiceNotFoundException */

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -258,6 +258,25 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     }
 
     /**
+     * @return array{cents: int, count: int}
+     */
+    public function billedTotalBetween(string $startInclusive, string $endExclusive): array
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COALESCE(SUM(total_cents), 0) AS cents, COUNT(*) AS cnt
+             FROM invoices
+             WHERE organization_id = ? AND is_deleted = 0
+               AND issued_at IS NOT NULL AND issued_at >= ? AND issued_at < ?',
+            [$this->orgId->get(), $startInclusive, $endExclusive],
+        );
+
+        return [
+            'cents' => $row !== null ? (int) $row['cents'] : 0,
+            'count' => $row !== null ? (int) $row['cnt'] : 0,
+        ];
+    }
+
+    /**
      * @return array{unpaid_count: int, overdue_count: int, recent_unpaid: list<Invoice>}
      */
     public function getDashboardData(string $now): array

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -39,6 +39,37 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         self::assertSame(0, $summary->receivedThisMonthCents);
         self::assertSame(0, $summary->receivedLastMonthCents);
         self::assertSame(['current' => 0, 'overdue_1_30' => 0, 'overdue_31_plus' => 0], $summary->aging);
+        self::assertSame(0, $summary->billedThisMonthCents);
+        self::assertSame(0, $summary->billedLastMonthCents);
+        self::assertCount(6, $summary->monthlyBilled);
+        self::assertSame(0, $summary->monthlyBilled[5]['billed_cents']);
+    }
+
+    public function test_billed_metrics_and_monthly_trend(): void
+    {
+        $thisMonth = date('Y-m-10 09:00:00');
+        $lastMonth = date('Y-m-10 09:00:00', (int) strtotime('first day of last month'));
+
+        // Issued this month: 1000 + 2000 (paid still counts as issued).
+        $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000, issuedAt: $thisMonth));
+        $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Paid, subtotalCents: 2000, taxCents: 0, totalCents: 2000, issuedAt: $thisMonth));
+        // Issued last month: 5000.
+        $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 5000, taxCents: 0, totalCents: 5000, issuedAt: $lastMonth));
+        // Draft (never issued) is excluded.
+        $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Draft, subtotalCents: 9999, taxCents: 0, totalCents: 9999));
+
+        $summary = $this->useCase->execute();
+
+        self::assertSame(3000, $summary->billedThisMonthCents);
+        self::assertSame(5000, $summary->billedLastMonthCents);
+
+        self::assertCount(6, $summary->monthlyBilled);
+        // Last bucket is the current month (oldest→newest).
+        self::assertSame(date('Y-m'), $summary->monthlyBilled[5]['month']);
+        self::assertSame(3000, $summary->monthlyBilled[5]['billed_cents']);
+        self::assertSame(2, $summary->monthlyBilled[5]['count']);
+        self::assertSame(5000, $summary->monthlyBilled[4]['billed_cents']);
+        self::assertSame(1, $summary->monthlyBilled[4]['count']);
     }
 
     public function test_received_this_month_sums_current_month_payments(): void

--- a/tests/Invoice/ExportInvoicesCsvUseCaseTest.php
+++ b/tests/Invoice/ExportInvoicesCsvUseCaseTest.php
@@ -147,6 +147,10 @@ final class ExportInvoicesCsvUseCaseTest extends TestCase
             {
                 return ['unpaid_count' => 0, 'overdue_count' => 0, 'recent_unpaid' => []];
             }
+            public function billedTotalBetween(string $startInclusive, string $endExclusive): array
+            {
+                return ['cents' => 0, 'count' => 0];
+            }
             public function save(Invoice $invoice): int
             {
                 return 0;

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -223,6 +223,25 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
         ];
     }
 
+    public function billedTotalBetween(string $startInclusive, string $endExclusive): array
+    {
+        $orgId = $this->orgId->get();
+        $cents = 0;
+        $count = 0;
+
+        foreach ($this->byId as $i) {
+            if ($i->organizationId !== $orgId || $i->isDeleted || $i->issuedAt === null) {
+                continue;
+            }
+            if ($i->issuedAt >= $startInclusive && $i->issuedAt < $endExclusive) {
+                $cents += $i->totalCents;
+                ++$count;
+            }
+        }
+
+        return ['cents' => $cents, 'count' => $count];
+    }
+
     public function save(Invoice $invoice): int
     {
         $id = $this->nextId++;


### PR DESCRIPTION
## 概要
ダッシュボードは入金・売掛（回収側）のみで、**請求発行（売上計上）側の指標が無かった**。経営/会計が「いくら請求を発行したか」を見られるよう、(A) 当月の請求発行額＋前月比 と (B) 直近6ヶ月の推移グラフを追加する。**Closes #272**。

スコープは運用サマリに限定（フル会計/売上分析にはしない・ADR 0002）。**暦月ベース**（締めサイクル単位は将来 (C) 入金予定で別途）。

## backend
- `InvoiceRepositoryInterface::billedTotalBetween()` を追加（発行済み＝`issued_at` 非null の `total_cents` 合計＋件数。下書き除外）。Pdo / InMemory / スタブ実装。
- `DashboardSummary` に `billed_this_month_cents` / `billed_last_month_cents` / `monthly_billed`（直近6ヶ月 `{month, billed_cents, count}`・古→新）。UseCase で算出、Handler で直列化。
- OpenAPI（`DashboardSummary` ＋ `MonthlyBilled`）、用語レジストリ更新。
- UseCase テスト（発行額集計・月次推移・下書き除外）。

## frontend
- dashboard model / mapper / hook に新フィールド、生成型再生成。
- **(A)** 「当月請求発行額」スタットカード＋前月比（既存の"当月入金額"と対称）。
- **(B)** 「請求発行額の推移」6ヶ月バーチャート（チャートライブラリ不使用・`theme` に `.bar-chart`）。
- i18n ja/en、mapper / msw テスト更新。

## 検証
- backend: `composer test（319）` / `analyse（0）` / `cs` / `openapi` / `mcp` グリーン。
- frontend: `type-check` / `lint` / `prettier` / `knip` / `vitest（162）` / `build` グリーン。
- 実機（dev）でシード実データの当月発行額¥658,000（MoM -46%）＋6ヶ月推移（1月¥0〜5月¥1,208,000）を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)