### PR TITLE
fix(frontend): ダッシュボード日別グラフのY軸ラベル左端の見切れを解消 (#304)

### DIFF
--- a/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
+++ b/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
@@ -357,7 +357,9 @@ function DailyCumulativeView({
     500000,
   )
 
-  // viewBox 0 -12 520 208 — plot x 40..508, baseline y 170, top y 20.
+  // viewBox -16 -12 536 208 — plot x 40..508, baseline y 170, top y 20.
+  // The left edge is pulled out to -16 so the Y-axis tick labels (right-aligned
+  // at x=34, e.g. 「1000万」) have gutter room instead of clipping at x=0 (#304).
   const x = (day: number): number =>
     daysInMonth > 1 ? 40 + ((day - 1) / (daysInMonth - 1)) * 468 : 40
   const y = (v: number): number => 170 - (v / niceMax) * 150
@@ -396,7 +398,7 @@ function DailyCumulativeView({
     <>
       <svg
         className="iss-line"
-        viewBox="0 -12 520 208"
+        viewBox="-16 -12 536 208"
         preserveAspectRatio="xMidYMid meet"
         role="img"
         aria-label={t('admin.dashboard.billedTrend')}

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1015,6 +1015,11 @@
     font-family: var(--font-num);
     font-size: 14px;
   }
+  /* Y-axis tick labels: smaller than data labels so multi-digit 万 values fit
+     the left gutter without clipping (#304). */
+  .lc-tx.axis {
+    font-size: 12px;
+  }
   .lc-tx.now,
   .lc-tx.proj {
     fill: var(--color-accent-deep);


### PR DESCRIPTION
Closes #304

## 症状
ダッシュボード「日別の積み上がり」グラフで、左側Y軸ラベル（金額目盛り）の**先頭桁が見切れる**。
例: 「950万」→「50万」、「475万」→「75万」。

## 原因
`ViewDashboard.tsx` の `DailyCumulativeView`（インライン SVG）。Y軸ラベルは
`<text x="34" textAnchor="end">`、viewBox 左端は x=0 で左ガターが約34単位しかない。
`.lc-tx` は 14px・「万」は全角(≈14単位)のため「950万」≈39単位 → 左端 x≈−5 で
viewBox 左端(x=0)にクリップされていた。桁が増えるほど悪化。

## 修正
- viewBox 左端を `0`→`-16` に拡張（`-16 -12 536 208`）。プロット座標(40..508)は不変、
  右端も 520 のまま。`preserveAspectRatio` で全体がわずかに（約3%）縮むのみ。
- 軸目盛りのみ `font-size: 12px`（`.lc-tx.axis`）。データラベル(14px)はそのまま。

## 確認（Playwright で実描画を目視）
- 950万/475万 → 全桁表示（修正前は先頭桁が欠落）
- 6100万/3050万（4桁の万）でもクリップなし・右側「着地」ラベルも正常
- [x] `npx prettier --check` / `npm run lint` / `npm run build` / `npm run test`（167 pass）

### Before → After
- Before: 上「**50**万」中「**75**万」（先頭桁欠落）
- After: 上「950万」中「475万」/ 大金額でも「6100万」「3050万」全桁表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)