### PR TITLE
design(frontend): ステータスバッジのミュート配色＋overdue鮮やかフラグ (#274)

### DIFF
--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -260,7 +260,7 @@ export function ListInvoices() {
                           {t(`admin.invoices.status.${invoice.status}`)}
                         </Badge>
                         {invoice.is_overdue && (
-                          <Badge tone="danger">{t('admin.invoices.status.overdue')}</Badge>
+                          <span className="flag-overdue">{t('admin.invoices.status.overdue')}</span>
                         )}
                       </span>
                     </td>

--- a/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
+++ b/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
@@ -142,7 +142,7 @@ export function ViewDashboard() {
                       {t(`admin.invoices.status.${invoice.status}`)}
                     </Badge>
                     {invoice.is_overdue && (
-                      <Badge tone="danger">{t('admin.invoices.status.overdue')}</Badge>
+                      <span className="flag-overdue">{t('admin.invoices.status.overdue')}</span>
                     )}
                   </div>
                   <div className="mini-right">

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -168,7 +168,9 @@ export function ViewInvoice({ invoiceId }: ViewInvoiceProps) {
           <Badge tone={invoiceStatusTone[invoice.status]}>
             {t(`admin.invoices.status.${invoice.status}`)}
           </Badge>
-          {invoice.is_overdue && <Badge tone="danger">{t('admin.invoices.status.overdue')}</Badge>}
+          {invoice.is_overdue && (
+            <span className="flag-overdue">{t('admin.invoices.status.overdue')}</span>
+          )}
           {invoice.is_qualified_invoice && (
             <Badge tone="brand">{t('admin.invoices.detail.qualified')}</Badge>
           )}

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -86,28 +86,39 @@
     white-space: nowrap;
   }
   .badge-neutral {
-    background: var(--color-neutral-soft);
-    color: var(--color-fg-muted);
+    background: var(--color-bdg-draft-bg);
+    color: var(--color-bdg-draft-fg);
+    border-color: color-mix(in oklch, var(--color-bdg-draft-fg) 20%, transparent);
   }
   .badge-info {
-    background: var(--color-info-soft);
-    color: var(--color-info);
+    background: var(--color-bdg-sent-bg);
+    color: var(--color-bdg-sent-fg);
+    border-color: color-mix(in oklch, var(--color-bdg-sent-fg) 22%, transparent);
   }
   .badge-ok {
-    background: var(--color-success-soft);
-    color: var(--color-success);
+    background: var(--color-bdg-acc-bg);
+    color: var(--color-bdg-acc-fg);
+    border-color: color-mix(in oklch, var(--color-bdg-acc-fg) 24%, transparent);
   }
   .badge-warn {
-    background: var(--color-warn-soft);
-    color: var(--color-warn);
+    background: var(--color-bdg-part-bg);
+    color: var(--color-bdg-part-fg);
+    border-color: color-mix(in oklch, var(--color-bdg-part-fg) 26%, transparent);
   }
   .badge-danger {
-    background: var(--color-danger-soft);
-    color: var(--color-danger);
+    background: var(--color-bdg-rej-bg);
+    color: var(--color-bdg-rej-fg);
+    border-color: color-mix(in oklch, var(--color-bdg-rej-fg) 26%, transparent);
   }
   .badge-brand {
     background: var(--color-accent-soft);
     color: var(--color-accent-hover);
+  }
+  /* Overdue stays a vivid functional flag (design 03), not a muted chip. */
+  .flag-overdue {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--color-danger);
   }
 
   /* Tabular numerals for amounts / document numbers */

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -40,6 +40,19 @@
   --color-info-soft: oklch(95% 0.025 235);
   --color-neutral-soft: oklch(93.5% 0.004 172);
 
+  /* Muted status-badge palette (design 03) — refined, low-chroma chips. Distinct
+     from --color-danger (functional error red), which stays vivid. */
+  --color-bdg-draft-fg: oklch(48% 0.01 245);
+  --color-bdg-draft-bg: oklch(95.5% 0.005 245);
+  --color-bdg-sent-fg: oklch(48% 0.045 248);
+  --color-bdg-sent-bg: oklch(95.5% 0.018 248);
+  --color-bdg-acc-fg: oklch(45% 0.052 162);
+  --color-bdg-acc-bg: oklch(94.8% 0.022 162);
+  --color-bdg-part-fg: oklch(52% 0.06 72);
+  --color-bdg-part-bg: oklch(95.2% 0.032 74);
+  --color-bdg-rej-fg: oklch(51% 0.078 33);
+  --color-bdg-rej-bg: oklch(95.2% 0.026 33);
+
   --color-focus-ring: oklch(43% 0.072 162);
 
   /* sidebar (product chrome) — deep green, always dark */


### PR DESCRIPTION
## 概要
デザイン指示書03の反映 **PR1**。ステータスタグを「くすんだ洗練配色」へ。機能的エラー赤は温存。Refs #274。

## 変更点
- 新規ミュートトークン `--color-bdg-{draft,sent,acc,part,rej}-{fg,bg}`（ライト固定）。
- `.badge-{neutral,info,ok,warn,danger}` を新トークン＋ヘアライン枠線に。`brand` は据え置き。
  - draft=ストーン / issued・sent=スレート / accepted・paid=セージ / partial・expired=オーカー / rejected=クレイ。
- **overdue** はミュートバッジではなく**鮮やかな `.flag-overdue`（赤太字テキスト）**へ（`ListInvoices`/`ViewInvoice`/`ViewDashboard`）。

## 検証
- `type-check`/`lint`/`prettier`/`vitest（162）`/`build` グリーン。
- 実機：ステータスがミュート chip、Overdue が鮮やかな赤フラグで表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)