### PR TITLE
design(frontend): ソートヘッダ磨き込み（シェブロン＋aria-sort＋深緑） (#274)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -18,6 +18,7 @@ import {
   Input,
   LinkButton,
   LoadingState,
+  SortableTh,
   Stack,
   Text,
 } from '@/shared/ui'
@@ -58,22 +59,15 @@ export function ListClients() {
     view.resetFilters()
   }
 
-  const sortIndicator = (field: ClientSortField): string =>
-    view.sort.field === field ? (view.sort.order === 'asc' ? ' ▲' : ' ▼') : ''
-
   const sortableTh = (field: ClientSortField, label: string): ReactNode => (
-    <th>
-      <button
-        type="button"
-        className="th-sort"
-        onClick={() => {
-          view.toggleSort(field)
-        }}
-      >
-        {label}
-        {sortIndicator(field)}
-      </button>
-    </th>
+    <SortableTh
+      label={label}
+      active={view.sort.field === field}
+      order={view.sort.order}
+      onToggle={() => {
+        view.toggleSort(field)
+      }}
+    />
   )
 
   return (

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -22,6 +22,7 @@ import {
   LinkButton,
   LoadingState,
   Select,
+  SortableTh,
   Stack,
   Text,
 } from '@/shared/ui'
@@ -58,22 +59,16 @@ export function ListInvoices() {
     view.resetFilters()
   }
 
-  const sortIndicator = (field: InvoiceSortField): string =>
-    view.sort.field === field ? (view.sort.order === 'asc' ? ' ▲' : ' ▼') : ''
-
   const sortableTh = (field: InvoiceSortField, label: string, right = false): ReactNode => (
-    <th className={right ? 'tr' : undefined}>
-      <button
-        type="button"
-        className="th-sort"
-        onClick={() => {
-          view.toggleSort(field)
-        }}
-      >
-        {label}
-        {sortIndicator(field)}
-      </button>
-    </th>
+    <SortableTh
+      label={label}
+      active={view.sort.field === field}
+      order={view.sort.order}
+      right={right}
+      onToggle={() => {
+        view.toggleSort(field)
+      }}
+    />
   )
 
   return (

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -21,6 +21,7 @@ import {
   LinkButton,
   LoadingState,
   Select,
+  SortableTh,
   Stack,
   Text,
 } from '@/shared/ui'
@@ -53,22 +54,16 @@ export function ListQuotes() {
     view.resetFilters()
   }
 
-  const sortIndicator = (field: QuoteSortField): string =>
-    view.sort.field === field ? (view.sort.order === 'asc' ? ' ▲' : ' ▼') : ''
-
   const sortableTh = (field: QuoteSortField, label: string, right = false): ReactNode => (
-    <th className={right ? 'tr' : undefined}>
-      <button
-        type="button"
-        className="th-sort"
-        onClick={() => {
-          view.toggleSort(field)
-        }}
-      >
-        {label}
-        {sortIndicator(field)}
-      </button>
-    </th>
+    <SortableTh
+      label={label}
+      active={view.sort.field === field}
+      order={view.sort.order}
+      right={right}
+      onToggle={() => {
+        view.toggleSort(field)
+      }}
+    />
   )
 
   return (

--- a/frontend/src/shared/ui/components/SortableTh.tsx
+++ b/frontend/src/shared/ui/components/SortableTh.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/shared/lib/cn'
+
+/**
+ * Sortable table header cell (design 03). Click toggles asc/desc; the active
+ * column is highlighted (deep green) and carries `aria-sort`, with a paired
+ * up/down chevron whose active half is emphasised.
+ */
+export interface SortableThProps {
+  label: string
+  /** True when this column is the active sort key. */
+  active: boolean
+  order: 'asc' | 'desc'
+  /** Right-aligned (numeric) columns mirror the label/chevron order. */
+  right?: boolean
+  onToggle: () => void
+}
+
+export function SortableTh({ label, active, order, right = false, onToggle }: SortableThProps) {
+  const ariaSort = active ? (order === 'asc' ? 'ascending' : 'descending') : 'none'
+
+  return (
+    <th className={cn('sortable', right && 'tr')} aria-sort={ariaSort}>
+      <button type="button" className="th-in" onClick={onToggle}>
+        {label}
+        <svg className="sort-ico" viewBox="0 0 10 14" aria-hidden="true">
+          <path className="up" d="M5 0l3.6 5H1.4z" />
+          <path className="dn" d="M5 14l3.6-5H1.4z" />
+        </svg>
+      </button>
+    </th>
+  )
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -31,6 +31,7 @@ export {
   type InlineAlertRecover,
 } from './components/InlineAlert'
 export { LineItemsTable, TotalRow } from './components/LineItemsTable'
+export { SortableTh, type SortableThProps } from './components/SortableTh'
 export { ToastProvider } from './toast/ToastProvider'
 export { useToast } from './toast/context'
 export type { ToastInput, ToastTone, ToastAction } from './toast/model'

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -31,11 +31,19 @@
     text-align: right;
   }
   /* clickable sort header: a button that inherits the th typography */
-  .th-sort {
+  /* Sortable column headers (design 03): chevron + aria-sort + active green */
+  .data-table thead th.sortable {
+    cursor: pointer;
+    user-select: none;
+  }
+  .data-table thead th.sortable .th-in {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
     font: inherit;
-    color: inherit;
     letter-spacing: inherit;
     text-transform: inherit;
+    color: inherit;
     background: none;
     border: 0;
     padding: 0;
@@ -43,8 +51,33 @@
     cursor: pointer;
     white-space: nowrap;
   }
-  .th-sort:hover {
+  .data-table thead th.tr.sortable .th-in {
+    flex-direction: row-reverse;
+  }
+  .data-table thead th.sortable:hover .th-in {
     color: var(--color-fg);
+  }
+  .data-table thead th.sortable .sort-ico {
+    width: 11px;
+    height: 11px;
+    flex: none;
+    display: block;
+  }
+  .data-table thead th.sortable .sort-ico .up,
+  .data-table thead th.sortable .sort-ico .dn {
+    fill: currentColor;
+    opacity: 0.3;
+    transition: opacity 0.12s;
+  }
+  .data-table thead th[aria-sort='ascending'],
+  .data-table thead th[aria-sort='descending'] {
+    color: var(--color-accent-deep);
+  }
+  .data-table thead th[aria-sort='ascending'] .sort-ico .up {
+    opacity: 1;
+  }
+  .data-table thead th[aria-sort='descending'] .sort-ico .dn {
+    opacity: 1;
   }
   .data-table tbody td {
     padding: 0.25rem 0.5625rem; /* 4px 9px — spec dir-c row padding (dense) */


### PR DESCRIPTION
## 概要
デザイン指示書03の反映 **PR2**。一覧テーブルのソートヘッダを磨き込む。Refs #274。

## 変更点
- 共有 `SortableTh` コンポーネント：`th.sortable` ＋ `aria-sort` ＋ 上下シェブロン（`.sort-ico` の up/dn パス）。右寄せ（数値）列は順序ミラー。アクティブ列は深緑（`--color-accent-deep`）、有効な向きのシェブロンを強調。
- theme：旧 `.th-sort` を `.data-table thead th.sortable` 系に置換。
- 見積/請求/取引先の3一覧の `sortableTh` を `SortableTh` に委譲（`▲`/`▼` テキストを廃止）。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（162）`/`build` グリーン。
- 実機：TOTAL クリックで昇順、`aria-sort="ascending"`＋深緑＋上シェブロン強調を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)