### PR TITLE
design(frontend): 本文に palt カーニング適用・ページサブ12px (#298)

### DIFF
--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -466,7 +466,7 @@
     color: var(--color-fg);
   }
   .page-sub {
-    font-size: var(--text-caption);
+    font-size: 0.75rem; /* 12px — spec .page-sub */
     color: var(--color-fg-muted);
     margin-top: 0.1875rem;
   }

--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -118,4 +118,6 @@ body {
   font-size: var(--text-body);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  /* Japanese proportional kerning (spec body): tightens kana/punctuation spacing. */
+  font-feature-settings: 'palt' 1;
 }


### PR DESCRIPTION
## 概要（Issue #298）
指示書 design 04 のタイポグラフィに合わせる。

1. **カーニング**: 指示書 body は `font-feature-settings: "palt" 1`（日本語プロポーショナル詰め）。未適用だったため、かな・約物の間隔が広く見えていた。→ body に追加。
2. **page-sub**: 指示書 12px。従来は `--text-caption`(11px)。→ 0.75rem(12px) に。

## root フォントサイズについて（ユーザー指摘の調査）
root(html) は 16px（ブラウザ既定）だが、`--text-*` トークンが rem 分数で較正済み：
- body: `0.8125rem`×16 = **13px**（指示書 13px 一致）
- page-title: `1.3125rem`×16 = **21px**（指示書 21px 一致）

root を 13px に変更すると全 rem トークンが 0.81倍に縮み総崩れになるため**変更しない**。見え方の差は palt カーニング欠落が主因だった。

## チェック
- frontend: lint / format / knip / test (167 passed) / build green
- 設定画面でカーニング詰まりを確認（スクリーンショット）

Closes #298。

🤖 Generated with [Claude Code](https://claude.com/claude-code)