### PR TITLE
feat(frontend): 取引先コンボボックスをサーバサイド検索に対応 (#328)

### DIFF
--- a/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
+++ b/frontend/src/features/create-invoice/hooks/use-create-invoice.ts
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect, useRef, type SyntheticEvent } from 'react'
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
 import {
   useFieldArray,
   useForm,
@@ -15,6 +15,7 @@ import {
 } from '@/entities/invoice'
 import { useLineItemSuggestions, type LineItemSuggestion } from '@/entities/line-item'
 import { useTranslation } from '@/shared/i18n'
+import { useDebouncedValue } from '@/shared/lib/use-debounced-value'
 import { useToast } from '@/shared/ui'
 
 const lineSchema = z.object({
@@ -80,6 +81,8 @@ export interface UseCreateInvoice {
   createClient: (name: string, nameKana: string | null) => Promise<number | null>
   /** History-based line-item suggestions (description + default price/rate). */
   lineSuggestions: LineItemSuggestion[]
+  /** Drives server-side client search (debounced) for the picker (#328). */
+  onClientQueryChange: (query: string) => void
   onSubmit: (event: SyntheticEvent) => void
   addLine: () => void
   isPending: boolean
@@ -92,10 +95,12 @@ export function useCreateInvoice(): UseCreateInvoice {
   const navigate = useNavigate()
   const create = useCreateInvoiceMutation()
   const createClientMutation = useCreateClient()
+  const [clientQuery, setClientQuery] = useState('')
+  const debouncedClientQuery = useDebouncedValue(clientQuery)
   const clientList = useClientList({
     limit: 100,
     offset: 0,
-    filters: { q: null },
+    filters: { q: debouncedClientQuery.trim() === '' ? null : debouncedClientQuery.trim() },
     sort: { field: null, order: 'asc' },
   })
   const lineSuggestions = useLineItemSuggestions()
@@ -167,6 +172,7 @@ export function useCreateInvoice(): UseCreateInvoice {
     clientsLoading: clientList.isPending,
     createClient,
     lineSuggestions: lineSuggestions.data ?? [],
+    onClientQueryChange: setClientQuery,
     onSubmit: (event) => {
       void submit(event)
     },

--- a/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
+++ b/frontend/src/features/create-invoice/ui/CreateInvoiceForm.tsx
@@ -42,6 +42,7 @@ export function CreateInvoiceForm() {
     clientsLoading,
     createClient,
     lineSuggestions,
+    onClientQueryChange,
     onSubmit,
     addLine,
     isPending,
@@ -109,6 +110,7 @@ export function CreateInvoiceForm() {
                     value={field.value}
                     onChange={field.onChange}
                     onCreate={createClient}
+                    onQueryChange={onClientQueryChange}
                     loading={clientsLoading}
                     invalid={errors.client_id !== undefined}
                     placeholder={t('admin.clientPicker.placeholder')}

--- a/frontend/src/features/create-quote/hooks/use-create-quote.ts
+++ b/frontend/src/features/create-quote/hooks/use-create-quote.ts
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect, useRef, type SyntheticEvent } from 'react'
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
 import {
   useFieldArray,
   useForm,
@@ -12,6 +12,7 @@ import { useClientList, useCreateClient, type Client } from '@/entities/client'
 import { useLineItemSuggestions, type LineItemSuggestion } from '@/entities/line-item'
 import { useCreateQuote as useCreateQuoteMutation, type CreateQuoteInput } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
+import { useDebouncedValue } from '@/shared/lib/use-debounced-value'
 import { useToast } from '@/shared/ui'
 
 const lineSchema = z.object({
@@ -81,6 +82,8 @@ export interface UseCreateQuote {
   createClient: (name: string, nameKana: string | null) => Promise<number | null>
   /** History-based line-item suggestions (description + default price/rate). */
   lineSuggestions: LineItemSuggestion[]
+  /** Drives server-side client search (debounced) for the picker (#328). */
+  onClientQueryChange: (query: string) => void
   onSubmit: (event: SyntheticEvent) => void
   addLine: () => void
   isPending: boolean
@@ -93,10 +96,12 @@ export function useCreateQuote(): UseCreateQuote {
   const navigate = useNavigate()
   const create = useCreateQuoteMutation()
   const createClientMutation = useCreateClient()
+  const [clientQuery, setClientQuery] = useState('')
+  const debouncedClientQuery = useDebouncedValue(clientQuery)
   const clientList = useClientList({
     limit: 100,
     offset: 0,
-    filters: { q: null },
+    filters: { q: debouncedClientQuery.trim() === '' ? null : debouncedClientQuery.trim() },
     sort: { field: null, order: 'asc' },
   })
   const lineSuggestions = useLineItemSuggestions()
@@ -169,6 +174,7 @@ export function useCreateQuote(): UseCreateQuote {
     clientsLoading: clientList.isPending,
     createClient,
     lineSuggestions: lineSuggestions.data ?? [],
+    onClientQueryChange: setClientQuery,
     onSubmit: (event) => {
       void submit(event)
     },

--- a/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
+++ b/frontend/src/features/create-quote/ui/CreateQuoteForm.tsx
@@ -44,6 +44,7 @@ export function CreateQuoteForm() {
     clientsLoading,
     createClient,
     lineSuggestions,
+    onClientQueryChange,
     onSubmit,
     addLine,
     isPending,
@@ -111,6 +112,7 @@ export function CreateQuoteForm() {
                       value={field.value}
                       onChange={field.onChange}
                       onCreate={createClient}
+                      onQueryChange={onClientQueryChange}
                       loading={clientsLoading}
                       invalid={errors.client_id !== undefined}
                       placeholder={t('admin.clientPicker.placeholder')}

--- a/frontend/src/shared/lib/use-debounced-value.ts
+++ b/frontend/src/shared/lib/use-debounced-value.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns `value` delayed by `delayMs` — updates only after the input has been
+ * stable for that long. Used to throttle typeahead queries before they hit the
+ * server (e.g. the client combobox search, #328).
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 250): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebounced(value)
+    }, delayMs)
+
+    return () => {
+      clearTimeout(handle)
+    }
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/frontend/src/shared/ui/components/ClientCombobox.test.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.test.tsx
@@ -97,6 +97,27 @@ describe('ClientCombobox', () => {
     expect(onCreate).toHaveBeenCalledWith('読みなし商店', null)
   })
 
+  it('reports the query and skips local filtering in server-search mode', () => {
+    const onQueryChange = vi.fn()
+    const { container, getByRole } = renderWithProviders(
+      <ClientCombobox
+        id="c"
+        clients={CLIENTS}
+        value={0}
+        onChange={vi.fn()}
+        onQueryChange={onQueryChange}
+      />,
+    )
+    const input = container.querySelector('#c') as HTMLInputElement
+
+    // Text that matches neither client locally; the server (parent) decides.
+    fireEvent.change(input, { target: { value: 'zzz' } })
+    expect(onQueryChange).toHaveBeenCalledWith('zzz')
+    // The parent-provided list is shown as-is — no client-side narrowing.
+    expect(getByRole('option', { name: /株式会社サンプル/ })).toBeTruthy()
+    expect(getByRole('option', { name: /Acme Foods/ })).toBeTruthy()
+  })
+
   it('shows the selected client name when value is set', () => {
     const { container } = renderWithProviders(
       <ClientCombobox id="c" clients={CLIENTS} value={2} onChange={vi.fn()} />,

--- a/frontend/src/shared/ui/components/ClientCombobox.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.tsx
@@ -25,6 +25,12 @@ export interface ClientComboboxProps {
   loading?: boolean
   invalid?: boolean
   placeholder?: string
+  /**
+   * Server-search mode (#328): when set, the typed text is reported here
+   * (debounce in the parent) and local filtering is skipped — `clients` is shown
+   * as already filtered by the server. Omit for the default local-filter mode.
+   */
+  onQueryChange?: (query: string) => void
   /** Label for the inline-create row, e.g. `「{name}」を新規登録`. */
   createLabel?: (name: string) => string
   /** Placeholder for the inline furigana (reading) input. */
@@ -53,11 +59,13 @@ export function ClientCombobox({
   loading = false,
   invalid = false,
   placeholder,
+  onQueryChange,
   createLabel,
   createKanaPlaceholder,
   createConfirmLabel,
   'aria-describedby': ariaDescribedBy,
 }: ClientComboboxProps) {
+  const serverFiltered = onQueryChange !== undefined
   const selected = clients.find((c) => c.id === value) ?? null
 
   const [text, setText] = useState(selected?.name ?? '')
@@ -80,8 +88,10 @@ export function ClientCombobox({
   const kanaRef = useRef<HTMLInputElement>(null)
 
   const q = norm(text)
+  // In server-search mode the parent already filtered `clients`; otherwise match
+  // by name / reading / registration number locally.
   const matches = (
-    q === ''
+    serverFiltered || q === ''
       ? clients
       : clients.filter(
           (c) =>
@@ -204,6 +214,7 @@ export function ClientCombobox({
           setOpen(true)
           setHighlight(0)
           resetCreate()
+          onQueryChange?.(e.target.value)
         }}
         onFocus={() => {
           setOpen(true)


### PR DESCRIPTION
Closes #328（#314 の残）

## 概要
取引先ピッカーは先頭100件をローカル絞り込みするため、取引先が100件を超えると候補に出なかった。入力を**デバウンスしてサーバ `q` 検索**する経路を追加。

## 変更
- `ClientCombobox` に **server-search モード（`onQueryChange`）**。指定時はローカル絞り込みを行わず、親が渡す server 絞り込み済み `clients` をそのまま表示。未指定なら従来挙動（**後方互換**）。
- 作成フック（quote/invoice）が `useDebouncedValue` で入力を 250ms デバウンスし、`useClientList` の `q` フィルタを駆動。`useDebouncedValue` フックを新設。
- backend は `/admin/clients` の `q` 検索を既に備えるため**変更なし**。

## 確認
- [x] `lint` / `knip` / `format` / `build` green
- [x] `vitest` **191**（ClientCombobox：server-search モードの1件追加）
- [x] e2e（create-invoice/quote）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)