### PR TITLE
feat(frontend): 免責事項を明示（ヘルプ節・発行確認・ログイン・導線リンク） (#308)

### DIFF
--- a/frontend/src/features/account-menu/ui/AccountMenu.tsx
+++ b/frontend/src/features/account-menu/ui/AccountMenu.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { LOCALES, useTranslation } from '@/shared/i18n'
 import { openShortcutsOverlay } from '@/shared/keyboard'
 import { cn } from '@/shared/lib/cn'
@@ -59,6 +60,10 @@ export function AccountMenu() {
       <button type="button" className="sf-logout" onClick={onSignOut}>
         {t('common.actions.signOut')}
       </button>
+
+      <Link to="/help#disclaimer" className="sf-legal">
+        {t('admin.nav.disclaimer')}
+      </Link>
     </div>
   )
 }

--- a/frontend/src/features/sign-in/ui/SignInForm.tsx
+++ b/frontend/src/features/sign-in/ui/SignInForm.tsx
@@ -74,6 +74,8 @@ export function SignInForm() {
           </svg>
           {t('admin.auth.secNote')}
         </p>
+
+        <p className="auth-disclaimer">{t('admin.auth.disclaimer')}</p>
       </Stack>
     </form>
   )

--- a/frontend/src/pages/help/help-content.ts
+++ b/frontend/src/pages/help/help-content.ts
@@ -413,6 +413,33 @@ export const HELP_SECTIONS: HelpSection[] = [
       },
     ],
   },
