### PR TITLE
design(frontend): ヘルプページを指示書 design 05 のレイアウトに刷新 (#310)

### DIFF
--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -1,105 +1,285 @@
+import { Fragment, useEffect, useState, type ReactNode } from 'react'
+import { useCompanySettings } from '@/entities/company-settings'
 import { useTranslation } from '@/shared/i18n'
-import { Stack } from '@/shared/ui'
-import { HELP_FAQ, HELP_LABELS, HELP_SECTIONS, type Bi, type HelpBlock } from './help-content'
+import { HELP_LABELS, HELP_SECTIONS, type Bi, type HelpBlock } from './help-content'
 
 /**
- * Help landing page (Issue #306): a beginner-oriented walkthrough of the
- * quote → invoice → payment flow plus an FAQ. Content lives in `help-content.ts`
- * as ja/en pairs and is picked by the active locale. Distinct from the `?`
- * shortcut cheat-sheet (keys), which is a separate overlay.
+ * Help page (design 05, Issue #310): a hero, a sticky numbered table of contents
+ * with scroll-spy, and numbered sections built from rich blocks (steps, status
+ * flows, glossary cards, notes, send-method cards, a keyboard grid, and an FAQ
+ * accordion). Content lives in `help-content.ts` as ja/en pairs. Distinct from
+ * the `?` shortcut overlay.
  */
 export function HelpPage() {
-  const { t, locale } = useTranslation()
+  const { locale } = useTranslation()
+  const company = useCompanySettings()
+  const supportEmail = company.data?.email ?? null
   const pick = (b: Bi): string => (locale === 'en' ? b.en : b.ja)
+  const activeId = useScrollSpy(HELP_SECTIONS.map((s) => s.id))
 
   return (
-    <Stack gap="md">
-      <div className="page-head">
-        <div>
-          <h1 className="page-title">{t('admin.help.title')}</h1>
-          <p className="page-sub">{t('admin.help.subtitle')}</p>
+    <div className="help-page" id="help-top">
+      <header className="help-hero">
+        <div className="eyebrow">{pick(HELP_LABELS.eyebrow)}</div>
+        <h1>{pick(HELP_LABELS.heroTitle)}</h1>
+        <p>{pick(HELP_LABELS.heroLede)}</p>
+        <div className="hero-meta">
+          <span className="hero-chip">{pick(HELP_LABELS.chipQualified)}</span>
+          <span className="hero-chip">{pick(HELP_LABELS.chipSelfhost)}</span>
+          <span className="hero-chip">
+            <b>{pick(HELP_LABELS.chipUpdated)}</b>{' '}
+            <span className="num">{HELP_LABELS.updatedDate}</span>
+          </span>
         </div>
-      </div>
+      </header>
 
-      <p className="help-intro">{pick(HELP_LABELS.intro)}</p>
-
-      <nav id="contents" className="card help-toc" aria-label={pick(HELP_LABELS.toc)}>
-        <p className="help-toc-h">{pick(HELP_LABELS.toc)}</p>
-        <ol>
-          {HELP_SECTIONS.map((s) => (
-            <li key={s.id}>
-              <a href={`#${s.id}`}>{pick(s.title)}</a>
-            </li>
+      <div className="help-layout">
+        <nav className="help-toc" id="toc" aria-label={pick(HELP_LABELS.toc)}>
+          <div className="toc-title">{pick(HELP_LABELS.toc)}</div>
+          {HELP_SECTIONS.map((s, i) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              className={[s.id === activeId ? 'active' : '', s.admin ? 'admin-only' : '']
+                .filter(Boolean)
+                .join(' ')}
+              data-admin-label={pick(HELP_LABELS.adminBadge)}
+            >
+              <span className="tn">{String(i + 1).padStart(2, '0')}</span>
+              {pick(s.title)}
+            </a>
           ))}
-          <li>
-            <a href="#faq">{pick(HELP_LABELS.faqTitle)}</a>
-          </li>
-        </ol>
-      </nav>
+        </nav>
 
-      {HELP_SECTIONS.map((s) => (
-        <section key={s.id} id={s.id} className="card help-section">
-          <h2 className="help-h">{pick(s.title)}</h2>
-          {s.lead !== undefined && <p className="help-lead">{pick(s.lead)}</p>}
-          {s.blocks.map((block, i) => (
-            <HelpBlockView key={i} block={block} pick={pick} />
+        <article className="help-article">
+          {HELP_SECTIONS.map((s, i) => (
+            <section key={s.id} id={s.id} className="hsec">
+              <div className="hsec-head">
+                <span className="hsec-no">{String(i + 1).padStart(2, '0')}</span>
+                <h2>
+                  {pick(s.title)}
+                  {s.admin === true && (
+                    <span className="tag-admin">{pick(HELP_LABELS.adminBadge)}</span>
+                  )}
+                </h2>
+              </div>
+              {s.blocks.map((block, bi) => (
+                <Block key={bi} block={block} pick={pick} />
+              ))}
+              <a className="backtop" href="#toc">
+                ↑ {pick(HELP_LABELS.backToToc)}
+              </a>
+            </section>
           ))}
-          <a className="help-top" href="#contents">
-            {pick(HELP_LABELS.backToTop)}
-          </a>
-        </section>
-      ))}
 
-      <section id="faq" className="card help-section">
-        <h2 className="help-h">{pick(HELP_LABELS.faqTitle)}</h2>
-        <dl className="help-faq">
-          {HELP_FAQ.map((item, i) => (
-            <div key={i} className="help-faq-item">
-              <dt>{pick(item.q)}</dt>
-              <dd>{pick(item.a)}</dd>
+          <div className="help-foot">
+            <div>
+              <div className="hf-t">{pick(HELP_LABELS.footTitle)}</div>
+              <div className="hf-d">{pick(HELP_LABELS.footDesc)}</div>
             </div>
-          ))}
-        </dl>
-        <a className="help-top" href="#contents">
-          {pick(HELP_LABELS.backToTop)}
-        </a>
-      </section>
-    </Stack>
+            {supportEmail !== null && (
+              <a className="btn-primary-link" href={`mailto:${supportEmail}`}>
+                {pick(HELP_LABELS.footButton)}
+              </a>
+            )}
+          </div>
+        </article>
+      </div>
+    </div>
   )
 }
 
-function HelpBlockView({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }) {
+/** Highlights the ToC entry for the last section scrolled past the top band. */
+function useScrollSpy(ids: string[]): string {
+  const [activeId, setActiveId] = useState(ids[0] ?? '')
+  useEffect(() => {
+    const onScroll = (): void => {
+      const threshold = window.scrollY + 120
+      let current = ids[0] ?? ''
+      for (const id of ids) {
+        const el = document.getElementById(id)
+        if (el === null) continue
+        const docTop = el.getBoundingClientRect().top + window.scrollY
+        if (docTop <= threshold) current = id
+      }
+      setActiveId(current)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+    // ids is a stable list derived from module constants.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  return activeId
+}
+
+/** Renders `` `code` `` spans within a (possibly bold) text fragment. */
+function renderCode(text: string): ReactNode[] {
+  return text.split(/(`[^`]+`)/g).map((p, i) =>
+    p.startsWith('`') && p.endsWith('`') ? (
+      <code key={i} className="tcode">
+        {p.slice(1, -1)}
+      </code>
+    ) : (
+      <Fragment key={i}>{p}</Fragment>
+    ),
+  )
+}
+
+/** Renders `**bold**` and `` `code` `` inline markup (code may nest in bold). */
+function Rich({ text }: { text: string }): ReactNode {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.startsWith('**') && p.endsWith('**') ? (
+          <b key={i}>{renderCode(p.slice(2, -2))}</b>
+        ) : (
+          <Fragment key={i}>{renderCode(p)}</Fragment>
+        ),
+      )}
+    </>
+  )
+}
+
+function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): ReactNode {
   switch (block.kind) {
-    case 'p':
-      return <p className="help-p">{pick(block.text)}</p>
+    case 'lede':
+      return (
+        <p className="lede">
+          <Rich text={pick(block.text)} />
+        </p>
+      )
+    case 'subhead':
+      return <div className="sub-h">{pick(block.text)}</div>
     case 'steps':
       return (
-        <ol className="help-steps">
+        <ol className="steps">
           {block.items.map((it, i) => (
-            <li key={i}>{pick(it)}</li>
+            <li key={i}>
+              <div className="st-t">{pick(it.title)}</div>
+              <div className="st-d">
+                <Rich text={pick(it.desc)} />
+              </div>
+            </li>
           ))}
         </ol>
       )
-    case 'list':
+    case 'proc':
       return (
-        <ul className="help-list">
+        <ol className="proc">
           {block.items.map((it, i) => (
-            <li key={i}>{pick(it)}</li>
+            <li key={i}>
+              <Rich text={pick(it)} />
+            </li>
           ))}
-        </ul>
+        </ol>
       )
-    case 'note':
-      return <p className="help-note">{pick(block.text)}</p>
-    case 'defs':
+    case 'flow':
       return (
-        <dl className="help-defs">
+        <div className="flow">
+          {block.chips.map((c, i) => (
+            <Fragment key={i}>
+              {i > 0 && <span className="farrow">→</span>}
+              <span className="fchip">{pick(c)}</span>
+            </Fragment>
+          ))}
+          {block.branch !== undefined && <span className="fbranch">{pick(block.branch)}</span>}
+        </div>
+      )
+    case 'terms':
+      return (
+        <dl className="terms">
           {block.items.map((it, i) => (
-            <div key={i}>
+            <div key={i} className="term">
               <dt>{pick(it.term)}</dt>
-              <dd>{pick(it.desc)}</dd>
+              <dd>
+                <Rich text={pick(it.desc)} />
+              </dd>
             </div>
           ))}
         </dl>
+      )
+    case 'deflist':
+      return (
+        <div className="deflist">
+          {block.items.map((it, i) => (
+            <div key={i} className="row">
+              <div className="dl-t">{pick(it.term)}</div>
+              <div className="dl-d">
+                <Rich text={pick(it.desc)} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+    case 'note':
+      return (
+        <div className={block.tone === 'warn' ? 'note warn' : 'note'}>
+          <span>
+            {block.title !== undefined && <span className="nt">{pick(block.title)}</span>}
+            <Rich text={pick(block.text)} />
+          </span>
+        </div>
+      )
+    case 'options':
+      return (
+        <div className="opt3">
+          {block.items.map((it, i) => (
+            <div key={i} className="opt">
+              <div className="opt-n">{String(i + 1).padStart(2, '0')}</div>
+              <div className="opt-t">{pick(it.title)}</div>
+              <div className="opt-d">{pick(it.desc)}</div>
+            </div>
+          ))}
+        </div>
+      )
+    case 'keys':
+      return (
+        <>
+          {block.groups.map((g, gi) => (
+            <Fragment key={gi}>
+              <div className="sub-h">{pick(g.heading)}</div>
+              <div className="kgrid">
+                {g.rows.map((r, ri) => (
+                  <div key={ri} className="kr">
+                    <span className="kl">{pick(r.label)}</span>
+                    <span className="kk">
+                      {r.caps.map((cap, ci) => (
+                        <kbd key={ci} className="kbd">
+                          {cap}
+                        </kbd>
+                      ))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </Fragment>
+          ))}
+        </>
+      )
+    case 'faq':
+      return (
+        <div className="faq">
+          {block.items.map((it, i) => (
+            <details key={i} open={i === 0}>
+              <summary>
+                <span className="q">Q</span>
+                <span className="qt">{pick(it.q)}</span>
+                <span className="chev" aria-hidden="true">
+                  ⌄
+                </span>
+              </summary>
+              <div className="fa-body">
+                <Rich text={pick(it.a)} />
+              </div>
+            </details>
+          ))}
+        </div>
       )
   }
 }

--- a/frontend/src/pages/help/help-content.ts
+++ b/frontend/src/pages/help/help-content.ts
@@ -1,124 +1,167 @@
 /**
- * Help-page content (Issue #306). Co-located bilingual ja/en pairs — like
- * `shared/keyboard/shortcuts-data.ts` — rather than locale-catalog keys, since
- * the page is long-form prose with lists and steps that don't fit flat keys.
- * `HelpPage` picks ja or en from the active locale.
+ * Help-page content (design 05, Issue #310). Co-located bilingual ja/en pairs —
+ * like `shared/keyboard/shortcuts-data.ts` — rather than locale-catalog keys,
+ * since the page is long-form prose with steps, flows, and an FAQ that don't fit
+ * flat keys. `HelpPage` picks ja or en from the active locale.
  *
- * Keep wording aligned with the real UI labels (the buttons / statuses a
- * beginner actually sees), so the guide stays accurate as a walkthrough.
+ * Inline markup inside any string: `**bold**` and `` `code` `` (rendered by the
+ * page's <Rich> helper). Keep wording aligned with the real UI labels (the
+ * buttons / statuses a beginner actually sees), so the guide stays accurate.
  */
 
-/** A translated string: primary ja + secondary en. */
+/** A translated string: primary ja + secondary en. May contain inline markup. */
 export interface Bi {
   ja: string
   en: string
 }
 
 export type HelpBlock =
-  | { kind: 'p'; text: Bi }
-  | { kind: 'steps'; items: Bi[] }
-  | { kind: 'list'; items: Bi[] }
-  | { kind: 'note'; text: Bi }
-  | { kind: 'defs'; items: { term: Bi; desc: Bi }[] }
+  | { kind: 'lede'; text: Bi }
+  | { kind: 'subhead'; text: Bi }
+  | { kind: 'steps'; items: { title: Bi; desc: Bi }[] }
+  | { kind: 'proc'; items: Bi[] }
+  | { kind: 'flow'; chips: Bi[]; branch?: Bi }
+  | { kind: 'terms'; items: { term: Bi; desc: Bi }[] }
+  | { kind: 'deflist'; items: { term: Bi; desc: Bi }[] }
+  | { kind: 'note'; tone?: 'warn'; title?: Bi; text: Bi }
+  | { kind: 'options'; items: { title: Bi; desc: Bi }[] }
+  | { kind: 'keys'; groups: { heading: Bi; rows: { label: Bi; caps: string[] }[] }[] }
+  | { kind: 'faq'; items: { q: Bi; a: Bi }[] }
 
 export interface HelpSection {
-  /** Anchor id, also used by the table of contents. */
+  /** Anchor id (also the ToC target). */
   id: string
   title: Bi
-  lead?: Bi
+  /** Marks the section as admin-only (badge in the ToC and the heading). */
+  admin?: boolean
   blocks: HelpBlock[]
 }
 
-export interface HelpFaqItem {
-  q: Bi
-  a: Bi
-}
-
 export const HELP_LABELS = {
-  intro: {
+  eyebrow: { ja: 'ヘルプ', en: 'Help' },
+  heroTitle: { ja: '操作ガイド・よくある質問', en: 'Guides & FAQ' },
+  heroLede: {
     ja: 'NeNe Invoice を初めて使う方向けの操作ガイドです。見積から請求・入金までの流れと、つまずきやすいポイントをまとめています。',
     en: 'A getting-started guide for people new to NeNe Invoice. It walks through the quote → invoice → payment flow and the spots people commonly get stuck on.',
   },
+  chipQualified: { ja: '適格請求書（インボイス）対応', en: 'Qualified invoice ready' },
+  chipSelfhost: { ja: '自己ホスト型', en: 'Self-hosted' },
+  chipUpdated: { ja: '最終更新', en: 'Updated' },
+  updatedDate: '2026-06-05',
   toc: { ja: '目次', en: 'Contents' },
-  faqTitle: { ja: 'よくある質問', en: 'Frequently asked questions' },
-  backToTop: { ja: '↑ 目次へ戻る', en: '↑ Back to contents' },
+  adminBadge: { ja: '管理者', en: 'Admin' },
+  backToToc: { ja: '目次へ戻る', en: 'Back to contents' },
+  footTitle: { ja: '解決しませんでしたか？', en: 'Still need help?' },
+  footDesc: {
+    ja: '管理者にお問い合わせいただくか、キーボードショートカット一覧（?）もご活用ください。',
+    en: 'Contact your administrator, or press ? for the keyboard-shortcut list.',
+  },
+  footButton: { ja: 'サポートへ問い合わせ', en: 'Contact support' },
+  faqTitle: { ja: 'よくある質問', en: 'FAQ' },
 } as const
 
 export const HELP_SECTIONS: HelpSection[] = [
   {
-    id: 'quickstart',
+    id: 's1',
     title: { ja: 'はじめに（クイックスタート）', en: 'Getting started (quick start)' },
-    lead: {
-      ja: 'NeNe Invoice は、見積・請求・入金をまとめて管理する自己ホスト型システムです。日本の適格請求書（インボイス）に対応しています。',
-      en: 'NeNe Invoice is a self-hosted system for managing quotes, invoices, and payments together. It supports Japan’s qualified invoice (invoice system) format.',
-    },
     blocks: [
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
-          ja: '全体の流れはシンプルです。見積書を作り、承認されたら請求書に変換し、請求書を「発行」して取引先へ送付し、入金されたら記録します。ダッシュボードで未払い・売掛・入金の状況をいつでも把握できます。',
-          en: 'The overall flow is simple: create a quote, convert it to an invoice once accepted, “issue” the invoice and send it to the client, then record the payment when it arrives. The dashboard shows your unpaid / receivable / payment situation at any time.',
+          ja: 'NeNe Invoice は、見積・請求・入金をまとめて管理する**自己ホスト型システム**です。日本の適格請求書（インボイス）に対応しています。',
+          en: 'NeNe Invoice is a **self-hosted system** for managing quotes, invoices, and payments together. It supports Japan’s qualified invoice format.',
         },
       },
+      {
+        kind: 'lede',
+        text: {
+          ja: '全体の流れはシンプルです。見積書を作り、承認されたら請求書に変換し、請求書を「発行」して取引先へ送付し、入金されたら記録します。ダッシュボードで未払い・売掛・入金の状況をいつでも把握できます。',
+          en: 'The flow is simple: create a quote, convert it to an invoice once accepted, “issue” the invoice and send it to the client, then record the payment when it arrives. The dashboard shows your unpaid / receivable / payment situation at any time.',
+        },
+      },
+      { kind: 'subhead', text: { ja: 'まず最初の3ステップ', en: 'The first three steps' } },
       {
         kind: 'steps',
         items: [
           {
-            ja: '会社情報を登録する（設定）。特に「登録番号（T＋13桁）」は請求書の発行に必須です。',
-            en: 'Register your company info (Settings). In particular the “registration number (T + 13 digits)” is required to issue invoices.',
+            title: {
+              ja: '会社情報を登録する（設定）',
+              en: 'Register your company info (Settings)',
+            },
+            desc: {
+              ja: '特に **登録番号（`T＋13桁`）** は請求書の発行に必須です。',
+              en: 'In particular the **registration number (`T + 13 digits`)** is required to issue invoices.',
+            },
           },
           {
-            ja: '取引先を登録する（取引先 → 取引先を作成）。',
-            en: 'Add your clients (Clients → Create client).',
+            title: { ja: '取引先を登録する', en: 'Add your clients' },
+            desc: {
+              ja: '「取引先 → 取引先を作成」から登録します。',
+              en: 'Add them from Clients → Create client.',
+            },
           },
           {
-            ja: '見積書、または請求書を作成する。',
-            en: 'Create a quote, or an invoice.',
+            title: { ja: '見積書、または請求書を作成する', en: 'Create a quote, or an invoice' },
+            desc: {
+              ja: '見積から始めても、請求書を直接作っても構いません。',
+              en: 'You can start from a quote, or create an invoice directly.',
+            },
           },
         ],
       },
       {
         kind: 'note',
+        title: {
+          ja: 'データはあなたの環境に保存されます。',
+          en: 'Your data stays in your environment.',
+        },
         text: {
-          ja: '自己ホスト型のため、データはあなたの環境のデータベースに保存されます。請求情報が外部サービスへ送信されることはありません。',
-          en: 'Because it is self-hosted, your data lives in your own database. Billing information is never sent to an external service.',
+          ja: '自己ホスト型のため、請求情報が外部サービスへ送信されることはありません。',
+          en: 'Because it is self-hosted, billing information is never sent to an external service.',
         },
       },
     ],
   },
   {
-    id: 'glossary',
+    id: 's2',
     title: { ja: '用語ミニ辞典', en: 'Mini glossary' },
     blocks: [
       {
-        kind: 'defs',
+        kind: 'lede',
+        text: {
+          ja: '画面でよく出てくる用語をかんたんに説明します。',
+          en: 'Quick explanations of terms you’ll see around the app.',
+        },
+      },
+      {
+        kind: 'terms',
         items: [
           {
             term: { ja: '適格請求書（インボイス）', en: 'Qualified invoice' },
             desc: {
-              ja: '登録番号や税率区分を記載した、仕入税額控除に使える請求書。NeNe Invoice の請求書は「発行」時にこの形式で採番されます。',
-              en: 'An invoice that lists the registration number and tax-rate breakdown so it can be used for input-tax credit. Invoices here are numbered in this format when you “issue” them.',
+              ja: '登録番号や税率区分を記載した、仕入税額控除に使える請求書。NeNe Invoice の請求書は**「発行」時にこの形式で採番**されます。',
+              en: 'An invoice listing the registration number and tax-rate breakdown, usable for input-tax credit. Invoices here are **numbered in this format when you “issue” them**.',
             },
           },
           {
             term: { ja: '登録番号', en: 'Registration number' },
             desc: {
-              ja: '適格請求書発行事業者の番号（T＋13桁）。会社設定に登録します。',
-              en: 'The qualified-invoice issuer number (T + 13 digits). Set it in company Settings.',
+              ja: '適格請求書発行事業者の番号（`T＋13桁`）。会社設定に登録します。',
+              en: 'The qualified-invoice issuer number (`T + 13 digits`). Set it in company Settings.',
             },
           },
           {
             term: { ja: '締め日／支払サイト', en: 'Closing day / payment terms' },
             desc: {
-              ja: '「毎月◯日締め・翌月△日払い」のような支払条件。設定しておくと請求書の支払期限が自動計算されます。',
-              en: 'Terms like “close on the Nth, pay on the Mth of next month.” Once set, an invoice’s due date is calculated automatically.',
+              ja: '「毎月◯日締め・翌月△日払い」のような支払条件。設定しておくと請求書の**支払期限が自動計算**されます。',
+              en: 'Terms like “close on the Nth, pay on the Mth of next month.” Once set, an invoice’s **due date is calculated automatically**.',
             },
           },
           {
-            term: { ja: '残高（売掛）', en: 'Outstanding (accounts receivable)' },
+            term: { ja: '残高（売掛）', en: 'Outstanding (receivable)' },
             desc: {
-              ja: '請求済みで、まだ入金されていない金額。合計から入金済みを引いた額です。',
-              en: 'Billed but not yet received. The total minus what has been paid.',
+              ja: '請求済みで、まだ入金されていない金額。**合計 − 入金済み** の額です。',
+              en: 'Billed but not yet received — **total − amount paid**.',
             },
           },
           {
@@ -133,160 +176,215 @@ export const HELP_SECTIONS: HelpSection[] = [
     ],
   },
   {
-    id: 'setup',
+    id: 's3',
     title: { ja: '初期設定', en: 'Initial setup' },
-    lead: {
-      ja: '最初に会社情報・既定値・ユーザーを整えておくと、以降の操作がスムーズです。',
-      en: 'Setting up your company info, defaults, and users first makes everything afterward smoother.',
-    },
     blocks: [
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
-          ja: '会社情報（設定）— 法人名（必須）・住所・電話・メール、振込先（銀行名／支店名／口座種別／口座番号）、そして登録番号（T＋13桁）を登録します。登録番号は請求書の発行に必須で、未登録だと発行できません。',
-          en: 'Company info (Settings) — legal name (required), address, phone, email, bank details (bank / branch / account type / number), and the registration number (T + 13 digits). The registration number is required to issue invoices; without it you cannot issue.',
+          ja: '最初に会社情報・既定値・ユーザーを整えておくと、以降の操作がスムーズです。',
+          en: 'Setting up your company info, defaults, and users first makes everything afterward smoother.',
         },
       },
       {
-        kind: 'p',
-        text: {
-          ja: '請求・見積の既定 — 「見積の有効期限（日数）」を入れると、見積作成時に有効期限が自動で入ります。「締め日・支払月・支払日」を設定すると、請求書の支払期限が自動計算されます（例: 末日締め・翌月末払い）。空欄なら毎回手入力です。',
-          en: 'Invoice / quote defaults — set “quote validity (days)” to auto-fill a quote’s expiry on creation. Set “closing day / payment month / pay day” to auto-calculate an invoice’s due date (e.g. close at month-end, pay end of next month). Leave blank to enter it each time.',
-        },
-      },
-      {
-        kind: 'p',
-        text: {
-          ja: 'ユーザーとロール — 管理者はユーザー管理を含む操作、メンバーは日常の見積・請求・入金、閲覧者は閲覧のみ、スーパー管理者は組織（テナント）全体の管理を担います。',
-          en: 'Users and roles — admins can manage users and operate the system, members handle day-to-day quotes / invoices / payments, viewers are read-only, and superadmins manage the whole organization (tenant).',
-        },
+        kind: 'deflist',
+        items: [
+          {
+            term: { ja: '会社情報（設定）', en: 'Company info (Settings)' },
+            desc: {
+              ja: '法人名（必須）・住所・電話・メール、振込先（銀行名／支店名／口座種別／口座番号）、そして**登録番号（`T＋13桁`）**を登録します。登録番号は請求書の発行に必須で、未登録だと発行できません。',
+              en: 'Legal name (required), address, phone, email, bank details (bank / branch / account type / number), and the **registration number (`T + 13 digits`)**. The registration number is required to issue invoices; without it you cannot issue.',
+            },
+          },
+          {
+            term: { ja: '請求・見積の既定', en: 'Invoice / quote defaults' },
+            desc: {
+              ja: '「見積の有効期限（日数）」を入れると、見積作成時に有効期限が自動で入ります。「締め日・支払月・支払日」を設定すると、請求書の支払期限が自動計算されます（例：末日締め・翌月末払い）。空欄なら毎回手入力です。',
+              en: 'Set “quote validity (days)” to auto-fill a quote’s expiry. Set “closing day / payment month / pay day” to auto-calculate an invoice’s due date (e.g. close at month-end, pay end of next month). Leave blank to enter it each time.',
+            },
+          },
+          {
+            term: { ja: 'ユーザーとロール', en: 'Users and roles' },
+            desc: {
+              ja: '**管理者**はユーザー管理を含む操作、**メンバー**は日常の見積・請求・入金、**閲覧者**は閲覧のみ、**スーパー管理者**は組織（テナント）全体の管理を担います。',
+              en: '**Admins** manage users and operate the system, **members** handle day-to-day quotes / invoices / payments, **viewers** are read-only, and **superadmins** manage the whole organization (tenant).',
+            },
+          },
+        ],
       },
     ],
   },
   {
-    id: 'clients',
+    id: 's4',
     title: { ja: '取引先', en: 'Clients' },
     blocks: [
       {
-        kind: 'steps',
+        kind: 'proc',
         items: [
           {
-            ja: '「取引先」→「取引先を作成」を開きます。',
-            en: 'Open Clients → Create client.',
+            ja: '「取引先」→「**取引先を作成**」を開きます。',
+            en: 'Open Clients → **Create client**.',
           },
           {
             ja: '名称（必須）・担当者・メール・登録番号などを入力して保存します。',
             en: 'Enter name (required), contact, email, registration number, etc., then save.',
           },
+          { ja: '編集は一覧の行から行います。', en: 'Edit a client from its row in the list.' },
         ],
       },
       {
-        kind: 'p',
+        kind: 'note',
         text: {
-          ja: '取引先のメールを登録しておくと、請求書の「メールで送信」が使えます。編集は一覧の行から行います。',
-          en: 'Registering the client’s email lets you use “Send by email” on an invoice. Edit a client from its row in the list.',
+          ja: '取引先のメールを登録しておくと、請求書の**「メールで送信」**が使えます。',
+          en: 'Registering the client’s email lets you use **“Send by email”** on an invoice.',
         },
       },
     ],
   },
   {
-    id: 'quotes',
+    id: 's5',
     title: { ja: '見積書', en: 'Quotes' },
     blocks: [
       {
-        kind: 'steps',
+        kind: 'proc',
         items: [
           {
-            ja: '「見積書」→「見積書を作成」を開きます。',
-            en: 'Open Quotes → Create quote.',
+            ja: '「見積書」→「**見積書を作成**」を開きます。',
+            en: 'Open Quotes → **Create quote**.',
           },
           {
             ja: '取引先を選び、品目・数量・単価・税率を入力します。行は必要なだけ追加できます。',
             en: 'Pick a client and enter line items (item, quantity, unit price, tax rate). Add as many rows as you need.',
           },
           {
-            ja: '有効期限を設定して保存すると「下書き」になります。',
-            en: 'Set the expiry and save — it becomes a “Draft.”',
+            ja: '有効期限を設定して保存すると「**下書き**」になります。',
+            en: 'Set the expiry and save — it becomes a **Draft**.',
           },
         ],
       },
+      { kind: 'subhead', text: { ja: '状態の流れ', en: 'Status flow' } },
       {
-        kind: 'p',
+        kind: 'flow',
+        chips: [
+          { ja: '下書き', en: 'Draft' },
+          { ja: '送付済み', en: 'Sent' },
+          { ja: '承認済み', en: 'Accepted' },
+        ],
+        branch: { ja: '／ 却下 ／ 期限切れ', en: '/ Rejected / Expired' },
+      },
+      {
+        kind: 'lede',
         text: {
-          ja: '状態の流れ: 下書き → 送付する（送付済み）→ 承認する（承認済み）／却下する／期限切れにする。詳細画面の操作ボタンで進めます。',
-          en: 'Status flow: Draft → Send (Sent) → Accept (Accepted) / Reject / Mark expired. Move through these with the action buttons on the detail screen.',
+          ja: '詳細画面の操作ボタンで進めます。PDF をダウンロードして送付できます。',
+          en: 'Move through these with the action buttons on the detail screen. You can download a PDF to send.',
         },
       },
       {
-        kind: 'p',
+        kind: 'note',
+        title: {
+          ja: '承認済みの見積は「請求書に変換する」が使えます。',
+          en: 'An accepted quote can use “Convert to invoice.”',
+        },
         text: {
-          ja: 'PDF をダウンロードして送付できます。承認済みの見積は「請求書に変換する」で、内容（取引先・明細・金額）を引き継いだ請求書の下書きを作成できます。',
-          en: 'You can download a PDF to send. An accepted quote can be turned into an invoice with “Convert to invoice,” which carries over the client, line items, and amounts as an invoice draft.',
+          ja: '内容（取引先・明細・金額）を引き継いだ請求書の下書きが作成されます。',
+          en: 'It creates an invoice draft carrying over the client, line items, and amounts.',
         },
       },
     ],
   },
   {
-    id: 'invoices',
+    id: 's6',
     title: { ja: '請求書', en: 'Invoices' },
     blocks: [
       {
-        kind: 'steps',
+        kind: 'proc',
         items: [
           {
-            ja: '「請求書」→「請求書を作成」、または承認済み見積から変換します。最初は「下書き（未採番）」です。',
-            en: 'Open Invoices → Create invoice, or convert from an accepted quote. It starts as a “Draft (not yet numbered).”',
+            ja: '「請求書」→「**請求書を作成**」、または承認済み見積から変換します。最初は「下書き（未採番）」です。',
+            en: 'Open Invoices → **Create invoice**, or convert from an accepted quote. It starts as a “Draft (not yet numbered).”',
           },
           {
-            ja: '内容を確認し「発行する（適格請求書）」を押します。確認後に請求番号が採番され「発行済み」になります。',
-            en: 'Review it and press “Issue (qualified invoice).” After confirmation it gets an invoice number and becomes “Issued.”',
+            ja: '内容を確認し「**発行する（適格請求書）**」を押します。確認後に請求番号が採番され「発行済み」になります。',
+            en: 'Review it and press **“Issue (qualified invoice).”** After confirmation it gets an invoice number and becomes “Issued.”',
           },
           {
-            ja: '発行後は内容が確定します（編集できません）。下書きのうちに必ず確認してください。',
-            en: 'Once issued, the contents are final (no longer editable). Always check while it is still a draft.',
+            ja: '発行後は内容が確定します（編集できません）。**下書きのうちに必ず確認**してください。',
+            en: 'Once issued, the contents are final (no longer editable). **Always check while it is still a draft.**',
           },
         ],
       },
       {
         kind: 'note',
+        tone: 'warn',
+        title: { ja: '発行には登録番号が必須です', en: 'Issuing requires a registration number' },
         text: {
-          ja: '発行には会社設定の登録番号（T＋13桁）が必須です。未登録だと「発行できませんでした。会社情報の登録番号をご確認ください」と表示されます → 設定で登録してください。',
-          en: 'Issuing requires the company registration number (T + 13 digits). Without it you’ll see “Could not issue — please check the registration number,” so register it in Settings.',
+          ja: '未登録だと「発行できませんでした。会社情報の登録番号をご確認ください」と表示されます。設定で `T＋13桁` の登録番号を保存してください。',
+          en: 'Without it you’ll see “Could not issue — please check the registration number.” Save the `T + 13-digit` number in Settings.',
+        },
+      },
+      { kind: 'subhead', text: { ja: '送付方法は3つ', en: 'Three ways to deliver it' } },
+      {
+        kind: 'options',
+        items: [
+          {
+            title: { ja: 'PDF をダウンロード', en: 'Download a PDF' },
+            desc: { ja: '手元に保存して送付できます。', en: 'Save it and send it yourself.' },
+          },
+          {
+            title: { ja: 'メールで送信', en: 'Send by email' },
+            desc: {
+              ja: '取引先メールへ直接送信します。',
+              en: 'Send straight to the client’s email.',
+            },
+          },
+          {
+            title: { ja: 'クライアント向けリンク', en: 'Client link' },
+            desc: {
+              ja: '期限つきの閲覧／DL用URL。ログイン不要で相手が開けます。',
+              en: 'A time-limited view/download URL the recipient opens without logging in.',
+            },
+          },
+        ],
+      },
+      {
+        kind: 'subhead',
+        text: { ja: '支払期限・残高と状態', en: 'Due date, outstanding, and status' },
+      },
+      {
+        kind: 'lede',
+        text: {
+          ja: '既定の支払条件があれば支払期限が自動で入ります。**残高 ＝ 合計 − 入金済み** です。',
+          en: 'With default payment terms, the due date is filled automatically. **Outstanding = total − amount paid.**',
         },
       },
       {
-        kind: 'p',
-        text: {
-          ja: '送付方法は3つ: ①PDF をダウンロード ②取引先メールへ「メールで送信」 ③「クライアント向けリンクを生成」（期限つきの閲覧／ダウンロードURL。ログイン不要で相手が開けます）。',
-          en: 'Three ways to deliver it: (1) download a PDF, (2) “Send by email” to the client, or (3) “Generate a client link” — a time-limited view/download URL the recipient can open without logging in.',
-        },
+        kind: 'flow',
+        chips: [
+          { ja: '下書き', en: 'Draft' },
+          { ja: '発行済み', en: 'Issued' },
+          { ja: '一部入金', en: 'Partially paid' },
+          { ja: '入金済み', en: 'Paid' },
+        ],
       },
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
-          ja: '支払期限・残高: 既定の支払条件があれば支払期限が自動で入ります。残高＝合計−入金済みです。',
-          en: 'Due date / outstanding: if you set default payment terms, the due date is filled automatically. Outstanding = total − amount paid.',
-        },
-      },
-      {
-        kind: 'p',
-        text: {
-          ja: '状態: 下書き → 発行済み → 一部入金 → 入金済み。支払期限を過ぎた未入金は「期限超過」と表示されます。',
-          en: 'Status: Draft → Issued → Partially paid → Paid. An unpaid invoice past its due date is flagged “Overdue.”',
+          ja: '支払期限を過ぎた未入金は「**期限超過**」と表示されます。',
+          en: 'An unpaid invoice past its due date is flagged **“Overdue.”**',
         },
       },
     ],
   },
   {
-    id: 'payments',
+    id: 's7',
     title: { ja: '入金管理', en: 'Payments' },
     blocks: [
       {
-        kind: 'steps',
+        kind: 'proc',
         items: [
           {
-            ja: '請求書の詳細画面で「入金を記録」を開きます。',
-            en: 'On the invoice detail screen, open “Record payment.”',
+            ja: '請求書の詳細画面で「**入金を記録**」を開きます。',
+            en: 'On the invoice detail screen, open **“Record payment.”**',
           },
           {
             ja: '金額（円）・方法（銀行振込／現金／その他）・備考を入力して記録します。',
@@ -294,122 +392,243 @@ export const HELP_SECTIONS: HelpSection[] = [
           },
           {
             ja: '記録すると請求書の入金状態が自動更新されます（全額で「入金済み」、一部で「一部入金」）。',
-            en: 'Recording auto-updates the invoice status (“Paid” in full, “Partially paid” in part).',
+            en: 'Recording auto-updates the status (“Paid” in full, “Partially paid” in part).',
           },
         ],
       },
       {
         kind: 'note',
+        title: { ja: '入金は手動で記録します。', en: 'Payments are recorded manually.' },
         text: {
-          ja: '入金は手動で記録します。銀行口座との自動連携・自動消込は現時点ではありません。数値の正確さは入金を登録する運用しだいです。',
-          en: 'Payments are recorded manually. There is currently no automatic bank-feed or auto-reconciliation, so accuracy depends on actually recording payments.',
+          ja: '銀行口座との自動連携・自動消込は現時点ではありません。数値の正確さは入金を登録する運用しだいです。',
+          en: 'There is no automatic bank-feed or auto-reconciliation yet, so accuracy depends on recording payments.',
         },
       },
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
-          ja: '残高を超える金額は記録できません（エラーになります）。誤って記録した入金は取り消せます（取り消すと状態も戻ります）。',
-          en: 'You cannot record more than the outstanding balance (it errors). A payment recorded by mistake can be voided, which reverts the status too.',
+          ja: '残高を超える金額は記録できません（エラーになります）。誤って記録した入金は**取り消せます**（取り消すと状態も戻ります）。',
+          en: 'You cannot record more than the outstanding balance (it errors). A payment recorded by mistake can be **voided** (which reverts the status too).',
         },
       },
     ],
   },
   {
-    id: 'dashboard',
+    id: 's8',
     title: { ja: 'ダッシュボードの見方', en: 'Reading the dashboard' },
     blocks: [
       {
-        kind: 'list',
+        kind: 'lede',
+        text: {
+          ja: '記録された請求・入金から自動計算される指標が並びます。入金を記録する運用が回っているほど、数値は実態に近づきます。',
+          en: 'The metrics are computed automatically from recorded invoices and payments. The more consistently payments are recorded, the closer they reflect reality.',
+        },
+      },
+      {
+        kind: 'deflist',
         items: [
           {
-            ja: '未払い請求書 — 未入金の件数と、残高の合計。',
-            en: 'Unpaid invoices — the count and the total outstanding.',
+            term: { ja: '未払い請求書', en: 'Unpaid invoices' },
+            desc: {
+              ja: '未入金の件数と、残高の合計。',
+              en: 'Count of unpaid invoices and the total outstanding.',
+            },
           },
           {
-            ja: '期限超過 — 支払期限を過ぎた未入金の件数。',
-            en: 'Overdue — count of unpaid invoices past their due date.',
+            term: { ja: '期限超過', en: 'Overdue' },
+            desc: {
+              ja: '支払期限を過ぎた未入金の件数。',
+              en: 'Count of unpaid invoices past their due date.',
+            },
           },
           {
-            ja: '当月入金額 — 今月記録された入金の合計（前月比つき）。',
-            en: 'Received this month — total payments recorded this month (with month-over-month change).',
+            term: { ja: '当月入金額', en: 'Received this month' },
+            desc: {
+              ja: '今月記録された入金の合計（前月比つき）。',
+              en: 'Total payments recorded this month (with month-over-month change).',
+            },
           },
           {
-            ja: '残高合計（売掛） — 未入金の合計。',
-            en: 'Outstanding (receivable) — total unpaid.',
+            term: { ja: '残高合計（売掛）', en: 'Outstanding (receivable)' },
+            desc: { ja: '未入金の合計。', en: 'Total unpaid.' },
           },
           {
-            ja: '当月請求発行額・着地見込み — 今月の発行額と、今のペースでの月末着地予測。前月比・前年同月比も表示。',
-            en: 'Billed this month / projected landing — what you’ve issued this month and the projected month-end total at the current pace, with prior-month and year-over-year comparisons.',
+            term: { ja: '当月請求発行額・着地見込み', en: 'Billed this month / projected landing' },
+            desc: {
+              ja: '今月の発行額と、今のペースでの月末着地予測。前月比・前年同月比も表示。',
+              en: 'This month’s issuance and the projected month-end total at the current pace, with prior-month and year-over-year comparisons.',
+            },
           },
           {
-            ja: '月別推移／日別の積み上がり — 発行額の推移と、当月の積み上がり。',
-            en: 'Monthly trend / daily cumulative — issuance over time and this month’s running total.',
+            term: { ja: '月別推移／日別の積み上がり', en: 'Monthly trend / daily cumulative' },
+            desc: {
+              ja: '発行額の推移と、当月の積み上がり。',
+              en: 'Issuance over time and this month’s running total.',
+            },
           },
           {
-            ja: '売掛エイジング — 売掛を滞留期間で分類。',
-            en: 'AR aging — receivables grouped by how overdue they are.',
+            term: { ja: '売掛エイジング', en: 'AR aging' },
+            desc: {
+              ja: '売掛を滞留期間で分類（未到来／1〜30日／31日以上）。',
+              en: 'Receivables grouped by how overdue they are (not due / 1–30 days / 31+ days).',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 's9',
+    title: { ja: '検索・絞り込み・並べ替え・CSV', en: 'Search, filter, sort, CSV' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '各一覧の上部に**フィルタバー**があります。条件を入れて「絞り込む」、「リセット」で解除。「表示中 N 件」で該当件数を確認できます。',
+          en: 'Each list has a **filter bar** at the top. Enter conditions and press “Apply,” or “Reset” to clear. “Showing N results” tells you how many match.',
+        },
+      },
+      {
+        kind: 'lede',
+        text: {
+          ja: '列の見出しをクリックすると**並べ替え**できます。請求・入金・監査ログは **CSV エクスポート**に対応しており、会計ソフトへの取込や控えに使えます。',
+          en: 'Click a column header to **sort**. Invoices, payments, and the audit log support **CSV export** for importing into accounting software or keeping records.',
+        },
+      },
+    ],
+  },
+  {
+    id: 's10',
+    title: { ja: '監査ログ', en: 'Audit log' },
+    admin: true,
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '監査ログは、発行・入金記録・取引先更新などの**操作履歴**を記録します。対象・操作・期間で絞り込み、行を開くと**変更前後の差分**を確認できます。',
+          en: 'The audit log records **actions** such as issuing, recording payments, and updating clients. Filter by entity, action, and date range; open a row to see the **before/after diff**.',
+        },
+      },
+    ],
+  },
+  {
+    id: 's11',
+    title: { ja: '便利な使い方', en: 'Handy tips' },
+    blocks: [
+      {
+        kind: 'keys',
+        groups: [
+          {
+            heading: { ja: '画面移動（g に続けてキー）', en: 'Navigate (g then a key)' },
+            rows: [
+              { label: { ja: 'ダッシュボード', en: 'Dashboard' }, caps: ['g', 'd'] },
+              { label: { ja: '見積', en: 'Quotes' }, caps: ['g', 'q'] },
+              { label: { ja: '請求', en: 'Invoices' }, caps: ['g', 'i'] },
+              { label: { ja: '取引先', en: 'Clients' }, caps: ['g', 'c'] },
+              { label: { ja: 'ユーザー', en: 'Users' }, caps: ['g', 'u'] },
+              { label: { ja: '設定', en: 'Settings' }, caps: ['g', 's'] },
+              { label: { ja: '監査ログ', en: 'Audit log' }, caps: ['g', 'a'] },
+              { label: { ja: 'ショートカット一覧', en: 'Shortcut list' }, caps: ['?'] },
+            ],
+          },
+          {
+            heading: { ja: '一覧・編集での操作', en: 'In lists and forms' },
+            rows: [
+              { label: { ja: '行を移動', en: 'Move rows' }, caps: ['j', 'k'] },
+              { label: { ja: '開く', en: 'Open' }, caps: ['Enter'] },
+              { label: { ja: '新規作成', en: 'New' }, caps: ['n'] },
+              { label: { ja: '検索', en: 'Search' }, caps: ['/'] },
+              { label: { ja: '送信', en: 'Submit' }, caps: ['⌘/Ctrl', 'Enter'] },
+              { label: { ja: '閉じる', en: 'Close' }, caps: ['Esc'] },
+            ],
           },
         ],
       },
       {
         kind: 'note',
+        title: { ja: '言語切替', en: 'Language' },
         text: {
-          ja: 'これらは記録された請求・入金から自動計算されます。入金を記録する運用が回っているほど、数値は実態に近づきます。',
-          en: 'These are computed automatically from recorded invoices and payments. The more consistently payments are recorded, the closer the numbers reflect reality.',
+          ja: '画面の言語切替（日本語 / English）で、いつでも表示言語を変えられます。',
+          en: 'Use the language switch (日本語 / English) to change the display language at any time.',
         },
       },
     ],
   },
   {
-    id: 'lists',
-    title: { ja: '検索・絞り込み・並べ替え・CSV', en: 'Search, filter, sort, CSV' },
+    id: 's12',
+    title: { ja: 'よくある質問', en: 'FAQ' },
     blocks: [
       {
-        kind: 'p',
-        text: {
-          ja: '各一覧の上部にフィルタバーがあります。条件を入れて「絞り込む」、「リセット」で解除。「表示中 N 件」で該当件数を確認できます。',
-          en: 'Each list has a filter bar at the top. Enter conditions and press “Apply,” or “Reset” to clear. “Showing N results” tells you how many match.',
-        },
-      },
-      {
-        kind: 'p',
-        text: {
-          ja: '列の見出しをクリックすると並べ替えできます。請求・入金・監査ログは CSV エクスポートに対応しており、会計ソフトへの取込や控えに使えます。',
-          en: 'Click a column header to sort. Invoices, payments, and the audit log can be exported as CSV for importing into accounting software or keeping records.',
-        },
-      },
-    ],
-  },
-  {
-    id: 'audit',
-    title: { ja: '監査ログ（管理者専用）', en: 'Audit log (admins only)' },
-    blocks: [
-      {
-        kind: 'p',
-        text: {
-          ja: '監査ログは、発行・入金記録・取引先更新などの操作履歴を記録します。対象・操作・期間で絞り込み、行を開くと変更前後の差分を確認できます。',
-          en: 'The audit log records actions such as issuing, recording payments, and updating clients. Filter by entity, action, and date range; open a row to see the before/after diff.',
-        },
-      },
-    ],
-  },
-  {
-    id: 'tips',
-    title: { ja: '便利な使い方', en: 'Handy tips' },
-    blocks: [
-      {
-        kind: 'p',
-        text: {
-          ja: 'キーボードショートカット: g に続けて d（ダッシュボード）/ q（見積）/ i（請求）/ c（取引先）/ u（ユーザー）/ s（設定）/ a（監査ログ）で画面移動。一覧では j・k で行移動、Enter で開く。n で新規作成、/ で検索、⌘（Windows は Ctrl）+ Enter で送信、Esc で閉じる。? でいつでも一覧を表示できます。',
-          en: 'Keyboard shortcuts: press g then d (Dashboard) / q (Quotes) / i (Invoices) / c (Clients) / u (Users) / s (Settings) / a (Audit log) to navigate. In lists, j・k move rows and Enter opens. n creates new, / focuses search, ⌘ (Ctrl on Windows) + Enter submits, Esc closes. Press ? anytime for the full list.',
-        },
-      },
-      {
-        kind: 'p',
-        text: {
-          ja: '言語切替: 画面の言語切替（日本語 / English）で、いつでも表示言語を変えられます。',
-          en: 'Language: use the language switch (日本語 / English) to change the display language at any time.',
-        },
+        kind: 'faq',
+        items: [
+          {
+            q: {
+              ja: '請求書を発行した後に内容は直せますか？',
+              en: 'Can I edit an invoice after issuing it?',
+            },
+            a: {
+              ja: 'いいえ。発行で請求番号が採番され、内容が確定します（適格請求書として確定するため）。修正が必要な場合は、**下書きのうちに内容を確認**してから発行してください。',
+              en: 'No. Issuing assigns the invoice number and finalizes the contents (it becomes a finalized qualified invoice). If you need changes, **review everything while it is still a draft**, then issue.',
+            },
+          },
+          {
+            q: {
+              ja: '「発行できませんでした。登録番号をご確認ください」と出ます',
+              en: 'I get “Could not issue — please check the registration number.”',
+            },
+            a: {
+              ja: '会社設定の「登録番号（インボイス）」が未登録です。設定 →「基本情報」で `T＋13桁` の登録番号を保存してから、もう一度発行してください。',
+              en: 'The “registration number (invoice)” in company Settings is missing. Go to Settings → Basic info, save the `T + 13-digit` number, then issue again.',
+            },
+          },
+          {
+            q: {
+              ja: '適格請求書（インボイス）とは？登録番号はどこに入れますか？',
+              en: 'What is a qualified invoice, and where do I enter the registration number?',
+            },
+            a: {
+              ja: '登録番号や税率区分を記載した、仕入税額控除に使える請求書です。会社設定に登録番号を入れておけば、**発行時に自動で請求書へ記載**されます。',
+              en: 'It’s an invoice listing the registration number and tax-rate breakdown, usable for input-tax credit. Once set in company Settings, it is **printed on the invoice automatically when you issue**.',
+            },
+          },
+          {
+            q: {
+              ja: '入金が銀行と自動で同期されません',
+              en: 'Payments don’t sync with my bank automatically.',
+            },
+            a: {
+              ja: '仕様です。入金は請求書の詳細画面から**手動で記録**します。記録すると、未払い・売掛・当月入金額などに反映されます。',
+              en: 'That’s by design. Record payments **manually** from the invoice detail screen. Once recorded, they flow into unpaid / receivable / received-this-month figures.',
+            },
+          },
+          {
+            q: {
+              ja: '見積から請求への変換で何が引き継がれますか？',
+              en: 'What carries over when I convert a quote to an invoice?',
+            },
+            a: {
+              ja: '取引先・明細（品目・数量・単価・税率）・金額を引き継いで、請求書の下書きを作成します。発行は別途「発行する」で行います。',
+              en: 'The client, line items (item, quantity, unit price, tax rate), and amounts carry over into an invoice draft. Issuing is a separate step via “Issue.”',
+            },
+          },
+          {
+            q: {
+              ja: 'パスワードを忘れた／ユーザーを追加したい',
+              en: 'I forgot my password / want to add a user.',
+            },
+            a: {
+              ja: '管理者がユーザー一覧から対象を編集し、新しいパスワードを設定できます。新規ユーザーは「**ユーザーを作成**」から追加します。',
+              en: 'An admin can edit the user from the Users list and set a new password. Add new users via **“Create user.”**',
+            },
+          },
+          {
+            q: { ja: 'データはどこに保存されますか？', en: 'Where is my data stored?' },
+            a: {
+              ja: '自己ホスト型なので、**あなたの環境のデータベース**に保存されます。請求ロジックが外部サービスへデータを送信することはありません。',
+              en: 'It’s self-hosted, so your data is stored in **your own database**. The billing logic never sends data to an external service.',
+            },
+          },
+        ],
       },
     ],
   },
@@ -418,96 +637,26 @@ export const HELP_SECTIONS: HelpSection[] = [
     title: { ja: '免責事項・ご利用にあたって', en: 'Disclaimer & terms of use' },
     blocks: [
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
           ja: '本ソフトウェア（NeNe Invoice）は、見積・請求・入金管理の作成を補助するツールであり、税務・会計・法務に関する助言を提供するものではありません。作成された請求書・帳票の内容、税率・税区分・登録番号の正確性、適格請求書としての要件充足、税務申告および帳簿・書類の保存（電子帳簿保存法等）については、最終的にご利用者ご自身および顧問税理士の責任でご確認ください。',
-          en: 'This software (NeNe Invoice) is a tool that helps you prepare quotes, invoices, and payment records. It does not provide tax, accounting, or legal advice. The contents of the invoices and documents it produces, the accuracy of tax rates / categories / registration numbers, whether they meet qualified-invoice requirements, and tax filing and record retention (including under the Electronic Books Preservation Act) are ultimately your responsibility and that of your tax accountant.',
+          en: 'This software (NeNe Invoice) is a tool that helps you prepare quotes, invoices, and payment records. It does not provide tax, accounting, or legal advice. The contents of the documents it produces, the accuracy of tax rates / categories / registration numbers, whether they meet qualified-invoice requirements, and tax filing and record retention (including under the Electronic Books Preservation Act) are ultimately your responsibility and that of your tax accountant.',
         },
       },
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
           ja: '本ソフトウェアは MIT ライセンスに基づき「現状有姿（AS IS）」で提供され、明示・黙示を問わずいかなる保証も行いません。本ソフトウェアの使用または使用不能から生じたいかなる損害についても、作者および権利者は責任を負いません。',
           en: 'This software is provided “AS IS” under the MIT License, without warranty of any kind, express or implied. The authors and copyright holders are not liable for any damages arising from the use of, or inability to use, this software.',
         },
       },
       {
-        kind: 'p',
+        kind: 'lede',
         text: {
           ja: '自己ホスト型のため、データのバックアップ・保管・セキュリティおよび法定保存期間の遵守は、運用される事業者の責任となります。また、法令・制度の改正への追随を保証するものではありません。',
           en: 'Because it is self-hosted, backing up, storing, and securing your data, and complying with statutory retention periods, are the responsibility of the operating business. Nor does it guarantee that it stays up to date with changes in laws or regulations.',
         },
       },
     ],
-  },
-]
-
-export const HELP_FAQ: HelpFaqItem[] = [
-  {
-    q: {
-      ja: '請求書を発行した後に内容は直せますか？',
-      en: 'Can I edit an invoice after issuing it?',
-    },
-    a: {
-      ja: 'いいえ。発行で請求番号が採番され、内容が確定します（適格請求書として確定するため）。修正が必要な場合は、下書きのうちに内容を確認してから発行してください。',
-      en: 'No. Issuing assigns the invoice number and finalizes the contents (it becomes a finalized qualified invoice). If you need changes, review everything while it is still a draft, then issue.',
-    },
-  },
-  {
-    q: {
-      ja: '「発行できませんでした。登録番号をご確認ください」と出ます',
-      en: 'I get “Could not issue — please check the registration number.”',
-    },
-    a: {
-      ja: '会社設定の「登録番号（インボイス）」が未登録です。設定 →「基本情報」で T＋13桁の登録番号を保存してから、もう一度発行してください。',
-      en: 'The “registration number (invoice)” in company Settings is missing. Go to Settings → Basic info, save the T + 13-digit number, then issue again.',
-    },
-  },
-  {
-    q: {
-      ja: '適格請求書（インボイス）とは？登録番号はどこに入れますか？',
-      en: 'What is a qualified invoice, and where do I enter the registration number?',
-    },
-    a: {
-      ja: '登録番号や税率区分を記載した、仕入税額控除に使える請求書です。会社設定に登録番号を入れておけば、発行時に自動で請求書へ記載されます。',
-      en: 'It’s an invoice listing the registration number and tax-rate breakdown, usable for input-tax credit. Once the registration number is set in company Settings, it is printed on the invoice automatically when you issue.',
-    },
-  },
-  {
-    q: {
-      ja: '入金が銀行と自動で同期されません',
-      en: 'Payments don’t sync with my bank automatically.',
-    },
-    a: {
-      ja: '仕様です。入金は請求書の詳細画面から手動で記録します。記録すると、未払い・売掛・当月入金額などに反映されます。',
-      en: 'That’s by design. Record payments manually from the invoice detail screen. Once recorded, they flow into unpaid / receivable / received-this-month figures.',
-    },
-  },
-  {
-    q: {
-      ja: '見積から請求への変換で何が引き継がれますか？',
-      en: 'What carries over when I convert a quote to an invoice?',
-    },
-    a: {
-      ja: '取引先・明細（品目・数量・単価・税率）・金額を引き継いで、請求書の下書きを作成します。発行は別途「発行する」で行います。',
-      en: 'The client, line items (item, quantity, unit price, tax rate), and amounts carry over into an invoice draft. Issuing is a separate step via “Issue.”',
-    },
-  },
-  {
-    q: {
-      ja: 'パスワードを忘れた／ユーザーを追加したい',
-      en: 'I forgot my password / want to add a user.',
-    },
-    a: {
-      ja: '管理者がユーザー一覧から対象を編集し、新しいパスワードを設定できます。新規ユーザーは「ユーザーを作成」から追加します。',
-      en: 'An admin can edit the user from the Users list and set a new password. Add new users via “Create user.”',
-    },
-  },
-  {
-    q: { ja: 'データはどこに保存されますか？', en: 'Where is my data stored?' },
-    a: {
-      ja: '自己ホスト型なので、あなたの環境のデータベースに保存されます。請求ロジックが外部サービスへデータを送信することはありません。',
-      en: 'It’s self-hosted, so your data is stored in your own database. The billing logic never sends data to an external service.',
-    },
   },
 ]

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -708,125 +708,585 @@
     background: var(--color-surface-overlay);
   }
 
-  /* ── Help page (#306): long-form guide + table of contents + FAQ ────────── */
-  .help-intro {
-    max-width: 64rem;
+  /* ════════════════════════════════════════════════════════════════════════
+     Help page (design 05, #310). Instruction tokens mapped to our --color-*:
+     --brand→accent, --brand-strong→accent-hover, --brand-soft→accent-soft,
+     --surface-sunk→surface-overlay, --on-brand→fg-inverse. Faint/subtle inks
+     and the softer brand tint are derived with color-mix.
+     ════════════════════════════════════════════════════════════════════════ */
+  .help-page {
+    --h-faint: color-mix(in oklch, var(--color-fg-muted) 55%, var(--color-surface));
+    --h-subtle: color-mix(in oklch, var(--color-fg-muted) 80%, var(--color-surface));
+    --h-brand-softer: color-mix(in oklch, var(--color-accent) 7%, var(--color-surface-raised));
+  }
+
+  /* hero */
+  .help-hero {
+    padding-bottom: 1.375rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .help-hero .eyebrow {
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-accent-hover);
+  }
+  .help-hero h1 {
+    font-size: 1.625rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0.5rem 0;
+    color: var(--color-fg);
+  }
+  .help-hero p {
+    font-size: 0.84375rem;
     color: var(--color-fg-muted);
-    line-height: 1.7;
+    line-height: 1.8;
+    max-width: 45rem;
+    margin: 0;
+  }
+  .help-hero .hero-meta {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1.125rem;
+    flex-wrap: wrap;
+  }
+  .help-hero .hero-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.6875rem;
+    color: var(--color-fg-muted);
+    background: var(--color-surface-overlay);
+    border: 1px solid var(--color-border);
+    padding: 0.25rem 0.6875rem;
+  }
+  .help-hero .hero-chip b {
+    color: var(--color-fg);
+    font-weight: 600;
+  }
+  .help-hero .hero-chip .num {
+    font-family: var(--font-num);
+  }
+
+  /* two-column: ToC rail + article */
+  .help-layout {
+    display: grid;
+    grid-template-columns: 13rem minmax(0, 1fr);
+    gap: 0 2rem;
+    align-items: start;
   }
   .help-toc {
-    padding: 1rem 1.25rem;
+    position: sticky;
+    top: 0.5rem;
+    align-self: start;
+    max-height: calc(100vh - 1rem);
+    overflow: auto;
+    padding: 1.25rem 0;
+    border-right: 1px solid var(--color-border);
   }
-  .help-toc-h {
+  .help-toc .toc-title {
+    font-size: 0.625rem;
     font-weight: 700;
-    margin-bottom: 0.5rem;
-  }
-  .help-toc ol {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    columns: 2;
-    column-gap: 1.5rem;
-  }
-  .help-toc li {
-    padding: 0.1875rem 0;
-    break-inside: avoid;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--h-subtle);
+    padding: 0 0.625rem;
+    margin-bottom: 0.625rem;
   }
   .help-toc a {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5625rem;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
+    color: var(--color-fg-muted);
+    text-decoration: none;
+    border-left: 2px solid transparent;
+    line-height: 1.45;
+  }
+  .help-toc a:hover {
+    color: var(--color-fg);
+    background: var(--h-brand-softer);
+  }
+  .help-toc a.active {
+    color: var(--color-accent-hover);
+    font-weight: 700;
+    border-left-color: var(--color-accent);
+    background: var(--h-brand-softer);
+  }
+  .help-toc a .tn {
+    font-family: var(--font-num);
+    font-size: 0.65625rem;
+    color: var(--h-faint);
+    flex: none;
+    width: 0.875rem;
+  }
+  .help-toc a.active .tn {
     color: var(--color-accent);
   }
-  .help-section {
-    max-width: 64rem;
-    scroll-margin-top: 1rem;
+  .help-toc a.admin-only::after {
+    content: attr(data-admin-label);
+    margin-left: auto;
+    font-size: 0.5625rem;
+    font-weight: 600;
+    color: var(--h-faint);
+    border: 1px solid var(--color-border);
+    padding: 0 0.3125rem;
+    line-height: 1.6;
+    flex: none;
   }
-  .help-h {
-    font-size: 1rem;
+
+  /* article + sections */
+  .help-article {
+    max-width: 55rem;
+    padding: 0.5rem 0 4rem;
+  }
+  .hsec {
+    scroll-margin-top: 0.75rem;
+    padding-top: 1.625rem;
+    margin-top: 1.625rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .hsec:first-of-type {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0.5rem;
+  }
+  .hsec-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 0.375rem;
+  }
+  .hsec-no {
+    font-family: var(--font-num);
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--h-faint);
+    letter-spacing: 0.04em;
+  }
+  .hsec h2 {
+    font-size: 1.1875rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0;
+    color: var(--color-fg);
+  }
+  .hsec h2 .tag-admin {
+    font-size: 0.65625rem;
+    font-weight: 600;
+    color: var(--color-fg-muted);
+    background: var(--color-surface-overlay);
+    border: 1px solid var(--color-border);
+    padding: 0.125rem 0.5rem;
+    margin-left: 0.625rem;
+    vertical-align: middle;
+  }
+  .help-article .lede {
+    font-size: 0.84375rem;
+    color: var(--color-fg-muted);
+    line-height: 1.85;
+    margin: 0.75rem 0 0;
+    max-width: 47.5rem;
+  }
+  .help-article .lede b {
+    color: var(--color-fg);
+    font-weight: 600;
+  }
+  .help-article .sub-h {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--h-subtle);
+    margin: 1.625rem 0 0.75rem;
+  }
+  code.tcode {
+    font-family: var(--font-num);
+    font-size: 0.71875rem;
+    background: var(--color-surface-overlay);
+    border: 1px solid var(--color-border);
+    padding: 1px 0.375rem;
+    color: var(--color-accent-hover);
+    font-weight: 600;
+  }
+
+  /* numbered steps (title + description, connected) */
+  .help-article .steps {
+    list-style: none;
+    counter-reset: step;
+    margin: 1.125rem 0 0;
+    padding: 0;
+  }
+  .help-article .steps > li {
+    counter-increment: step;
+    position: relative;
+    display: grid;
+    grid-template-columns: 1.75rem 1fr;
+    gap: 0.875rem;
+    padding: 0 0 1.125rem;
+  }
+  .help-article .steps > li::before {
+    content: counter(step);
+    grid-row: 1 / span 2;
+    width: 1.625rem;
+    height: 1.625rem;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-num);
+    font-size: 0.78125rem;
+    font-weight: 700;
+    color: var(--color-fg-inverse);
+    background: var(--color-accent);
+  }
+  .help-article .steps > li:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 0.78125rem;
+    top: 1.875rem;
+    bottom: 0.25rem;
+    width: 1px;
+    background: var(--color-border-strong);
+  }
+  .help-article .steps .st-t {
+    font-size: 0.84375rem;
+    font-weight: 600;
+    color: var(--color-fg);
+    line-height: 1.5;
+  }
+  .help-article .steps .st-d {
+    font-size: 0.78125rem;
+    color: var(--color-fg-muted);
+    line-height: 1.7;
+    margin-top: 0.25rem;
+  }
+
+  /* plain numbered procedure */
+  .help-article ol.proc {
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+    counter-reset: p;
+  }
+  .help-article ol.proc > li {
+    counter-increment: p;
+    position: relative;
+    padding: 0 0 0.6875rem 1.875rem;
+    font-size: 0.8125rem;
+    color: var(--color-fg);
+    line-height: 1.7;
+  }
+  .help-article ol.proc > li::before {
+    content: counter(p);
+    position: absolute;
+    left: 0;
+    top: 1px;
+    font-family: var(--font-num);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    color: var(--color-accent-hover);
+    width: 1.1875rem;
+    height: 1.1875rem;
+    display: grid;
+    place-items: center;
+    border: 1px solid color-mix(in oklch, var(--color-accent) 30%, var(--color-border));
+  }
+
+  /* status-flow chips */
+  .flow {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4375rem;
+    margin: 1rem 0 0;
+  }
+  .flow .fchip {
+    font-size: 0.71875rem;
+    font-weight: 600;
+    color: var(--color-fg);
+    background: var(--color-surface-overlay);
+    border: 1px solid var(--color-border-strong);
+    padding: 0.25rem 0.6875rem;
+    white-space: nowrap;
+  }
+  .flow .farrow {
+    color: var(--h-faint);
+    font-weight: 700;
+  }
+  .flow .fbranch {
+    font-size: 0.6875rem;
+    color: var(--color-fg-muted);
+    padding: 0 0.125rem;
+  }
+
+  /* term glossary cards */
+  .terms {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    background: var(--color-border);
+    border: 1px solid var(--color-border);
+    margin-top: 1.125rem;
+  }
+  .terms .term {
+    background: var(--color-surface-raised);
+    padding: 0.875rem 1rem;
+    margin: 0;
+  }
+  .terms .term dt {
+    font-size: 0.8125rem;
     font-weight: 700;
     color: var(--color-fg);
-    padding-bottom: 0.625rem;
-    margin-bottom: 0.875rem;
-    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 0.3125rem;
   }
-  .help-lead {
+  .terms .term dd {
+    font-size: 0.75rem;
     color: var(--color-fg-muted);
     line-height: 1.7;
-    margin-bottom: 0.875rem;
+    margin: 0;
   }
-  .help-p {
-    line-height: 1.8;
-    margin-bottom: 0.75rem;
+  .terms .term dd b {
+    color: var(--color-fg);
+    font-weight: 600;
   }
-  .help-steps,
-  .help-list {
-    margin: 0 0 0.875rem;
-    padding-left: 1.5rem;
-    line-height: 1.8;
-  }
-  .help-steps {
-    list-style: decimal;
-  }
-  .help-list {
-    list-style: disc;
-  }
-  .help-steps li,
-  .help-list li {
-    margin-bottom: 0.375rem;
-    padding-left: 0.25rem;
-  }
-  .help-note {
-    margin: 0 0 0.875rem;
-    padding: 0.6875rem 0.875rem;
+
+  /* callout note */
+  .help-article .note {
+    display: flex;
+    gap: 0.6875rem;
+    align-items: flex-start;
+    padding: 0.8125rem 0.9375rem;
+    margin: 1.125rem 0 0;
+    font-size: 0.78125rem;
+    line-height: 1.72;
+    color: var(--color-fg);
     background: var(--color-accent-soft);
+    border: 1px solid color-mix(in oklch, var(--color-accent) 20%, transparent);
     border-left: 3px solid var(--color-accent);
-    line-height: 1.7;
   }
-  .help-defs {
-    margin: 0;
+  .help-article .note b {
+    font-weight: 700;
   }
-  .help-defs > div {
-    padding: 0.625rem 0;
+  .help-article .note .nt {
+    display: block;
+    font-weight: 700;
+    margin-bottom: 0.125rem;
+  }
+  .help-article .note.warn {
+    background: var(--color-danger-soft);
+    border-color: color-mix(in oklch, var(--color-danger) 28%, transparent);
+    border-left-color: var(--color-danger);
+  }
+  .help-article .note.warn code.tcode {
+    color: var(--color-danger);
+    border-color: color-mix(in oklch, var(--color-danger) 30%, transparent);
+  }
+
+  /* definition rows */
+  .deflist {
+    margin: 1rem 0 0;
+    border-top: 1px solid var(--color-border);
+  }
+  .deflist > .row {
+    display: grid;
+    grid-template-columns: 10.5rem 1fr;
+    gap: 1.125rem;
+    padding: 0.8125rem 0.125rem;
     border-bottom: 1px solid var(--color-border);
   }
-  .help-defs > div:last-child {
-    border-bottom: none;
-  }
-  .help-defs dt {
+  .deflist > .row .dl-t {
+    font-size: 0.78125rem;
     font-weight: 700;
-    margin-bottom: 0.1875rem;
+    color: var(--color-fg);
   }
-  .help-defs dd {
-    margin: 0;
+  .deflist > .row .dl-d {
+    font-size: 0.78125rem;
     color: var(--color-fg-muted);
     line-height: 1.7;
   }
-  .help-faq {
-    margin: 0;
+  .deflist > .row .dl-d b {
+    color: var(--color-fg);
+    font-weight: 600;
   }
-  .help-faq-item {
-    padding: 0.875rem 0;
+
+  /* send-method cards */
+  .opt3 {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+  .opt3 .opt {
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
+    padding: 0.9375rem;
+  }
+  .opt3 .opt .opt-n {
+    font-family: var(--font-num);
+    font-size: 0.6875rem;
+    font-weight: 700;
+    color: var(--color-accent-hover);
+  }
+  .opt3 .opt .opt-t {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: var(--color-fg);
+    margin: 0.4375rem 0 0.3125rem;
+  }
+  .opt3 .opt .opt-d {
+    font-size: 0.71875rem;
+    color: var(--color-fg-muted);
+    line-height: 1.65;
+  }
+
+  /* keyboard grid (reuses .kbd keycap) */
+  .kgrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    background: var(--color-border);
+    border: 1px solid var(--color-border);
+    margin-top: 1rem;
+  }
+  .kgrid .kr {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.875rem;
+    background: var(--color-surface-raised);
+    padding: 0.5625rem 0.875rem;
+  }
+  .kgrid .kr .kl {
+    font-size: 0.78125rem;
+    color: var(--color-fg);
+  }
+  .kgrid .kr .kk {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  /* FAQ accordion */
+  .faq {
+    margin-top: 1.125rem;
+    border-top: 1px solid var(--color-border-strong);
+  }
+  .faq details {
     border-bottom: 1px solid var(--color-border);
   }
-  .help-faq-item:last-child {
-    border-bottom: none;
+  .faq summary {
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.9375rem 0.25rem;
+    font-size: 0.84375rem;
+    font-weight: 600;
+    color: var(--color-fg);
   }
-  .help-faq dt {
+  .faq summary::-webkit-details-marker {
+    display: none;
+  }
+  .faq summary .q {
+    flex: none;
+    font-family: var(--font-num);
+    font-size: 0.8125rem;
     font-weight: 700;
-    margin-bottom: 0.375rem;
+    color: var(--color-accent-hover);
+    width: 1rem;
   }
-  .help-faq dt::before {
-    content: 'Q. ';
-    color: var(--color-accent);
+  .faq summary .qt {
+    flex: 1;
+    line-height: 1.55;
   }
-  .help-faq dd {
-    margin: 0;
+  .faq summary .chev {
+    flex: none;
+    width: 1rem;
+    text-align: center;
+    color: var(--h-faint);
+    transition: transform 0.18s ease;
+  }
+  .faq details[open] summary .chev {
+    transform: rotate(180deg);
+    color: var(--color-accent-hover);
+  }
+  .faq .fa-body {
+    padding: 0 0.25rem 1.125rem 2rem;
+    font-size: 0.78125rem;
     color: var(--color-fg-muted);
-    line-height: 1.8;
+    line-height: 1.85;
   }
-  .help-top {
+  .faq .fa-body b {
+    color: var(--color-fg);
+    font-weight: 600;
+  }
+
+  /* back-to-contents link */
+  .backtop {
     display: inline-block;
-    margin-top: 0.5rem;
-    font-size: var(--text-caption);
+    margin-top: 1.25rem;
+    font-size: 0.71875rem;
+    font-weight: 600;
     color: var(--color-fg-muted);
+    text-decoration: none;
+  }
+  .backtop:hover {
+    color: var(--color-accent-hover);
+  }
+
+  /* still-need-help footer */
+  .help-foot {
+    margin-top: 2.5rem;
+    padding: 1.375rem 1.5rem;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .help-foot .hf-t {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--color-fg);
+  }
+  .help-foot .hf-d {
+    font-size: 0.75rem;
+    color: var(--color-fg-muted);
+    margin-top: 0.1875rem;
+  }
+  .help-foot .btn-primary-link {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.78125rem;
+    font-weight: 600;
+    color: var(--color-fg-inverse);
+    background: var(--color-accent);
+    text-decoration: none;
+  }
+  .help-foot .btn-primary-link:hover {
+    background: var(--color-accent-hover);
+  }
+
+  @media (max-width: 900px) {
+    .help-layout {
+      grid-template-columns: 1fr;
+    }
+    .help-toc {
+      display: none;
+    }
+    .terms,
+    .opt3,
+    .kgrid {
+      grid-template-columns: 1fr;
+    }
   }
 
   /* Receivable-aging progress bar */


### PR DESCRIPTION
Closes #310

## 概要
Claude Design のヘルプ指示書（design 05、`NeNe Invoice ヘルプ.html`）に合わせて `HelpPage` を刷新。
内容（章立て・文章）は #306/#308 から維持しつつ、**構造・見た目を全面更新**（**日本語＋English**）。

## 主な変更
- **ヒーロー見出し**（eyebrow＋大見出し＋説明＋メタチップ：適格請求書対応／自己ホスト／最終更新）
- **2カラム＋スクロール追従の番号付き目次**（現在地ハイライト＝scroll-spy、監査ログに「管理者」バッジ）
- 章ごとに番号＋区切り線、リッチ部品（**steps / proc / 状態フロー / 用語カード / note(info·warn) /
  deflist / 送付3カード / キーボードグリッド（`.kbd` 流用）/ FAQ アコーディオン / フッター / 目次へ戻る**）
- `help-content.ts` を新ブロックモデル（ja/en）に再構成。`**bold**`・`` `code` `` の軽量インライン記法
  （code は bold 内ネスト可）。
- 指示書の design system（`--brand` 等）を当アプリの `--color-*` にマッピングして `.help-*` CSS を刷新。
- 免責は**13章**として維持（`/help#disclaimer` 導線も継続）。サポートは**会社設定メールへの mailto**
  （未設定ならボタン非表示）。
- 全幅ブリードは `.app-content` の padding がブレークポイントで変わるため、インセット（コンテナ内）で実装。

## 確認
- [x] `npm run lint` / `prettier --check` / `npm run knip`（unused なし）/ `npm run build` / `npm run test`（167 pass）
- [x] `tsc -p tsconfig.app.json` で help 配下に新規型エラーなし
- [x] Playwright で ja/en を目視 — ヒーロー・番号ToC・各リッチ部品・FAQアコーディオン・mailtoフッターが正常描画
- [x] **scroll-spy** が章スクロールに追従（最上部で先頭章を active）
- [x] `` `code` `` の bold 内ネスト（例「登録番号（`T＋13桁`）」）が正しくチップ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)