### PR TITLE
refactor(backend): リクエスト解析・バリデーションをNENE2標準に統一 (#336)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -115,7 +115,8 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 
 | Slug | Use |
 | --- | --- |
-| `validation-failed` | Request body/field validation error |
+| `invalid-json` | Malformed / empty / non-object request body (400; framework `JsonRequestBodyParser`) |
+| `validation-failed` | Request body/field validation error (422; `errors[]` carries field + code) |
 | `invoice-not-found` | Invoice id/token not found |
 | `quote-not-found` | Quote id not found |
 | `client-not-found` | Client id not found |

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace NeneInvoice\Auth;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -24,17 +27,16 @@ final readonly class LoginHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        $email = $body['email'] ?? null;
+        if (!is_string($email) || $email === '') {
+            throw new ValidationException([new ValidationError('body.email', 'Email is required.', 'required')]);
         }
 
-        $email = $decoded['email'] ?? null;
-        $password = $decoded['password'] ?? null;
-
-        if (!is_string($email) || $email === '' || !is_string($password) || $password === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "email" and "password" are required.');
+        $password = $body['password'] ?? null;
+        if (!is_string($password) || $password === '') {
+            throw new ValidationException([new ValidationError('body.password', 'Password is required.', 'required')]);
         }
 
         $serverParams = $request->getServerParams();

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -60,7 +60,6 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateClientHandler => new CreateClientHandler(
                     self::createUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -68,7 +67,6 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): UpdateClientHandler => new UpdateClientHandler(
                     self::updateUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/Client/CreateClientHandler.php
+++ b/src/Client/CreateClientHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -19,31 +21,26 @@ final readonly class CreateClientHandler implements RequestHandlerInterface
     public function __construct(
         private CreateClientUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $name = $decoded['name'] ?? null;
+        $name = $body['name'] ?? null;
 
         if (!is_string($name) || $name === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
+            throw new ValidationException([new ValidationError('body.name', 'Name is required.', 'required')]);
         }
 
         $client = $this->useCase->execute(AuthContext::userId($request), new CreateClientInput(
             name: $name,
-            nameKana: ClientField::optionalString($decoded, 'name_kana'),
-            contactName: ClientField::optionalString($decoded, 'contact_name'),
-            email: ClientField::optionalString($decoded, 'email'),
-            billingAddress: ClientField::optionalString($decoded, 'billing_address'),
-            registrationNumber: ClientField::optionalString($decoded, 'registration_number'),
+            nameKana: ClientField::optionalString($body, 'name_kana'),
+            contactName: ClientField::optionalString($body, 'contact_name'),
+            email: ClientField::optionalString($body, 'email'),
+            billingAddress: ClientField::optionalString($body, 'billing_address'),
+            registrationNumber: ClientField::optionalString($body, 'registration_number'),
         ));
 
         return $this->json->create(ClientResponse::toArray($client), 201);

--- a/src/Client/UpdateClientHandler.php
+++ b/src/Client/UpdateClientHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,7 +22,6 @@ final readonly class UpdateClientHandler implements RequestHandlerInterface
     public function __construct(
         private UpdateClientUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -29,25 +30,21 @@ final readonly class UpdateClientHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $name = $decoded['name'] ?? null;
+        $name = $body['name'] ?? null;
 
         if (!is_string($name) || $name === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"name" is required.');
+            throw new ValidationException([new ValidationError('body.name', 'Name is required.', 'required')]);
         }
 
         $client = $this->useCase->execute(AuthContext::userId($request), $id, new UpdateClientInput(
             name: $name,
-            nameKana: ClientField::optionalString($decoded, 'name_kana'),
-            contactName: ClientField::optionalString($decoded, 'contact_name'),
-            email: ClientField::optionalString($decoded, 'email'),
-            billingAddress: ClientField::optionalString($decoded, 'billing_address'),
-            registrationNumber: ClientField::optionalString($decoded, 'registration_number'),
+            nameKana: ClientField::optionalString($body, 'name_kana'),
+            contactName: ClientField::optionalString($body, 'contact_name'),
+            email: ClientField::optionalString($body, 'email'),
+            billingAddress: ClientField::optionalString($body, 'billing_address'),
+            registrationNumber: ClientField::optionalString($body, 'registration_number'),
         ));
 
         return $this->json->create(ClientResponse::toArray($client));

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -50,7 +50,6 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): UpdateCompanySettingsHandler => new UpdateCompanySettingsHandler(
                     self::updateUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,29 +22,20 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
     public function __construct(
         private UpdateCompanySettingsUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
+        $decoded = JsonRequestBodyParser::parse($request);
 
         $legalName = $decoded['legal_name'] ?? null;
 
         if (!is_string($legalName) || $legalName === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"legal_name" is required.');
+            throw new ValidationException([new ValidationError('body.legal_name', 'Legal name is required.', 'required')]);
         }
 
-        $rangeError = $this->validateBillingDefaults($decoded);
-
-        if ($rangeError !== null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $rangeError);
-        }
+        $this->validateBillingDefaults($decoded);
 
         $settings = $this->useCase->execute(AuthContext::userId($request), new UpdateCompanySettingsInput(
             legalName: $legalName,
@@ -81,27 +74,32 @@ final readonly class UpdateCompanySettingsHandler implements RequestHandlerInter
     }
 
     /**
-     * Validates the billing-default integers (Issue #268). Returns an error
-     * message, or null when all are absent / null / valid.
+     * Validates the billing-default integers (Issue #268). Absent / null values
+     * are allowed; out-of-range values raise a 422 with field-scoped errors.
      *
      * @param array<string, mixed> $body
+     *
+     * @throws ValidationException
      */
-    private function validateBillingDefaults(array $body): ?string
+    private function validateBillingDefaults(array $body): void
     {
-        if (!$this->isNullOrIntInRange($body['default_quote_validity_days'] ?? null, 1, 3650)) {
-            return '"default_quote_validity_days" must be an integer between 1 and 3650.';
-        }
-        if (!$this->isNullOrIntInRange($body['default_payment_closing_day'] ?? null, 1, 31)) {
-            return '"default_payment_closing_day" must be an integer between 1 and 31.';
-        }
-        if (!$this->isNullOrIntInRange($body['default_payment_month_offset'] ?? null, 0, 12)) {
-            return '"default_payment_month_offset" must be an integer between 0 and 12.';
-        }
-        if (!$this->isNullOrIntInRange($body['default_payment_pay_day'] ?? null, 1, 31)) {
-            return '"default_payment_pay_day" must be an integer between 1 and 31.';
+        $ranges = [
+            'default_quote_validity_days'  => [1, 3650],
+            'default_payment_closing_day'  => [1, 31],
+            'default_payment_month_offset' => [0, 12],
+            'default_payment_pay_day'      => [1, 31],
+        ];
+
+        $errors = [];
+        foreach ($ranges as $key => [$min, $max]) {
+            if (!$this->isNullOrIntInRange($body[$key] ?? null, $min, $max)) {
+                $errors[] = new ValidationError('body.' . $key, sprintf('%s must be an integer between %d and %d.', $key, $min, $max), 'out_of_range');
+            }
         }
 
-        return null;
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
     }
 
     private function isNullOrIntInRange(mixed $value, int $min, int $max): bool

--- a/src/Invoice/CreateInvoiceHandler.php
+++ b/src/Invoice/CreateInvoiceHandler.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Auth\AuthContext;
-use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemRequest;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -21,65 +21,22 @@ final readonly class CreateInvoiceHandler implements RequestHandlerInterface
     public function __construct(
         private CreateInvoiceUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $clientId = $decoded['client_id'] ?? null;
-
-        if (!is_int($clientId) && !(is_string($clientId) && ctype_digit($clientId))) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"client_id" is required.');
-        }
-
-        $rawLines = $decoded['line_items'] ?? null;
-
-        if (!is_array($rawLines) || $rawLines === []) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"line_items" must be a non-empty array.');
-        }
-
-        $lines = [];
-        foreach ($rawLines as $raw) {
-            if (!is_array($raw)) {
-                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item must be an object.');
-            }
-
-            $description = $raw['description'] ?? null;
-            $quantity = $raw['quantity'] ?? null;
-            $unitPrice = $raw['unit_price_cents'] ?? null;
-            $taxRate = $raw['tax_rate_bps'] ?? null;
-
-            if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
-                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).');
-            }
-
-            $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
-        }
+        $body = JsonRequestBodyParser::parse($request);
 
         $result = $this->useCase->execute(
             AuthContext::userId($request),
             new CreateInvoiceInput(
-                clientId: (int) $clientId,
-                lines: $lines,
-                notes: $this->optional($decoded, 'notes'),
+                clientId: LineItemRequest::requireClientId($body),
+                lines: LineItemRequest::parseLines($body),
+                notes: LineItemRequest::optionalString($body, 'notes'),
             ),
         );
 
         return $this->json->create(InvoiceResponse::toArray($result->invoice, $result->lines), 201);
-    }
-
-    /** @param array<string, mixed> $body */
-    private function optional(array $body, string $key): ?string
-    {
-        $value = $body[$key] ?? null;
-
-        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -119,7 +119,6 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateInvoiceHandler => new CreateInvoiceHandler(
                     self::resolve($c, CreateInvoiceUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/Item/CreateItemHandler.php
+++ b/src/Item/CreateItemHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
@@ -19,25 +19,12 @@ final readonly class CreateItemHandler implements RequestHandlerInterface
     public function __construct(
         private CreateItemUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $parsed = ItemField::parse($decoded);
-
-        if ($parsed['error'] !== null || $parsed['input'] === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $parsed['error'] ?? 'Invalid item payload.');
-        }
-
-        $values = $parsed['input'];
+        $values = ItemField::parse(JsonRequestBodyParser::parse($request));
 
         $item = $this->useCase->execute(AuthContext::userId($request), new CreateItemInput(
             description: $values->description,

--- a/src/Item/ItemField.php
+++ b/src/Item/ItemField.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
 /**
  * Parses + validates the item write payload shared by create and update.
  *
@@ -19,25 +22,34 @@ final class ItemField
     /**
      * @param array<string, mixed> $body
      *
-     * @return array{error: ?string, input: ?ItemWriteValues}
+     * @throws ValidationException
      */
-    public static function parse(array $body): array
+    public static function parse(array $body): ItemWriteValues
     {
+        $errors = [];
+
         $description = $body['description'] ?? null;
         if (!is_string($description) || trim($description) === '') {
-            return ['error' => '"description" is required.', 'input' => null];
+            $errors[] = new ValidationError('body.description', 'Description is required.', 'required');
+            $description = '';
         }
 
         $price = $body['default_unit_price_cents'] ?? null;
         if (!is_int($price) || $price < 0) {
-            return ['error' => '"default_unit_price_cents" must be a non-negative integer.', 'input' => null];
+            $errors[] = new ValidationError('body.default_unit_price_cents', 'Default unit price must be a non-negative integer.', 'invalid');
+            $price = 0;
         }
 
         $tax = $body['default_tax_rate_bps'] ?? null;
         if (!is_int($tax) || !in_array($tax, self::ALLOWED_TAX_RATES, true)) {
-            return ['error' => '"default_tax_rate_bps" must be one of 800 or 1000.', 'input' => null];
+            $errors[] = new ValidationError('body.default_tax_rate_bps', 'Default tax rate must be one of 800 or 1000.', 'invalid');
+            $tax = 1000;
         }
 
-        return ['error' => null, 'input' => new ItemWriteValues(trim($description), $price, $tax)];
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        return new ItemWriteValues(trim($description), $price, $tax);
     }
 }

--- a/src/Item/ItemServiceProvider.php
+++ b/src/Item/ItemServiceProvider.php
@@ -60,7 +60,6 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateItemHandler => new CreateItemHandler(
                     self::createUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -68,7 +67,6 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): UpdateItemHandler => new UpdateItemHandler(
                     self::updateUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/Item/UpdateItemHandler.php
+++ b/src/Item/UpdateItemHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -21,7 +21,6 @@ final readonly class UpdateItemHandler implements RequestHandlerInterface
     public function __construct(
         private UpdateItemUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -30,19 +29,7 @@ final readonly class UpdateItemHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $parsed = ItemField::parse($decoded);
-
-        if ($parsed['error'] !== null || $parsed['input'] === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $parsed['error'] ?? 'Invalid item payload.');
-        }
-
-        $values = $parsed['input'];
+        $values = ItemField::parse(JsonRequestBodyParser::parse($request));
 
         $item = $this->useCase->execute(AuthContext::userId($request), $id, new UpdateItemInput(
             description: $values->description,

--- a/src/LineItem/LineItemRequest.php
+++ b/src/LineItem/LineItemRequest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Shared parsing/validation for document write payloads (quote & invoice create):
+ * the required client id, the non-empty line-item array, and optional strings.
+ * Throws {@see ValidationException} (→ 422 with `errors[]`) on malformed input;
+ * tax-rate / amount business rules are enforced later in the use case.
+ */
+final class LineItemRequest
+{
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @throws ValidationException
+     */
+    public static function requireClientId(array $body): int
+    {
+        $clientId = $body['client_id'] ?? null;
+
+        if (is_int($clientId)) {
+            return $clientId;
+        }
+
+        if (is_string($clientId) && ctype_digit($clientId)) {
+            return (int) $clientId;
+        }
+
+        throw new ValidationException([new ValidationError('body.client_id', 'A client_id is required.', 'required')]);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<LineItemInput>
+     * @throws ValidationException
+     */
+    public static function parseLines(array $body): array
+    {
+        $rawLines = $body['line_items'] ?? null;
+
+        if (!is_array($rawLines) || $rawLines === []) {
+            throw new ValidationException([new ValidationError('body.line_items', 'line_items must be a non-empty array.', 'required')]);
+        }
+
+        $lines = [];
+        foreach (array_values($rawLines) as $index => $raw) {
+            $field = 'body.line_items.' . $index;
+
+            if (!is_array($raw)) {
+                throw new ValidationException([new ValidationError($field, 'Each line item must be an object.', 'invalid')]);
+            }
+
+            $description = $raw['description'] ?? null;
+            $quantity = $raw['quantity'] ?? null;
+            $unitPrice = $raw['unit_price_cents'] ?? null;
+            $taxRate = $raw['tax_rate_bps'] ?? null;
+
+            if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
+                throw new ValidationException([new ValidationError($field, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).', 'invalid')]);
+            }
+
+            $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Returns a trimmed-non-empty string for the key, or null when missing/blank.
+     *
+     * @param array<string, mixed> $body
+     */
+    public static function optionalString(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -19,26 +21,24 @@ final readonly class CreateOrganizationHandler implements RequestHandlerInterfac
     public function __construct(
         private CreateOrganizationUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        $name = $body['name'] ?? null;
+        if (!is_string($name) || $name === '') {
+            throw new ValidationException([new ValidationError('body.name', 'Name is required.', 'required')]);
         }
 
-        $name = $decoded['name'] ?? null;
-        $slug = $decoded['slug'] ?? null;
-
-        if (!is_string($name) || $name === '' || !is_string($slug) || $slug === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "name" and "slug" are required.');
+        $slug = $body['slug'] ?? null;
+        if (!is_string($slug) || $slug === '') {
+            throw new ValidationException([new ValidationError('body.slug', 'Slug is required.', 'required')]);
         }
 
-        $plan = $decoded['plan'] ?? 'free';
+        $plan = $body['plan'] ?? 'free';
         $plan = is_string($plan) && $plan !== '' ? $plan : 'free';
 
         $organization = $this->useCase->execute(AuthContext::userId($request), new CreateOrganizationInput($name, $slug, $plan));

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -57,7 +57,6 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 static fn (ContainerInterface $c): CreateOrganizationHandler => new CreateOrganizationHandler(
                     self::createUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/Quote/ChangeQuoteStatusHandler.php
+++ b/src/Quote/ChangeQuoteStatusHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,7 +22,6 @@ final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
     public function __construct(
         private ChangeQuoteStatusUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -29,12 +30,12 @@ final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
-        $statusValue = is_array($decoded) ? ($decoded['status'] ?? null) : null;
+        $body = JsonRequestBodyParser::parse($request);
+        $statusValue = $body['status'] ?? null;
         $target = is_string($statusValue) ? QuoteStatus::tryFrom($statusValue) : null;
 
         if ($target === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"status" must be one of: draft, sent, accepted, rejected, expired.');
+            throw new ValidationException([new ValidationError('body.status', 'Status must be one of: draft, sent, accepted, rejected, expired.', 'invalid')]);
         }
 
         $quote = $this->useCase->execute(AuthContext::userId($request), $id, $target);

--- a/src/Quote/CreateQuoteHandler.php
+++ b/src/Quote/CreateQuoteHandler.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Auth\AuthContext;
-use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemRequest;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -20,66 +20,23 @@ final readonly class CreateQuoteHandler implements RequestHandlerInterface
     public function __construct(
         private CreateQuoteUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $clientId = $decoded['client_id'] ?? null;
-
-        if (!is_int($clientId) && !(is_string($clientId) && ctype_digit($clientId))) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"client_id" is required.');
-        }
-
-        $rawLines = $decoded['line_items'] ?? null;
-
-        if (!is_array($rawLines) || $rawLines === []) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"line_items" must be a non-empty array.');
-        }
-
-        $lines = [];
-        foreach ($rawLines as $raw) {
-            if (!is_array($raw)) {
-                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item must be an object.');
-            }
-
-            $description = $raw['description'] ?? null;
-            $quantity = $raw['quantity'] ?? null;
-            $unitPrice = $raw['unit_price_cents'] ?? null;
-            $taxRate = $raw['tax_rate_bps'] ?? null;
-
-            if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
-                return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).');
-            }
-
-            $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
-        }
+        $body = JsonRequestBodyParser::parse($request);
 
         $result = $this->useCase->execute(
             AuthContext::userId($request),
             new CreateQuoteInput(
-                clientId: (int) $clientId,
-                lines: $lines,
-                validUntil: $this->optional($decoded, 'valid_until'),
-                notes: $this->optional($decoded, 'notes'),
+                clientId: LineItemRequest::requireClientId($body),
+                lines: LineItemRequest::parseLines($body),
+                validUntil: LineItemRequest::optionalString($body, 'valid_until'),
+                notes: LineItemRequest::optionalString($body, 'notes'),
             ),
         );
 
         return $this->json->create(QuoteResponse::toArray($result->quote, $result->lines), 201);
-    }
-
-    /** @param array<string, mixed> $body */
-    private function optional(array $body, string $key): ?string
-    {
-        $value = $body[$key] ?? null;
-
-        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -78,7 +78,6 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateQuoteHandler => new CreateQuoteHandler(
                     self::resolve($c, CreateQuoteUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -100,7 +99,6 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ChangeQuoteStatusHandler => new ChangeQuoteStatusHandler(
                     self::resolve($c, ChangeQuoteStatusUseCase::class),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/src/ServiceApi/RecordServicePaymentHandler.php
+++ b/src/ServiceApi/RecordServicePaymentHandler.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace NeneInvoice\ServiceApi;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use Psr\Http\Message\ResponseInterface;
@@ -40,20 +43,19 @@ final readonly class RecordServicePaymentHandler implements RequestHandlerInterf
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
-        $decoded = is_array($decoded) ? $decoded : [];
+        $decoded = JsonRequestBodyParser::parse($request);
 
         $amountValue = $decoded['amount_cents'] ?? null;
         $amountCents = is_int($amountValue) ? $amountValue : (is_numeric($amountValue) ? (int) $amountValue : 0);
 
         $paidAt = $this->stringOrNull($decoded, 'paid_at');
         if ($paidAt === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"paid_at" (bank value date) is required.');
+            throw new ValidationException([new ValidationError('body.paid_at', 'paid_at (bank value date) is required.', 'required')]);
         }
 
         $idempotencyKey = $this->stringOrNull($decoded, 'idempotency_key');
         if ($idempotencyKey === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"idempotency_key" is required.');
+            throw new ValidationException([new ValidationError('body.idempotency_key', 'idempotency_key is required.', 'required')]);
         }
 
         $result = $this->useCase->execute(null, $invoiceId, new RecordPaymentInput(

--- a/src/Template/CreateTemplateHandler.php
+++ b/src/Template/CreateTemplateHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
@@ -19,22 +19,12 @@ final readonly class CreateTemplateHandler implements RequestHandlerInterface
     public function __construct(
         private CreateTemplateUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $parsed = TemplateField::parse($decoded);
-        if ($parsed['error'] !== null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $parsed['error']);
-        }
+        $parsed = TemplateField::parse(JsonRequestBodyParser::parse($request));
 
         $result = $this->useCase->execute(
             AuthContext::userId($request),

--- a/src/Template/TemplateField.php
+++ b/src/Template/TemplateField.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\LineItem\LineItemInput;
 
 /**
@@ -21,26 +23,27 @@ final class TemplateField
     /**
      * @param array<string, mixed> $body
      *
-     * @return array{error: ?string, name: string, notes: ?string, lines: list<LineItemInput>}
+     * @return array{name: string, notes: ?string, lines: list<LineItemInput>}
+     * @throws ValidationException
      */
     public static function parse(array $body): array
     {
-        $fail = static fn (string $message): array => ['error' => $message, 'name' => '', 'notes' => null, 'lines' => []];
-
         $name = $body['name'] ?? null;
         if (!is_string($name) || trim($name) === '') {
-            return $fail('"name" is required.');
+            throw new ValidationException([new ValidationError('body.name', 'Name is required.', 'required')]);
         }
 
         $rawLines = $body['line_items'] ?? [];
         if (!is_array($rawLines)) {
-            return $fail('"line_items" must be an array.');
+            throw new ValidationException([new ValidationError('body.line_items', 'line_items must be an array.', 'invalid')]);
         }
 
         $lines = [];
-        foreach ($rawLines as $raw) {
+        foreach (array_values($rawLines) as $index => $raw) {
+            $field = 'body.line_items.' . $index;
+
             if (!is_array($raw)) {
-                return $fail('Each line item must be an object.');
+                throw new ValidationException([new ValidationError($field, 'Each line item must be an object.', 'invalid')]);
             }
 
             $description = $raw['description'] ?? null;
@@ -49,11 +52,11 @@ final class TemplateField
             $taxRate = $raw['tax_rate_bps'] ?? null;
 
             if (!is_string($description) || $description === '' || !is_int($quantity) || !is_int($unitPrice) || !is_int($taxRate)) {
-                return $fail('Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).');
+                throw new ValidationException([new ValidationError($field, 'Each line item needs description (string) and quantity / unit_price_cents / tax_rate_bps (integers).', 'invalid')]);
             }
 
             if ($quantity <= 0 || $unitPrice < 0 || !in_array($taxRate, self::ALLOWED_TAX_RATES, true)) {
-                return $fail('Line item quantity must be > 0, unit price >= 0, and tax rate one of 800 or 1000.');
+                throw new ValidationException([new ValidationError($field, 'Line item quantity must be > 0, unit price >= 0, and tax rate one of 800 or 1000.', 'invalid')]);
             }
 
             $lines[] = new LineItemInput($description, $quantity, $unitPrice, $taxRate);
@@ -62,7 +65,6 @@ final class TemplateField
         $notes = $body['notes'] ?? null;
 
         return [
-            'error' => null,
             'name' => trim($name),
             'notes' => is_string($notes) && $notes !== '' ? $notes : null,
             'lines' => $lines,

--- a/src/Template/TemplateServiceProvider.php
+++ b/src/Template/TemplateServiceProvider.php
@@ -53,11 +53,11 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 CreateTemplateHandler::class,
-                static fn (ContainerInterface $c): CreateTemplateHandler => new CreateTemplateHandler(self::resolve($c, CreateTemplateUseCase::class), self::json($c), self::problemDetails($c)),
+                static fn (ContainerInterface $c): CreateTemplateHandler => new CreateTemplateHandler(self::resolve($c, CreateTemplateUseCase::class), self::json($c)),
             )
             ->set(
                 UpdateTemplateHandler::class,
-                static fn (ContainerInterface $c): UpdateTemplateHandler => new UpdateTemplateHandler(self::resolve($c, UpdateTemplateUseCase::class), self::json($c), self::problemDetails($c)),
+                static fn (ContainerInterface $c): UpdateTemplateHandler => new UpdateTemplateHandler(self::resolve($c, UpdateTemplateUseCase::class), self::json($c)),
             )
             ->set(
                 DeleteTemplateHandler::class,

--- a/src/Template/UpdateTemplateHandler.php
+++ b/src/Template/UpdateTemplateHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
@@ -20,7 +20,6 @@ final readonly class UpdateTemplateHandler implements RequestHandlerInterface
     public function __construct(
         private UpdateTemplateUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -29,16 +28,7 @@ final readonly class UpdateTemplateHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
-
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $parsed = TemplateField::parse($decoded);
-        if ($parsed['error'] !== null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, $parsed['error']);
-        }
+        $parsed = TemplateField::parse(JsonRequestBodyParser::parse($request));
 
         $result = $this->useCase->execute(
             AuthContext::userId($request),

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use NeneInvoice\Auth\Role;
 use Psr\Http\Message\ResponseInterface;
@@ -20,30 +22,27 @@ final readonly class CreateUserHandler implements RequestHandlerInterface
     public function __construct(
         private CreateUserUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
+        $email = $body['email'] ?? null;
+        if (!is_string($email) || $email === '') {
+            throw new ValidationException([new ValidationError('body.email', 'Email is required.', 'required')]);
         }
 
-        $email = $decoded['email'] ?? null;
-        $password = $decoded['password'] ?? null;
-        $roleValue = $decoded['role'] ?? null;
-
-        if (!is_string($email) || $email === '' || !is_string($password) || $password === '') {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Both "email" and "password" are required.');
+        $password = $body['password'] ?? null;
+        if (!is_string($password) || $password === '') {
+            throw new ValidationException([new ValidationError('body.password', 'Password is required.', 'required')]);
         }
 
+        $roleValue = $body['role'] ?? null;
         $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
-
         if ($role === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
+            throw new ValidationException([new ValidationError('body.role', 'A valid role is required.', 'invalid')]);
         }
 
         $user = $this->useCase->execute(AuthContext::userId($request), new CreateUserInput($email, $password, $role));

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Auth\AuthContext;
 use NeneInvoice\Auth\Role;
 use Psr\Http\Message\ResponseInterface;
@@ -24,7 +26,6 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
     public function __construct(
         private UpdateUserUseCase $useCase,
         private JsonResponseFactory $json,
-        private ProblemDetailsResponseFactory $problemDetails,
     ) {
     }
 
@@ -33,26 +34,20 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
-        $decoded = json_decode((string) $request->getBody(), true);
+        $body = JsonRequestBodyParser::parse($request);
 
-        if (!is_array($decoded)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'Request body must be a JSON object.');
-        }
-
-        $roleValue = $decoded['role'] ?? null;
-        $status = $decoded['status'] ?? null;
-
+        $roleValue = $body['role'] ?? null;
         $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
-
         if ($role === null) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, 'A valid "role" is required.');
+            throw new ValidationException([new ValidationError('body.role', 'A valid role is required.', 'invalid')]);
         }
 
+        $status = $body['status'] ?? null;
         if (!is_string($status) || !in_array($status, self::ALLOWED_STATUSES, true)) {
-            return $this->problemDetails->create($request, 'validation-failed', 'Validation Failed', 422, '"status" must be one of: active, invited.');
+            throw new ValidationException([new ValidationError('body.status', 'Status must be one of: active, invited.', 'invalid')]);
         }
 
-        $passwordValue = $decoded['password'] ?? null;
+        $passwordValue = $body['password'] ?? null;
         $password = is_string($passwordValue) && $passwordValue !== '' ? $passwordValue : null;
 
         $user = $this->useCase->execute(AuthContext::userId($request), $id, new UpdateUserInput($role, $status, $password));

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -48,7 +48,6 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateUserHandler => new CreateUserHandler(
                     self::createUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(
@@ -56,7 +55,6 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): UpdateUserHandler => new UpdateUserHandler(
                     self::updateUseCase($c),
                     self::json($c),
-                    self::problemDetails($c),
                 ),
             )
             ->set(

--- a/tests/ServiceApi/RecordServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/RecordServicePaymentHandlerTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\ServiceApi;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use Nene2\Validation\ValidationException;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Payment\PaymentExceedsOutstandingException;
@@ -94,16 +95,17 @@ final class RecordServicePaymentHandlerTest extends TestCase
         self::assertSame(800, $this->payments->totalPaidForInvoice($this->invoiceId));
     }
 
-    public function test_missing_idempotency_key_is_422(): void
+    public function test_missing_idempotency_key_is_rejected(): void
     {
-        $response = $this->handler->handle($this->request(['amount_cents' => 800, 'paid_at' => '2026-04-20']));
-        self::assertSame(422, $response->getStatusCode());
+        // ValidationException is mapped to 422 (+ errors[]) by the error middleware.
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['amount_cents' => 800, 'paid_at' => '2026-04-20']));
     }
 
-    public function test_missing_paid_at_is_422(): void
+    public function test_missing_paid_at_is_rejected(): void
     {
-        $response = $this->handler->handle($this->request(['amount_cents' => 800, 'idempotency_key' => 'k1']));
-        self::assertSame(422, $response->getStatusCode());
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['amount_cents' => 800, 'idempotency_key' => 'k1']));
     }
 
     public function test_over_allocation_throws_exceeds_outstanding(): void


### PR DESCRIPTION
Closes #336（監査 A-1 / A-2）

## 概要
全 write 系ハンドラの **手書き `json_decode`＋手動 `validation-failed`** を、フレームワーク標準に置換。`ErrorHandlerMiddleware` が `JsonBodyParseException`→400・`ValidationException`→422(errors[]) を**標準で**変換するため追加配線は不要。

## 変更
- ボディ解析を **`JsonRequestBodyParser::parse()`** に統一。空/不正/非オブジェクトは **400 `invalid-json`**（従来は誤って 422）に正規化。
- フィールド検証を **`ValidationException([new ValidationError(field, msg, code)])`** に統一し、**422 `validation-failed` ＋ `errors[]`**（`field=body.*`、`code` は snake_case）を返す → 用語レジストリ §4 の契約を**実装で充足**。
- 対象: Client/Item/Template/User の create/update、Organization create、Quote create/changeStatus、Invoice create、Company update、Login、ServiceApi record payment。
- 重複していた line / client_id / optional パースを共通 **`LineItem\LineItemRequest`** に集約。`Item/TemplateField` は ValidationException 送出に変更。不要になった `ProblemDetailsResponseFactory` 依存を各ハンドラ/プロバイダから除去。

## 対象外（意図的）
- オプショナルbody（`IssueInvoice` / 管理 `RecordPayment` / `VoidServicePayment`）は寛容パース＋use case 検証のまま。`Login`/`ServiceApi` は credentials / scope 用に `problemDetails` を保持。

## 確認
- [x] `composer check`（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev 実地：空body→**400**、`{}`→**422＋errors[]**（`body.name`/`required`）、配列→**400**

🤖 Generated with [Claude Code](https://claude.com/claude-code)