### PR TITLE
design(frontend): サイドバー・トップバーをスクロール追従しない固定に (#312)

### DIFF
--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -780,9 +780,10 @@
   }
   .help-toc {
     position: sticky;
-    top: 0.5rem;
+    /* sits below the sticky 56px topbar (#312) */
+    top: 4rem;
     align-self: start;
-    max-height: calc(100vh - 1rem);
+    max-height: calc(100vh - 4.5rem);
     overflow: auto;
     padding: 1.25rem 0;
     border-right: 1px solid var(--color-border);
@@ -845,7 +846,8 @@
     padding: 0.5rem 0 4rem;
   }
   .hsec {
-    scroll-margin-top: 0.75rem;
+    /* clears the sticky topbar when jumping to an anchor (#312) */
+    scroll-margin-top: 4.5rem;
     padding-top: 1.625rem;
     margin-top: 1.625rem;
     border-top: 1px solid var(--color-border);
@@ -2016,7 +2018,21 @@
   .app-main {
     min-width: 0;
   }
+  /* Desktop: pin the sidebar to the viewport so it stays put while the content
+     scrolls. align-self:start keeps it from stretching so sticky has room to
+     move; the inner nav scrolls if it overflows. The mobile @media further
+     below overrides this to an off-canvas drawer. (#312) */
+  .side {
+    position: sticky;
+    top: 0;
+    align-self: start;
+    height: 100vh;
+  }
+  /* Pin the topbar too, so the breadcrumb stays visible while scrolling. */
   .topbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
     padding: 0 var(--spacing-inline-lg);
     height: 56px;
   }


### PR DESCRIPTION
Closes #313

## 背景
サイドバーがページと一緒にスクロールして見えなくなる、という指摘。指示書 design 06
（HTML・CSS とも design 05 と完全同一で、inline style に**固定サイドバー仕様**を含む）に合わせて修正。

現状の `.side` にはデスクトップ用ルールが無く、グリッド列として本文と一緒にスクロールしていた。

> 注: 手順ミスで先に Issue を作らずブランチ名/PR を #312 にしてしまったため、Issue は #313。
> ブランチ名 `design/312-fixed-sidebar` と番号が前後しているが内容は同一。

## 変更
- **`.side`（デスクトップ）**: `position: sticky; top: 0; height: 100vh; align-self: start`。
  内側 nav は既存の `overflow-y-auto` でオーバーフロー時のみスクロール。
  モバイルの off-canvas ドロワー（`@media` で `position: absolute`）は不変。
- **`.topbar`**: `position: sticky; top: 0; z-index: 30` でパンくずを固定。
- 追従が効くよう、ヘルプ目次 `.help-toc` の `top` を 0.5rem→4rem、`.hsec` の
  `scroll-margin-top` を 0.75rem→4.5rem（固定56pxトップバー分のオフセット）。

副次効果: サイドバーフッター（言語切替・ログアウト・免責リンク）が常時到達可能に。

## 確認
- [x] `npm run lint` / `prettier --check` / `npm run knip` / `npm run build` / `npm run test`（167 pass）
- [x] `npx playwright test`（**55 e2e pass** — グローバル変更のため全件実行）
- [x] Playwright で目視 — ヘルプ／ダッシュボードをスクロールしてもサイドバー全体（フッター含む）とトップバーが固定。本文のみスクロール。ヘルプ目次もトップバー下に追従し scroll-spy 更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)