### PR TITLE
feat(line-item): 品目サジェストをマスタ優先＋履歴フォールバックに統合 (#323 PR-3)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -58,6 +58,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
 | `payment.method` | `bank_transfer`, `cash`, `other` |
 | `line_item.parent_type` | `quote`, `invoice` |
+| `line_item_suggestion.source` | `master`, `history` |
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
 | `user.status` | `active`, `invited` |
 | Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
@@ -99,7 +100,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
-| Line-item suggestion read model | `items` → `description`, `unit_price_cents`, `tax_rate_bps`, `usage_count` | `count`, `times_used`, `frequency`, `default_price_cents` |
+| Line-item suggestion read model | `items` → `description`, `unit_price_cents`, `tax_rate_bps`, `usage_count`, `source` (`master`/`history`) | `count`, `times_used`, `frequency`, `default_price_cents`, `origin`, `kind` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
 the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1448,7 +1448,13 @@ components:
         usage_count:
           type: integer
           description: How many times this description appears in recent history.
-      required: [description, unit_price_cents, tax_rate_bps, usage_count]
+        source:
+          type: string
+          enum: [master, history]
+          description: >
+            Where the suggestion came from — `master` (item master, authoritative)
+            or `history` (derived from past documents).
+      required: [description, unit_price_cents, tax_rate_bps, usage_count, source]
     LineItemSuggestionList:
       type: object
       properties:

--- a/frontend/e2e/create-invoice.spec.ts
+++ b/frontend/e2e/create-invoice.spec.ts
@@ -27,6 +27,7 @@ const SUGGESTION = {
   unit_price_cents: 30000,
   tax_rate_bps: 1000,
   usage_count: 4,
+  source: 'history',
 }
 
 /** Reaches /invoices/new through login → invoices list → "請求書を作成". */

--- a/frontend/e2e/create-quote.spec.ts
+++ b/frontend/e2e/create-quote.spec.ts
@@ -25,6 +25,7 @@ const SUGGESTION = {
   unit_price_cents: 30000,
   tax_rate_bps: 1000,
   usage_count: 4,
+  source: 'history',
 }
 
 /** Reaches /quotes/new through login → quotes list → "見積書を作成". */

--- a/frontend/src/entities/line-item/mapper.ts
+++ b/frontend/src/entities/line-item/mapper.ts
@@ -7,5 +7,6 @@ export function toLineItemSuggestion(dto: LineItemSuggestionDto): LineItemSugges
     unit_price_cents: dto.unit_price_cents,
     tax_rate_bps: dto.tax_rate_bps,
     usage_count: dto.usage_count,
+    source: dto.source,
   }
 }

--- a/frontend/src/entities/line-item/model.ts
+++ b/frontend/src/entities/line-item/model.ts
@@ -1,11 +1,13 @@
 /**
- * A history-based line-item suggestion (#315). Field names mirror the API
- * (snake_case). Defaults are conveniences — the operator edits price/rate per
- * line after picking; they never override the tax that applies to a sale.
+ * A line-item suggestion. Field names mirror the API (snake_case). `source` is
+ * the item master (#323, authoritative) or past-document history (#315).
+ * Defaults are conveniences — the operator edits price/rate per line after
+ * picking; they never override the tax that applies to a sale.
  */
 export interface LineItemSuggestion {
   description: string
   unit_price_cents: number
   tax_rate_bps: number
   usage_count: number
+  source: 'master' | 'history'
 }

--- a/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
+++ b/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
@@ -66,8 +66,12 @@ export function CreateInvoiceForm() {
     }
   }
 