+  {
+    id: 'disclaimer',
+    title: { ja: '免責事項・ご利用にあたって', en: 'Disclaimer & terms of use' },
+    blocks: [
+      {
+        kind: 'p',
+        text: {
+          ja: '本ソフトウェア（NeNe Invoice）は、見積・請求・入金管理の作成を補助するツールであり、税務・会計・法務に関する助言を提供するものではありません。作成された請求書・帳票の内容、税率・税区分・登録番号の正確性、適格請求書としての要件充足、税務申告および帳簿・書類の保存（電子帳簿保存法等）については、最終的にご利用者ご自身および顧問税理士の責任でご確認ください。',
+          en: 'This software (NeNe Invoice) is a tool that helps you prepare quotes, invoices, and payment records. It does not provide tax, accounting, or legal advice. The contents of the invoices and documents it produces, the accuracy of tax rates / categories / registration numbers, whether they meet qualified-invoice requirements, and tax filing and record retention (including under the Electronic Books Preservation Act) are ultimately your responsibility and that of your tax accountant.',
+        },
+      },
+      {
+        kind: 'p',
+        text: {
+          ja: '本ソフトウェアは MIT ライセンスに基づき「現状有姿（AS IS）」で提供され、明示・黙示を問わずいかなる保証も行いません。本ソフトウェアの使用または使用不能から生じたいかなる損害についても、作者および権利者は責任を負いません。',
+          en: 'This software is provided “AS IS” under the MIT License, without warranty of any kind, express or implied. The authors and copyright holders are not liable for any damages arising from the use of, or inability to use, this software.',
+        },
+      },
+      {
+        kind: 'p',
+        text: {
+          ja: '自己ホスト型のため、データのバックアップ・保管・セキュリティおよび法定保存期間の遵守は、運用される事業者の責任となります。また、法令・制度の改正への追随を保証するものではありません。',
+          en: 'Because it is self-hosted, backing up, storing, and securing your data, and complying with statutory retention periods, are the responsibility of the operating business. Nor does it guarantee that it stays up to date with changes in laws or regulations.',
+        },
+      },
+    ],
+  },
 ]
 
 export const HELP_FAQ: HelpFaqItem[] = [

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -33,6 +33,8 @@ export const enMessages: MessageCatalog = {
   'admin.auth.forgotPasswordPrompt': 'Forgot your password?',
   'admin.auth.forgotPasswordLink': 'Forgot your password?',
   'admin.auth.secNote': 'Passwords are stored hashed, never in plain text.',
+  'admin.auth.disclaimer':
+    'Provided without warranty under the MIT License. Final tax and accounting checks are your responsibility.',
   'admin.auth.brandTagline': 'Billing, done right — from quote to payment, end to end.',
   'admin.auth.brandLead':
     'Robust quote, invoice & payment management built for the Japanese qualified-invoice system. Close your back office accurately and on time.',
@@ -62,6 +64,7 @@ export const enMessages: MessageCatalog = {
   'admin.nav.auditLogs': 'Audit logs',
   'admin.nav.settings': 'Settings',
   'admin.nav.help': 'Help',
+  'admin.nav.disclaimer': 'Disclaimer',
   'admin.nav.shortcuts': 'Keyboard shortcuts',
   'admin.help.title': 'Help',
   'admin.help.subtitle': 'Guides & FAQ',
@@ -337,7 +340,7 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.issue.successBodyNoNumber': 'The invoice has been issued.',
   'admin.invoices.issue.confirmTitle': 'Issue this invoice?',
   'admin.invoices.issue.confirmMessage':
-    'Issuing allocates the invoice number and locks the contents (no further edits).',
+    'Issuing allocates the invoice number and locks the contents (no further edits). The accuracy of the contents and their tax treatment are your responsibility to verify.',
   'admin.payments.title': 'Payments',
   'admin.payments.loading': 'Loading payments…',
   'admin.payments.empty': 'No payments yet.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -36,6 +36,8 @@ export const jaMessages = {
   'admin.auth.forgotPasswordPrompt': 'パスワードをお忘れですか？',
   'admin.auth.forgotPasswordLink': 'パスワードをお忘れですか？',
   'admin.auth.secNote': 'パスワードはハッシュ化して安全に保管されます。',
+  'admin.auth.disclaimer':
+    '本ソフトウェアは MIT ライセンスに基づき無保証で提供されます。税務・会計上の最終確認はご利用者の責任で行ってください。',
   'admin.auth.brandTagline': '請求業務を、確実に。見積から入金まで一気通貫で。',
   'admin.auth.brandLead':
     '適格請求書（インボイス）制度に対応した、堅牢な見積・請求・入金管理。バックオフィスの締め作業を、正確かつ滞りなく。',
@@ -65,6 +67,7 @@ export const jaMessages = {
   'admin.nav.auditLogs': '監査ログ',
   'admin.nav.settings': '設定',
   'admin.nav.help': 'ヘルプ',
+  'admin.nav.disclaimer': '免責事項',
   'admin.nav.shortcuts': 'キーボードショートカット',
   'admin.help.title': 'ヘルプ',
   'admin.help.subtitle': '操作ガイド・よくある質問',
@@ -342,7 +345,7 @@ export const jaMessages = {
   'admin.invoices.issue.successBodyNoNumber': '請求書を発行しました。',
   'admin.invoices.issue.confirmTitle': '請求書を発行しますか？',
   'admin.invoices.issue.confirmMessage':
-    '発行すると番号が採番され、内容は確定（変更不可）になります。',
+    '発行すると番号が採番され、内容は確定（変更不可）になります。内容の正確性および税務上の取り扱いは、ご利用者の責任でご確認ください。',
   'admin.payments.title': '入金',
   'admin.payments.loading': '入金を読み込み中…',
   'admin.payments.empty': '入金はまだありません。',

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -1506,6 +1506,13 @@
     margin-top: 1px;
     color: var(--color-success);
   }
+  /* Sign-in disclaimer line (#308): smaller, muted, below the security note. */
+  .auth-disclaimer {
+    margin-top: 0.625rem;
+    font-size: var(--text-caption);
+    color: var(--color-fg-muted);
+    line-height: 1.6;
+  }
   .auth-foot {
     display: flex;
     gap: 1rem;
@@ -1687,6 +1694,19 @@
   .sf-logout:hover {
     background: var(--color-side-active);
     color: var(--color-side-fg);
+  }
+  /* Disclaimer link in the sidebar footer (#308): quiet, links to /help#disclaimer. */
+  .sf-legal {
+    display: block;
+    margin-top: 8px;
+    text-align: center;
+    font-size: 10.5px;
+    color: var(--color-side-fg-muted);
+    text-decoration: none;
+  }
+  .sf-legal:hover {
+    color: var(--color-side-fg);
+    text-decoration: underline;
   }
 
   /* Spec .tbl-wrap: the table sits inside a bordered box (square, no radius). */


### PR DESCRIPTION
Closes #308

## 概要
税務・会計を扱う OSS として、利用者向けの免責表示を追加（**日本語＋English**）。
現状 `LICENSE`（MIT 無保証）は配布向けで UI から見えなかった。

## 配置（A〜D）
- **A. ヘルプに「免責事項・ご利用にあたって」節**（`help-content.ts`、id=`disclaimer`／目次にも自動掲載）。
  利用者・顧問税理士の最終責任／MIT「現状有姿」無保証／自己ホストのデータ・法定保存責任／法令追随非保証。
- **B. 請求書 発行確認ダイアログ**に「内容の正確性および税務上の取り扱いは、ご利用者の責任でご確認ください。」を追記（`issue.confirmMessage`、発行のたび毎回表示）。
- **C. ログイン画面フッター**に無保証＋利用者責任の一文（`admin.auth.disclaimer`）。
- **D. サイドバーフッターに「免責事項」リンク**（`/help#disclaimer` へ、`admin.nav.disclaimer`）。

## 方針メモ
- ⚠️ **請求書PDF本体には載せない**（顧客向け正式書類のため）。免責はアプリ内・ドキュメント側に限定。
- 文言は差し替え可能な構造（i18n / content モジュール）。**公開前に弁護士・税理士レビュー推奨**（本PRは表示の実装）。

## 確認
- [x] `npm run lint` / `prettier --check` / `npm run knip`（unused なし）/ `npm run build` / `npm run test`（167 pass）
- [x] e2e: `sign-in` / `issue-invoice`（pass）
- [x] Playwright で ja の A・C・D を目視（ヘルプ節・ログイン文・サイドバーリンク→`#disclaimer` 遷移）。B は文字列追記＋issue-invoice e2e で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)