### PR TITLE
refactor(backend): list系のデッドコードを削除 (#335)

### DIFF
--- a/src/Client/ClientListFilter.php
+++ b/src/Client/ClientListFilter.php
@@ -14,9 +14,4 @@ final readonly class ClientListFilter
         public ?string $search = null,
     ) {
     }
-
-    public function isEmpty(): bool
-    {
-        return $this->search === null;
-    }
 }

--- a/src/Client/ClientRepositoryInterface.php
+++ b/src/Client/ClientRepositoryInterface.php
@@ -14,11 +14,6 @@ interface ClientRepositoryInterface
 {
     public function findById(int $id): ?Client;
 
-    /** @return list<Client> */
-    public function findAll(int $limit, int $offset): array;
-
-    public function count(): int;
-
     /**
      * Admin list: searched + sorted.
      *

--- a/src/Client/ListClientsUseCase.php
+++ b/src/Client/ListClientsUseCase.php
@@ -11,14 +11,6 @@ final readonly class ListClientsUseCase
     ) {
     }
 
-    public function execute(int $limit, int $offset): ListClientsResult
-    {
-        return new ListClientsResult(
-            $this->clients->findAll($limit, $offset),
-            $this->clients->count(),
-        );
-    }
-
     /** Admin list: search + sort. */
     public function executeAdmin(
         ClientListFilter $filter,

--- a/src/Client/PdoClientRepository.php
+++ b/src/Client/PdoClientRepository.php
@@ -30,27 +30,6 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         return $row !== null ? $this->mapRow($row) : null;
     }
 
-    /** @return list<Client> */
-    public function findAll(int $limit, int $offset): array
-    {
-        $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM clients WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$this->orgId->get(), $limit, $offset],
-        );
-
-        return array_map(fn (array $row): Client => $this->mapRow($row), $rows);
-    }
-
-    public function count(): int
-    {
-        $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM clients WHERE organization_id = ? AND is_deleted = 0',
-            [$this->orgId->get()],
-        );
-
-        return $row !== null ? (int) $row['cnt'] : 0;
-    }
-
     /**
      * Admin list: searched + sorted.
      *

--- a/src/Item/ItemListFilter.php
+++ b/src/Item/ItemListFilter.php
@@ -14,9 +14,4 @@ final readonly class ItemListFilter
         public ?string $search = null,
     ) {
     }
-
-    public function isEmpty(): bool
-    {
-        return $this->search === null;
-    }
 }

--- a/src/Item/ItemRepositoryInterface.php
+++ b/src/Item/ItemRepositoryInterface.php
@@ -17,8 +17,6 @@ interface ItemRepositoryInterface
     /** @return list<Item> */
     public function findAll(int $limit, int $offset): array;
 
-    public function count(): int;
-
     /**
      * Admin list: searched + sorted.
      *

--- a/src/Item/ListItemsUseCase.php
+++ b/src/Item/ListItemsUseCase.php
@@ -11,14 +11,6 @@ final readonly class ListItemsUseCase
     ) {
     }
 
-    public function execute(int $limit, int $offset): ListItemsResult
-    {
-        return new ListItemsResult(
-            $this->items->findAll($limit, $offset),
-            $this->items->count(),
-        );
-    }
-
     /** Admin list: search + sort. */
     public function executeAdmin(
         ItemListFilter $filter,

--- a/src/Item/PdoItemRepository.php
+++ b/src/Item/PdoItemRepository.php
@@ -41,16 +41,6 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
         return array_map(fn (array $row): Item => $this->mapRow($row), $rows);
     }
 
