### PR TITLE
refactor(backend): ダウンロードトークン生成を SecureTokenHelper に統一 (#341)

### DIFF
--- a/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
+++ b/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
 use Nene2\Routing\Router;
 use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
@@ -44,7 +45,7 @@ final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterfac
     {
         $params    = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $rawToken  = is_array($params) && isset($params['token']) ? (string) $params['token'] : '';
-        $tokenHash = hash('sha256', $rawToken);
+        $tokenHash = SecureTokenHelper::hash($rawToken);
 
         $record = $this->tokens->findByHash($tokenHash);
 

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 
 use DateTimeImmutable;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
@@ -48,8 +49,8 @@ final readonly class GenerateDownloadTokenUseCase
 
         $organizationId = $this->orgId->get();
 
-        $rawToken  = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
-        $tokenHash = hash('sha256', $rawToken);
+        // 256-bit token; only its SHA-256 hash is persisted (see SecureTokenHelper).
+        [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
         $now       = new DateTimeImmutable();
         $expiresAt = $now->modify('+' . self::TTL_DAYS . ' days')->format('Y-m-d H:i:s');
         $createdAt = $now->format('Y-m-d H:i:s');


### PR DESCRIPTION
Closes #341（監査 A-5）

手書きの `random_bytes`＋base64url＋`hash('sha256')` を `Nene2\Http\SecureTokenHelper` に置換。
- 生成: `generateWithHash()`、検証: `hash()`。
- セキュリティ等価（ハッシュのみ保存・期限切れ404）。ハッシュ関数同一のため既存トークンも互換。

確認: composer check（test 346 / phpstan / cs / openapi / mcp）green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)