### PR TITLE
design(frontend): ショートカットヒント規約（kbdバリアント＋aria-keyshortcuts） (#274 完了)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -76,25 +76,29 @@ export function ListClients() {
         <Text as="h1" variant="heading-md">
           {t('admin.clients.title')}
         </Text>
-        <LinkButton to="/clients/new" size="sm">
+        <LinkButton to="/clients/new" size="sm" aria-keyshortcuts="n">
           {t('admin.clients.newButton')}
-          <KbdHint>n</KbdHint>
+          <KbdHint variant="solid">n</KbdHint>
         </LinkButton>
       </div>
 
       <form onSubmit={onSubmit}>
         <div className="flex flex-wrap items-end gap-inline-sm">
-          <Field id="client-q" label={t('admin.clients.filter.search')} hint={<KbdHint>/</KbdHint>}>
-            <Input
-              id="client-q"
-              data-kbd="search"
-              className="w-72"
-              value={draft.q ?? ''}
-              placeholder={t('admin.clients.filter.searchPlaceholder')}
-              onChange={(e) => {
-                setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
-              }}
-            />
+          <Field id="client-q" label={t('admin.clients.filter.search')}>
+            <div className="field-kbd w-72">
+              <Input
+                id="client-q"
+                data-kbd="search"
+                aria-keyshortcuts="/"
+                className="w-full pr-9"
+                value={draft.q ?? ''}
+                placeholder={t('admin.clients.filter.searchPlaceholder')}
+                onChange={(e) => {
+                  setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
+                }}
+              />
+              <KbdHint>/</KbdHint>
+            </div>
           </Field>
           <Button type="submit" size="sm">
             {t('admin.clients.filter.apply')}

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -98,9 +98,9 @@ export function ListInvoices() {
               ? t('admin.invoices.export.downloading')
               : t('admin.invoices.export.payments')}
           </Button>
-          <LinkButton to="/invoices/new" size="sm">
+          <LinkButton to="/invoices/new" size="sm" aria-keyshortcuts="n">
             {t('admin.invoices.newButton')}
-            <KbdHint>n</KbdHint>
+            <KbdHint variant="solid">n</KbdHint>
           </LinkButton>
         </Stack>
       </div>
@@ -114,16 +114,21 @@ export function ListInvoices() {
       <form onSubmit={onSubmit}>
         <Stack gap="sm">
           <div className="audit-filters">
-            <Field id="inv-q" label={t('admin.invoices.filter.search')} hint={<KbdHint>/</KbdHint>}>
-              <Input
-                id="inv-q"
-                data-kbd="search"
-                value={draft.q ?? ''}
-                placeholder={t('admin.invoices.filter.searchPlaceholder')}
-                onChange={(e) => {
-                  setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
-                }}
-              />
+            <Field id="inv-q" label={t('admin.invoices.filter.search')}>
+              <div className="field-kbd">
+                <Input
+                  id="inv-q"
+                  data-kbd="search"
+                  aria-keyshortcuts="/"
+                  className="pr-9"
+                  value={draft.q ?? ''}
+                  placeholder={t('admin.invoices.filter.searchPlaceholder')}
+                  onChange={(e) => {
+                    setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
+                  }}
+                />
+                <KbdHint>/</KbdHint>
+              </div>
             </Field>
             <Field id="inv-status" label={t('admin.invoices.filter.status')}>
               <Select

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -72,25 +72,30 @@ export function ListQuotes() {
         <Text as="h1" variant="heading-md">
           {t('admin.quotes.title')}
         </Text>
-        <LinkButton to="/quotes/new" size="sm">
+        <LinkButton to="/quotes/new" size="sm" aria-keyshortcuts="n">
           {t('admin.quotes.newButton')}
-          <KbdHint>n</KbdHint>
+          <KbdHint variant="solid">n</KbdHint>
         </LinkButton>
       </div>
 
       <form onSubmit={onSubmit}>
         <Stack gap="sm">
           <div className="audit-filters">
-            <Field id="q-q" label={t('admin.quotes.filter.search')} hint={<KbdHint>/</KbdHint>}>
-              <Input
-                id="q-q"
-                data-kbd="search"
-                value={draft.q ?? ''}
-                placeholder={t('admin.quotes.filter.searchPlaceholder')}
-                onChange={(e) => {
-                  setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
-                }}
-              />
+            <Field id="q-q" label={t('admin.quotes.filter.search')}>
+              <div className="field-kbd">
+                <Input
+                  id="q-q"
+                  data-kbd="search"
+                  aria-keyshortcuts="/"
+                  className="pr-9"
+                  value={draft.q ?? ''}
+                  placeholder={t('admin.quotes.filter.searchPlaceholder')}
+                  onChange={(e) => {
+                    setDraft({ ...draft, q: trimmedOrNull(e.target.value) })
+                  }}
+                />
+                <KbdHint>/</KbdHint>
+              </div>
             </Field>
             <Field id="q-status" label={t('admin.quotes.filter.status')}>
               <Select

--- a/frontend/src/features/list-users/ui/ListUsers.tsx
+++ b/frontend/src/features/list-users/ui/ListUsers.tsx
@@ -58,9 +58,9 @@ export function ListUsers() {
         <Text as="h1" variant="heading-md">
           {t('admin.users.title')}
         </Text>
-        <LinkButton to="/users/new" size="sm">
+        <LinkButton to="/users/new" size="sm" aria-keyshortcuts="n">
           {t('admin.users.newButton')}
-          <KbdHint>n</KbdHint>
+          <KbdHint variant="solid">n</KbdHint>
         </LinkButton>
       </div>
 

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import { AccountMenu } from '@/features/account-menu'
 import { useTranslation, type MessageKey } from '@/shared/i18n'
-import { KeyboardShortcuts, openShortcutsOverlay } from '@/shared/keyboard'
+import { KbdHint, KeyboardShortcuts, openShortcutsOverlay } from '@/shared/keyboard'
 import { cn } from '@/shared/lib/cn'
 
 /** Monogram NN mark (logo concept 03 — overlapping N's). */
@@ -268,6 +268,7 @@ export function AppShell() {
           <button
             type="button"
             onClick={openShortcutsOverlay}
+            aria-keyshortcuts="?"
             className="mb-stack-xs flex w-full items-center gap-inline-sm rounded-none px-inline-sm py-stack-xs text-body text-side-fg-muted transition-colors hover:bg-side-active/60 hover:text-side-fg"
           >
             <svg
@@ -282,7 +283,7 @@ export function AppShell() {
               <path d="M5 8h.01M8 8h.01M11 8h.01M14 8h.01M5 11h.01M14 11h.01M8 11h4" />
             </svg>
             <span className="flex-1 text-left">{t('admin.nav.shortcuts')}</span>
-            <kbd className="kbd">?</kbd>
+            <KbdHint variant="outline">?</KbdHint>
           </button>
           <AccountMenu />
         </div>

--- a/frontend/src/shared/keyboard/KbdHint.tsx
+++ b/frontend/src/shared/keyboard/KbdHint.tsx
@@ -1,11 +1,25 @@
 /**
- * Inline keycap hint (Issue #257, spec §04). A small, muted `.kbd` shown next
- * to the two most-frequent affordances only — search (`/`) and new (`n`). It is
- * decorative (`aria-hidden`) and hides on touch devices via `.kbd-hint`.
+ * Inline keycap hint (Issue #257 §04 / design 03 convention). A small, decorative
+ * `.kbd` shown next to the few most-frequent affordances only — search (`/`) and
+ * new (`n`). The control carries `aria-keyshortcuts`; this keycap is `aria-hidden`
+ * and hides on touch devices.
+ *
+ * Variant adapts contrast to the surface (design 03 §02):
+ * - `solid` — on a filled/accent button (translucent white).
+ * - `ghost` — on a plain/muted surface (default).
+ * - `outline` — on the deep-green sidebar (border only).
  */
-export function KbdHint({ children }: { children: string }) {
+export type KbdHintVariant = 'solid' | 'ghost' | 'outline'
+
+export function KbdHint({
+  children,
+  variant = 'ghost',
+}: {
+  children: string
+  variant?: KbdHintVariant
+}) {
   return (
-    <kbd className="kbd kbd-hint" aria-hidden="true">
+    <kbd className={`kbd kbd-hint ${variant}`} aria-hidden="true">
       {children}
     </kbd>
   )

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1459,18 +1459,45 @@
   .kbd.wide {
     padding: 0 9px;
   }
-  /* inline hint keycap (spec §04) — smaller, muted, hidden on touch */
+  /* Inline hint keycap (design 03 §02/§03) — control-internal size, 3 contrast
+     variants by surface, decorative + hidden on touch. */
   .kbd-hint {
-    height: 18px;
-    min-width: 18px;
+    height: 17px;
+    min-width: 17px;
     padding: 0 5px;
-    font-size: 10.5px;
+    font-size: 10px;
     border-bottom-width: 1px;
     box-shadow: none;
+  }
+  .kbd-hint.ghost {
+    background: var(--color-surface-overlay);
+    border-color: var(--color-border-strong);
     color: var(--color-fg-muted);
   }
+  .kbd-hint.solid {
+    background: color-mix(in oklch, #fff 22%, transparent);
+    border-color: color-mix(in oklch, #fff 30%, transparent);
+    color: #fff;
+  }
+  .kbd-hint.outline {
+    background: transparent;
+    border-color: color-mix(in oklch, currentColor 35%, transparent);
+    color: inherit;
+  }
+  /* Keycap pinned inside an input's right edge (e.g. search `/`). */
+  .field-kbd {
+    position: relative;
+  }
+  .field-kbd > .kbd {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
   @media (hover: none) {
-    .kbd-hint {
+    .kbd-hint,
+    .field-kbd > .kbd {
       display: none;
     }
   }


### PR DESCRIPTION
## 概要
デザイン指示書03の反映 **PR6（最終）**。「ショートカットヒント表示規約」に整合させる。**Closes #274**。

## 変更点
- **KbdHint に variant**（`solid`=半透明白 / `ghost`=沈色 / `outline`=枠線のみ）。下地に応じてコントラストを切替。サイズを規約準拠（17px / 10px / 下線1px）に。
- **新規ボタン**（4一覧）：半透明白キーキャップ（solid）＋ `aria-keyshortcuts="n"`。
- **検索欄**（3一覧）：キーキャップを**入力欄内の右端**へ（`.field-kbd`）＋ `aria-keyshortcuts="/"`。
- **サイドバーのショートカット起点**：枠線のみ（outline）＋ `aria-keyshortcuts="?"`。
- theme に `.kbd-hint.{solid,ghost,outline}` と `.field-kbd`、タッチ非表示を整備。
- キーキャップは `aria-hidden`、操作キーは `aria-keyshortcuts` で読み上げ対応。

※ 監査ログの自然言語化（「請求書を発行」等＋`title` に原イベント名）は既に実装済みのため対象外。

## 検証
- `type-check`/`lint`/`prettier`/`knip`/`vitest`/`build` グリーン。
- 実機：検索 `/` キーキャップが入力欄内、新規 `n` が半透明白、各コントロールに `aria-keyshortcuts` を確認。

## #274 全体（デザイン03）の到達点
PR1 バッジ配色 / PR2 ソートヘッダ / PR3 支払サイト＋プレビュー / PR4 `u`・`/`先頭欄＋?起動ボタン / PR5 ヘルプ画面 / PR6 ヒント規約。§08 追加推奨ショートカット（⌘K/p/x/r）は将来スコープ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)