### PR TITLE
feat(dashboard): 前年同月比・日別累積の請求発行額API (#281)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -95,7 +95,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Billing defaults (issuer) | `default_quote_validity_days`, `default_payment_closing_day`, `default_payment_month_offset`, `default_payment_pay_day` | `quote_validity`, `closing_day`, `payment_site`, `pay_day`, `net_days` |
 | Client fields | `contact_name`, `billing_address` | `contact`, `address` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
-| Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents` |
+| Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1330,7 +1330,31 @@ components:
           description: Issued-invoice totals for the last 6 calendar months, oldest first.
           items:
             $ref: '#/components/schemas/MonthlyBilled'
-      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid, received_this_month_cents, received_last_month_cents, aging, billed_this_month_cents, billed_last_month_cents, monthly_billed]
+        billed_prev_year_month_cents:
+          type: integer
+          description: Total of invoices issued in the same month one year ago, in cents (year-over-year).
+        billed_daily_current:
+          type: array
+          description: Cumulative issued total per day for the current month, day 1 to today.
+          items:
+            $ref: '#/components/schemas/DailyBilled'
+        billed_daily_prev_month:
+          type: array
+          description: Cumulative issued total per day for the full previous month (pace comparison).
+          items:
+            $ref: '#/components/schemas/DailyBilled'
+      required: [unpaid_count, overdue_count, outstanding_total_cents, recent_unpaid, received_this_month_cents, received_last_month_cents, aging, billed_this_month_cents, billed_last_month_cents, monthly_billed, billed_prev_year_month_cents, billed_daily_current, billed_daily_prev_month]
+    DailyBilled:
+      type: object
+      description: Cumulative issued-invoice total at a given day of the month.
+      properties:
+        day:
+          type: integer
+          description: Day of month (1–31).
+        cumulative_cents:
+          type: integer
+          description: Cumulative issued total from day 1 through this day, in cents.
+      required: [day, cumulative_cents]
     MonthlyBilled:
       type: object
       description: Issued-invoice total for one calendar month.

--- a/src/Dashboard/DashboardSummary.php
+++ b/src/Dashboard/DashboardSummary.php
@@ -16,6 +16,8 @@ final readonly class DashboardSummary
      * @param list<Invoice>                                                $recentUnpaid
      * @param array{current: int, overdue_1_30: int, overdue_31_plus: int} $aging outstanding receivable bucketed by overdue age, in cents
      * @param list<array{month: string, billed_cents: int, count: int}>    $monthlyBilled issued-invoice totals per month (oldest→newest, Issue #272)
+     * @param list<array{day: int, cumulative_cents: int}>                 $billedDailyCurrent cumulative issued total per day, current month 1..today (Issue #281)
+     * @param list<array{day: int, cumulative_cents: int}>                 $billedDailyPrevMonth cumulative issued total per day, full previous month
      */
     public function __construct(
         public int $unpaidCount,
@@ -28,6 +30,9 @@ final readonly class DashboardSummary
         public int $billedThisMonthCents,
         public int $billedLastMonthCents,
         public array $monthlyBilled,
+        public int $billedPrevYearMonthCents,
+        public array $billedDailyCurrent,
+        public array $billedDailyPrevMonth,
     ) {
     }
 }

--- a/src/Dashboard/GetDashboardHandler.php
+++ b/src/Dashboard/GetDashboardHandler.php
@@ -57,6 +57,9 @@ final readonly class GetDashboardHandler implements RequestHandlerInterface
             'billed_this_month_cents'   => $summary->billedThisMonthCents,
             'billed_last_month_cents'   => $summary->billedLastMonthCents,
             'monthly_billed'            => $summary->monthlyBilled,
+            'billed_prev_year_month_cents' => $summary->billedPrevYearMonthCents,
+            'billed_daily_current'      => $summary->billedDailyCurrent,
+            'billed_daily_prev_month'   => $summary->billedDailyPrevMonth,
         ]);
     }
 }

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -39,6 +39,25 @@ final readonly class GetDashboardSummaryUseCase
         $billedThisMonth = $this->invoices->billedTotalBetween($thisMonthStart, $nextMonthStart);
         $billedLastMonth = $this->invoices->billedTotalBetween($lastMonthStart, $thisMonthStart);
 
+        // Prior-year same month (YoY hero).
+        $prevYearStart = $nowDt->modify('first day of this month')->modify('-1 year');
+        $billedPrevYearMonth = $this->invoices->billedTotalBetween(
+            $prevYearStart->format('Y-m-01 00:00:00'),
+            $prevYearStart->modify('first day of next month')->format('Y-m-01 00:00:00'),
+        );
+
+        // Daily cumulative pace — current month (1..today) and the full prior month.
+        $today = (int) $nowDt->format('j');
+        $prevMonthLen = (int) $nowDt->modify('first day of last month')->format('t');
+        $dailyCurrent = $this->dailyCumulative(
+            $this->invoices->billedRowsBetween($thisMonthStart, $nextMonthStart),
+            $today,
+        );
+        $dailyPrev = $this->dailyCumulative(
+            $this->invoices->billedRowsBetween($lastMonthStart, $thisMonthStart),
+            $prevMonthLen,
+        );
+
         return new DashboardSummary(
             unpaidCount: $data['unpaid_count'],
             overdueCount: $data['overdue_count'],
@@ -50,7 +69,39 @@ final readonly class GetDashboardSummaryUseCase
             billedThisMonthCents: $billedThisMonth['cents'],
             billedLastMonthCents: $billedLastMonth['cents'],
             monthlyBilled: $this->monthlyBilled($nowDt),
+            billedPrevYearMonthCents: $billedPrevYearMonth['cents'],
+            billedDailyCurrent: $dailyCurrent,
+            billedDailyPrevMonth: $dailyPrev,
         );
+    }
+
+    /**
+     * Builds a per-day cumulative series from issued-invoice rows. Date grouping
+     * is in PHP (dialect-agnostic). Days are 1..$daysCount inclusive.
+     *
+     * @param list<array{issued_at: string, total_cents: int}> $rows
+     *
+     * @return list<array{day: int, cumulative_cents: int}>
+     */
+    private function dailyCumulative(array $rows, int $daysCount): array
+    {
+        $perDay = array_fill(1, max($daysCount, 1), 0);
+
+        foreach ($rows as $row) {
+            $day = (int) substr($row['issued_at'], 8, 2);
+            if ($day >= 1 && $day <= $daysCount) {
+                $perDay[$day] += $row['total_cents'];
+            }
+        }
+
+        $series = [];
+        $cumulative = 0;
+        for ($d = 1; $d <= $daysCount; ++$d) {
+            $cumulative += $perDay[$d];
+            $series[] = ['day' => $d, 'cumulative_cents' => $cumulative];
+        }
+
+        return $series;
     }
 
     /**

--- a/src/Invoice/InvoiceRepositoryInterface.php
+++ b/src/Invoice/InvoiceRepositoryInterface.php
@@ -54,6 +54,15 @@ interface InvoiceRepositoryInterface
      */
     public function billedTotalBetween(string $startInclusive, string $endExclusive): array;
 
+    /**
+     * Issued invoices within [start, end) as `{issued_at, total_cents}` rows —
+     * used to build daily-cumulative billing (drafts excluded). Date grouping is
+     * done in PHP so the query stays dialect-agnostic.
+     *
+     * @return list<array{issued_at: string, total_cents: int}>
+     */
+    public function billedRowsBetween(string $startInclusive, string $endExclusive): array;
+
     public function save(Invoice $invoice): int;
 
     /** @throws InvoiceNotFoundException */

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -276,6 +276,26 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         ];
     }
 
+    public function billedRowsBetween(string $startInclusive, string $endExclusive): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT issued_at, total_cents
+             FROM invoices
+             WHERE organization_id = ? AND is_deleted = 0
+               AND issued_at IS NOT NULL AND issued_at >= ? AND issued_at < ?
+             ORDER BY issued_at ASC',
+            [$this->orgId->get(), $startInclusive, $endExclusive],
+        );
+
+        return array_map(
+            static fn (array $row): array => [
+                'issued_at' => (string) $row['issued_at'],
+                'total_cents' => (int) $row['total_cents'],
+            ],
+            $rows,
+        );
+    }
+
     /**
      * @return array{unpaid_count: int, overdue_count: int, recent_unpaid: list<Invoice>}
      */

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -43,6 +43,28 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         self::assertSame(0, $summary->billedLastMonthCents);
         self::assertCount(6, $summary->monthlyBilled);
         self::assertSame(0, $summary->monthlyBilled[5]['billed_cents']);
+        self::assertSame(0, $summary->billedPrevYearMonthCents);
+        self::assertNotEmpty($summary->billedDailyCurrent);
+        self::assertSame(1, $summary->billedDailyCurrent[0]['day']);
+        self::assertSame(0, $summary->billedDailyCurrent[0]['cumulative_cents']);
+    }
+
+    public function test_year_over_year_and_daily_cumulative(): void
+    {
+        $issue = function (string $issuedAt, int $cents): void {
+            $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: $cents, taxCents: 0, totalCents: $cents, issuedAt: $issuedAt));
+        };
+        $issue(date('Y-m-01 10:00:00'), 3000); // this month, day 1
+        $issue(date('Y-m-01 10:00:00', (int) strtotime('first day of last month')), 4000); // last month, day 1
+        $issue(date('Y-m-01 10:00:00', (int) strtotime('-1 year')), 5000); // same month last year, day 1
+
+        $summary = $this->useCase->execute();
+
+        self::assertSame(5000, $summary->billedPrevYearMonthCents);
+
+        // Day-1 invoices: cumulative is constant from day 1 onward.
+        self::assertSame(3000, $summary->billedDailyCurrent[0]['cumulative_cents']);
+        self::assertSame(4000, $summary->billedDailyPrevMonth[0]['cumulative_cents']);
     }
 
     public function test_billed_metrics_and_monthly_trend(): void

--- a/tests/Invoice/ExportInvoicesCsvUseCaseTest.php
+++ b/tests/Invoice/ExportInvoicesCsvUseCaseTest.php
@@ -151,6 +151,10 @@ final class ExportInvoicesCsvUseCaseTest extends TestCase
             {
                 return ['cents' => 0, 'count' => 0];
             }
+            public function billedRowsBetween(string $startInclusive, string $endExclusive): array
+            {
+                return [];
+            }
             public function save(Invoice $invoice): int
             {
                 return 0;

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -242,6 +242,23 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
         return ['cents' => $cents, 'count' => $count];
     }
 
+    public function billedRowsBetween(string $startInclusive, string $endExclusive): array
+    {
+        $orgId = $this->orgId->get();
+        $rows = [];
+
+        foreach ($this->byId as $i) {
+            if ($i->organizationId !== $orgId || $i->isDeleted || $i->issuedAt === null) {
+                continue;
+            }
+            if ($i->issuedAt >= $startInclusive && $i->issuedAt < $endExclusive) {
+                $rows[] = ['issued_at' => $i->issuedAt, 'total_cents' => $i->totalCents];
+            }
+        }
+
+        return $rows;
+    }
+
     public function save(Invoice $invoice): int
     {
         $id = $this->nextId++;


### PR DESCRIPTION
## 概要
ダッシュボードチャート刷新の **PR3a（バックエンド）**。日別累積折れ線・前年同月比ヒーロー用のデータを供給する。Refs #281。

## 変更点
- `DashboardSummary` に追加：
  - `billed_prev_year_month_cents`（前年同月、YoY）
  - `billed_daily_current`（当月 1..今日 の日別累積）
  - `billed_daily_prev_month`（先月全体の日別累積・ペース比較）
- `InvoiceRepositoryInterface::billedRowsBetween()`（発行済みの `issued_at`/`total_cents` 行。**日付グルーピングは PHP 側**でダイアレクト非依存）。Pdo/InMemory/スタブ。
- UseCase で YoY 算出＋日別累積系列（`dailyCumulative` ヘルパー）、Handler 直列化。
- OpenAPI（`DashboardSummary`＋`DailyBilled`）、用語レジストリ更新。
- UseCase テスト（YoY・日別累積・空組織）。

## 検証
- `composer test（320）`/`analyse（0）`/`cs`/`openapi`/`mcp` グリーン。

## 後続
- PR3b（フロント）: YoY チップ＋日別折れ線ビュー＋バー/折れ線セグメントトグル。

🤖 Generated with [Claude Code](https://claude.com/claude-code)