### PR TITLE
feat(frontend): DatePicker をキーボード直接入力対応に (#317)

### DIFF
--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -6,6 +6,7 @@ export const enMessages: MessageCatalog = {
   'common.actions.retry': 'Retry',
   'common.actions.close': 'Close',
   'common.datePicker.placeholder': 'Select date',
+  'common.datePicker.open': 'Open calendar',
   'common.datePicker.title': '{{month}}/{{year}}',
   'common.datePicker.prevMonth': 'Previous month',
   'common.datePicker.nextMonth': 'Next month',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -7,6 +7,7 @@ export const jaMessages = {
   'common.actions.retry': '再試行',
   'common.actions.close': '閉じる',
   'common.datePicker.placeholder': '日付を選択',
+  'common.datePicker.open': 'カレンダーを開く',
   'common.datePicker.title': '{{year}}年 {{month}}月',
   'common.datePicker.prevMonth': '前の月',
   'common.datePicker.nextMonth': '次の月',

--- a/frontend/src/shared/ui/components/DatePicker.test.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.test.tsx
@@ -4,12 +4,12 @@ import { renderWithProviders } from '@tests/render/render-with-providers'
 import { DatePicker } from './DatePicker'
 
 describe('DatePicker', () => {
-  it('shows the formatted value and opens the calendar on click', () => {
+  it('shows the value as editable text and opens the calendar via the icon', () => {
     const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
-    expect(container.querySelector('.dp-val')?.textContent).toBe('2026 / 06 / 15')
+    expect((container.querySelector('.dp-input') as HTMLInputElement).value).toBe('2026/06/15')
     expect(container.querySelector('.dp.open')).toBeNull()
 
-    fireEvent.click(container.querySelector('.dp-field') as HTMLElement)
+    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
     expect(container.querySelector('.dp.open')).not.toBeNull()
   })
 
@@ -17,7 +17,7 @@ describe('DatePicker', () => {
     const onChange = vi.fn()
     const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
 
-    fireEvent.click(container.querySelector('.dp-field') as HTMLElement)
+    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
     const day20 = [...container.querySelectorAll('.dp-day:not(.out)')].find(
       (d) => d.textContent === '20',
     )
@@ -32,9 +32,43 @@ describe('DatePicker', () => {
       <DatePicker value="2026-06-15" onChange={onChange} />,
     )
 
-    fireEvent.click(container.querySelector('.dp-field') as HTMLElement)
+    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
     fireEvent.click(getByText('Clear'))
 
     expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('commits a typed date on blur (accepts - or / separators, 1–2 digits)', () => {
+    const onChange = vi.fn()
+    const { container } = renderWithProviders(<DatePicker value="" onChange={onChange} />)
+    const input = container.querySelector('.dp-input') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '2026/7/3' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith('2026-07-03')
+  })
+
+  it('commits a typed date on Enter without submitting the form', () => {
+    const onChange = vi.fn()
+    const { container } = renderWithProviders(<DatePicker value="" onChange={onChange} />)
+    const input = container.querySelector('.dp-input') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '2026-12-31' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith('2026-12-31')
+  })
+
+  it('reverts an invalid typed date on blur without emitting', () => {
+    const onChange = vi.fn()
+    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
+    const input = container.querySelector('.dp-input') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '2026/02/30' } }) // not a real date
+    fireEvent.blur(input)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('2026/06/15')
   })
 })

--- a/frontend/src/shared/ui/components/DatePicker.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.tsx
@@ -5,8 +5,10 @@ import { cn } from '@/shared/lib/cn'
 /**
  * Custom date picker (design 04) — replaces the native OS date control with a
  * themed calendar popover. Controlled: `value` is a `YYYY-MM-DD` string (or '');
- * `onChange` emits the same. Closes on outside click / Esc; flips up/right near
- * the viewport edge.
+ * `onChange` emits the same. The field accepts **direct keyboard input** (#317):
+ * type a date (`2026-06-06`, `2026/6/6`, …) and commit on Enter/blur; the
+ * calendar icon opens the popover for mouse users. Closes on outside click / Esc;
+ * flips up/right near the viewport edge.
  */
 export interface DatePickerProps {
   id?: string
@@ -19,8 +21,8 @@ export interface DatePickerProps {
 const pad = (n: number): string => (n < 10 ? `0${String(n)}` : String(n))
 const isoOf = (d: Date): string =>
   `${String(d.getFullYear())}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-const fmt = (d: Date): string =>
-  `${String(d.getFullYear())} / ${pad(d.getMonth() + 1)} / ${pad(d.getDate())}`
+/** Editable display: `YYYY/MM/DD` (or '' when unset). */
+const display = (iso: string): string => iso.replaceAll('-', '/')
 const parseIso = (s: string): Date | null => {
   const p = s.split('-')
   if (p.length !== 3) return null
@@ -28,6 +30,23 @@ const parseIso = (s: string): Date | null => {
   return Number.isNaN(d.getTime()) ? null : d
 }
 const midnight = (d: Date): number => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+
+/**
+ * Parses typed input into an ISO date. Accepts `-`, `/`, or `.` separators and
+ * 1–2 digit month/day. Returns the `YYYY-MM-DD` string, `''` for empty input
+ * (clears), or `null` when the text is not a valid date.
+ */
+const parseInput = (s: string): string | null => {
+  const t = s.trim()
+  if (t === '') return ''
+  const m = /^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$/.exec(t)
+  if (m === null) return null
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])]
+  const dt = new Date(y, mo - 1, d)
+  // Reject overflow like 2026/02/30 (which JS would roll over to March).
+  if (dt.getFullYear() !== y || dt.getMonth() !== mo - 1 || dt.getDate() !== d) return null
+  return isoOf(dt)
+}
 
 export function DatePicker({
   id,
@@ -42,8 +61,30 @@ export function DatePicker({
   const [open, setOpen] = useState(false)
   const [view, setView] = useState(() => selected ?? new Date())
   const [flip, setFlip] = useState({ up: false, right: false })
+  // Editable text mirrors `value`; kept local while typing, normalized on commit.
+  const [text, setText] = useState(() => display(value))
+  // Re-sync the field when the committed value changes (calendar pick, form
+  // reset, parent update) — the React "adjust state during render" pattern, so
+  // it never fires mid-typing (we commit only on Enter/blur).
+  const [lastValue, setLastValue] = useState(value)
+  if (value !== lastValue) {
+    setLastValue(value)
+    setText(display(value))
+  }
   const wrapRef = useRef<HTMLDivElement>(null)
   const popRef = useRef<HTMLDivElement>(null)
+
+  /** Commits the typed text on blur/Enter: set, clear, or revert if invalid. */
+  const commitText = (): void => {
+    const parsed = parseInput(text)
+    if (parsed === null) {
+      setText(display(value)) // invalid → revert to last committed
+    } else if (parsed !== value) {
+      onChange(parsed) // valid change (set or clear) — effect normalizes text
+    } else {
+      setText(display(value)) // unchanged → tidy formatting
+    }
+  }
 
   const dow =
     locale === 'ja'
@@ -105,32 +146,54 @@ export function DatePicker({
 
   return (
     <div ref={wrapRef} className={cn('dp', open && 'open')}>
-      <button
-        type="button"
-        id={id}
-        className="dp-field input"
-        aria-describedby={ariaDescribedBy}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        onClick={() => {
-          if (open) setOpen(false)
-          else openPicker()
-        }}
-      >
-        <span className={cn('dp-val', selected === null && 'is-ph')}>
-          {selected !== null ? fmt(selected) : (placeholder ?? t('common.datePicker.placeholder'))}
-        </span>
-        <svg
-          className="dp-ico"
-          viewBox="0 0 18 18"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
+      <div className="dp-field">
+        <input
+          type="text"
+          id={id}
+          className="dp-input"
+          value={text}
+          placeholder={placeholder ?? t('common.datePicker.placeholder')}
+          inputMode="numeric"
+          autoComplete="off"
+          aria-describedby={ariaDescribedBy}
+          onChange={(e) => {
+            setText(e.target.value)
+          }}
+          onBlur={commitText}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              // Don't submit the surrounding form; just commit the date.
+              e.preventDefault()
+              commitText()
+            } else if (e.key === 'ArrowDown' && !open) {
+              e.preventDefault()
+              openPicker()
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="dp-ico-btn"
+          aria-label={t('common.datePicker.open')}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          onClick={() => {
+            if (open) setOpen(false)
+            else openPicker()
+          }}
         >
-          <rect x="2.5" y="3.8" width="13" height="11.7" rx="1.6" />
-          <path d="M2.5 7.2h13M6 2.2v3M12 2.2v3" />
-        </svg>
-      </button>
+          <svg
+            className="dp-ico"
+            viewBox="0 0 18 18"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <rect x="2.5" y="3.8" width="13" height="11.7" rx="1.6" />
+            <path d="M2.5 7.2h13M6 2.2v3M12 2.2v3" />
+          </svg>
+        </button>
+      </div>
 
       <div
         ref={popRef}

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -227,39 +227,59 @@
   .dp-field {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 8px;
     width: 100%;
     padding: 0.25rem 0.5rem;
-    text-align: left;
     line-height: 1.2;
-    cursor: pointer;
     color: var(--color-fg);
     background: var(--color-surface-raised);
     border: 1px solid var(--color-border);
     font-size: var(--text-body);
   }
-  .dp-field .dp-val {
+  /* Editable text field (#317): borderless, fills the box; the box owns the
+     border and focus ring via :focus-within. */
+  .dp-input {
+    flex: 1;
+    min-width: 0;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    color: inherit;
+    font-size: inherit;
     font-family: var(--font-num);
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.01em;
+    outline: none;
   }
-  .dp-field .dp-val.is-ph {
+  .dp-input::placeholder {
     color: var(--color-fg-muted);
     font-family: var(--font-sans);
     letter-spacing: 0;
   }
-  .dp-field .dp-ico {
-    width: 16px;
-    height: 16px;
+  .dp-ico-btn {
     flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
     color: var(--color-fg-muted);
   }
+  .dp-ico {
+    width: 16px;
+    height: 16px;
+    display: block;
+  }
+  .dp-field:focus-within,
   .dp.open .dp-field {
     border-color: var(--color-accent);
     box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-accent) 28%, transparent);
   }
-  .dp.open .dp-field .dp-ico {
+  .dp-field:focus-within .dp-ico-btn,
+  .dp.open .dp-ico-btn {
     color: var(--color-accent);
   }
   .dp-pop {


### PR DESCRIPTION
Closes #317

## 背景
カスタム DatePicker は `.dp-field` が `<button>` 起点のポップオーバーで、**テキスト直接入力ができなかった**。
マウス必須はキーボード派にストレス。全日付欄（見積/請求の各日付・入金日・監査ログ期間）に効く。

## 変更
- トリガを `<button>` → **`<input type="text">`＋カレンダー切替アイコン**に。
  - `2026-06-06` / `2026/6/6` / `2026.6.6`（1〜2桁の月日可）をパース → **Enter / blur で確定**。
  - 内部 `value`/`onChange` 契約（`YYYY-MM-DD`）は維持。**無効入力は元の値へリバート**。
    `2026/02/30` のようなロールオーバーも弾く。
  - **Enter はフォーム送信を抑止**して日付のみ確定。`ArrowDown` でカレンダーを開く。
- マウス派向けに**ポップオーバー（アイコンで開く）は維持**。日選択/今日/クリアは従来どおり。
- フォーカスリングを `:focus-within` に。表示は `YYYY/MM/DD`（編集しやすい形）・等幅で他入力と整合。
- 設計04の角丸カスタム datepicker を踏襲（ネイティブ `<input type=date>` には替えない）。
- prop 同期は effect でなく「レンダー時調整」パターン（`react-hooks/set-state-in-effect` 回避）。
- i18n に `common.datePicker.open`（カレンダーを開く / Open calendar）追加。

## 確認
- [x] `npm run lint` / `prettier --check` / `npm run knip` / `npm run build`
- [x] `npm run test`（**170 pass** — DatePicker 単体テストを直接入力/Enter/無効リバート分まで拡充）
- [x] e2e（一時）: 監査ログの開始日に `2026/6/3` を直接入力 → `2026/06/03` に正規化 → 絞り込みで
  `created_from=2026-06-03` がクエリに到達することを確認。
- [x] 実画面スクショで入力欄＋アイコンの見た目が他入力と整合

> #317（DatePicker）は、先に立てた #314/#315/#316 と合わせた一連の入力効率化のうち「やりやすいもの」から着手した最初の1本です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)