-  const suggestionMeta = (s: LineSuggestion): string =>
-    `${formatYen(s.unit_price_cents)} · ${formatTaxRate(s.tax_rate_bps)} · ${t('admin.lineItemSuggest.usage', { count: s.usage_count })}`
+  const suggestionMeta = (s: LineSuggestion): string => {
+    const parts = [formatYen(s.unit_price_cents), formatTaxRate(s.tax_rate_bps)]
+    if (s.source === 'master') parts.push(t('admin.lineItemSuggest.master'))
+    if (s.usage_count > 0) parts.push(t('admin.lineItemSuggest.usage', { count: s.usage_count }))
+    return parts.join(' · ')
+  }
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   // Empty number inputs surface as NaN; computeDocumentTotals coerces those to 0.

--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -68,8 +68,12 @@ export function CreateQuoteForm() {
     }
   }
 
-  const suggestionMeta = (s: LineSuggestion): string =>
-    `${formatYen(s.unit_price_cents)} · ${formatTaxRate(s.tax_rate_bps)} · ${t('admin.lineItemSuggest.usage', { count: s.usage_count })}`
+  const suggestionMeta = (s: LineSuggestion): string => {
+    const parts = [formatYen(s.unit_price_cents), formatTaxRate(s.tax_rate_bps)]
+    if (s.source === 'master') parts.push(t('admin.lineItemSuggest.master'))
+    if (s.usage_count > 0) parts.push(t('admin.lineItemSuggest.usage', { count: s.usage_count }))
+    return parts.join(' · ')
+  }
 
   // Live totals preview (backend stays authoritative; mirrors TaxCalculator).
   const watched = useWatch({ control, name: 'line_items' })

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -747,6 +747,11 @@ export interface components {
             tax_rate_bps: number;
             /** @description How many times this description appears in recent history. */
             usage_count: number;
+            /**
+             * @description Where the suggestion came from — `master` (item master, authoritative) or `history` (derived from past documents).
+             * @enum {string}
+             */
+            source: "master" | "history";
         };
         LineItemSuggestionList: {
             items: components["schemas"]["LineItemSuggestion"][];

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -179,6 +179,7 @@ export const enMessages: MessageCatalog = {
   'admin.clientPicker.registered': 'Registered “{{name}}” as a client',
   'admin.clientPicker.registerError': 'Could not register the client.',
   'admin.lineItemSuggest.usage': 'used {{count}}×',
+  'admin.lineItemSuggest.master': 'Master',
   'admin.clients.filter.search': 'Search',
   'admin.clients.filter.searchPlaceholder': 'Search by name, reading, contact or email',
   'admin.clients.create.title': 'Create client',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -185,6 +185,7 @@ export const jaMessages = {
   'admin.clientPicker.registered': '「{{name}}」を取引先に登録しました',
   'admin.clientPicker.registerError': '取引先を登録できませんでした。',
   'admin.lineItemSuggest.usage': '{{count}}回使用',
+  'admin.lineItemSuggest.master': 'マスタ',
   'admin.clients.filter.search': '検索',
   'admin.clients.filter.searchPlaceholder': '名称・読み・担当者・メールで検索',
   'admin.clients.create.title': '取引先の作成',

--- a/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
+++ b/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
@@ -7,6 +7,7 @@ export interface LineSuggestion {
   unit_price_cents: number
   tax_rate_bps: number
   usage_count: number
+  source?: 'master' | 'history'
 }
 
 export interface LineItemSuggestInputProps {

--- a/src/LineItem/LineItemServiceProvider.php
+++ b/src/LineItem/LineItemServiceProvider.php
@@ -11,6 +11,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Item\ItemRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -38,6 +39,7 @@ final readonly class LineItemServiceProvider implements ServiceProviderInterface
                 ListLineItemSuggestionsUseCase::class,
                 static fn (ContainerInterface $c): ListLineItemSuggestionsUseCase => new ListLineItemSuggestionsUseCase(
                     self::resolve($c, LineItemRepositoryInterface::class),
+                    self::resolve($c, ItemRepositoryInterface::class),
                 ),
             )
             ->set(

--- a/src/LineItem/LineItemSuggestion.php
+++ b/src/LineItem/LineItemSuggestion.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace NeneInvoice\LineItem;
 
 /**
- * A history-based line-item suggestion (#315): a distinct description the org has
- * used before, with the default unit price / tax rate to pre-fill when chosen.
+ * A line-item suggestion: a distinct description with the default unit price /
+ * tax rate to pre-fill when chosen. Sources are the authoritative item master
+ * (#323) and past-document history (#315); `source` marks which one, and
+ * `usageCount` is how often the description appears in history (0 for a master
+ * row never used yet).
  *
  * The defaults are conveniences only — they never override the tax that applies
  * to a given sale; the operator can edit price and rate per line after picking.
@@ -19,6 +22,7 @@ final readonly class LineItemSuggestion
         public int $unitPriceCents,
         public int $taxRateBps,
         public int $usageCount,
+        public LineItemSuggestionSource $source = LineItemSuggestionSource::History,
     ) {
     }
 }

--- a/src/LineItem/LineItemSuggestionResponse.php
+++ b/src/LineItem/LineItemSuggestionResponse.php
@@ -10,7 +10,7 @@ namespace NeneInvoice\LineItem;
  */
 final readonly class LineItemSuggestionResponse
 {
-    /** @return array{description: string, unit_price_cents: int, tax_rate_bps: int, usage_count: int} */
+    /** @return array{description: string, unit_price_cents: int, tax_rate_bps: int, usage_count: int, source: string} */
     public static function toArray(LineItemSuggestion $suggestion): array
     {
         return [
@@ -18,6 +18,7 @@ final readonly class LineItemSuggestionResponse
             'unit_price_cents' => $suggestion->unitPriceCents,
             'tax_rate_bps'     => $suggestion->taxRateBps,
             'usage_count'      => $suggestion->usageCount,
+            'source'           => $suggestion->source->value,
         ];
     }
 }

--- a/src/LineItem/LineItemSuggestionSource.php
+++ b/src/LineItem/LineItemSuggestionSource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+/**
+ * Where a line-item suggestion came from (#323 PR-3). `master` rows are the
+ * authoritative item master (品目); `history` rows are derived from past
+ * documents and shown only when not already covered by the master.
+ */
+enum LineItemSuggestionSource: string
+{
+    case Master = 'master';
+    case History = 'history';
+}

--- a/src/LineItem/ListLineItemSuggestionsUseCase.php
+++ b/src/LineItem/ListLineItemSuggestionsUseCase.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace NeneInvoice\LineItem;
 
+use NeneInvoice\Item\ItemRepositoryInterface;
+
 /**
- * Builds history-based line-item suggestions for the caller's organization
- * (#315, Phase 1). Reads recent line items (newest first) and folds them by
- * description: usage count is the number of occurrences, and the default price /
- * tax rate are taken from the most recent occurrence (recency tracks current
- * pricing better than an all-time mode). No dedicated item master is involved.
+ * Builds line-item suggestions for the caller's organization: the authoritative
+ * item master (#323) first, then history-derived descriptions not already in the
+ * master as a fallback (#315). History is folded by description — usage count is
+ * the number of occurrences and the default price / tax come from the most
+ * recent one (recency tracks current pricing). Master rows carry their own
+ * defaults (the master is the source of truth) and the history usage count for
+ * the same description, so a frequently-used master item still sorts high.
  */
 final readonly class ListLineItemSuggestionsUseCase
 {
@@ -19,23 +23,90 @@ final readonly class ListLineItemSuggestionsUseCase
      */
     private const SCAN_LIMIT = 500;
 
+    /** How many master items to pull (org item catalogs are small in practice). */
+    private const MASTER_LIMIT = 200;
+
     /** Upper bound on suggestions returned to the client. */
     private const MAX_SUGGESTIONS = 100;
 
     public function __construct(
         private LineItemRepositoryInterface $lineItems,
+        private ItemRepositoryInterface $items,
     ) {
     }
 
-    /** @return list<LineItemSuggestion> ordered by usage desc, then recency */
+    /** @return list<LineItemSuggestion> master first (by usage, then name), then history-only by usage */
     public function execute(): array
+    {
+        $history = $this->aggregateHistory();
+
+        // Master is authoritative: emit every master row with its own defaults,
+        // attaching the history usage for the same description (0 if never used).
+        $masterEntries = [];
+        $seen = [];
+        foreach ($this->items->findAll(self::MASTER_LIMIT, 0) as $item) {
+            $description = trim($item->description);
+            if ($description === '') {
+                continue;
+            }
+
+            $key = mb_strtolower($description);
+            $seen[$key] = true;
+            $masterEntries[] = [
+                'suggestion' => new LineItemSuggestion(
+                    description: $description,
+                    unitPriceCents: $item->defaultUnitPriceCents,
+                    taxRateBps: $item->defaultTaxRateBps,
+                    usageCount: $history[$key]['usage'] ?? 0,
+                    source: LineItemSuggestionSource::Master,
+                ),
+                'sortKey' => $description,
+            ];
+        }
+
+        usort(
+            $masterEntries,
+            static function (array $a, array $b): int {
+                $byUsage = $b['suggestion']->usageCount <=> $a['suggestion']->usageCount;
+
+                return $byUsage !== 0 ? $byUsage : strcmp($a['sortKey'], $b['sortKey']);
+            },
+        );
+
+        // History fallback: descriptions not covered by the master, by usage then
+        // recency (lower rank = seen sooner = more recent).
+        $historyEntries = array_values(array_filter(
+            $history,
+            static fn (array $h): bool => !isset($seen[mb_strtolower($h['suggestion']->description)]),
+        ));
+
+        usort(
+            $historyEntries,
+            static function (array $a, array $b): int {
+                $byUsage = $b['suggestion']->usageCount <=> $a['suggestion']->usageCount;
+
+                return $byUsage !== 0 ? $byUsage : $a['rank'] <=> $b['rank'];
+            },
+        );
+
+        $suggestions = array_map(
+            static fn (array $entry): LineItemSuggestion => $entry['suggestion'],
+            [...$masterEntries, ...$historyEntries],
+        );
+
+        return array_slice($suggestions, 0, self::MAX_SUGGESTIONS);
+    }
+
+    /**
+     * Folds recent line items by normalized description.
+     *
+     * @return array<string, array{suggestion: LineItemSuggestion, usage: int, rank: int}>
+     */
+    private function aggregateHistory(): array
     {
         $rows = $this->lineItems->recentForOrganization(self::SCAN_LIMIT);
 
-        // Rows arrive newest-first, so the first time we see a description its
-        // values are the most recent — keep those as the defaults and only bump
-        // the count on later (older) occurrences.
-        /** @var array<string, array{suggestion: LineItemSuggestion, rank: int}> $byDescription */
+        /** @var array<string, array{suggestion: LineItemSuggestion, usage: int, rank: int}> $byDescription */
         $byDescription = [];
         $rank = 0;
 
@@ -54,39 +125,26 @@ final readonly class ListLineItemSuggestionsUseCase
                         unitPriceCents: $row['unit_price_cents'],
                         taxRateBps: $row['tax_rate_bps'],
                         usageCount: 1,
+                        source: LineItemSuggestionSource::History,
                     ),
+                    'usage' => 1,
                     'rank' => $rank++,
                 ];
                 continue;
             }
 
             $existing = $byDescription[$key]['suggestion'];
+            $usage = $existing->usageCount + 1;
             $byDescription[$key]['suggestion'] = new LineItemSuggestion(
                 description: $existing->description,
                 unitPriceCents: $existing->unitPriceCents,
                 taxRateBps: $existing->taxRateBps,
-                usageCount: $existing->usageCount + 1,
+                usageCount: $usage,
+                source: LineItemSuggestionSource::History,
             );
+            $byDescription[$key]['usage'] = $usage;
         }
 
-        $entries = array_values($byDescription);
-
-        // Most-used first; ties broken by recency (lower rank = seen sooner =
-        // more recent) so the ordering is deterministic.
-        usort(
-            $entries,
-            static function (array $a, array $b): int {
-                $byUsage = $b['suggestion']->usageCount <=> $a['suggestion']->usageCount;
-
-                return $byUsage !== 0 ? $byUsage : $a['rank'] <=> $b['rank'];
-            },
-        );
-
-        $suggestions = array_map(
-            static fn (array $entry): LineItemSuggestion => $entry['suggestion'],
-            $entries,
-        );
-
-        return array_slice($suggestions, 0, self::MAX_SUGGESTIONS);
+        return $byDescription;
     }
 }

