### PR TITLE
refactor(backend): ページネーションをNENE2標準に統一 (#337)

### DIFF
--- a/src/Audit/ListAuditLogsHandler.php
+++ b/src/Audit/ListAuditLogsHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Audit;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -17,9 +19,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListAuditLogsHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListAuditLogsUseCase $useCase,
         private JsonResponseFactory $json,
@@ -28,23 +27,18 @@ final readonly class ListAuditLogsHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
         $filter = AuditLogFilterFactory::fromQueryParams($query);
 
-        $result = $this->useCase->execute($filter, $limit, $offset);
+        $result = $this->useCase->execute($filter, $pagination->limit, $pagination->offset);
 
-        return $this->json->create([
-            'items' => array_map(static fn (AuditLog $log): array => AuditLogResponse::toArray($log), $result->items),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+        return $this->json->create((new PaginationResponse(
+            items: array_map(static fn (AuditLog $log): array => AuditLogResponse::toArray($log), $result->items),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }

--- a/src/Client/ListClientsHandler.php
+++ b/src/Client/ListClientsHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Client;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListClientsHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListClientsUseCase $useCase,
         private JsonResponseFactory $json,
@@ -26,13 +25,8 @@ final readonly class ListClientsHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
         $searchValue = $query['q'] ?? null;
         $search      = is_string($searchValue) && trim($searchValue) !== '' ? trim($searchValue) : null;
@@ -43,13 +37,13 @@ final readonly class ListClientsHandler implements RequestHandlerInterface
             is_string($orderValue) ? $orderValue : null,
         );
 
-        $result = $this->useCase->executeAdmin(new ClientListFilter($search), $sort, $limit, $offset);
+        $result = $this->useCase->executeAdmin(new ClientListFilter($search), $sort, $pagination->limit, $pagination->offset);
 
-        return $this->json->create([
-            'items' => array_map(static fn (Client $c): array => ClientResponse::toArray($c), $result->items),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+        return $this->json->create((new PaginationResponse(
+            items: array_map(static fn (Client $c): array => ClientResponse::toArray($c), $result->items),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }

--- a/src/Invoice/ListInvoicesHandler.php
+++ b/src/Invoice/ListInvoicesHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListInvoicesHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListInvoicesUseCase $useCase,
         private JsonResponseFactory $json,
@@ -26,13 +25,8 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
         $filter = $this->buildFilter($query);
         $sort   = InvoiceSort::fromInput(
@@ -40,12 +34,12 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
             self::stringParam($query, 'order'),
         );
 
-        $result      = $this->useCase->executeAdmin($filter, $sort, $limit, $offset);
+        $result      = $this->useCase->executeAdmin($filter, $sort, $pagination->limit, $pagination->offset);
         $outstanding = $result->outstandingByInvoiceId;
         $clientNames = $result->clientNameByInvoiceId;
 
-        return $this->json->create([
-            'items' => array_map(
+        return $this->json->create((new PaginationResponse(
+            items: array_map(
                 static fn (Invoice $i): array => InvoiceResponse::toArray(
                     $i,
                     null,
@@ -54,10 +48,10 @@ final readonly class ListInvoicesHandler implements RequestHandlerInterface
                 ),
                 $result->items,
             ),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 
     /**

--- a/src/Item/ListItemsHandler.php
+++ b/src/Item/ListItemsHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Item;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListItemsHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListItemsUseCase $useCase,
         private JsonResponseFactory $json,
@@ -26,13 +25,8 @@ final readonly class ListItemsHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
         $searchValue = $query['q'] ?? null;
         $search      = is_string($searchValue) && trim($searchValue) !== '' ? trim($searchValue) : null;
@@ -43,13 +37,13 @@ final readonly class ListItemsHandler implements RequestHandlerInterface
             is_string($orderValue) ? $orderValue : null,
         );
 
-        $result = $this->useCase->executeAdmin(new ItemListFilter($search), $sort, $limit, $offset);
+        $result = $this->useCase->executeAdmin(new ItemListFilter($search), $sort, $pagination->limit, $pagination->offset);
 
-        return $this->json->create([
-            'items' => array_map(static fn (Item $i): array => ItemResponse::toArray($i), $result->items),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+        return $this->json->create((new PaginationResponse(
+            items: array_map(static fn (Item $i): array => ItemResponse::toArray($i), $result->items),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Organization;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -14,9 +16,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListOrganizationsHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListOrganizationsUseCase $useCase,
         private JsonResponseFactory $json,
@@ -25,21 +24,15 @@ final readonly class ListOrganizationsHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
+        $pagination = PaginationQueryParser::parse($request);
 
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
+        $result = $this->useCase->execute($pagination->limit, $pagination->offset);
 
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
-
-        $result = $this->useCase->execute($limit, $offset);
-
-        return $this->json->create([
-            'items' => array_map(static fn (Organization $o): array => OrganizationResponse::toArray($o), $result->items),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+        return $this->json->create((new PaginationResponse(
+            items: array_map(static fn (Organization $o): array => OrganizationResponse::toArray($o), $result->items),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }

--- a/src/Quote/ListQuotesHandler.php
+++ b/src/Quote/ListQuotesHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListQuotesHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListQuotesUseCase $useCase,
         private JsonResponseFactory $json,
@@ -26,22 +25,17 @@ final readonly class ListQuotesHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
         $filter = $this->buildFilter($query);
         $sort   = QuoteSort::fromInput(self::stringParam($query, 'sort'), self::stringParam($query, 'order'));
 
-        $result      = $this->useCase->executeAdmin($filter, $sort, $limit, $offset);
+        $result      = $this->useCase->executeAdmin($filter, $sort, $pagination->limit, $pagination->offset);
         $clientNames = $result->clientNameByQuoteId;
 
-        return $this->json->create([
-            'items' => array_map(
+        return $this->json->create((new PaginationResponse(
+            items: array_map(
                 static fn (Quote $q): array => QuoteResponse::toArray(
                     $q,
                     null,
@@ -49,10 +43,10 @@ final readonly class ListQuotesHandler implements RequestHandlerInterface
                 ),
                 $result->items,
             ),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 
     /**

--- a/src/ServiceApi/ListServiceInvoicesHandler.php
+++ b/src/ServiceApi/ListServiceInvoicesHandler.php
@@ -6,6 +6,8 @@ namespace NeneInvoice\ServiceApi;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceStatus;
@@ -22,9 +24,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListServiceInvoicesHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListInvoicesUseCase $useCase,
         private JsonResponseFactory $json,
@@ -40,27 +39,24 @@ final readonly class ListServiceInvoicesHandler implements RequestHandlerInterfa
             return $this->problemDetails->create($request, 'insufficient-scope', 'Forbidden', 403, 'The service token is not scoped to an organization.');
         }
 
+        $pagination = PaginationQueryParser::parse($request);
         $query = $request->getQueryParams();
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
 
-        $result = $this->useCase->execute($limit, $offset, $this->filterFrom($query));
+        $result = $this->useCase->execute($pagination->limit, $pagination->offset, $this->filterFrom($query));
         $outstanding = $result->outstandingByInvoiceId;
 
-        return $this->json->create([
-            'items' => array_map(
+        return $this->json->create((new PaginationResponse(
+            items: array_map(
                 static fn (Invoice $i): array => ServiceInvoiceResponse::listItem(
                     $i,
                     $i->id !== null ? ($outstanding[$i->id] ?? $i->totalCents) : $i->totalCents,
                 ),
                 $result->items,
             ),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 
     /**

--- a/src/Template/ListTemplatesHandler.php
+++ b/src/Template/ListTemplatesHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\Template;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -15,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListTemplatesHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 50;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListTemplatesUseCase $useCase,
         private JsonResponseFactory $json,
@@ -26,24 +25,18 @@ final readonly class ListTemplatesHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
+        $pagination = PaginationQueryParser::parse($request, 50);
 
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
+        $result = $this->useCase->execute($pagination->limit, $pagination->offset);
 
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
-
-        $result = $this->useCase->execute($limit, $offset);
-
-        return $this->json->create([
-            'items' => array_map(
+        return $this->json->create((new PaginationResponse(
+            items: array_map(
                 static fn (Template $t): array => TemplateResponse::toArray($t, []),
                 $result->items,
             ),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneInvoice\User;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -16,9 +18,6 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class ListUsersHandler implements RequestHandlerInterface
 {
-    private const DEFAULT_LIMIT = 20;
-    private const MAX_LIMIT = 100;
-
     public function __construct(
         private ListUsersUseCase $useCase,
         private JsonResponseFactory $json,
@@ -27,21 +26,15 @@ final readonly class ListUsersHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
+        $pagination = PaginationQueryParser::parse($request);
 
-        $limit = isset($query['limit']) && is_numeric($query['limit']) ? (int) $query['limit'] : self::DEFAULT_LIMIT;
-        $limit = max(1, min(self::MAX_LIMIT, $limit));
+        $result = $this->useCase->execute($pagination->limit, $pagination->offset);
 
-        $offset = isset($query['offset']) && is_numeric($query['offset']) ? (int) $query['offset'] : 0;
-        $offset = max(0, $offset);
-
-        $result = $this->useCase->execute($limit, $offset);
-
-        return $this->json->create([
-            'items' => array_map(static fn (User $u): array => UserResponse::toArray($u), $result->items),
-            'total' => $result->total,
-            'limit' => $limit,
-            'offset' => $offset,
-        ]);
+        return $this->json->create((new PaginationResponse(
+            items: array_map(static fn (User $u): array => UserResponse::toArray($u), $result->items),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
     }
 }


### PR DESCRIPTION
Closes #337（監査 A-3）

## 概要
9つの List ハンドラがコピペしていた limit/offset クランプ＋レスポンス組み立てをフレームワーク標準に置換。

## 変更
- `PaginationQueryParser::parse($request, default, max)` でクエリ解析（範囲外は **422 ValidationException**、従来の暗黙クランプから準拠挙動へ）。Template は default=50。
- レスポンスを `PaginationResponse(items, limit, offset, total)->toArray()` に統一。
- 各ハンドラの `DEFAULT_LIMIT`/`MAX_LIMIT` 定数と手書きクランプを削除。
- 対象: Client / Item / Quote / Invoice / Template / Organization / User / Audit / ServiceApi(list)。`q`/`sort`/filter 等の追加クエリ解析は維持。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- レスポンス形（items/total/limit/offset）は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)