### PR TITLE
design(frontend): 一覧の削除アクションを枠線なし赤文字リンクにする (#290)

### DIFF
--- a/frontend/src/features/list-clients/ui/ListClients.tsx
+++ b/frontend/src/features/list-clients/ui/ListClients.tsx
@@ -154,15 +154,15 @@ export function ListClients() {
                       >
                         {t('admin.clients.editButton')}
                       </Link>
-                      <Button
-                        variant="ghost"
-                        size="sm"
+                      <button
+                        type="button"
+                        className="cursor-pointer border-0 bg-transparent p-0 text-body text-danger"
                         onClick={() => {
                           setPendingDelete(client)
                         }}
                       >
                         {t('admin.clients.delete.action')}
-                      </Button>
+                      </button>
                     </Stack>
                   </td>
                 </tr>

--- a/frontend/src/features/list-users/ui/ListUsers.tsx
+++ b/frontend/src/features/list-users/ui/ListUsers.tsx
@@ -6,7 +6,6 @@ import { KbdHint, useRowCursor } from '@/shared/keyboard'
 import {
   Badge,
   type BadgeTone,
-  Button,
   ConfirmDialog,
   EmptyState,
   ErrorState,
@@ -108,15 +107,15 @@ export function ListUsers() {
                       <Link to={`/users/${String(user.id)}/edit`} className="text-body text-accent">
                         {t('admin.users.editButton')}
                       </Link>
-                      <Button
-                        variant="ghost"
-                        size="sm"
+                      <button
+                        type="button"
+                        className="cursor-pointer border-0 bg-transparent p-0 text-body text-danger"
                         onClick={() => {
                           setPendingDelete(user)
                         }}
                       >
                         {t('admin.users.delete.action')}
-                      </Button>
+                      </button>
                     </Stack>
                   </td>
                 </tr>


### PR DESCRIPTION
## 概要
ユーザー一覧・取引先一覧の「削除」アクションが枠線付き ghost ボタンになっていた。指示書 design 04 では削除は **枠線なしの赤文字リンク**（`btn-link` + `--color-danger`）で、隣の「編集」リンク（緑テキスト）と揃った見た目。

Before: 編集＝テキストリンク（緑）／削除＝枠線付きボタン（不揃い）
After: 編集＝緑テキスト／削除＝赤テキスト、いずれも枠線・背景なしで統一

## 変更
- `ListUsers.tsx` / `ListClients.tsx` の削除を `<button class="... text-body text-danger">`（枠線・背景・余白なし）に変更
- `<button>` のまま（`role=button` 維持）なので ConfirmDialog 起動・e2e セレクタ（`getByRole('button', { name: '削除' })`）は不変
- `ListUsers` の未使用 `Button` import を削除

## チェック
- frontend: type-check / lint / format / knip / test (167 passed) / build すべて green
- dev サーバでユーザー一覧の表示確認（スクリーンショット）

Closes #290。

🤖 Generated with [Claude Code](https://claude.com/claude-code)