--- a/tests/LineItem/ListLineItemSuggestionsUseCaseTest.php
+++ b/tests/LineItem/ListLineItemSuggestionsUseCaseTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\LineItem;
 
+use NeneInvoice\Item\Item;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\LineItemSuggestionSource;
 use NeneInvoice\LineItem\ListLineItemSuggestionsUseCase;
+use NeneInvoice\Tests\Support\InMemoryItemRepository;
 use PHPUnit\Framework\TestCase;
 
 final class ListLineItemSuggestionsUseCaseTest extends TestCase
@@ -14,12 +17,12 @@ final class ListLineItemSuggestionsUseCaseTest extends TestCase
     public function test_groups_by_description_counts_usage_and_orders_by_most_used(): void
     {
         // Rows arrive newest-first (as the repository returns them).
-        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+        $useCase = $this->useCase([
             ['description' => 'Consulting', 'unit_price_cents' => 15000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
             ['description' => 'Design',     'unit_price_cents' => 8000,  'tax_rate_bps' => 800,  'created_at' => '2026-06-04 10:00:00'],
             ['description' => 'Consulting', 'unit_price_cents' => 12000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-03 10:00:00'],
             ['description' => 'Consulting', 'unit_price_cents' => 10000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-02 10:00:00'],
-        ]));
+        ]);
 
         $suggestions = $useCase->execute();
 
@@ -27,6 +30,7 @@ final class ListLineItemSuggestionsUseCaseTest extends TestCase
         // Consulting (3 uses) ranks above Design (1 use).
         self::assertSame('Consulting', $suggestions[0]->description);
         self::assertSame(3, $suggestions[0]->usageCount);
+        self::assertSame(LineItemSuggestionSource::History, $suggestions[0]->source);
         // Default price/rate come from the most recent occurrence (15000, not 10000).
         self::assertSame(15000, $suggestions[0]->unitPriceCents);
         self::assertSame(1000, $suggestions[0]->taxRateBps);
@@ -36,10 +40,10 @@ final class ListLineItemSuggestionsUseCaseTest extends TestCase
 
     public function test_folds_case_and_whitespace_variants_keeping_first_seen_label(): void
     {
-        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+        $useCase = $this->useCase([
             ['description' => 'Web制作', 'unit_price_cents' => 50000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
             ['description' => '  web制作 ', 'unit_price_cents' => 40000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-04 10:00:00'],
-        ]));
+        ]);
 
         $suggestions = $useCase->execute();
 
@@ -50,11 +54,63 @@ final class ListLineItemSuggestionsUseCaseTest extends TestCase
 
     public function test_skips_blank_descriptions(): void
     {
-        $useCase = new ListLineItemSuggestionsUseCase($this->repoReturning([
+        $useCase = $this->useCase([
             ['description' => '   ', 'unit_price_cents' => 1000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
-        ]));
+        ]);
 
         self::assertSame([], $useCase->execute());
+    }
+
+    public function test_master_items_lead_with_their_own_defaults_and_history_usage(): void
+    {
+        // History has a cheaper/older price for the same description; the master
+        // is authoritative for the defaults but inherits the history usage count.
+        $master = new InMemoryItemRepository();
+        $master->save(new Item(organizationId: 1, description: '保守サポート', defaultUnitPriceCents: 50000, defaultTaxRateBps: 1000));
+
+        $useCase = $this->useCase(
+            [
+                ['description' => '保守サポート', 'unit_price_cents' => 30000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-05 10:00:00'],
+                ['description' => 'スポット作業', 'unit_price_cents' => 9000, 'tax_rate_bps' => 1000, 'created_at' => '2026-06-04 10:00:00'],
+            ],
+            $master,
+        );
+
+        $suggestions = $useCase->execute();
+
+        self::assertCount(2, $suggestions);
+        // Master row leads, uses its own default price (50000, not history 30000).
+        self::assertSame('保守サポート', $suggestions[0]->description);
+        self::assertSame(LineItemSuggestionSource::Master, $suggestions[0]->source);
+        self::assertSame(50000, $suggestions[0]->unitPriceCents);
+        self::assertSame(1, $suggestions[0]->usageCount); // history usage attached
+        // History-only description falls through after the master.
+        self::assertSame('スポット作業', $suggestions[1]->description);
+        self::assertSame(LineItemSuggestionSource::History, $suggestions[1]->source);
+    }
+
+    public function test_unused_master_item_appears_with_zero_usage(): void
+    {
+        $master = new InMemoryItemRepository();
+        $master->save(new Item(organizationId: 1, description: '新サービス', defaultUnitPriceCents: 12000, defaultTaxRateBps: 800));
+
+        $suggestions = $this->useCase([], $master)->execute();
+
+        self::assertCount(1, $suggestions);
+        self::assertSame('新サービス', $suggestions[0]->description);
+        self::assertSame(0, $suggestions[0]->usageCount);
+        self::assertSame(LineItemSuggestionSource::Master, $suggestions[0]->source);
+    }
+
+    /**
+     * @param list<array{description: string, unit_price_cents: int, tax_rate_bps: int, created_at: string}> $rows
+     */
+    private function useCase(array $rows, ?InMemoryItemRepository $master = null): ListLineItemSuggestionsUseCase
+    {
+        return new ListLineItemSuggestionsUseCase(
+            $this->repoReturning($rows),
+            $master ?? new InMemoryItemRepository(),
+        );
     }
 
     /**


### PR DESCRIPTION
Closes #323（PR-3。PR-1 #324・PR-2 #325 マージ済み）

## 概要
#315 の履歴ベースサジェストに #323 の**品目マスタ**を統合。マスタを正本として**先頭**に出し、マスタ未登録の説明は**履歴から補完**する。

## 変更
- **`ListLineItemSuggestionsUseCase` に `ItemRepository` を注入**。マスタ各行は自身の既定単価/税率を採用し、同名の履歴使用回数を付与（未使用は 0）。並びは **マスタ（使用回数→名前）→ 履歴のみ（使用回数→新しさ）**。
- `LineItemSuggestion` に **`source`（`master`|`history`）** を追加。レスポンス・OpenAPI・用語レジストリ（read model＋enum）を同一PRで更新。
- フロント：`source` をモデル/マッパーに追加。作成フォームの候補サブ行に**「マスタ」ラベル**を表示し、使用回数は 1 回以上のみ表示。i18n（ja/en）。`schema.gen` 再生成。

## コンプラ
- 既定の単価/税率は利便性のための値で、**適用税率を上書きしない**。金額は integer cents。

## 確認
- [x] `composer check` — test **337** / phpstan **0** / cs / openapi / mcp green
- [x] frontend `lint` / `knip` / `format` / `build` green、`vitest` **189**、e2e（create-invoice/quote）green
- [x] dev サーバーで実データ確認：マスタ行が先頭（source=master・自身の既定価格）＋履歴フォールバック（source=history）

これで #323（品目マスタ正本化）完了：PR-1 API ＋ PR-2 管理UI ＋ PR-3 サジェスト統合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)