-    public function count(): int
-    {
-        $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM items WHERE organization_id = ? AND is_deleted = 0',
-            [$this->orgId->get()],
-        );
-
-        return $row !== null ? (int) $row['cnt'] : 0;
-    }
-
     /**
      * Admin list: searched + sorted.
      *

--- a/src/Quote/ListQuotesUseCase.php
+++ b/src/Quote/ListQuotesUseCase.php
@@ -11,14 +11,6 @@ final readonly class ListQuotesUseCase
     ) {
     }
 
-    public function execute(int $limit, int $offset): ListQuotesResult
-    {
-        return new ListQuotesResult(
-            $this->quotes->findAll($limit, $offset),
-            $this->quotes->count(),
-        );
-    }
-
     /**
      * Admin list: search / filter / sort, with client names resolved by the
      * query's join (so the UI shows names, not ids).

--- a/src/Quote/PdoQuoteRepository.php
+++ b/src/Quote/PdoQuoteRepository.php
@@ -30,27 +30,6 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         return $row !== null ? $this->mapRow($row) : null;
     }
 
-    /** @return list<Quote> */
-    public function findAll(int $limit, int $offset): array
-    {
-        $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$this->orgId->get(), $limit, $offset],
-        );
-
-        return array_map(fn (array $row): Quote => $this->mapRow($row), $rows);
-    }
-
-    public function count(): int
-    {
-        $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM quotes WHERE organization_id = ? AND is_deleted = 0',
-            [$this->orgId->get()],
-        );
-
-        return $row !== null ? (int) $row['cnt'] : 0;
-    }
-
     /**
      * Admin list: filtered + searched + sorted, joined with the client name.
      *

--- a/src/Quote/QuoteListFilter.php
+++ b/src/Quote/QuoteListFilter.php
@@ -25,14 +25,4 @@ final readonly class QuoteListFilter
         public ?int $totalMax = null,
     ) {
     }
-
-    public function isEmpty(): bool
-    {
-        return $this->statuses === []
-            && $this->search === null
-            && $this->validFrom === null
-            && $this->validTo === null
-            && $this->totalMin === null
-            && $this->totalMax === null;
-    }
 }

--- a/src/Quote/QuoteRepositoryInterface.php
+++ b/src/Quote/QuoteRepositoryInterface.php
@@ -13,11 +13,6 @@ interface QuoteRepositoryInterface
 {
     public function findById(int $id): ?Quote;
 
-    /** @return list<Quote> */
-    public function findAll(int $limit, int $offset): array;
-
-    public function count(): int;
-
     /**
      * Admin list: filtered + searched + sorted, joined with the client name.
      *

--- a/tests/Client/ClientQueryUseCasesTest.php
+++ b/tests/Client/ClientQueryUseCasesTest.php
@@ -6,7 +6,9 @@ namespace NeneInvoice\Tests\Client;
 
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientListFilter;
 use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\ClientSort;
 use NeneInvoice\Client\GetClientByIdUseCase;
 use NeneInvoice\Client\ListClientsUseCase;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
@@ -30,7 +32,7 @@ final class ClientQueryUseCasesTest extends TestCase
 
     public function test_list_is_scoped_to_organization(): void
     {
-        $result = (new ListClientsUseCase($this->repo))->execute(10, 0);
+        $result = (new ListClientsUseCase($this->repo))->executeAdmin(new ClientListFilter(), new ClientSort(), 10, 0);
 
         self::assertSame(2, $result->total);
         self::assertCount(2, $result->items);

--- a/tests/Client/PdoClientRepositoryTest.php
+++ b/tests/Client/PdoClientRepositoryTest.php
@@ -9,7 +9,9 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Client\Client;
+use NeneInvoice\Client\ClientListFilter;
 use NeneInvoice\Client\ClientNotFoundException;
+use NeneInvoice\Client\ClientSort;
 use NeneInvoice\Client\PdoClientRepository;
 use PHPUnit\Framework\TestCase;
 
@@ -71,11 +73,11 @@ final class PdoClientRepositoryTest extends TestCase
         $this->repository->save(new Client(organizationId: 2, name: 'C'));
 
         $this->orgId->set(1);
-        self::assertSame(2, $this->repository->count());
-        self::assertCount(2, $this->repository->findAll(10, 0));
+        self::assertSame(2, $this->repository->countForAdminList(new ClientListFilter()));
+        self::assertCount(2, $this->repository->findForAdminList(new ClientListFilter(), new ClientSort(), 10, 0));
 
         $this->orgId->set(2);
-        self::assertSame(1, $this->repository->count());
+        self::assertSame(1, $this->repository->countForAdminList(new ClientListFilter()));
     }
 
     public function test_find_by_id_is_scoped_to_organization(): void
@@ -97,8 +99,8 @@ final class PdoClientRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->count());
-        self::assertCount(0, $this->repository->findAll(10, 0));
+        self::assertSame(0, $this->repository->countForAdminList(new ClientListFilter()));
+        self::assertCount(0, $this->repository->findForAdminList(new ClientListFilter(), new ClientSort(), 10, 0));
     }
 
     public function test_delete_throws_for_unknown_client(): void

--- a/tests/Item/PdoItemRepositoryTest.php
+++ b/tests/Item/PdoItemRepositoryTest.php
@@ -62,7 +62,7 @@ final class PdoItemRepositoryTest extends TestCase
         $this->repository->save(new Item(organizationId: 1, description: 'Mine', defaultUnitPriceCents: 1000, defaultTaxRateBps: 1000));
 
         $this->orgId->set(2);
-        self::assertSame(0, $this->repository->count());
+        self::assertSame(0, $this->repository->countForAdminList(new ItemListFilter()));
         self::assertCount(0, $this->repository->findAll(20, 0));
     }
 
@@ -96,7 +96,7 @@ final class PdoItemRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->count());
+        self::assertSame(0, $this->repository->countForAdminList(new ItemListFilter()));
     }
 
     public function test_delete_missing_throws(): void

--- a/tests/Quote/PdoQuoteRepositoryTest.php
+++ b/tests/Quote/PdoQuoteRepositoryTest.php
@@ -10,7 +10,9 @@ use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Quote\PdoQuoteRepository;
 use NeneInvoice\Quote\Quote;
+use NeneInvoice\Quote\QuoteListFilter;
 use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteSort;
 use NeneInvoice\Quote\QuoteStatus;
 use PHPUnit\Framework\TestCase;
 
@@ -36,9 +38,11 @@ final class PdoQuoteRepositoryTest extends TestCase
         $factory = new PdoConnectionFactory($config);
         $pdo = $factory->create();
 
-        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/quotes.sql');
-        self::assertIsString($schema);
-        $pdo->exec($schema);
+        foreach (['quotes', 'clients'] as $table) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . "/database/schema/{$table}.sql");
+            self::assertIsString($schema);
+            $pdo->exec($schema);
+        }
 
         $this->orgId = new RequestScopedHolder();
         $this->orgId->set(1);
@@ -79,11 +83,11 @@ final class PdoQuoteRepositoryTest extends TestCase
         $this->repository->save($this->draft(2, 9, 'EST-2026-001'));
 
         $this->orgId->set(1);
-        self::assertSame(2, $this->repository->count());
-        self::assertCount(2, $this->repository->findAll(10, 0));
+        self::assertSame(2, $this->repository->countForAdminList(new QuoteListFilter()));
+        self::assertCount(2, $this->repository->findForAdminList(new QuoteListFilter(), new QuoteSort(), 10, 0));
 
         $this->orgId->set(2);
-        self::assertSame(1, $this->repository->count());
+        self::assertSame(1, $this->repository->countForAdminList(new QuoteListFilter()));
         // A caller in another org must not read the row even by direct id.
         self::assertNull($this->repository->findById($org1QuoteId));
     }
@@ -118,7 +122,7 @@ final class PdoQuoteRepositoryTest extends TestCase
         $this->repository->delete($id);
 
         self::assertNull($this->repository->findById($id));
-        self::assertSame(0, $this->repository->count());
+        self::assertSame(0, $this->repository->countForAdminList(new QuoteListFilter()));
     }
 
     public function test_delete_throws_for_unknown_quote(): void

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -13,7 +13,9 @@ use NeneInvoice\Quote\CreateQuoteInput;
 use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\GetQuoteByIdUseCase;
 use NeneInvoice\Quote\ListQuotesUseCase;
+use NeneInvoice\Quote\QuoteListFilter;
 use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Quote\QuoteSort;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
@@ -99,10 +101,10 @@ final class QuoteQueryUseCasesTest extends TestCase
         $useCase = new ListQuotesUseCase($this->quotes);
 
         // org 1 has the quote from setUp; org 2 sees none (holder-scoped)
-        self::assertSame(1, $useCase->execute(20, 0)->total);
+        self::assertSame(1, $useCase->executeAdmin(new QuoteListFilter(), new QuoteSort(), 20, 0)->total);
 
         $this->holder->set(2);
-        self::assertSame(0, $useCase->execute(20, 0)->total);
+        self::assertSame(0, $useCase->executeAdmin(new QuoteListFilter(), new QuoteSort(), 20, 0)->total);
     }
 
     public function test_list_pagination_limit_and_offset(): void
@@ -118,11 +120,11 @@ final class QuoteQueryUseCasesTest extends TestCase
         }
 
         $useCase = new ListQuotesUseCase($this->quotes);
-        $page    = $useCase->execute(3, 0);
+        $page    = $useCase->executeAdmin(new QuoteListFilter(), new QuoteSort(), 3, 0);
         self::assertSame(5, $page->total);
         self::assertCount(3, $page->items);
 
-        $page2 = $useCase->execute(3, 3);
+        $page2 = $useCase->executeAdmin(new QuoteListFilter(), new QuoteSort(), 3, 3);
         self::assertCount(2, $page2->items);
     }
 }

--- a/tests/Support/InMemoryClientRepository.php
+++ b/tests/Support/InMemoryClientRepository.php
@@ -50,25 +50,6 @@ final class InMemoryClientRepository implements ClientRepositoryInterface
     }
 
     /** @return list<Client> */
