### PR TITLE
feat(line-item): 見積/請求の品目を履歴ベースでサジェスト (#315)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -97,6 +97,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
+| Line-item suggestion read model | `items` → `description`, `unit_price_cents`, `tax_rate_bps`, `usage_count` | `count`, `times_used`, `frequency`, `default_price_cents` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
 the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are
@@ -159,6 +160,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listQuotes`, `getQuoteById`, `createQuote`, `changeQuoteStatus`, `getQuotePdf`, `convertQuoteToInvoice` | Quote |
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice`, `getInvoicePdf`, `generateDownloadToken`, `downloadInvoicePdf`, `sendInvoiceEmail` | Invoice |
 | `listPayments`, `recordPayment` | Payment (operator `/admin/*`) |
+| `listLineItemSuggestions` | LineItem (history-based suggestions) |
 
 ### Service API (`/api/*`, NeNe Clear — ADR 0009)
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: Invoices (請求書), including issue and quote conversion.
   - name: Payments
     description: Payments (入金) recorded against invoices.
+  - name: LineItems
+    description: Document line items (品目) and history-based suggestions.
 paths:
   /health:
     get:
@@ -114,6 +116,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DashboardSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+  /admin/line-items/suggestions:
+    get:
+      tags: [LineItems]
+      summary: List line-item suggestions
+      description: >
+        History-based line-item suggestions for the caller's organization,
+        aggregated from past invoices and quotes (distinct descriptions with the
+        default unit price / tax rate, ordered by usage). The defaults are
+        conveniences and never override the tax that applies to a sale. Returned
+        in full for client-side typeahead filtering. Requires ViewBilling.
+      operationId: listLineItemSuggestions
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Line-item suggestions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineItemSuggestionList'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1294,6 +1320,30 @@ components:
           type: string
           description: Token expiry timestamp (Y-m-d H:i:s).
       required: [url, expires_at]
+    LineItemSuggestion:
+      type: object
+      properties:
+        description:
+          type: string
+          description: A distinct line-item description the organization has used before.
+        unit_price_cents:
+          type: integer
+          description: Default unit price in cents (from the most recent use; editable per line).
+        tax_rate_bps:
+          type: integer
+          description: Default tax rate in basis points (from the most recent use; editable per line).
+        usage_count:
+          type: integer
+          description: How many times this description appears in recent history.
+      required: [description, unit_price_cents, tax_rate_bps, usage_count]
+    LineItemSuggestionList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineItemSuggestion'
+      required: [items]
     DashboardSummary:
       type: object
       properties:

--- a/frontend/e2e/create-invoice.spec.ts
+++ b/frontend/e2e/create-invoice.spec.ts
@@ -22,12 +22,21 @@ const INVOICE = {
   total_cents: 110000,
   line_items: [],
 }
+const SUGGESTION = {
+  description: 'コンサルティング（10時間）',
+  unit_price_cents: 30000,
+  tax_rate_bps: 1000,
+  usage_count: 4,
+}
 
 /** Reaches /invoices/new through login → invoices list → "請求書を作成". */
 test.describe('Create invoice', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/admin/clients*', (route) =>
       route.fulfill(json({ items: [CLIENT], total: 1, limit: 100, offset: 0 })),
+    )
+    await page.route('**/admin/line-items/suggestions*', (route) =>
+      route.fulfill(json({ items: [SUGGESTION] })),
     )
     await page.route('**/admin/invoices*', (route, request) => {
       if (request.method() === 'GET') {
@@ -76,5 +85,13 @@ test.describe('Create invoice', () => {
     await page.getByRole('button', { name: '作成する' }).click()
 
     await expect(page).toHaveURL(/\/invoices\/7$/)
+  })
+
+  test('picks a line-item suggestion to fill the description and unit price', async ({ page }) => {
+    await page.locator('#line-0-description').fill('コンサル')
+    await page.getByRole('option', { name: /コンサルティング（10時間）/ }).click()
+
+    await expect(page.locator('#line-0-description')).toHaveValue('コンサルティング（10時間）')
+    await expect(page.locator('#line-0-unit')).toHaveValue('30000')
   })
 })

--- a/frontend/e2e/create-quote.spec.ts
+++ b/frontend/e2e/create-quote.spec.ts
@@ -20,12 +20,21 @@ const QUOTE = {
   total_cents: 110000,
   line_items: [],
 }
+const SUGGESTION = {
+  description: 'コンサルティング（10時間）',
+  unit_price_cents: 30000,
+  tax_rate_bps: 1000,
+  usage_count: 4,
+}
 
 /** Reaches /quotes/new through login → quotes list → "見積書を作成". */
 test.describe('Create quote', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/admin/clients*', (route) =>
       route.fulfill(json({ items: [CLIENT], total: 1, limit: 100, offset: 0 })),
+    )
+    await page.route('**/admin/line-items/suggestions*', (route) =>
+      route.fulfill(json({ items: [SUGGESTION] })),
     )
     await page.route('**/admin/quotes*', (route, request) => {
       if (request.method() === 'GET') {
@@ -72,5 +81,13 @@ test.describe('Create quote', () => {
     await page.getByRole('button', { name: '作成する' }).click()
 
     await expect(page).toHaveURL(/\/quotes\/1$/)
+  })
+
+  test('picks a line-item suggestion to fill the description and unit price', async ({ page }) => {
+    await page.locator('#line-0-description').fill('コンサル')
+    await page.getByRole('option', { name: /コンサルティング（10時間）/ }).click()
+
+    await expect(page.locator('#line-0-description')).toHaveValue('コンサルティング（10時間）')
+    await expect(page.locator('#line-0-unit')).toHaveValue('30000')
   })
 })

--- a/frontend/src/entities/line-item/api-types.ts
+++ b/frontend/src/entities/line-item/api-types.ts
@@ -1,0 +1,4 @@
+import type { components } from '@/shared/api/schema.gen'
+
+export type LineItemSuggestionDto = components['schemas']['LineItemSuggestion']
+export type LineItemSuggestionListDto = components['schemas']['LineItemSuggestionList']

--- a/frontend/src/entities/line-item/index.ts
+++ b/frontend/src/entities/line-item/index.ts
@@ -1,0 +1,3 @@
+export type { LineItemSuggestion } from './model'
+export { lineItemKeys } from './query-keys'
+export { useLineItemSuggestions } from './queries'

--- a/frontend/src/entities/line-item/mapper.ts
+++ b/frontend/src/entities/line-item/mapper.ts
@@ -1,0 +1,11 @@
+import type { LineItemSuggestionDto } from './api-types'
+import type { LineItemSuggestion } from './model'
+
+export function toLineItemSuggestion(dto: LineItemSuggestionDto): LineItemSuggestion {
+  return {
+    description: dto.description,
+    unit_price_cents: dto.unit_price_cents,
+    tax_rate_bps: dto.tax_rate_bps,
+    usage_count: dto.usage_count,
+  }
+}

--- a/frontend/src/entities/line-item/model.ts
+++ b/frontend/src/entities/line-item/model.ts
@@ -1,0 +1,11 @@
+/**
+ * A history-based line-item suggestion (#315). Field names mirror the API
+ * (snake_case). Defaults are conveniences — the operator edits price/rate per
+ * line after picking; they never override the tax that applies to a sale.
+ */
+export interface LineItemSuggestion {
+  description: string
+  unit_price_cents: number
+  tax_rate_bps: number
+  usage_count: number
+}

--- a/frontend/src/entities/line-item/queries.ts
+++ b/frontend/src/entities/line-item/queries.ts
@@ -1,0 +1,22 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiClient } from '@/shared/api/client'
+import type { AppError } from '@/shared/api/errors'
+import type { LineItemSuggestionListDto } from './api-types'
+import { toLineItemSuggestion } from './mapper'
+import type { LineItemSuggestion } from './model'
+import { lineItemKeys } from './query-keys'
+
+/**
+ * GET /admin/line-items/suggestions — history-based suggestions, mapped to
+ * models before reaching the cache. The full set is fetched once and filtered
+ * client-side by the suggest input (same approach as the client picker).
+ */
+export function useLineItemSuggestions(): UseQueryResult<LineItemSuggestion[], AppError> {
+  return useQuery<LineItemSuggestion[], AppError>({
+    queryKey: lineItemKeys.suggestions(),
+    queryFn: async () => {
+      const dto = await apiClient.get<LineItemSuggestionListDto>('/admin/line-items/suggestions')
+      return dto.items.map(toLineItemSuggestion)
+    },
+  })
+}

--- a/frontend/src/entities/line-item/query-keys.ts
+++ b/frontend/src/entities/line-item/query-keys.ts
@@ -1,0 +1,4 @@
+export const lineItemKeys = {
+  all: ['line-items'] as const,
+  suggestions: () => [...lineItemKeys.all, 'suggestions'] as const,
+}

--- a/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
+++ b/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom'
 import { z } from 'zod'
 import { useClientList, useCreateClient, type Client } from '@/entities/client'
 import { useCreateInvoice as useCreateInvoiceMutation } from '@/entities/invoice'
+import { useLineItemSuggestions, type LineItemSuggestion } from '@/entities/line-item'
 import { useTranslation } from '@/shared/i18n'
 import { useToast } from '@/shared/ui'
 
@@ -42,6 +43,8 @@ export interface UseCreateInvoice {
   clientsLoading: boolean
   /** Inline-registers a new client by name; resolves to its id (or null). */
   createClient: (name: string) => Promise<number | null>
+  /** History-based line-item suggestions (description + default price/rate). */
+  lineSuggestions: LineItemSuggestion[]
   onSubmit: (event: SyntheticEvent) => void
   addLine: () => void
   isPending: boolean
@@ -60,6 +63,7 @@ export function useCreateInvoice(): UseCreateInvoice {
     filters: { q: null },
     sort: { field: null, order: 'asc' },
   })
+  const lineSuggestions = useLineItemSuggestions()
 
   const form = useForm<CreateInvoiceFormValues>({
     resolver: zodResolver(schema),
@@ -107,6 +111,7 @@ export function useCreateInvoice(): UseCreateInvoice {
     clients: clientList.data?.items ?? [],
     clientsLoading: clientList.isPending,
     createClient,
+    lineSuggestions: lineSuggestions.data ?? [],
     onSubmit: (event) => {
       void submit(event)
     },

--- a/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
+++ b/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
@@ -9,6 +9,8 @@ import {
   Field,
   InlineAlert,
   Input,
+  type LineSuggestion,
+  LineItemSuggestInput,
   Select,
   Stack,
   Text,
@@ -39,6 +41,7 @@ export function CreateInvoiceForm() {
     clients,
     clientsLoading,
     createClient,
+    lineSuggestions,
     onSubmit,
     addLine,
     isPending,
@@ -47,9 +50,24 @@ export function CreateInvoiceForm() {
   const {
     control,
     register,
+    setValue,
     formState: { errors },
   } = form
   const { gridRef } = useLineGridEnter(lines.fields.length, addLine)
+
+  // Picking a suggestion fills the row's description and its default unit price
+  // / tax rate (still editable). The rate guard keeps the value within the
+  // form's allowed set; current data only ever uses 8% / 10%.
+  const applySuggestion = (index: number, s: LineSuggestion): void => {
+    setValue(`line_items.${index}.description`, s.description, { shouldValidate: true })
+    setValue(`line_items.${index}.unit_price_cents`, s.unit_price_cents, { shouldValidate: true })
+    if (s.tax_rate_bps === 800 || s.tax_rate_bps === 1000) {
+      setValue(`line_items.${index}.tax_rate_bps`, s.tax_rate_bps, { shouldValidate: true })
+    }
+  }
+
+  const suggestionMeta = (s: LineSuggestion): string =>
+    `${formatYen(s.unit_price_cents)} · ${formatTaxRate(s.tax_rate_bps)} · ${t('admin.lineItemSuggest.usage', { count: s.usage_count })}`
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   // Empty number inputs surface as NaN; computeDocumentTotals coerces those to 0.
@@ -117,11 +135,23 @@ export function CreateInvoiceForm() {
                 const amount = (line?.quantity || 0) * (line?.unit_price_cents || 0)
                 return (
                   <div className="line-row" key={field.id}>
-                    <Input
-                      id={`line-${index}-description`}
-                      aria-label={t('admin.invoices.line.description')}
-                      aria-invalid={errors.line_items?.[index]?.description ? true : undefined}
-                      {...register(`line_items.${index}.description`)}
+                    <Controller
+                      control={control}
+                      name={`line_items.${index}.description`}
+                      render={({ field }) => (
+                        <LineItemSuggestInput
+                          id={`line-${index}-description`}
+                          aria-label={t('admin.invoices.line.description')}
+                          invalid={errors.line_items?.[index]?.description !== undefined}
+                          value={field.value}
+                          onChange={field.onChange}
+                          suggestions={lineSuggestions}
+                          onPick={(s) => {
+                            applySuggestion(index, s)
+                          }}
+                          renderMeta={suggestionMeta}
+                        />
+                      )}
                     />
                     <Input
                       id={`line-${index}-quantity`}

--- a/frontend/src/features/create-quote/hooks/use-create-quote.ts
+++ b/frontend/src/features/create-quote/hooks/use-create-quote.ts
@@ -9,6 +9,7 @@ import {
 import { useNavigate } from 'react-router-dom'
 import { z } from 'zod'
 import { useClientList, useCreateClient, type Client } from '@/entities/client'
+import { useLineItemSuggestions, type LineItemSuggestion } from '@/entities/line-item'
 import { useCreateQuote as useCreateQuoteMutation } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
 import { useToast } from '@/shared/ui'
@@ -43,6 +44,8 @@ export interface UseCreateQuote {
   clientsLoading: boolean
   /** Inline-registers a new client by name; resolves to its id (or null). */
   createClient: (name: string) => Promise<number | null>
+  /** History-based line-item suggestions (description + default price/rate). */
+  lineSuggestions: LineItemSuggestion[]
   onSubmit: (event: SyntheticEvent) => void
   addLine: () => void
   isPending: boolean
@@ -61,6 +64,7 @@ export function useCreateQuote(): UseCreateQuote {
     filters: { q: null },
     sort: { field: null, order: 'asc' },
   })
+  const lineSuggestions = useLineItemSuggestions()
 
   const form = useForm<CreateQuoteFormValues>({
     resolver: zodResolver(schema),
@@ -109,6 +113,7 @@ export function useCreateQuote(): UseCreateQuote {
     clients: clientList.data?.items ?? [],
     clientsLoading: clientList.isPending,
     createClient,
+    lineSuggestions: lineSuggestions.data ?? [],
     onSubmit: (event) => {
       void submit(event)
     },

--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -11,6 +11,8 @@ import {
   FormRow,
   InlineAlert,
   Input,
+  type LineSuggestion,
+  LineItemSuggestInput,
   Select,
   Stack,
   Text,
@@ -41,6 +43,7 @@ export function CreateQuoteForm() {
     clients,
     clientsLoading,
     createClient,
+    lineSuggestions,
     onSubmit,
     addLine,
     isPending,
@@ -49,9 +52,24 @@ export function CreateQuoteForm() {
   const {
     control,
     register,
+    setValue,
     formState: { errors },
   } = form
   const { gridRef } = useLineGridEnter(lines.fields.length, addLine)
+
+  // Picking a suggestion fills the row's description and its default unit price
+  // / tax rate (still editable). The rate guard keeps the value within the
+  // form's allowed set; current data only ever uses 8% / 10%.
+  const applySuggestion = (index: number, s: LineSuggestion): void => {
+    setValue(`line_items.${index}.description`, s.description, { shouldValidate: true })
+    setValue(`line_items.${index}.unit_price_cents`, s.unit_price_cents, { shouldValidate: true })
+    if (s.tax_rate_bps === 800 || s.tax_rate_bps === 1000) {
+      setValue(`line_items.${index}.tax_rate_bps`, s.tax_rate_bps, { shouldValidate: true })
+    }
+  }
+
+  const suggestionMeta = (s: LineSuggestion): string =>
+    `${formatYen(s.unit_price_cents)} · ${formatTaxRate(s.tax_rate_bps)} · ${t('admin.lineItemSuggest.usage', { count: s.usage_count })}`
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   const watched = useWatch({ control, name: 'line_items' })
@@ -129,11 +147,23 @@ export function CreateQuoteForm() {
                 const amount = (line?.quantity || 0) * (line?.unit_price_cents || 0)
                 return (
                   <div className="line-row" key={field.id}>
-                    <Input
-                      id={`line-${index}-description`}
-                      aria-label={t('admin.invoices.line.description')}
-                      aria-invalid={errors.line_items?.[index]?.description ? true : undefined}
-                      {...register(`line_items.${index}.description`)}
+                    <Controller
+                      control={control}
+                      name={`line_items.${index}.description`}
+                      render={({ field }) => (
+                        <LineItemSuggestInput
+                          id={`line-${index}-description`}
+                          aria-label={t('admin.invoices.line.description')}
+                          invalid={errors.line_items?.[index]?.description !== undefined}
+                          value={field.value}
+                          onChange={field.onChange}
+                          suggestions={lineSuggestions}
+                          onPick={(s) => {
+                            applySuggestion(index, s)
+                          }}
+                          renderMeta={suggestionMeta}
+                        />
+                      )}
                     />
                     <Input
                       id={`line-${index}-quantity`}

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -84,6 +84,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/line-items/suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List line-item suggestions
+         * @description History-based line-item suggestions for the caller's organization, aggregated from past invoices and quotes (distinct descriptions with the default unit price / tax rate, ordered by usage). The defaults are conveniences and never override the tax that applies to a sale. Returned in full for client-side typeahead filtering. Requires ViewBilling.
+         */
+        get: operations["listLineItemSuggestions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/audit-logs": {
         parameters: {
             query?: never;
@@ -675,6 +695,19 @@ export interface components {
             /** @description Token expiry timestamp (Y-m-d H:i:s). */
             expires_at: string;
         };
+        LineItemSuggestion: {
+            /** @description A distinct line-item description the organization has used before. */
+            description: string;
+            /** @description Default unit price in cents (from the most recent use; editable per line). */
+            unit_price_cents: number;
+            /** @description Default tax rate in basis points (from the most recent use; editable per line). */
+            tax_rate_bps: number;
+            /** @description How many times this description appears in recent history. */
+            usage_count: number;
+        };
+        LineItemSuggestionList: {
+            items: components["schemas"]["LineItemSuggestion"][];
+        };
         DashboardSummary: {
             /** @description Number of issued + partially_paid invoices. */
             unpaid_count: number;
@@ -1175,6 +1208,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DashboardSummary"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["InsufficientCapability"];
+        };
+    };
+    listLineItemSuggestions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Line-item suggestions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LineItemSuggestionList"];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -177,6 +177,7 @@ export const enMessages: MessageCatalog = {
   'admin.clientPicker.create': 'Register “{{name}}” as a new client',
   'admin.clientPicker.registered': 'Registered “{{name}}” as a client',
   'admin.clientPicker.registerError': 'Could not register the client.',
+  'admin.lineItemSuggest.usage': 'used {{count}}×',
   'admin.clients.filter.search': 'Search',
   'admin.clients.filter.searchPlaceholder': 'Search by name, reading, contact or email',
   'admin.clients.create.title': 'Create client',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -183,6 +183,7 @@ export const jaMessages = {
   'admin.clientPicker.create': '「{{name}}」を新規取引先として登録',
   'admin.clientPicker.registered': '「{{name}}」を取引先に登録しました',
   'admin.clientPicker.registerError': '取引先を登録できませんでした。',
+  'admin.lineItemSuggest.usage': '{{count}}回使用',
   'admin.clients.filter.search': '検索',
   'admin.clients.filter.searchPlaceholder': '名称・読み・担当者・メールで検索',
   'admin.clients.create.title': '取引先の作成',

--- a/frontend/src/shared/ui/components/LineItemSuggestInput.test.tsx
+++ b/frontend/src/shared/ui/components/LineItemSuggestInput.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+import { LineItemSuggestInput, type LineSuggestion } from './LineItemSuggestInput'
+
+const SUGGESTIONS: LineSuggestion[] = [
+  {
+    description: 'Web制作（基本プラン）',
+    unit_price_cents: 300000,
+    tax_rate_bps: 1000,
+    usage_count: 5,
+  },
+  { description: 'コンサルティング', unit_price_cents: 30000, tax_rate_bps: 1000, usage_count: 2 },
+]
+
+describe('LineItemSuggestInput', () => {
+  it('suggests by description substring and fills the row on pick', () => {
+    const onChange = vi.fn()
+    const onPick = vi.fn()
+    const { container, getByRole } = renderWithProviders(
+      <LineItemSuggestInput
+        id="d"
+        value=""
+        onChange={onChange}
+        suggestions={SUGGESTIONS}
+        onPick={onPick}
+      />,
+    )
+    const input = container.querySelector('#d') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'Web' } })
+    expect(onChange).toHaveBeenCalledWith('Web')
+
+    fireEvent.mouseDown(getByRole('option', { name: /Web制作/ }))
+    expect(onPick).toHaveBeenCalledWith(SUGGESTIONS[0])
+  })
+
+  it('renders the meta sub-line when provided', () => {
+    const { container, getByText } = renderWithProviders(
+      <LineItemSuggestInput
+        id="d"
+        value=""
+        onChange={vi.fn()}
+        suggestions={SUGGESTIONS}
+        onPick={vi.fn()}
+        renderMeta={(s) => `¥${String(s.unit_price_cents)} · ${String(s.usage_count)}×`}
+      />,
+    )
+    fireEvent.focus(container.querySelector('#d') as HTMLInputElement)
+    expect(getByText('¥300000 · 5×')).toBeTruthy()
+  })
+
+  it('picks the highlighted suggestion on Enter and stops the event', () => {
+    const onPick = vi.fn()
+    // value is the filter text (the field is free text the parent controls).
+    const { container, getByRole } = renderWithProviders(
+      <LineItemSuggestInput
+        id="d"
+        value="コンサル"
+        onChange={vi.fn()}
+        suggestions={SUGGESTIONS}
+        onPick={onPick}
+      />,
+    )
+    const input = container.querySelector('#d') as HTMLInputElement
+
+    fireEvent.focus(input) // open the menu
+    expect(getByRole('option', { name: /コンサルティング/ })).toBeTruthy()
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onPick).toHaveBeenCalledWith(SUGGESTIONS[1])
+  })
+
+  it('does not pick on Enter when there are no matches (free text passes through)', () => {
+    const onPick = vi.fn()
+    const { container } = renderWithProviders(
+      <LineItemSuggestInput
+        id="d"
+        value="完全に新しい品目"
+        onChange={vi.fn()}
+        suggestions={SUGGESTIONS}
+        onPick={onPick}
+      />,
+    )
+    const input = container.querySelector('#d') as HTMLInputElement
+
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onPick).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
+++ b/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
@@ -1,0 +1,155 @@
+import { useRef, useState, type KeyboardEvent } from 'react'
+import { cn } from '@/shared/lib/cn'
+
+/** Minimal shape the suggest input needs from a line-item suggestion (#315). */
+export interface LineSuggestion {
+  description: string
+  unit_price_cents: number
+  tax_rate_bps: number
+  usage_count: number
+}
+
+export interface LineItemSuggestInputProps {
+  id?: string
+  /** The description text (this field stays free text; the parent owns it). */
+  value: string
+  onChange: (description: string) => void
+  /** Candidate suggestions, already loaded by the parent. */
+  suggestions: LineSuggestion[]
+  /** Chosen a suggestion → fill description + default unit price / tax rate. */
+  onPick: (suggestion: LineSuggestion) => void
+  /** Optional sub-line under each option (e.g. price · rate · used N×). */
+  renderMeta?: (suggestion: LineSuggestion) => string
+  'aria-label'?: string
+  invalid?: boolean
+}
+
+const norm = (s: string): string => s.trim().toLowerCase()
+
+/**
+ * Typeahead for a line-item description (#315, Phase 1). The field is plain free
+ * text — past descriptions are offered as you type, and picking one fills the
+ * row's default unit price / tax rate (editable afterwards). It lives inside the
+ * line grid, whose Enter-navigation is a *native* listener on the grid
+ * container; to win the race we handle keys in the capture phase and only stop
+ * propagation for the keys we consume, so Enter on free text still advances the
+ * grid as usual.
+ */
+export function LineItemSuggestInput({
+  id,
+  value,
+  onChange,
+  suggestions,
+  onPick,
+  renderMeta,
+  'aria-label': ariaLabel,
+  invalid = false,
+}: LineItemSuggestInputProps) {
+  const [open, setOpen] = useState(false)
+  const [highlight, setHighlight] = useState(0)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  const q = norm(value)
+  const matches = (
+    q === '' ? suggestions : suggestions.filter((s) => s.description.toLowerCase().includes(q))
+  ).slice(0, 50)
+
+  const canPick = open && matches.length > 0
+
+  const pick = (suggestion: LineSuggestion): void => {
+    onPick(suggestion)
+    setOpen(false)
+  }
+
+  // Capture phase: runs before the grid's native bubble listener, so we can
+  // claim Enter when the menu is actionable and otherwise let the grid have it.
+  const onKeyDownCapture = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      if (matches.length === 0) return
+      e.preventDefault()
+      e.stopPropagation()
+      if (!open) {
+        setOpen(true)
+        setHighlight(0)
+      } else {
+        setHighlight((h) => Math.min(h + 1, matches.length - 1))
+      }
+    } else if (e.key === 'ArrowUp') {
+      if (!open) return
+      e.preventDefault()
+      e.stopPropagation()
+      setHighlight((h) => Math.max(h - 1, 0))
+    } else if (e.key === 'Enter') {
+      if (!canPick) return // free text → let the grid advance to the next cell
+      e.preventDefault()
+      e.stopPropagation()
+      e.nativeEvent.stopImmediatePropagation() // beat the grid's native listener
+      const m = matches[Math.min(highlight, matches.length - 1)]
+      if (m !== undefined) pick(m)
+    } else if (e.key === 'Escape') {
+      if (!open) return
+      e.preventDefault()
+      e.stopPropagation()
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className={cn('combo', open && 'open')}
+      onBlur={(e) => {
+        if (wrapRef.current !== null && !wrapRef.current.contains(e.relatedTarget)) {
+          setOpen(false)
+        }
+      }}
+    >
+      <input
+        type="text"
+        id={id}
+        className="combo-input"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={id !== undefined ? `${id}-list` : undefined}
+        aria-label={ariaLabel}
+        aria-invalid={invalid ? true : undefined}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value)
+          setOpen(true)
+          setHighlight(0)
+        }}
+        onFocus={() => {
+          setOpen(true)
+        }}
+        onKeyDownCapture={onKeyDownCapture}
+      />
+
+      {open && matches.length > 0 && (
+        <ul className="combo-pop" id={id !== undefined ? `${id}-list` : undefined} role="listbox">
+          {matches.map((s, i) => (
+            <li key={s.description}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={i === highlight}
+                className={cn('combo-opt', i === highlight && 'hl')}
+                onMouseEnter={() => {
+                  setHighlight(i)
+                }}
+                onMouseDown={(e) => {
+                  e.preventDefault() // keep focus; avoid blur-close before click
+                  pick(s)
+                }}
+              >
+                <span className="combo-name">{s.description}</span>
+                {renderMeta !== undefined && <span className="combo-sub">{renderMeta(s)}</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -17,6 +17,11 @@ export {
 } from './components/ClientCombobox'
 export { DatePicker, type DatePickerProps } from './components/DatePicker'
 export {
+  LineItemSuggestInput,
+  type LineItemSuggestInputProps,
+  type LineSuggestion,
+} from './components/LineItemSuggestInput'
+export {
   FormLayout,
   type FormLayoutProps,
   FormRow,

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -22,6 +22,7 @@ use NeneInvoice\Invoice\InvoiceRouteRegistrar;
 use NeneInvoice\Invoice\InvoiceValidationExceptionHandler;
 use NeneInvoice\Invoice\QualifiedInvoiceIncompleteExceptionHandler;
 use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadTokenRouteRegistrar;
+use NeneInvoice\LineItem\LineItemRouteRegistrar;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -85,6 +86,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $paymentRoutes = $container->get(PaymentRouteRegistrar::class);
                     $serviceApiRoutes = $container->get(ServiceApiRouteRegistrar::class);
                     $downloadTokenRoutes = $container->get(InvoiceDownloadTokenRouteRegistrar::class);
+                    $lineItemRoutes = $container->get(LineItemRouteRegistrar::class);
 
                     if (!$dashboardRoutes instanceof DashboardRouteRegistrar) {
                         throw new LogicException('Dashboard route registrar service is invalid.');
@@ -134,7 +136,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Invoice download token route registrar service is invalid.');
                     }
 
-                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes];
+                    if (!$lineItemRoutes instanceof LineItemRouteRegistrar) {
+                        throw new LogicException('Line item route registrar service is invalid.');
+                    }
+
+                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes];
                 },
             )
             ->set(

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -38,7 +38,7 @@ final class CapabilityResolver
             return Capability::ViewBilling;
         }
 
-        foreach (['/admin/clients', '/admin/quotes', '/admin/invoices', '/admin/payments'] as $prefix) {
+        foreach (['/admin/clients', '/admin/quotes', '/admin/invoices', '/admin/payments', '/admin/line-items'] as $prefix) {
             if (str_starts_with($path, $prefix)) {
                 return self::isReadMethod($method) ? Capability::ViewBilling : Capability::ManageBilling;
             }

--- a/src/LineItem/LineItemRepositoryInterface.php
+++ b/src/LineItem/LineItemRepositoryInterface.php
@@ -20,4 +20,13 @@ interface LineItemRepositoryInterface
     public function replaceForParent(LineItemParent $parentType, int $parentId, array $lines): void;
 
     public function deleteForParent(LineItemParent $parentType, int $parentId): void;
+
+    /**
+     * Recent line-item rows across the caller's organization (invoices + quotes),
+     * newest first, for building history-based suggestions (#315). Org scoping is
+     * applied via the request holder; soft-deleted parents are excluded.
+     *
+     * @return list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}>
+     */
+    public function recentForOrganization(int $limit): array;
 }

--- a/src/LineItem/LineItemRouteRegistrar.php
+++ b/src/LineItem/LineItemRouteRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class LineItemRouteRegistrar
+{
+    public function __construct(private ListLineItemSuggestionsHandler $suggestions)
+    {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $suggestions = $this->suggestions;
+        $router->get(
+            '/admin/line-items/suggestions',
+            static fn (ServerRequestInterface $r) => $suggestions->handle($r),
+        );
+    }
+}

--- a/src/LineItem/LineItemServiceProvider.php
+++ b/src/LineItem/LineItemServiceProvider.php
@@ -8,26 +8,78 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the shared line-item repository.
+ * Wires the shared line-item repository and the history-based suggestion
+ * endpoint (#315).
  */
 final readonly class LineItemServiceProvider implements ServiceProviderInterface
 {
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            LineItemRepositoryInterface::class,
-            static function (ContainerInterface $c): LineItemRepositoryInterface {
-                $query = $c->get(DatabaseQueryExecutorInterface::class);
+        $builder
+            ->set(
+                LineItemRepositoryInterface::class,
+                static function (ContainerInterface $c): LineItemRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
 
-                if (!$query instanceof DatabaseQueryExecutorInterface) {
-                    throw new LogicException('Database query executor service is invalid.');
-                }
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
 
-                return new PdoLineItemRepository($query);
-            },
-        );
+                    return new PdoLineItemRepository($query, self::orgHolder($c));
+                },
+            )
+            ->set(
+                ListLineItemSuggestionsUseCase::class,
+                static fn (ContainerInterface $c): ListLineItemSuggestionsUseCase => new ListLineItemSuggestionsUseCase(
+                    self::resolve($c, LineItemRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                ListLineItemSuggestionsHandler::class,
+                static fn (ContainerInterface $c): ListLineItemSuggestionsHandler => new ListLineItemSuggestionsHandler(
+                    self::resolve($c, ListLineItemSuggestionsUseCase::class),
+                    self::resolve($c, JsonResponseFactory::class),
+                ),
+            )
+            ->set(
+                LineItemRouteRegistrar::class,
+                static fn (ContainerInterface $c): LineItemRouteRegistrar => new LineItemRouteRegistrar(
+                    self::resolve($c, ListLineItemSuggestionsHandler::class),
+                ),
+            );
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Organization id holder service is invalid.');
+        }
+
+        return $holder;
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
     }
 }

--- a/src/LineItem/LineItemSuggestion.php
+++ b/src/LineItem/LineItemSuggestion.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * A history-based line-item suggestion (#315): a distinct description the org has
+ * used before, with the default unit price / tax rate to pre-fill when chosen.
+ *
+ * The defaults are conveniences only — they never override the tax that applies
+ * to a given sale; the operator can edit price and rate per line after picking.
+ * Money is integer cents; tax rate is basis points.
+ */
+final readonly class LineItemSuggestion
+{
+    public function __construct(
+        public string $description,
+        public int $unitPriceCents,
+        public int $taxRateBps,
+        public int $usageCount,
+    ) {
+    }
+}

--- a/src/LineItem/LineItemSuggestionResponse.php
+++ b/src/LineItem/LineItemSuggestionResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Serializes {@see LineItemSuggestion} to the snake_case JSON shape returned by
+ * `GET /admin/line-items/suggestions`.
+ */
+final readonly class LineItemSuggestionResponse
+{
+    /** @return array{description: string, unit_price_cents: int, tax_rate_bps: int, usage_count: int} */
+    public static function toArray(LineItemSuggestion $suggestion): array
+    {
+        return [
+            'description'      => $suggestion->description,
+            'unit_price_cents' => $suggestion->unitPriceCents,
+            'tax_rate_bps'     => $suggestion->taxRateBps,
+            'usage_count'      => $suggestion->usageCount,
+        ];
+    }
+}

--- a/src/LineItem/ListLineItemSuggestionsHandler.php
+++ b/src/LineItem/ListLineItemSuggestionsHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/line-items/suggestions` — history-based line-item suggestions for
+ * the resolved organization (#315). The full set is returned for client-side
+ * typeahead filtering, mirroring how the client picker loads its candidates.
+ * Capability: ViewBilling (via the `/admin/line-items` prefix).
+ */
+final readonly class ListLineItemSuggestionsHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ListLineItemSuggestionsUseCase $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $suggestions = $this->useCase->execute();
+
+        return $this->json->create([
+            'items' => array_map(
+                static fn (LineItemSuggestion $s): array => LineItemSuggestionResponse::toArray($s),
+                $suggestions,
+            ),
+        ]);
+    }
+}

--- a/src/LineItem/ListLineItemSuggestionsUseCase.php
+++ b/src/LineItem/ListLineItemSuggestionsUseCase.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Builds history-based line-item suggestions for the caller's organization
+ * (#315, Phase 1). Reads recent line items (newest first) and folds them by
+ * description: usage count is the number of occurrences, and the default price /
+ * tax rate are taken from the most recent occurrence (recency tracks current
+ * pricing better than an all-time mode). No dedicated item master is involved.
+ */
+final readonly class ListLineItemSuggestionsUseCase
+{
+    /**
+     * How many recent rows to scan. Generous enough to surface real repeats
+     * while keeping the per-request aggregation cheap.
+     */
+    private const SCAN_LIMIT = 500;
+
+    /** Upper bound on suggestions returned to the client. */
+    private const MAX_SUGGESTIONS = 100;
+
+    public function __construct(
+        private LineItemRepositoryInterface $lineItems,
+    ) {
+    }
+
+    /** @return list<LineItemSuggestion> ordered by usage desc, then recency */
+    public function execute(): array
+    {
+        $rows = $this->lineItems->recentForOrganization(self::SCAN_LIMIT);
+
+        // Rows arrive newest-first, so the first time we see a description its
+        // values are the most recent — keep those as the defaults and only bump
+        // the count on later (older) occurrences.
+        /** @var array<string, array{suggestion: LineItemSuggestion, rank: int}> $byDescription */
+        $byDescription = [];
+        $rank = 0;
+
+        foreach ($rows as $row) {
+            $description = trim($row['description']);
+            if ($description === '') {
+                continue;
+            }
+
+            $key = mb_strtolower($description);
+
+            if (!isset($byDescription[$key])) {
+                $byDescription[$key] = [
+                    'suggestion' => new LineItemSuggestion(
+                        description: $description,
+                        unitPriceCents: $row['unit_price_cents'],
+                        taxRateBps: $row['tax_rate_bps'],
+                        usageCount: 1,
+                    ),
+                    'rank' => $rank++,
+                ];
+                continue;
+            }
+
+            $existing = $byDescription[$key]['suggestion'];
+            $byDescription[$key]['suggestion'] = new LineItemSuggestion(
+                description: $existing->description,
+                unitPriceCents: $existing->unitPriceCents,
+                taxRateBps: $existing->taxRateBps,
+                usageCount: $existing->usageCount + 1,
+            );
+        }
+
+        $entries = array_values($byDescription);
+
+        // Most-used first; ties broken by recency (lower rank = seen sooner =
+        // more recent) so the ordering is deterministic.
+        usort(
+            $entries,
+            static function (array $a, array $b): int {
+                $byUsage = $b['suggestion']->usageCount <=> $a['suggestion']->usageCount;
+
+                return $byUsage !== 0 ? $byUsage : $a['rank'] <=> $b['rank'];
+            },
+        );
+
+        $suggestions = array_map(
+            static fn (array $entry): LineItemSuggestion => $entry['suggestion'],
+            $entries,
+        );
+
+        return array_slice($suggestions, 0, self::MAX_SUGGESTIONS);
+    }
+}

--- a/src/LineItem/PdoLineItemRepository.php
+++ b/src/LineItem/PdoLineItemRepository.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace NeneInvoice\LineItem;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
 
 final readonly class PdoLineItemRepository implements LineItemRepositoryInterface
 {
     private const COLUMNS = 'id, parent_type, parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order, created_at, updated_at';
 
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
     ) {
     }
 
@@ -57,6 +62,52 @@ final readonly class PdoLineItemRepository implements LineItemRepositoryInterfac
         $this->query->execute(
             'DELETE FROM line_items WHERE parent_type = ? AND parent_id = ?',
             [$parentType->value, $parentId],
+        );
+    }
+
+    /**
+     * @return list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}>
+     */
+    public function recentForOrganization(int $limit): array
+    {
+        $orgId = $this->orgId->get();
+
+        // Pull the org's line items from both document types in one pass. The
+        // org boundary lives on the parent (line_items has no organization_id),
+        // so we join through invoices/quotes and exclude soft-deleted parents.
+        // Aggregation (group by description, pick defaults) happens in PHP to
+        // stay dialect-agnostic — same approach as the dashboard series.
+        $rows = $this->query->fetchAll(
+            'SELECT li.description AS description, li.unit_price_cents AS unit_price_cents,
+                    li.tax_rate_bps AS tax_rate_bps, li.created_at AS created_at
+               FROM line_items li
+               JOIN invoices i ON li.parent_type = ? AND li.parent_id = i.id
+              WHERE i.organization_id = ? AND i.is_deleted = 0
+             UNION ALL
+             SELECT li.description AS description, li.unit_price_cents AS unit_price_cents,
+                    li.tax_rate_bps AS tax_rate_bps, li.created_at AS created_at
+               FROM line_items li
+               JOIN quotes q ON li.parent_type = ? AND li.parent_id = q.id
+              WHERE q.organization_id = ? AND q.is_deleted = 0
+             ORDER BY created_at DESC, description ASC
+             LIMIT ?',
+            [
+                LineItemParent::Invoice->value,
+                $orgId,
+                LineItemParent::Quote->value,
+                $orgId,
+                $limit,
+            ],
+        );
+
+        return array_map(
+            static fn (array $row): array => [
+                'description'      => (string) $row['description'],
+                'unit_price_cents' => (int) $row['unit_price_cents'],
+                'tax_rate_bps'     => (int) $row['tax_rate_bps'],
+                'created_at'       => (string) $row['created_at'],
+            ],
+            $rows,
         );
     }
 

--- a/tests/LineItem/ListLineItemSuggestionsUseCaseTest.php
+++ b/tests/LineItem/ListLineItemSuggestionsUseCaseTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\LineItem;
+
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\ListLineItemSuggestionsUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class ListLineItemSuggestionsUseCaseTest extends TestCase
+{
+    public function test_groups_by_description_counts_usage_and_orders_by_most_used(): void
+    {
+        // Rows arrive newest-first (as the repository returns them).
+        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+            ['description' => 'Consulting', 'unit_price_cents' => 15000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
+            ['description' => 'Design',     'unit_price_cents' => 8000,  'tax_rate_bps' => 800,  'created_at' => '2026-06-04 10:00:00'],
+            ['description' => 'Consulting', 'unit_price_cents' => 12000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-03 10:00:00'],
+            ['description' => 'Consulting', 'unit_price_cents' => 10000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-02 10:00:00'],
+        ]));
+
+        $suggestions = $useCase->execute();
+
+        self::assertCount(2, $suggestions);
+        // Consulting (3 uses) ranks above Design (1 use).
+        self::assertSame('Consulting', $suggestions[0]->description);
+        self::assertSame(3, $suggestions[0]->usageCount);
+        // Default price/rate come from the most recent occurrence (15000, not 10000).
+        self::assertSame(15000, $suggestions[0]->unitPriceCents);
+        self::assertSame(1000, $suggestions[0]->taxRateBps);
+        self::assertSame('Design', $suggestions[1]->description);
+        self::assertSame(1, $suggestions[1]->usageCount);
+    }
+
+    public function test_folds_case_and_whitespace_variants_keeping_first_seen_label(): void
+    {
+        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+            ['description' => 'Web制作', 'unit_price_cents' => 50000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
+            ['description' => '  web制作 ', 'unit_price_cents' => 40000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-04 10:00:00'],
+        ]));
+
+        $suggestions = $useCase->execute();
+
+        self::assertCount(1, $suggestions);
+        self::assertSame('Web制作', $suggestions[0]->description); // first-seen (most recent) label
+        self::assertSame(2, $suggestions[0]->usageCount);
+    }
+
+    public function test_skips_blank_descriptions(): void
+    {
+        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+            ['description' => '   ', 'unit_price_cents' => 1000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
+        ]));
+
+        self::assertSame([], $useCase->execute());
+    }
+
+    /**
+     * @param list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}> $rows
+     */
+    private function repoReturning(array $rows): LineItemRepositoryInterface
+    {
+        return new class ($rows) implements LineItemRepositoryInterface {
+            /** @param list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}> $rows */
+            public function __construct(private readonly array $rows)
+            {
+            }
+
+            public function findByParent(LineItemParent $parentType, int $parentId): array
+            {
+                return [];
+            }
+
+            public function replaceForParent(LineItemParent $parentType, int $parentId, array $lines): void
+            {
+            }
+
+            public function deleteForParent(LineItemParent $parentType, int $parentId): void
+            {
+            }
+
+            /** @return list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}> */
+            public function recentForOrganization(int $limit): array
+            {
+                return array_slice($this->rows, 0, $limit);
+            }
+        };
+    }
+}

--- a/tests/LineItem/PdoLineItemRepositoryTest.php
+++ b/tests/LineItem/PdoLineItemRepositoryTest.php
@@ -7,14 +7,19 @@ namespace NeneInvoice\Tests\LineItem;
 use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\PdoLineItemRepository;
+use PDO;
 use PHPUnit\Framework\TestCase;
 
 final class PdoLineItemRepositoryTest extends TestCase
 {
     private PdoLineItemRepository $repository;
+    private PDO $pdo;
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
 
     protected function setUp(): void
     {
@@ -30,13 +35,17 @@ final class PdoLineItemRepositoryTest extends TestCase
             charset: 'utf8',
         );
         $factory = new PdoConnectionFactory($config);
-        $pdo = $factory->create();
+        $this->pdo = $factory->create();
 
-        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/line_items.sql');
-        self::assertIsString($schema);
-        $pdo->exec($schema);
+        foreach (['line_items', 'invoices', 'quotes'] as $table) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . "/database/schema/{$table}.sql");
+            self::assertIsString($schema);
+            $this->pdo->exec($schema);
+        }
 
-        $this->repository = new PdoLineItemRepository(new PdoDatabaseQueryExecutor($factory, $pdo));
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoLineItemRepository(new PdoDatabaseQueryExecutor($factory, $this->pdo), $this->orgId);
     }
 
     public function test_replace_then_find_returns_lines_in_sort_order(): void
@@ -93,5 +102,73 @@ final class PdoLineItemRepositoryTest extends TestCase
         $this->repository->deleteForParent(LineItemParent::Quote, 10);
 
         self::assertCount(0, $this->repository->findByParent(LineItemParent::Quote, 10));
+    }
+
+    public function test_recent_for_organization_scopes_by_org_and_excludes_deleted(): void
+    {
+        // Org 1: one live invoice, one live quote, one soft-deleted invoice.
+        $invoiceLive    = $this->insertInvoice(orgId: 1, isDeleted: false);
+        $quoteLive      = $this->insertQuote(orgId: 1, isDeleted: false);
+        $invoiceDeleted = $this->insertInvoice(orgId: 1, isDeleted: true);
+        // Org 2: must never leak into org 1's suggestions.
+        $invoiceOtherOrg = $this->insertInvoice(orgId: 2, isDeleted: false);
+
+        $this->insertLineItem(LineItemParent::Invoice, $invoiceLive, 'Consulting', 12000, 1000, '2026-06-01 09:00:00');
+        $this->insertLineItem(LineItemParent::Quote, $quoteLive, 'Design', 8000, 800, '2026-06-02 09:00:00');
+        $this->insertLineItem(LineItemParent::Invoice, $invoiceDeleted, 'Hidden', 99999, 1000, '2026-06-03 09:00:00');
+        $this->insertLineItem(LineItemParent::Invoice, $invoiceOtherOrg, 'Other org', 50000, 1000, '2026-06-04 09:00:00');
+
+        $rows = $this->repository->recentForOrganization(100);
+
+        $descriptions = array_map(static fn (array $r): string => $r['description'], $rows);
+        self::assertSame(['Design', 'Consulting'], $descriptions); // newest first, no Hidden/Other org
+        self::assertSame(8000, $rows[0]['unit_price_cents']);
+        self::assertSame(800, $rows[0]['tax_rate_bps']);
+    }
+
+    private function insertInvoice(int $orgId, bool $isDeleted): int
+    {
+        $this->pdo->exec(sprintf(
+            "INSERT INTO invoices (organization_id, client_id, status, is_deleted, created_at, updated_at)
+             VALUES (%d, 1, 'draft', %d, '2026-06-01 00:00:00', '2026-06-01 00:00:00')",
+            $orgId,
+            $isDeleted ? 1 : 0,
+        ));
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function insertQuote(int $orgId, bool $isDeleted): int
+    {
+        $this->pdo->exec(sprintf(
+            "INSERT INTO quotes (organization_id, client_id, quote_number, status, is_deleted, created_at, updated_at)
+             VALUES (%d, 1, 'Q-%d', 'draft', %d, '2026-06-01 00:00:00', '2026-06-01 00:00:00')",
+            $orgId,
+            random_int(1, 1_000_000),
+            $isDeleted ? 1 : 0,
+        ));
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function insertLineItem(
+        LineItemParent $parentType,
+        int $parentId,
+        string $description,
+        int $unitPriceCents,
+        int $taxRateBps,
+        string $createdAt,
+    ): void {
+        $this->pdo->exec(sprintf(
+            "INSERT INTO line_items (parent_type, parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order, created_at, updated_at)
+             VALUES ('%s', %d, '%s', 1, %d, %d, 0, '%s', '%s')",
+            $parentType->value,
+            $parentId,
+            $description,
+            $unitPriceCents,
+            $taxRateBps,
+            $createdAt,
+            $createdAt,
+        ));
     }
 }

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -24,6 +24,7 @@ final class OpenApiContractTest extends TestCase
     private const EXPECTED_OPERATION_IDS = [
         'getHealth',
         'getDashboard',
+        'listLineItemSuggestions',
         'login',
         'getCurrentUser',
         'listAuditLogs',

--- a/tests/Support/InMemoryLineItemRepository.php
+++ b/tests/Support/InMemoryLineItemRepository.php
@@ -55,6 +55,33 @@ final class InMemoryLineItemRepository implements LineItemRepositoryInterface
         unset($this->byParent[$this->key($parentType, $parentId)]);
     }
 
+    /**
+     * Returns every stored line as a suggestion row, newest-first by created_at.
+     * Org/soft-delete scoping is a SQL concern; this fake holds only one org's
+     * line items, so use-case tests drive aggregation through what they seed.
+     *
+     * @return list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}>
+     */
+    public function recentForOrganization(int $limit): array
+    {
+        $rows = [];
+
+        foreach ($this->byParent as $lines) {
+            foreach ($lines as $line) {
+                $rows[] = [
+                    'description'      => $line->description,
+                    'unit_price_cents' => $line->unitPriceCents,
+                    'tax_rate_bps'     => $line->taxRateBps,
+                    'created_at'       => $line->createdAt ?? '',
+                ];
+            }
+        }
+
+        usort($rows, static fn (array $a, array $b): int => $b['created_at'] <=> $a['created_at']);
+
+        return array_slice($rows, 0, $limit);
+    }
+
     private function key(LineItemParent $parentType, int $parentId): string
     {
         return $parentType->value . ':' . $parentId;


### PR DESCRIPTION
Closes #315（Phase 1：履歴ベース。品目マスタは Phase 2 で別Issue化）

## 概要
見積・請求の明細で、過去に使った品目（説明）を**説明欄でタイプアヘッド表示**し、
選ぶと**既定の単価・税率を補完**する。専用の辞書管理画面は作らず、価値の大半を低コストで。

## バックエンド
- **`GET /admin/line-items/suggestions`**（ViewBilling）。`line_items` を `invoices` /
  `quotes` に **org 結合**して直近を取得し、**説明文ごとに PHP 側で集計**（使用回数＝件数、
  既定の単価/税率＝**直近の値**）。集計は方言非依存（dashboard と同方針）。soft-delete 親は除外。
- 既定の単価/税率は**利便性のための値で、適用税率を上書きしない**（黙って誤らせない）。金額は integer cents。
- `PdoLineItemRepository` に org ホルダーを注入し `recentForOrganization()` を追加。

## フロント
- `entities/line-item`（query）＋ `shared/ui` の **`LineItemSuggestInput`**（プレゼンテーショナル）。
  説明欄は**自由入力のまま**、候補選択で `description` ＋ `unit_price_cents` ＋ `tax_rate_bps` を補完。
- グリッドの Enter ナビ（**ネイティブ listener**）と競合しないよう **capture フェーズ**で処理し、
  消費したキーのみ伝播停止。**自由入力＋Enter は従来どおり次セルへ**。
- 見積・請求フォームに `Controller` + `LineItemSuggestInput` で適用。i18n（ja/en）。

## 確認
- [x] `composer check` — test **324**・phpstan **0**・cs・openapi・mcp すべて green
- [x] frontend `lint` / `knip` / `format` / `build` green
- [x] `vitest` **178**（`LineItemSuggestInput` 単体 4件追加）
- [x] e2e `create-invoice` / `create-quote` **8 pass**（品目サジェスト選択→単価補完を2件追加）
- [x] dev サーバーで実データの集計レスポンスを確認
- [x] 用語レジストリ（`usage_count` read model・operationId）と OpenAPI を同一PRで更新

## 残（#315 の発展、別Issue化可）
- Phase 2: 品目マスタ（`items`＝説明＋既定単価＋既定税率、org スコープ）の正本化
- 100件超でのサーバサイド検索（現状は直近最大100件をクライアント絞り込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)