### PR TITLE
design(frontend): サイドバーにヘルプ項目＋ヘルプ画面（スタブ） (#274)

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -6,6 +6,7 @@ import { ClientEditPage } from '@/pages/client-edit'
 import { ClientsPage } from '@/pages/clients'
 import { CompanySettingsPage } from '@/pages/company-settings'
 import { DashboardPage } from '@/pages/dashboard'
+import { HelpPage } from '@/pages/help'
 import { InvoiceCreatePage } from '@/pages/invoice-create'
 import { QuoteCreatePage } from '@/pages/quote-create'
 import { QuoteDetailPage } from '@/pages/quote-detail'
@@ -37,6 +38,7 @@ const router = createBrowserRouter([
       { path: 'users/new', element: <UserCreatePage /> },
       { path: 'users/:id/edit', element: <UserEditPage /> },
       { path: 'audit-logs', element: <AuditLogsPage /> },
+      { path: 'help', element: <HelpPage /> },
     ],
   },
   { path: '*', element: <Navigate to="/invoices" replace /> },

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from '@/shared/i18n'
+import { EmptyState, Stack } from '@/shared/ui'
+
+/**
+ * Help landing page (design 03 — stub). FAQ / operation guides connect here
+ * later. Distinct from the `?` shortcut cheat-sheet (keys), which is separate.
+ */
+export function HelpPage() {
+  const { t } = useTranslation()
+
+  return (
+    <Stack gap="md">
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">{t('admin.help.title')}</h1>
+          <p className="page-sub">{t('admin.help.subtitle')}</p>
+        </div>
+      </div>
+      <div className="panel">
+        <div className="panel-body">
+          <EmptyState message={t('admin.help.comingSoon')} />
+        </div>
+      </div>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/help/index.ts
+++ b/frontend/src/pages/help/index.ts
@@ -1,0 +1,1 @@
+export { HelpPage } from './HelpPage'

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -98,6 +98,13 @@ const ICONS: Record<string, ReactNode> = {
       <path d="M7.5 13.5h5" />
     </>,
   ),
+  help: icon(
+    <>
+      <circle cx="10" cy="10" r="7.5" />
+      <path d="M7.8 7.8a2.2 2.2 0 1 1 3 2.05c-.7.3-1 .7-1 1.45v.4" />
+      <path d="M9.8 14.2v.1" />
+    </>,
+  ),
   more: icon(
     <>
       <circle cx="4" cy="10" r="1.4" />
@@ -149,6 +156,7 @@ const NAV: NavGroup[] = [
     items: [
       { to: '/users', label: 'admin.nav.users', iconKey: 'users' },
       { to: '/audit-logs', label: 'admin.nav.auditLogs', iconKey: 'audit' },
+      { to: '/help', label: 'admin.nav.help', iconKey: 'help' },
       { to: '/settings', label: 'admin.nav.settings', iconKey: 'settings' },
     ],
   },
@@ -169,7 +177,7 @@ const BOTTOM_TABS: BottomTab[] = [
   { to: '/clients', label: 'admin.bottomNav.clients', iconKey: 'clients' },
 ]
 /** Routes that live behind the 「メニュー」 tab (not direct bottom tabs). */
-const DRAWER_ROUTES = ['/users', '/audit-logs', '/settings']
+const DRAWER_ROUTES = ['/users', '/audit-logs', '/help', '/settings']
 
 interface BottomNavProps {
   pathname: string

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -48,7 +48,12 @@ export const enMessages: MessageCatalog = {
   'admin.nav.users': 'Users',
   'admin.nav.auditLogs': 'Audit logs',
   'admin.nav.settings': 'Settings',
+  'admin.nav.help': 'Help',
   'admin.nav.shortcuts': 'Keyboard shortcuts',
+  'admin.help.title': 'Help',
+  'admin.help.subtitle': 'Guides & FAQ',
+  'admin.help.comingSoon':
+    'Operation guides and FAQ are coming soon. Press ? for the keyboard shortcuts.',
   'admin.nav.primary': 'Primary navigation',
   'admin.bottomNav.dashboard': 'Dashboard',
   'admin.bottomNav.quotes': 'Quotes',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -49,7 +49,12 @@ export const jaMessages = {
   'admin.nav.users': 'ユーザー',
   'admin.nav.auditLogs': '監査ログ',
   'admin.nav.settings': '設定',
+  'admin.nav.help': 'ヘルプ',
   'admin.nav.shortcuts': 'キーボードショートカット',
+  'admin.help.title': 'ヘルプ',
+  'admin.help.subtitle': '操作ガイド・よくある質問',
+  'admin.help.comingSoon':
+    '操作ガイドとよくある質問を準備中です。キーボードショートカットの一覧は ? キーで開けます。',
   'admin.nav.primary': '主要ナビゲーション',
   'admin.bottomNav.dashboard': 'ダッシュボード',
   'admin.bottomNav.quotes': '見積',


### PR DESCRIPTION
## 概要
デザイン指示書03の反映 **PR5**。ヘルプ導線。Refs #274。

## 変更点
- サイドバー「管理」グループに **ヘルプ** ナビ項目（?アイコン）＋ `/help` ルート。
- **HelpPage（スタブ）**：見出し＋「準備中」パネル。後日 FAQ/操作ガイドを接続。`?` キー一覧（ショートカット）とは役割を分離。
- `DRAWER_ROUTES` に `/help`、i18n（`admin.nav.help` / `admin.help.*`）ja/en。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest`/`build` グリーン。実機で /help 表示確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)