### PR TITLE
design(frontend): 本文ベースフォントを12.5pxに（指示書案C準拠） (#300)

### DIFF
--- a/frontend/src/shared/ui/theme/themes/default.css
+++ b/frontend/src/shared/ui/theme/themes/default.css
@@ -80,7 +80,8 @@
   --font-sans: 'Noto Sans JP', system-ui, sans-serif;
   --font-num: 'Roboto Mono', 'Noto Sans JP', monospace;
   --text-caption: 0.6875rem;
-  --text-body: 0.8125rem;
+  /* spec 案C(.dir-c) base = 12.5px。16px ルート換算 0.78125rem。 */
+  --text-body: 0.78125rem;
   --text-heading-sm: 1.125rem;
   --text-heading-md: 1.5rem;
   --font-weight-medium: 500;


### PR DESCRIPTION
Closes #300

## 概要
指示書 design 04 の採用プロファイル **案C（`.dir-c`）** はベースフォントを `--fs-base: 12.5px` に上書きしている（`assets/theme.css:167`）。フロントの本文ベース `--text-body` は `0.8125rem`（16px ルート換算 = 13px）で **0.5px 大きかった**ため、`0.78125rem`（12.5px）に較正した。

> 2026-06-05 引き継ぎ書は「指示書=13px で一致、変更不要」としていたが、これは案C上書き**前**の既定値（`theme.css:84` の `--fs-base: 13px`）を見ていた誤り。実効ベースは案Cの 12.5px。

## 変更
- `frontend/src/shared/ui/theme/themes/default.css`: `--text-body` を `0.8125rem` → `0.78125rem`

## 影響範囲
- `body` に適用される本文ベースのため、明示 `font-size` を持たない全テキスト（段落・テーブルセル・各種ラベル等）に連鎖する。
- page-title(21px)/page-sub(12px) など較正済みの px/rem は指示書と既に一致のため変更なし。
- 個別コンポーネントの raw `0.8125rem`（`.panel-head h3` 等）はベースではないためスコープ外。

## 確認
- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] `npm run build`
- [x] `npm run test`（167件 pass）
- [x] Playwright でダッシュボード／監査ログを目視（本文が締まり、レイアウト崩れなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)