### PR TITLE
design(frontend): サイドバーフッターを指示書の side-foot 構成に刷新する (#286)

### DIFF
--- a/frontend/src/features/account-menu/hooks/use-account-menu.test.ts
+++ b/frontend/src/features/account-menu/hooks/use-account-menu.test.ts
@@ -5,13 +5,14 @@ import { renderHookWithProviders } from '@tests/render/render-with-providers'
 import { useAccountMenu } from './use-account-menu'
 
 describe('useAccountMenu', () => {
-  it('exposes the current user email and signs out', async () => {
+  it('exposes the current user email and role and signs out', async () => {
     setAuthToken('test-token')
     const { result } = renderHookWithProviders(() => useAccountMenu())
 
     await waitFor(() => {
       expect(result.current.email).toBe('admin@example.com')
     })
+    expect(result.current.role).toBe('admin')
 
     act(() => {
       result.current.onSignOut()

--- a/frontend/src/features/account-menu/hooks/use-account-menu.ts
+++ b/frontend/src/features/account-menu/hooks/use-account-menu.ts
@@ -1,8 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { signOut, useCurrentUser } from '@/entities/auth'
+import { signOut, useCurrentUser, type Role } from '@/entities/auth'
 
 export interface UseAccountMenu {
   email: string | null
+  role: Role | null
   onSignOut: () => void
 }
 
@@ -13,6 +14,7 @@ export function useAccountMenu(): UseAccountMenu {
 
   return {
     email: me.data?.email ?? null,
+    role: me.data?.role ?? null,
     onSignOut: () => {
       signOut()
       queryClient.clear()

--- a/frontend/src/features/account-menu/ui/AccountMenu.tsx
+++ b/frontend/src/features/account-menu/ui/AccountMenu.tsx
@@ -1,25 +1,43 @@
 import { LOCALES, useTranslation } from '@/shared/i18n'
+import { openShortcutsOverlay } from '@/shared/keyboard'
 import { cn } from '@/shared/lib/cn'
 import { useAccountMenu } from '../hooks/use-account-menu'
 
-/** Sidebar account summary + language switch + sign-out, themed for the chrome. */
+/** Sidebar footer (design 04 `.side-foot`): user identity + keyboard-shortcut
+ *  launcher + language segment + sign-out, themed for the deep-green chrome. */
 export function AccountMenu() {
   const { t, locale, setLocale } = useTranslation()
-  const { email, onSignOut } = useAccountMenu()
+  const { email, role, onSignOut } = useAccountMenu()
+
+  const initial = email !== null && email.length > 0 ? email[0].toUpperCase() : '—'
 
   return (
-    <div className="flex flex-col gap-stack-sm">
-      {email !== null && (
-        <span className="truncate text-caption text-side-fg-muted" title={email}>
-          {t('admin.account.signedInAs', { email })}
+    <div className="side-foot">
+      <div className="sf-user">
+        <span className="side-avatar" aria-hidden="true">
+          {initial}
         </span>
-      )}
+        <div className="min-w-0">
+          {email !== null && (
+            <div className="sf-mail truncate" title={email}>
+              {email}
+            </div>
+          )}
+          {role !== null && <div className="sf-role">{t(`admin.users.role.${role}`)}</div>}
+        </div>
+      </div>
 
-      <div
-        className="flex border border-side-border"
-        role="group"
-        aria-label={t('common.locale.label')}
+      <button
+        type="button"
+        className="sf-help"
+        onClick={openShortcutsOverlay}
+        aria-keyshortcuts="?"
       >
+        <span>{t('admin.nav.shortcuts')}</span>
+        <span className="sf-help-k">?</span>
+      </button>
+
+      <div className="sf-lang" role="group" aria-label={t('common.locale.label')}>
         {LOCALES.map((loc) => {
           const active = locale === loc.id
           return (
@@ -30,13 +48,7 @@ export function AccountMenu() {
               onClick={() => {
                 setLocale(loc.id)
               }}
-              className={cn(
-                'flex-1 px-inline-sm py-stack-xs text-caption transition-colors',
-                'focus-visible:outline-2 focus-visible:outline-focus-ring',
-                active
-                  ? 'bg-side-active font-medium text-side-fg'
-                  : 'text-side-fg-muted hover:bg-side-active/60 hover:text-side-fg',
-              )}
+              className={cn('sf-lang-btn', active && 'is-on')}
             >
               {t(loc.labelKey)}
             </button>
@@ -44,11 +56,7 @@ export function AccountMenu() {
         })}
       </div>
 
-      <button
-        type="button"
-        onClick={onSignOut}
-        className="w-full border border-side-border px-inline-sm py-stack-xs text-body text-side-fg transition-colors hover:bg-side-active focus-visible:outline-2 focus-visible:outline-focus-ring"
-      >
+      <button type="button" className="sf-logout" onClick={onSignOut}>
         {t('common.actions.signOut')}
       </button>
     </div>

--- a/frontend/src/pages/layout/AppShell.tsx
+++ b/frontend/src/pages/layout/AppShell.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { NavLink, Outlet, useLocation } from 'react-router-dom'
 import { AccountMenu } from '@/features/account-menu'
 import { useTranslation, type MessageKey } from '@/shared/i18n'
-import { KbdHint, KeyboardShortcuts, openShortcutsOverlay } from '@/shared/keyboard'
+import { KeyboardShortcuts } from '@/shared/keyboard'
 import { cn } from '@/shared/lib/cn'
 
 /** Monogram NN mark (logo concept 03 — overlapping N's). */
@@ -264,29 +264,7 @@ export function AppShell() {
           ))}
         </nav>
 
-        <div className="border-t border-side-border px-inline-sm py-stack-sm text-side-fg">
-          <button
-            type="button"
-            onClick={openShortcutsOverlay}
-            aria-keyshortcuts="?"
-            className="mb-stack-xs flex w-full items-center gap-inline-sm rounded-none px-inline-sm py-stack-xs text-body text-side-fg-muted transition-colors hover:bg-side-active/60 hover:text-side-fg"
-          >
-            <svg
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              className="size-4.5 shrink-0"
-              aria-hidden="true"
-            >
-              <rect x="2" y="5" width="16" height="10" rx="1.5" />
-              <path d="M5 8h.01M8 8h.01M11 8h.01M14 8h.01M5 11h.01M14 11h.01M8 11h4" />
-            </svg>
-            <span className="flex-1 text-left">{t('admin.nav.shortcuts')}</span>
-            <KbdHint variant="outline">?</KbdHint>
-          </button>
-          <AccountMenu />
-        </div>
+        <AccountMenu />
       </aside>
 
       <div className="side-backdrop" aria-hidden="true" onClick={closeNav} />

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1304,6 +1304,124 @@
   .side-backdrop {
     display: none;
   }
+
+  /* Sidebar footer — user identity / shortcuts / language / logout (design 04) */
+  .side-foot {
+    border-top: 1px solid var(--color-side-border);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 9px;
+    font-size: 11.5px;
+    color: var(--color-side-fg-muted);
+  }
+  .side-foot .sf-user {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+  }
+  .side-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    flex: none;
+    background: var(--color-side-active);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 12px;
+  }
+  .side-foot .sf-mail {
+    color: var(--color-side-fg);
+    font-weight: 500;
+  }
+  .side-foot .sf-role {
+    color: var(--color-side-fg-muted);
+  }
+  .sf-help {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 9px;
+    background: transparent;
+    border: 1px solid var(--color-side-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-side-fg-muted);
+    font-family: inherit;
+    font-size: 11.5px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  .sf-help:hover {
+    background: var(--color-side-active);
+    color: var(--color-side-fg);
+  }
+  .sf-help-k {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    flex: none;
+    font-family: var(--font-num);
+    font-size: 11px;
+    font-weight: 600;
+    border: 1px solid var(--color-side-border);
+    border-radius: 4px;
+    color: var(--color-side-fg);
+  }
+  .sf-lang {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    border: 1px solid var(--color-side-border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .sf-lang-btn {
+    padding: 6px 8px;
+    background: transparent;
+    border: none;
+    color: var(--color-side-fg-muted);
+    font-family: inherit;
+    font-size: 11.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  .sf-lang-btn + .sf-lang-btn {
+    border-left: 1px solid var(--color-side-border);
+  }
+  .sf-lang-btn:hover {
+    color: var(--color-side-fg);
+  }
+  .sf-lang-btn.is-on {
+    background: var(--color-side-active);
+    color: #fff;
+  }
+  .sf-logout {
+    width: 100%;
+    padding: 7px 9px;
+    background: transparent;
+    border: 1px solid var(--color-side-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-side-fg-muted);
+    font-family: inherit;
+    font-size: 11.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  .sf-logout:hover {
+    background: var(--color-side-active);
+    color: var(--color-side-fg);
+  }
+
   /* Spec .tbl-wrap: the table sits inside a bordered box (square, no radius). */
   .table-scroll {
     width: 100%;

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1355,7 +1355,9 @@
     font-size: 11.5px;
     font-weight: 500;
     cursor: pointer;
-    transition: background 0.12s ease, color 0.12s ease;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
   }
   .sf-help:hover {
     background: var(--color-side-active);
@@ -1392,7 +1394,9 @@
     font-size: 11.5px;
     font-weight: 600;
     cursor: pointer;
-    transition: background 0.12s ease, color 0.12s ease;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
   }
   .sf-lang-btn + .sf-lang-btn {
     border-left: 1px solid var(--color-side-border);
@@ -1415,7 +1419,9 @@
     font-size: 11.5px;
     font-weight: 600;
     cursor: pointer;
-    transition: background 0.12s ease, color 0.12s ease;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
   }
   .sf-logout:hover {
     background: var(--color-side-active);


### PR DESCRIPTION
## 概要
指示書 design 04 の `.side-foot` 構成反映漏れ（Issue #286 PR2）を対応する。

サイドバー下部を、指示書どおり4ブロック構成に統一した。

- **`.sf-user`**: アバター（メール先頭文字のイニシャル）＋メールアドレス＋ロール（管理者 等）
- **`.sf-help`**: キーボードショートカット起動ボタン＋右端に `?` キーキャップ
- **`.sf-lang`**: 日本語／English のセグメント切替（現在の言語を `is-on`）
- **`.sf-logout`**: ログアウト

## 変更
- `AccountMenu.tsx`: `.side-foot` 全体を描画するよう刷新。ショートカット起動は `openShortcutsOverlay` を直接呼ぶ。
- `AppShell.tsx`: 独自フッター（ショートカットボタン＋枠）を撤去し `<AccountMenu />` に集約。未使用の `KbdHint` / `openShortcutsOverlay` import を削除。
- `use-account-menu.ts`: `role` を公開（ロール表示用）。テストにロール検証を追加。
- `theme/index.css`: `side-foot` / `sf-user` / `sf-help` / `sf-lang` / `sf-logout` / `side-avatar` の CSS を追加（`--color-side-*` にマップ）。

## チェック
- frontend: type-check / lint / format / knip / test (167 passed) / build すべて green
- 既存 e2e（account-menu / language-switcher）はセレクタ互換（メール文言・ログアウト・English ボタンとも維持）
- dev サーバで `.side-foot` 表示確認（スクリーンショット）

Part of #286。カレンダー角丸＋設定カード（PR3）は別PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)