### PR TITLE
design(frontend): カレンダーの角丸復元と設定フォームの白カード化 (#286)

### DIFF
--- a/frontend/src/features/edit-company-settings/ui/EditCompanySettings.tsx
+++ b/frontend/src/features/edit-company-settings/ui/EditCompanySettings.tsx
@@ -124,133 +124,149 @@ export function EditCompanySettings() {
             {t('admin.settings.title')}
           </Text>
 
-          <Field
-            id="legal_name"
-            label={t('admin.settings.legalName')}
-            error={errors.legal_name ? t('admin.settings.legalNameRequired') : undefined}
-          >
-            <Input
-              id="legal_name"
-              aria-invalid={errors.legal_name ? true : undefined}
-              {...register('legal_name')}
-            />
-          </Field>
-
-          <Field id="address" label={t('admin.settings.address')}>
-            <Input id="address" {...register('address')} />
-          </Field>
-
-          <Field id="phone" label={t('admin.settings.phone')}>
-            <Input id="phone" type="tel" {...register('phone')} />
-          </Field>
-
-          <Field id="email" label={t('admin.settings.email')}>
-            <Input id="email" type="email" {...register('email')} />
-          </Field>
-
-          <Field id="registration_number" label={t('admin.settings.registrationNumber')}>
-            <Input
-              id="registration_number"
-              placeholder="T1234567890123"
-              {...register('registration_number')}
-            />
-            <Text variant="muted" className="text-caption">
-              {t('admin.settings.registrationNumberHint')}
-            </Text>
-          </Field>
-
-          <Text variant="heading-sm">{t('admin.settings.bankSection')}</Text>
-
-          <FormRow>
-            <Field id="bank_name" label={t('admin.settings.bankName')}>
-              <Input id="bank_name" {...register('bank_name')} />
-            </Field>
-            <Field id="bank_branch" label={t('admin.settings.bankBranch')}>
-              <Input id="bank_branch" {...register('bank_branch')} />
-            </Field>
-          </FormRow>
-
-          <FormRow>
-            <Field id="account_type" label={t('admin.settings.accountType')}>
-              <Input
-                id="account_type"
-                placeholder={t('admin.settings.accountTypePlaceholder')}
-                {...register('account_type')}
-              />
-            </Field>
-            <Field id="account_number" label={t('admin.settings.accountNumber')}>
-              <Input id="account_number" {...register('account_number')} />
-            </Field>
-          </FormRow>
-
-          <div className="field-sep" />
-          <Text variant="heading-sm">{t('admin.settings.billingSection')}</Text>
-
-          <Field id="default_quote_validity_days" label={t('admin.settings.quoteValidityDays')}>
-            <Input
-              id="default_quote_validity_days"
-              type="number"
-              min={1}
-              max={3650}
-              inputMode="numeric"
-              placeholder={t('admin.settings.quoteValidityPlaceholder')}
-              {...register('default_quote_validity_days')}
-            />
-            <Text variant="muted" className="text-caption">
-              {t('admin.settings.quoteValidityHint')}
-            </Text>
-          </Field>
-
-          <Text variant="muted" className="text-caption">
-            {t('admin.settings.paymentTermsHint')}
-          </Text>
-          <div className="pay-site">
-            <Field id="default_payment_closing_day" label={t('admin.settings.closingDay')}>
-              <Select id="default_payment_closing_day" {...register('default_payment_closing_day')}>
-                <option value="">{t('admin.settings.monthEnd')}</option>
-                {DAY_OPTIONS.map((d) => (
-                  <option key={d} value={d}>
-                    {t('admin.settings.dayNth', { n: d })}
-                  </option>
-                ))}
-              </Select>
-            </Field>
-            <div className="ps-arrow" aria-hidden="true">
-              <svg
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.7"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+          <div className="card">
+            <div className="section-title">{t('admin.settings.basicSection')}</div>
+            <Stack gap="md">
+              <Field
+                id="legal_name"
+                label={t('admin.settings.legalName')}
+                error={errors.legal_name ? t('admin.settings.legalNameRequired') : undefined}
               >
-                <path d="M2 8h11M9 4l4 4-4 4" />
-              </svg>
-            </div>
-            <Field id="default_payment_month_offset" label={t('admin.settings.monthOffset')}>
-              <Select
-                id="default_payment_month_offset"
-                {...register('default_payment_month_offset')}
-              >
-                <option value="0">{t('admin.settings.offsetCurrent')}</option>
-                <option value="1">{t('admin.settings.offsetNext')}</option>
-                <option value="2">{t('admin.settings.offsetNext2')}</option>
-                <option value="">{t('admin.settings.paymentTermsOff')}</option>
-              </Select>
-            </Field>
-            <Field id="default_payment_pay_day" label={t('admin.settings.payDay')}>
-              <Select id="default_payment_pay_day" {...register('default_payment_pay_day')}>
-                <option value="">{t('admin.settings.monthEnd')}</option>
-                {DAY_OPTIONS.map((d) => (
-                  <option key={d} value={d}>
-                    {t('admin.settings.dayNth', { n: d })}
-                  </option>
-                ))}
-              </Select>
-            </Field>
+                <Input
+                  id="legal_name"
+                  aria-invalid={errors.legal_name ? true : undefined}
+                  {...register('legal_name')}
+                />
+              </Field>
+
+              <Field id="address" label={t('admin.settings.address')}>
+                <Input id="address" {...register('address')} />
+              </Field>
+
+              <FormRow>
+                <Field id="phone" label={t('admin.settings.phone')}>
+                  <Input id="phone" type="tel" {...register('phone')} />
+                </Field>
+                <Field id="email" label={t('admin.settings.email')}>
+                  <Input id="email" type="email" {...register('email')} />
+                </Field>
+              </FormRow>
+
+              <Field id="registration_number" label={t('admin.settings.registrationNumber')}>
+                <Input
+                  id="registration_number"
+                  placeholder="T1234567890123"
+                  {...register('registration_number')}
+                />
+                <Text variant="muted" className="text-caption">
+                  {t('admin.settings.registrationNumberHint')}
+                </Text>
+              </Field>
+            </Stack>
           </div>
 
-          <PayPreview control={state.form.control} />
+          <div className="card">
+            <div className="section-title">{t('admin.settings.bankSection')}</div>
+            <Stack gap="md">
+              <FormRow>
+                <Field id="bank_name" label={t('admin.settings.bankName')}>
+                  <Input id="bank_name" {...register('bank_name')} />
+                </Field>
+                <Field id="bank_branch" label={t('admin.settings.bankBranch')}>
+                  <Input id="bank_branch" {...register('bank_branch')} />
+                </Field>
+              </FormRow>
+
+              <FormRow>
+                <Field id="account_type" label={t('admin.settings.accountType')}>
+                  <Input
+                    id="account_type"
+                    placeholder={t('admin.settings.accountTypePlaceholder')}
+                    {...register('account_type')}
+                  />
+                </Field>
+                <Field id="account_number" label={t('admin.settings.accountNumber')}>
+                  <Input id="account_number" {...register('account_number')} />
+                </Field>
+              </FormRow>
+            </Stack>
+          </div>
+
+          <div className="card">
+            <div className="section-title">{t('admin.settings.billingSection')}</div>
+            <Stack gap="md">
+              <Field id="default_quote_validity_days" label={t('admin.settings.quoteValidityDays')}>
+                <Input
+                  id="default_quote_validity_days"
+                  type="number"
+                  min={1}
+                  max={3650}
+                  inputMode="numeric"
+                  placeholder={t('admin.settings.quoteValidityPlaceholder')}
+                  {...register('default_quote_validity_days')}
+                />
+                <Text variant="muted" className="text-caption">
+                  {t('admin.settings.quoteValidityHint')}
+                </Text>
+              </Field>
+
+              <div className="field-sep" />
+
+              <Text variant="muted" className="text-caption">
+                {t('admin.settings.paymentTermsHint')}
+              </Text>
+              <div className="pay-site">
+                <Field id="default_payment_closing_day" label={t('admin.settings.closingDay')}>
+                  <Select
+                    id="default_payment_closing_day"
+                    {...register('default_payment_closing_day')}
+                  >
+                    <option value="">{t('admin.settings.monthEnd')}</option>
+                    {DAY_OPTIONS.map((d) => (
+                      <option key={d} value={d}>
+                        {t('admin.settings.dayNth', { n: d })}
+                      </option>
+                    ))}
+                  </Select>
+                </Field>
+                <div className="ps-arrow" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.7"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M2 8h11M9 4l4 4-4 4" />
+                  </svg>
+                </div>
+                <Field id="default_payment_month_offset" label={t('admin.settings.monthOffset')}>
+                  <Select
+                    id="default_payment_month_offset"
+                    {...register('default_payment_month_offset')}
+                  >
+                    <option value="0">{t('admin.settings.offsetCurrent')}</option>
+                    <option value="1">{t('admin.settings.offsetNext')}</option>
+                    <option value="2">{t('admin.settings.offsetNext2')}</option>
+                    <option value="">{t('admin.settings.paymentTermsOff')}</option>
+                  </Select>
+                </Field>
+                <Field id="default_payment_pay_day" label={t('admin.settings.payDay')}>
+                  <Select id="default_payment_pay_day" {...register('default_payment_pay_day')}>
+                    <option value="">{t('admin.settings.monthEnd')}</option>
+                    {DAY_OPTIONS.map((d) => (
+                      <option key={d} value={d}>
+                        {t('admin.settings.dayNth', { n: d })}
+                      </option>
+                    ))}
+                  </Select>
+                </Field>
+              </div>
+
+              <PayPreview control={state.form.control} />
+            </Stack>
+          </div>
 
           {state.errorMessage !== null && (
             <Text variant="muted" role="alert">

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -416,6 +416,7 @@ export const enMessages: MessageCatalog = {
   'admin.settings.title': 'Company Settings',
   'admin.settings.loading': 'Loading settings…',
   'admin.settings.loadError': 'Could not load settings.',
+  'admin.settings.basicSection': 'Basic info',
   'admin.settings.legalName': 'Legal name',
   'admin.settings.legalNameRequired': 'Legal name is required.',
   'admin.settings.address': 'Address',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -418,6 +418,7 @@ export const jaMessages = {
   'admin.settings.title': '会社設定',
   'admin.settings.loading': '設定を読み込み中…',
   'admin.settings.loadError': '設定を取得できませんでした。',
+  'admin.settings.basicSection': '基本情報',
   'admin.settings.legalName': '法人名',
   'admin.settings.legalNameRequired': '法人名は必須です。',
   'admin.settings.address': '住所',

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -267,6 +267,7 @@
     padding: 12px 12px 11px;
     background: var(--color-surface-raised);
     border: 1px solid var(--color-border);
+    border-radius: 13px;
     box-shadow: var(--shadow-pop);
     opacity: 0;
     transform: translateY(-5px) scale(0.985);
@@ -312,6 +313,7 @@
     display: grid;
     place-items: center;
     border: none;
+    border-radius: 9px;
     background: none;
     cursor: pointer;
     color: var(--color-fg-muted);
@@ -357,6 +359,7 @@
     cursor: pointer;
     padding: 0;
     height: 33px;
+    border-radius: 10px;
     display: grid;
     place-items: center;
     position: relative;
@@ -419,6 +422,7 @@
     font-weight: 600;
     padding: 7px 0;
     border: 1px solid var(--color-border-strong);
+    border-radius: 9px;
     background: var(--color-surface-raised);
     color: var(--color-fg-muted);
     transition:


### PR DESCRIPTION
## 概要
指示書 design 04 反映漏れ（Issue #286 PR3）の最終対応。カレンダーの角丸復元と設定フォームの白カード化。

### 1. カレンダー（datepicker）の角丸を復元
指示書の datepicker は角丸が意図された要素（`.dir-c` 角ゼロでも維持）。案C 角ゼロを誤って適用していたため復元した。
- `.dp-pop` → `border-radius: 13px`
- `.dp-nav` → `border-radius: 9px`
- `.dp-day` → `border-radius: 10px`
- `.dp-foot button` → `border-radius: 9px`

### 2. 設定フォームを白 `.card` 3枚で囲う
指示書どおり、フォームを3セクションのカードに分割（各カード `.section-title` ＋ `.card`）。
- **基本情報**: 法人名 / 住所 / 電話・メール（1行）/ 登録番号
- **振込先**: 銀行名・支店名 / 口座種別・口座番号
- **請求・見積の既定**: 見積有効期限 → field-sep → 支払サイト（締め日／支払月／支払日）＋プレビュー
- `basicSection`（基本情報）メッセージキーを追加

## チェック
- frontend: type-check / lint / format / knip / test (167 passed) / build すべて green
- dev サーバで設定3カード・カレンダー角丸を表示確認（スクリーンショット）

Closes #286。（PR1=ダッシュボード3カラム #287 マージ済、PR2=サイドバーフッター #288）

🤖 Generated with [Claude Code](https://claude.com/claude-code)