-    public function findAll(int $limit, int $offset): array
-    {
-        $matches = array_values(array_filter(
-            $this->byId,
-            fn (Client $c): bool => $c->organizationId === $this->orgId->get() && !$c->isDeleted,
-        ));
-
-        return array_slice($matches, $offset, $limit);
-    }
-
-    public function count(): int
-    {
-        return count(array_filter(
-            $this->byId,
-            fn (Client $c): bool => $c->organizationId === $this->orgId->get() && !$c->isDeleted,
-        ));
-    }
-
-    /** @return list<Client> */
     public function findForAdminList(ClientListFilter $filter, ClientSort $sort, int $limit, int $offset): array
     {
         $matches = $this->adminFiltered($filter);

--- a/tests/Support/InMemoryItemRepository.php
+++ b/tests/Support/InMemoryItemRepository.php
@@ -60,14 +60,6 @@ final class InMemoryItemRepository implements ItemRepositoryInterface
         return array_slice($matches, $offset, $limit);
     }
 
-    public function count(): int
-    {
-        return count(array_filter(
-            $this->byId,
-            fn (Item $i): bool => $i->organizationId === $this->orgId->get() && !$i->isDeleted,
-        ));
-    }
-
     /** @return list<Item> */
     public function findForAdminList(ItemListFilter $filter, ItemSort $sort, int $limit, int $offset): array
     {

--- a/tests/Support/InMemoryQuoteRepository.php
+++ b/tests/Support/InMemoryQuoteRepository.php
@@ -47,25 +47,6 @@ final class InMemoryQuoteRepository implements QuoteRepositoryInterface
             : null;
     }
 
