### PR TITLE
design(frontend): 見積・請求の状態バッジを68px幅で揃える (#294)

### DIFF
--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -254,7 +254,7 @@ export function ListInvoices() {
                     </td>
                     <td data-label={t('admin.invoices.col.status')}>
                       <span className="flex items-center gap-inline-xs">
-                        <Badge tone={invoiceStatusTone[invoice.status]}>
+                        <Badge tone={invoiceStatusTone[invoice.status]} className="badge-status">
                           {t(`admin.invoices.status.${invoice.status}`)}
                         </Badge>
                         {invoice.is_overdue && (

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -205,7 +205,7 @@ export function ListQuotes() {
                       </Link>
                     </td>
                     <td data-label={t('admin.quotes.col.status')}>
-                      <Badge tone={quoteStatusTone[quote.status]}>
+                      <Badge tone={quoteStatusTone[quote.status]} className="badge-status">
                         {t(`admin.quotes.status.${quote.status}`)}
                       </Badge>
                     </td>

--- a/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
+++ b/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
@@ -172,7 +172,7 @@ export function ViewDashboard() {
                     >
                       {invoice.invoice_number ?? '—'}
                     </Link>
-                    <Badge tone={invoiceStatusTone[invoice.status]}>
+                    <Badge tone={invoiceStatusTone[invoice.status]} className="badge-status">
                       {t(`admin.invoices.status.${invoice.status}`)}
                     </Badge>
                     {invoice.is_overdue && (

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -165,7 +165,7 @@ export function ViewInvoice({ invoiceId }: ViewInvoiceProps) {
           </div>
         )}
         <Stack direction="row" gap="md">
-          <Badge tone={invoiceStatusTone[invoice.status]}>
+          <Badge tone={invoiceStatusTone[invoice.status]} className="badge-status">
             {t(`admin.invoices.status.${invoice.status}`)}
           </Badge>
           {invoice.is_overdue && (

--- a/frontend/src/features/view-quote/ui/ViewQuote.tsx
+++ b/frontend/src/features/view-quote/ui/ViewQuote.tsx
@@ -116,7 +116,7 @@ export function ViewQuote({ quoteId }: ViewQuoteProps) {
         )}
 
         <Stack direction="row" gap="md">
-          <Badge tone={quoteStatusTone[quote.status]}>
+          <Badge tone={quoteStatusTone[quote.status]} className="badge-status">
             {t(`admin.quotes.status.${quote.status}`)}
           </Badge>
           {quote.issued_at !== null && (

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -147,6 +147,11 @@
     background: var(--color-accent-soft);
     color: var(--color-accent-hover);
   }
+  /* Quote/invoice status chips share a fixed 68px width so they align in a column. */
+  .badge-status {
+    min-width: 68px;
+    justify-content: center;
+  }
   /* Overdue stays a vivid functional flag (design 03), not a muted chip. */
   .flag-overdue {
     font-size: 11px;


### PR DESCRIPTION
## 概要
見積・請求の状態バッジ（下書き・送付済み・発行済み・一部入金 等）がラベル長でばらつき、列内で揃わない。全て **68px 幅**に統一して縦に揃える（Issue #294）。

## 変更
- `.badge-status`（`min-width: 68px` ＋ `justify-content: center`）を theme に追加
- 見積・請求の状態バッジに適用：ListInvoices / ListQuotes / ViewInvoice / ViewQuote / ダッシュボード未払い一覧
- ユーザー・取引先の状態バッジ、適格請求書ブランドバッジは対象外

最長ラベル（発行済み・一部入金＝4文字）も 68px に収まるため、全バッジが均一幅で表示される。

## チェック
- frontend: lint / format / knip / test (167 passed) / build green
- 請求一覧で 68px 揃いを確認（スクリーンショット）

Closes #294。

🤖 Generated with [Claude Code](https://claude.com/claude-code)