### PR TITLE
feat(frontend): 取引先インライン登録をフリガナ対応に拡張 (#327)

### DIFF
--- a/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
+++ b/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
@@ -76,8 +76,8 @@ export interface UseCreateInvoice {
   lines: UseFieldArrayReturn<CreateInvoiceFormValues, 'line_items'>
   clients: Client[]
   clientsLoading: boolean
-  /** Inline-registers a new client by name; resolves to its id (or null). */
-  createClient: (name: string) => Promise<number | null>
+  /** Inline-registers a new client (name + optional reading); resolves to its id (or null). */
+  createClient: (name: string, nameKana: string | null) => Promise<number | null>
   /** History-based line-item suggestions (description + default price/rate). */
   lineSuggestions: LineItemSuggestion[]
   onSubmit: (event: SyntheticEvent) => void
@@ -142,11 +142,11 @@ export function useCreateInvoice(): UseCreateInvoice {
     )
   })
 
-  const createClient = async (name: string): Promise<number | null> => {
+  const createClient = async (name: string, nameKana: string | null): Promise<number | null> => {
     try {
       const client = await createClientMutation.mutateAsync({
         name,
-        name_kana: null,
+        name_kana: nameKana,
         contact_name: null,
         email: null,
         billing_address: null,

--- a/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
+++ b/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
@@ -113,6 +113,8 @@ export function CreateInvoiceForm() {
                     invalid={errors.client_id !== undefined}
                     placeholder={t('admin.clientPicker.placeholder')}
                     createLabel={(name) => t('admin.clientPicker.create', { name })}
+                    createKanaPlaceholder={t('admin.clientPicker.kanaPlaceholder')}
+                    createConfirmLabel={t('admin.clientPicker.createConfirm')}
                   />
                 )}
               />

--- a/frontend/src/features/create-quote/hooks/use-create-quote.ts
+++ b/frontend/src/features/create-quote/hooks/use-create-quote.ts
@@ -77,8 +77,8 @@ export interface UseCreateQuote {
   lines: UseFieldArrayReturn<CreateQuoteFormValues, 'line_items'>
   clients: Client[]
   clientsLoading: boolean
-  /** Inline-registers a new client by name; resolves to its id (or null). */
-  createClient: (name: string) => Promise<number | null>
+  /** Inline-registers a new client (name + optional reading); resolves to its id (or null). */
+  createClient: (name: string, nameKana: string | null) => Promise<number | null>
   /** History-based line-item suggestions (description + default price/rate). */
   lineSuggestions: LineItemSuggestion[]
   onSubmit: (event: SyntheticEvent) => void
@@ -144,11 +144,11 @@ export function useCreateQuote(): UseCreateQuote {
     )
   })
 
-  const createClient = async (name: string): Promise<number | null> => {
+  const createClient = async (name: string, nameKana: string | null): Promise<number | null> => {
     try {
       const client = await createClientMutation.mutateAsync({
         name,
-        name_kana: null,
+        name_kana: nameKana,
         contact_name: null,
         email: null,
         billing_address: null,

--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -115,6 +115,8 @@ export function CreateQuoteForm() {
                       invalid={errors.client_id !== undefined}
                       placeholder={t('admin.clientPicker.placeholder')}
                       createLabel={(name) => t('admin.clientPicker.create', { name })}
+                      createKanaPlaceholder={t('admin.clientPicker.kanaPlaceholder')}
+                      createConfirmLabel={t('admin.clientPicker.createConfirm')}
                     />
                   )}
                 />

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -176,6 +176,8 @@ export const enMessages: MessageCatalog = {
   'admin.clients.newButton': 'Create client',
   'admin.clientPicker.placeholder': 'Search clients (name, reading, reg. no.)',
   'admin.clientPicker.create': 'Register “{{name}}” as a new client',
+  'admin.clientPicker.kanaPlaceholder': 'Reading (optional)',
+  'admin.clientPicker.createConfirm': 'Add',
   'admin.clientPicker.registered': 'Registered “{{name}}” as a client',
   'admin.clientPicker.registerError': 'Could not register the client.',
   'admin.lineItemSuggest.usage': 'used {{count}}×',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -182,6 +182,8 @@ export const jaMessages = {
   // Shared client picker (combobox) — quote & invoice forms.
   'admin.clientPicker.placeholder': '取引先を検索（名称・読み・登録番号）',
   'admin.clientPicker.create': '「{{name}}」を新規取引先として登録',
+  'admin.clientPicker.kanaPlaceholder': 'フリガナ／読み（任意）',
+  'admin.clientPicker.createConfirm': '登録',
   'admin.clientPicker.registered': '「{{name}}」を取引先に登録しました',
   'admin.clientPicker.registerError': '取引先を登録できませんでした。',
   'admin.lineItemSuggest.usage': '{{count}}回使用',

--- a/frontend/src/shared/ui/components/ClientCombobox.test.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.test.tsx
@@ -41,7 +41,7 @@ describe('ClientCombobox', () => {
     expect(onChange).toHaveBeenCalledWith(2)
   })
 
-  it('offers inline registration for an unknown name and selects the new id', async () => {
+  it('captures a reading and inline-registers an unknown name with it', async () => {
     const onChange = vi.fn()
     const onCreate = vi.fn(() => Promise.resolve(99))
     const { container, getByText } = renderWithProviders(
@@ -52,19 +52,49 @@ describe('ClientCombobox', () => {
         onChange={onChange}
         onCreate={onCreate}
         createLabel={(name) => `「${name}」を登録`}
+        createConfirmLabel="登録"
       />,
     )
     const input = container.querySelector('#c') as HTMLInputElement
 
     fireEvent.change(input, { target: { value: '新しい取引先' } })
-    const createButton = getByText('「新しい取引先」を登録')
-    fireEvent.mouseDown(createButton)
+    // Step 1: open the inline-create form (does not create yet).
+    fireEvent.mouseDown(getByText('「新しい取引先」を登録'))
+    expect(onCreate).not.toHaveBeenCalled()
 
-    expect(onCreate).toHaveBeenCalledWith('新しい取引先')
+    // Step 2: type a reading and confirm.
+    const kana = container.querySelector('.combo-createform .combo-input') as HTMLInputElement
+    fireEvent.change(kana, { target: { value: 'アタラシイトリヒキサキ' } })
+    fireEvent.mouseDown(getByText('登録'))
+
+    expect(onCreate).toHaveBeenCalledWith('新しい取引先', 'アタラシイトリヒキサキ')
     // onCreate resolves to 99 → selection committed.
     await vi.waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(99)
     })
+  })
+
+  it('inline-registers with a null reading when none is entered', () => {
+    const onChange = vi.fn()
+    const onCreate = vi.fn(() => Promise.resolve(7))
+    const { container, getByText } = renderWithProviders(
+      <ClientCombobox
+        id="c"
+        clients={CLIENTS}
+        value={0}
+        onChange={onChange}
+        onCreate={onCreate}
+        createLabel={(name) => `「${name}」を登録`}
+        createConfirmLabel="登録"
+      />,
+    )
+    const input = container.querySelector('#c') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: '読みなし商店' } })
+    fireEvent.mouseDown(getByText('「読みなし商店」を登録'))
+    fireEvent.mouseDown(getByText('登録'))
+
+    expect(onCreate).toHaveBeenCalledWith('読みなし商店', null)
   })
 
   it('shows the selected client name when value is set', () => {

--- a/frontend/src/shared/ui/components/ClientCombobox.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type KeyboardEvent } from 'react'
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
 import { cn } from '@/shared/lib/cn'
 
 /** Minimal shape the combobox needs from a client (取引先). */
@@ -17,15 +17,20 @@ export interface ClientComboboxProps {
   value: number
   onChange: (clientId: number) => void
   /**
-   * Inline-registers the typed name as a new client and resolves to its id (or
-   * `null` on failure). When omitted, no "register" affordance is shown.
+   * Inline-registers the typed name (with an optional reading) as a new client
+   * and resolves to its id (or `null` on failure). When omitted, no "register"
+   * affordance is shown.
    */
-  onCreate?: (name: string) => Promise<number | null>
+  onCreate?: (name: string, nameKana: string | null) => Promise<number | null>
   loading?: boolean
   invalid?: boolean
   placeholder?: string
   /** Label for the inline-create row, e.g. `「{name}」を新規登録`. */
   createLabel?: (name: string) => string
+  /** Placeholder for the inline furigana (reading) input. */
+  createKanaPlaceholder?: string
+  /** Label for the inline-create confirm button. */
+  createConfirmLabel?: string
   'aria-describedby'?: string
 }
 
@@ -34,9 +39,10 @@ const norm = (s: string): string => s.trim().toLowerCase()
 /**
  * Typeahead client picker (#314): filter by name / reading (name_kana) /
  * registration number, pick with mouse or keyboard, and — when the typed name
- * matches nothing — register it as a new client inline (`onCreate`). Controlled
- * by `value` (a client id); presentational, so the create mutation lives in the
- * parent hook.
+ * matches nothing — register it as a new client inline (`onCreate`). The inline
+ * create expands to a small form so a reading (furigana) can be captured up
+ * front (#327). Controlled by `value` (a client id); presentational, so the
+ * create mutation lives in the parent hook.
  */
 export function ClientCombobox({
   id,
@@ -48,6 +54,8 @@ export function ClientCombobox({
   invalid = false,
   placeholder,
   createLabel,
+  createKanaPlaceholder,
+  createConfirmLabel,
   'aria-describedby': ariaDescribedBy,
 }: ClientComboboxProps) {
   const selected = clients.find((c) => c.id === value) ?? null
@@ -65,7 +73,11 @@ export function ClientCombobox({
   const [open, setOpen] = useState(false)
   const [highlight, setHighlight] = useState(0)
   const [creating, setCreating] = useState(false)
+  // Inline-create sub-form (name is the typed text; capture an optional reading).
+  const [createMode, setCreateMode] = useState(false)
+  const [kana, setKana] = useState('')
   const wrapRef = useRef<HTMLDivElement>(null)
+  const kanaRef = useRef<HTMLInputElement>(null)
 
   const q = norm(text)
   const matches = (
@@ -82,8 +94,19 @@ export function ClientCombobox({
   const showCreate = onCreate !== undefined && q !== '' && !exact
   const rowCount = matches.length + (showCreate ? 1 : 0)
 
+  // Focus the reading input when the inline-create form opens.
+  useEffect(() => {
+    if (createMode) kanaRef.current?.focus()
+  }, [createMode])
+
+  const resetCreate = (): void => {
+    setCreateMode(false)
+    setKana('')
+  }
+
   const close = (): void => {
     setOpen(false)
+    resetCreate()
     setText(selected?.name ?? '')
   }
 
@@ -91,6 +114,12 @@ export function ClientCombobox({
     onChange(client.id)
     setText(client.name)
     setOpen(false)
+    resetCreate()
+  }
+
+  const enterCreateMode = (): void => {
+    setHighlight(matches.length)
+    setCreateMode(true)
   }
 
   const runCreate = async (): Promise<void> => {
@@ -98,12 +127,13 @@ export function ClientCombobox({
     const name = text.trim()
     if (name === '') return
     setCreating(true)
-    const newId = await onCreate(name)
+    const newId = await onCreate(name, kana.trim() === '' ? null : kana.trim())
     setCreating(false)
     if (newId !== null) {
       onChange(newId)
       setText(name)
       setOpen(false)
+      resetCreate()
     }
   }
 
@@ -126,13 +156,23 @@ export function ClientCombobox({
         const m = matches[highlight]
         if (m !== undefined) pick(m)
       } else if (showCreate) {
-        void runCreate()
+        enterCreateMode()
       }
     } else if (e.key === 'Escape') {
       if (open) {
         e.preventDefault()
         close()
       }
+    }
+  }
+
+  const onKanaKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void runCreate()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      resetCreate()
     }
   }
 
@@ -163,6 +203,7 @@ export function ClientCombobox({
           setText(e.target.value)
           setOpen(true)
           setHighlight(0)
+          resetCreate()
         }}
         onFocus={() => {
           setOpen(true)
@@ -197,7 +238,7 @@ export function ClientCombobox({
             </li>
           ))}
 
-          {showCreate && (
+          {showCreate && !createMode && (
             <li>
               <button
                 type="button"
@@ -207,11 +248,42 @@ export function ClientCombobox({
                 }}
                 onMouseDown={(e) => {
                   e.preventDefault()
-                  void runCreate()
+                  enterCreateMode()
                 }}
                 disabled={creating}
               >
                 {createLabel !== undefined ? createLabel(text.trim()) : `+ ${text.trim()}`}
+              </button>
+            </li>
+          )}
+
+          {showCreate && createMode && (
+            <li className="combo-createform">
+              <span className="combo-createform-label">
+                {createLabel !== undefined ? createLabel(text.trim()) : `+ ${text.trim()}`}
+              </span>
+              <input
+                ref={kanaRef}
+                type="text"
+                className="combo-input"
+                autoComplete="off"
+                placeholder={createKanaPlaceholder}
+                value={kana}
+                onChange={(e) => {
+                  setKana(e.target.value)
+                }}
+                onKeyDown={onKanaKeyDown}
+              />
+              <button
+                type="button"
+                className="combo-createform-confirm"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  void runCreate()
+                }}
+                disabled={creating}
+              >
+                {createConfirmLabel ?? '+'}
               </button>
             </li>
           )}

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -304,6 +304,42 @@
     opacity: 0.6;
     cursor: progress;
   }
+  .combo-createform {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.5rem;
+    margin-top: 0.125rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .combo-createform-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: var(--text-caption);
+    font-weight: 600;
+    color: var(--color-accent-hover);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .combo-createform .combo-input {
+    flex: 0 1 9rem;
+    width: auto;
+  }
+  .combo-createform-confirm {
+    flex: 0 0 auto;
+    padding: 0.25rem 0.625rem;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: var(--color-on-accent, #fff);
+    font-size: var(--text-caption);
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .combo-createform-confirm:disabled {
+    opacity: 0.6;
+    cursor: progress;
+  }
 
   /* ── Custom date picker (design 04) ────────────────────────────────────── */
   .dp {


### PR DESCRIPTION
Closes #327（#314 の残）

## 概要
取引先コンボボックスのインライン登録（名前のみ）を、**名前＋フリガナ(name_kana)の小フォーム**に拡張。

## 変更
- `ClientCombobox`：「『○○』を新規登録」を**2段階化**。確定操作で読み入力フォームを開き、フリガナ（任意）を入れて登録 → `onCreate(name, nameKana)` を呼び即選択。キーボード（Enterで開く→読み入力Enterで確定／Escで戻る）・マウス両対応。
- 作成フック `createClient(name, nameKana)` に拡張し `name_kana` を保存（**backend 変更なし**）。
- i18n（ja/en）、小フォームの CSS。

## 確認
- [x] `lint` / `knip` / `format` / `build` green
- [x] `vitest` **190**（ClientCombobox：読みあり/なし登録の2件を更新・追加）
- [x] e2e（create-invoice/quote）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)