-    /** @return list<Quote> */
-    public function findAll(int $limit, int $offset): array
-    {
-        $matches = array_values(array_filter(
-            $this->byId,
-            fn (Quote $q): bool => $q->organizationId === $this->orgId->get() && !$q->isDeleted,
-        ));
-
-        return array_slice($matches, $offset, $limit);
-    }
-
-    public function count(): int
-    {
-        return count(array_filter(
-            $this->byId,
-            fn (Quote $q): bool => $q->organizationId === $this->orgId->get() && !$q->isDeleted,
-        ));
-    }
-
     /**
      * Admin list fake: applies the admin filters + sort. The fake has no client
      * data, so search matches quote_number only and clientName is empty (the


### PR DESCRIPTION
Closes #335（バックエンド監査の最優先項目）

## 概要
admin list（検索/ソート）移行で残った旧「汎用 list」デッドコードを削除。

## 削除
- 未使用 `List{Clients,Items,Quotes}UseCase::execute(limit,offset)`（ハンドラは `executeAdmin` のみ使用）
- `{Client,Item,Quote}ListFilter::isEmpty()`（参照ゼロ）
- リポジトリ未使用メソッド：Client `findAll`/`count`、Quote `findAll`/`count`、Item `count`（Item `findAll` はサジェストが使うため残置）。Interface / Pdo / InMemory を更新

## テスト
- org スコープ検証は admin 経路（`findForAdminList`/`countForAdminList`）に置換して維持。Pdo quote テストは JOIN 用に clients スキーマも読み込み。

## 対象外
- **Invoice**：`ListInvoicesUseCase::execute` は ServiceApi（機械API）が使用中のため温存（findFiltered/countFiltered/findAll/count/isEmpty すべて生存）。

## 確認
- [x] composer check（test **346** / phpstan / cs / openapi / mcp）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)