### PR TITLE
design(frontend): キーボード u(一覧へ戻る)・/先頭欄＋サイドバーのショートカット起動 (#274)

### DIFF
--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import { AccountMenu } from '@/features/account-menu'
 import { useTranslation, type MessageKey } from '@/shared/i18n'
-import { KeyboardShortcuts } from '@/shared/keyboard'
+import { KeyboardShortcuts, openShortcutsOverlay } from '@/shared/keyboard'
 import { cn } from '@/shared/lib/cn'
 
 /** Monogram NN mark (logo concept 03 — overlapping N's). */
@@ -257,6 +257,25 @@ export function AppShell() {
         </nav>
 
         <div className="border-t border-side-border px-inline-sm py-stack-sm text-side-fg">
+          <button
+            type="button"
+            onClick={openShortcutsOverlay}
+            className="mb-stack-xs flex w-full items-center gap-inline-sm rounded-none px-inline-sm py-stack-xs text-body text-side-fg-muted transition-colors hover:bg-side-active/60 hover:text-side-fg"
+          >
+            <svg
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              className="size-4.5 shrink-0"
+              aria-hidden="true"
+            >
+              <rect x="2" y="5" width="16" height="10" rx="1.5" />
+              <path d="M5 8h.01M8 8h.01M11 8h.01M14 8h.01M5 11h.01M14 11h.01M8 11h4" />
+            </svg>
+            <span className="flex-1 text-left">{t('admin.nav.shortcuts')}</span>
+            <kbd className="kbd">?</kbd>
+          </button>
           <AccountMenu />
         </div>
       </aside>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -48,6 +48,7 @@ export const enMessages: MessageCatalog = {
   'admin.nav.users': 'Users',
   'admin.nav.auditLogs': 'Audit logs',
   'admin.nav.settings': 'Settings',
+  'admin.nav.shortcuts': 'Keyboard shortcuts',
   'admin.nav.primary': 'Primary navigation',
   'admin.bottomNav.dashboard': 'Dashboard',
   'admin.bottomNav.quotes': 'Quotes',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -49,6 +49,7 @@ export const jaMessages = {
   'admin.nav.users': 'ユーザー',
   'admin.nav.auditLogs': '監査ログ',
   'admin.nav.settings': '設定',
+  'admin.nav.shortcuts': 'キーボードショートカット',
   'admin.nav.primary': '主要ナビゲーション',
   'admin.bottomNav.dashboard': 'ダッシュボード',
   'admin.bottomNav.quotes': '見積',

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, waitFor } from '@testing-library/react'
+import { act, fireEvent, waitFor } from '@testing-library/react'
 import { useLocation } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { KeyboardShortcuts } from './KeyboardShortcuts'
+import { openShortcutsOverlay } from './overlay-control'
 import { useRowCursor } from './use-row-cursor'
 
 function LocationProbe() {
@@ -37,6 +38,37 @@ describe('KeyboardShortcuts', () => {
     await waitFor(() => {
       expect(getByTestId('loc')).toHaveTextContent('/invoices')
     })
+  })
+
+  it('returns to the parent list with u', async () => {
+    const { getByTestId } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <LocationProbe />
+      </>,
+    )
+
+    fireEvent.keyDown(document.body, { key: 'g' })
+    fireEvent.keyDown(document.body, { key: 'i' })
+    fireEvent.keyDown(document.body, { key: 'n' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/invoices/new')
+    })
+
+    fireEvent.keyDown(document.body, { key: 'u' })
+    await waitFor(() => {
+      expect(getByTestId('loc').textContent).toBe('/invoices')
+    })
+  })
+
+  it('opens the cheat-sheet via openShortcutsOverlay()', () => {
+    const { getByRole, queryByRole } = renderWithProviders(<KeyboardShortcuts />)
+    expect(queryByRole('dialog')).not.toBeInTheDocument()
+
+    act(() => {
+      openShortcutsOverlay()
+    })
+    expect(getByRole('dialog')).toBeInTheDocument()
   })
 
   it('opens the cheat-sheet on ? and closes it on Esc', () => {

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { SHOW_SHORTCUTS_EVENT } from './overlay-control'
 import { ShortcutsOverlay } from './ShortcutsOverlay'
 import { KBD_LIST_EVENT, type RowCursorAction } from './use-row-cursor'
 
@@ -27,6 +28,13 @@ const NEW_ROUTE: Record<string, string> = {
   '/invoices': '/invoices/new',
   '/clients': '/clients/new',
   '/users': '/users/new',
+}
+
+/** Parent list roots for `u` (back to list). */
+const LIST_ROOTS = ['/invoices', '/quotes', '/clients', '/users', '/audit-logs']
+
+function parentListOf(path: string): string | null {
+  return LIST_ROOTS.find((root) => path.startsWith(`${root}/`)) ?? null
 }
 
 /** True when focus sits in an editable control — single keys must not fire. */
@@ -60,6 +68,16 @@ export function KeyboardShortcuts() {
   useEffect(() => {
     overlayRef.current = overlayOpen
   }, [overlayOpen])
+  // The sidebar "shortcuts" button opens the cheat-sheet via this event.
+  useEffect(() => {
+    const open = (): void => {
+      setOverlayOpen(true)
+    }
+    document.addEventListener(SHOW_SHORTCUTS_EVENT, open)
+    return () => {
+      document.removeEventListener(SHOW_SHORTCUTS_EVENT, open)
+    }
+  }, [])
   useEffect(() => {
     pendingRef.current = pendingG
   }, [pendingG])
@@ -133,12 +151,16 @@ export function KeyboardShortcuts() {
         return
       }
 
-      // Layer 2 — focus the list search box (`/`).
+      // Layer 2 — focus the search box, or the first form field (spec §08).
       if (e.key === '/') {
-        const search = document.querySelector('[data-kbd="search"]')
-        if (search instanceof HTMLElement) {
+        const target =
+          document.querySelector('[data-kbd="search"]') ??
+          document.querySelector(
+            'form input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]), form textarea, form select',
+          )
+        if (target instanceof HTMLElement) {
           e.preventDefault()
-          search.focus()
+          target.focus()
         }
         return
       }
@@ -149,6 +171,16 @@ export function KeyboardShortcuts() {
         if (dest !== undefined) {
           e.preventDefault()
           void navigate(dest)
+        }
+        return
+      }
+
+      // Layer 2 — back to the parent list (`u`), Gmail-style.
+      if (e.key === 'u') {
+        const list = parentListOf(pathRef.current)
+        if (list !== null) {
+          e.preventDefault()
+          void navigate(list)
         }
         return
       }

--- a/frontend/src/shared/keyboard/index.ts
+++ b/frontend/src/shared/keyboard/index.ts
@@ -1,4 +1,5 @@
 export { KeyboardShortcuts } from './KeyboardShortcuts'
+export { openShortcutsOverlay } from './overlay-control'
 export { KbdHint } from './KbdHint'
 export { isMacPlatform } from './platform'
 export { useLineGridEnter } from './use-line-grid-enter'

--- a/frontend/src/shared/keyboard/overlay-control.ts
+++ b/frontend/src/shared/keyboard/overlay-control.ts
@@ -1,0 +1,7 @@
+/** Event the sidebar button dispatches to open the `?` cheat-sheet overlay. */
+export const SHOW_SHORTCUTS_EVENT = 'kbd:show-shortcuts'
+
+/** Opens the keyboard cheat-sheet from outside the dispatcher (e.g. sidebar). */
+export function openShortcutsOverlay(): void {
+  document.dispatchEvent(new CustomEvent(SHOW_SHORTCUTS_EVENT))
+}

--- a/frontend/src/shared/keyboard/shortcuts-data.ts
+++ b/frontend/src/shared/keyboard/shortcuts-data.ts
@@ -62,6 +62,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
           { caps: ['o'], join: 'none' },
         ],
       },
+      { ja: '一覧へ戻る', en: 'Back to list', combos: [{ caps: ['u'], join: 'none' }] },
     ],
   },
   {
@@ -69,7 +70,11 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     en: 'Actions',
     rows: [
       { ja: '新規作成', en: 'New', combos: [{ caps: ['n'], join: 'none' }] },
-      { ja: '検索にフォーカス', en: 'Focus search', combos: [{ caps: ['/'], join: 'none' }] },
+      {
+        ja: '検索 / 先頭欄へ',
+        en: 'Focus search / field',
+        combos: [{ caps: ['/'], join: 'none' }],
+      },
     ],
   },
   {


### PR DESCRIPTION
## 概要
デザイン指示書03の反映 **PR4**。キーボード操作とヘルプ導線の追補。Refs #274。

## 変更点
- **`u` = 一覧へ戻る**：詳細/新規から親リスト root へ（`/invoices/5`→`/invoices`、`/clients/5/edit`→`/clients` 等）。
- **`/` の一般化**：検索ボックス（`[data-kbd="search"]`）が無ければ**フォーム先頭の入力欄**へフォーカス（§08）。
- **サイドバー下部に「キーボードショートカット」ボタン**（`?` キーキャップ付き）。`openShortcutsOverlay()` が `kbd:show-shortcuts` を発行し、`?` オーバーレイを開く。
- `?` チートシートに「一覧へ戻る `u`」を追加、`/` ラベルを「検索/先頭欄へ」に更新。
- 関数 export を `overlay-control.ts` に分離（react-refresh 警告回避）。
- ディスパッチャのテスト（`u` 戻り・ボタン起動）追加、i18n ja/en。

※ サイドバーの言語切替・ログアウトは既に実装済み。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest（164）`/`build` グリーン。
- 実機：サイドバーボタンで `?` 起動、`j`→`o` で詳細→`u` で一覧へ戻るを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)