### PR TITLE
fix(backend): 複数書き込みユースケースをトランザクション境界で囲う (#338)

### DIFF
--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -10,8 +10,10 @@ use Nene2\Config\AppConfig;
 use Nene2\Config\ConfigLoader;
 use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
@@ -131,6 +133,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     }
 
                     return new PdoDatabaseQueryExecutor($connectionFactory);
+                },
+            )
+            ->set(
+                DatabaseTransactionManagerInterface::class,
+                static function (ContainerInterface $container): DatabaseTransactionManagerInterface {
+                    $connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+
+                    if (!$connectionFactory instanceof DatabaseConnectionFactoryInterface) {
+                        throw new LogicException('Database connection factory service is invalid.');
+                    }
+
+                    return new PdoDatabaseTransactionManager($connectionFactory);
                 },
             )
             ->set(

--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItem;
@@ -18,16 +21,23 @@ use NeneInvoice\Quote\QuoteValidationException;
 /**
  * Converts an accepted quote into a new draft invoice, copying the client,
  * totals, and line items. The invoice is numbered and validated later, at issue.
+ *
+ * The duplicate-guard, copy, and writes run inside one transaction (repositories
+ * rebuilt from the transaction-bound executor via the injected factories), so a
+ * failure leaves no half-converted invoice.
  */
 final readonly class ConvertQuoteToInvoiceUseCase
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private QuoteRepositoryInterface $quotes,
-        private InvoiceRepositoryInterface $invoices,
-        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $invoicesFactory,
+        private Closure $lineItemsFactory,
         private AuditRecorderInterface $audit,
         private RequestScopedHolder $orgId,
     ) {
@@ -52,49 +62,57 @@ final readonly class ConvertQuoteToInvoiceUseCase
             throw new QuoteValidationException('Only an accepted quote can be converted to an invoice.');
         }
 
-        // One invoice per quote: re-converting an already-converted quote would
-        // create duplicate invoices (accounting integrity, diagnostic R2-2).
-        if ($this->invoices->existsForQuote($quoteId)) {
-            throw new QuoteValidationException('This quote has already been converted to an invoice.');
-        }
+        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $organizationId,
+            $quote,
+            $quoteId,
+        ): InvoiceWithLines {
+            $invoices  = ($this->invoicesFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
 
-        $invoiceId = $this->invoices->save(new Invoice(
-            organizationId: $organizationId,
-            clientId: $quote->clientId,
-            status: InvoiceStatus::Draft,
-            subtotalCents: $quote->subtotalCents,
-            taxCents: $quote->taxCents,
-            totalCents: $quote->totalCents,
-            quoteId: $quote->id,
-            notes: $quote->notes,
-        ));
+            // One invoice per quote: re-converting an already-converted quote would
+            // create duplicate invoices (accounting integrity, diagnostic R2-2).
+            if ($invoices->existsForQuote($quoteId)) {
+                throw new QuoteValidationException('This quote has already been converted to an invoice.');
+            }
 
-        $quoteLines = $this->lineItems->findByParent(LineItemParent::Quote, $quoteId);
-        $invoiceLines = [];
-        foreach ($quoteLines as $line) {
-            $invoiceLines[] = new LineItem(
-                parentType: LineItemParent::Invoice,
-                parentId: $invoiceId,
-                description: $line->description,
-                quantity: $line->quantity,
-                unitPriceCents: $line->unitPriceCents,
-                taxRateBps: $line->taxRateBps,
-                sortOrder: $line->sortOrder,
-            );
-        }
+            $invoiceId = $invoices->save(new Invoice(
+                organizationId: $organizationId,
+                clientId: $quote->clientId,
+                status: InvoiceStatus::Draft,
+                subtotalCents: $quote->subtotalCents,
+                taxCents: $quote->taxCents,
+                totalCents: $quote->totalCents,
+                quoteId: $quote->id,
+                notes: $quote->notes,
+            ));
 
-        $this->lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $invoiceLines);
+            $invoiceLines = [];
+            foreach ($lineItems->findByParent(LineItemParent::Quote, $quoteId) as $line) {
+                $invoiceLines[] = new LineItem(
+                    parentType: LineItemParent::Invoice,
+                    parentId: $invoiceId,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $line->sortOrder,
+                );
+            }
 
-        $saved = $this->invoices->findById($invoiceId);
+            $lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $invoiceLines);
 
-        if ($saved === null) {
-            throw new LogicException('Invoice disappeared immediately after conversion.');
-        }
+            $saved = $invoices->findById($invoiceId);
 
-        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
+            if ($saved === null) {
+                throw new LogicException('Invoice disappeared immediately after conversion.');
+            }
 
-        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $invoiceId, null, InvoiceResponse::toArray($saved, $lines));
+            return new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+        });
 
-        return new InvoiceWithLines($saved, $lines);
+        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
+
+        return $result;
     }
 }

--- a/src/Invoice/CreateInvoiceUseCase.php
+++ b/src/Invoice/CreateInvoiceUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
@@ -15,11 +18,13 @@ use NeneInvoice\LineItem\TaxCalculator;
 
 /**
  * Creates a draft invoice directly (without an originating quote): validates the
- * client and lines, computes totals (TaxCalculator, ADR 0004), persists the
- * header and line items, and records an audit entry.
+ * client and lines, computes totals (TaxCalculator, ADR 0004), then persists the
+ * header and line items **atomically** (one transaction) and records an audit entry.
  *
  * No number is allocated here — drafts have no `invoice_number`; numbering happens
- * at issue time ({@see IssueInvoiceUseCase}), so a draft can be edited freely.
+ * at issue time ({@see IssueInvoiceUseCase}), so a draft can be edited freely. The
+ * header + line writes run inside the transaction manager, so the repositories are
+ * rebuilt from the transaction-bound executor via the injected factories.
  */
 final readonly class CreateInvoiceUseCase
 {
@@ -27,11 +32,14 @@ final readonly class CreateInvoiceUseCase
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];
 
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private InvoiceRepositoryInterface $invoices,
-        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $invoicesFactory,
+        private Closure $lineItemsFactory,
         private ClientRepositoryInterface $clients,
         private TaxCalculator $taxCalculator,
         private AuditRecorderInterface $audit,
@@ -71,41 +79,50 @@ final readonly class CreateInvoiceUseCase
 
         $totals = $this->taxCalculator->calculate($input->lines);
 
-        $invoiceId = $this->invoices->save(new Invoice(
-            organizationId: $organizationId,
-            clientId: $input->clientId,
-            status: InvoiceStatus::Draft,
-            subtotalCents: $totals->subtotalCents,
-            taxCents: $totals->taxCents,
-            totalCents: $totals->totalCents,
-            notes: $input->notes,
-        ));
+        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $organizationId,
+            $input,
+            $totals,
+        ): InvoiceWithLines {
+            $invoices  = ($this->invoicesFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
 
-        $lineEntities = [];
-        foreach ($input->lines as $index => $line) {
-            $lineEntities[] = new LineItem(
-                parentType: LineItemParent::Invoice,
-                parentId: $invoiceId,
-                description: $line->description,
-                quantity: $line->quantity,
-                unitPriceCents: $line->unitPriceCents,
-                taxRateBps: $line->taxRateBps,
-                sortOrder: $index,
-            );
-        }
+            $invoiceId = $invoices->save(new Invoice(
+                organizationId: $organizationId,
+                clientId: $input->clientId,
+                status: InvoiceStatus::Draft,
+                subtotalCents: $totals->subtotalCents,
+                taxCents: $totals->taxCents,
+                totalCents: $totals->totalCents,
+                notes: $input->notes,
+            ));
 
-        $this->lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $lineEntities);
+            $lineEntities = [];
+            foreach ($input->lines as $index => $line) {
+                $lineEntities[] = new LineItem(
+                    parentType: LineItemParent::Invoice,
+                    parentId: $invoiceId,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $index,
+                );
+            }
 
-        $saved = $this->invoices->findById($invoiceId);
+            $lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $lineEntities);
 
-        if ($saved === null) {
-            throw new LogicException('Invoice disappeared immediately after creation.');
-        }
+            $saved = $invoices->findById($invoiceId);
 
-        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
+            if ($saved === null) {
+                throw new LogicException('Invoice disappeared immediately after creation.');
+            }
 
-        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $invoiceId, null, InvoiceResponse::toArray($saved, $lines));
+            return new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+        });
 
-        return new InvoiceWithLines($saved, $lines);
+        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
+
+        return $result;
     }
 }

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Invoice;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -18,6 +19,7 @@ use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\PdoLineItemRepository;
 use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Mailer\MailerInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
@@ -48,24 +50,34 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 ConvertQuoteToInvoiceUseCase::class,
-                static fn (ContainerInterface $c): ConvertQuoteToInvoiceUseCase => new ConvertQuoteToInvoiceUseCase(
-                    self::resolve($c, QuoteRepositoryInterface::class),
-                    self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, LineItemRepositoryInterface::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): ConvertQuoteToInvoiceUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new ConvertQuoteToInvoiceUseCase(
+                        self::resolve($c, QuoteRepositoryInterface::class),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
+                        static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                        self::resolve($c, AuditRecorderInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 CreateInvoiceUseCase::class,
-                static fn (ContainerInterface $c): CreateInvoiceUseCase => new CreateInvoiceUseCase(
-                    self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, LineItemRepositoryInterface::class),
-                    self::resolve($c, ClientRepositoryInterface::class),
-                    self::resolve($c, TaxCalculator::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): CreateInvoiceUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new CreateInvoiceUseCase(
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
+                        static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                        self::resolve($c, ClientRepositoryInterface::class),
+                        self::resolve($c, TaxCalculator::class),
+                        self::resolve($c, AuditRecorderInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 IssueInvoiceUseCase::class,

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
+use Closure;
 use DateTimeImmutable;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
@@ -19,8 +22,13 @@ use NeneInvoice\LineItem\TaxCalculator;
 
 /**
  * Creates a draft quote: validates the client and lines, computes totals
- * (TaxCalculator, ADR 0004), allocates a quote number, persists the header and
- * line items, and records an audit entry.
+ * (TaxCalculator, ADR 0004), allocates a quote number, then persists the header
+ * and line items **atomically** (one transaction) and records an audit entry.
+ *
+ * The header + line writes run inside {@see DatabaseTransactionManagerInterface},
+ * so the repositories are rebuilt from the transaction-bound executor via the
+ * injected factories (a pre-built repository would use a different connection and
+ * escape the transaction). Reads/validation and audit stay outside.
  */
 final readonly class CreateQuoteUseCase
 {
@@ -28,11 +36,14 @@ final readonly class CreateQuoteUseCase
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];
 
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): QuoteRepositoryInterface $quotesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private QuoteRepositoryInterface $quotes,
-        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $quotesFactory,
+        private Closure $lineItemsFactory,
         private ClientRepositoryInterface $clients,
         private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
@@ -80,43 +91,54 @@ final readonly class CreateQuoteUseCase
         $validUntil = $input->validUntil
             ?? $this->companySettings->find()?->quoteValidUntilFrom(new DateTimeImmutable('today'));
 
-        $quoteId = $this->quotes->save(new Quote(
-            organizationId: $organizationId,
-            clientId: $input->clientId,
-            quoteNumber: $number,
-            status: QuoteStatus::Draft,
-            subtotalCents: $totals->subtotalCents,
-            taxCents: $totals->taxCents,
-            totalCents: $totals->totalCents,
-            validUntil: $validUntil,
-            notes: $input->notes,
-        ));
+        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $organizationId,
+            $input,
+            $number,
+            $totals,
+            $validUntil,
+        ): QuoteWithLines {
+            $quotes    = ($this->quotesFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
 
-        $lineEntities = [];
-        foreach ($input->lines as $index => $line) {
-            $lineEntities[] = new LineItem(
-                parentType: LineItemParent::Quote,
-                parentId: $quoteId,
-                description: $line->description,
-                quantity: $line->quantity,
-                unitPriceCents: $line->unitPriceCents,
-                taxRateBps: $line->taxRateBps,
-                sortOrder: $index,
-            );
-        }
+            $quoteId = $quotes->save(new Quote(
+                organizationId: $organizationId,
+                clientId: $input->clientId,
+                quoteNumber: $number,
+                status: QuoteStatus::Draft,
+                subtotalCents: $totals->subtotalCents,
+                taxCents: $totals->taxCents,
+                totalCents: $totals->totalCents,
+                validUntil: $validUntil,
+                notes: $input->notes,
+            ));
 
-        $this->lineItems->replaceForParent(LineItemParent::Quote, $quoteId, $lineEntities);
+            $lineEntities = [];
+            foreach ($input->lines as $index => $line) {
+                $lineEntities[] = new LineItem(
+                    parentType: LineItemParent::Quote,
+                    parentId: $quoteId,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $index,
+                );
+            }
 
-        $saved = $this->quotes->findById($quoteId);
+            $lineItems->replaceForParent(LineItemParent::Quote, $quoteId, $lineEntities);
 
-        if ($saved === null) {
-            throw new LogicException('Quote disappeared immediately after creation.');
-        }
+            $saved = $quotes->findById($quoteId);
 
-        $lines = $this->lineItems->findByParent(LineItemParent::Quote, $quoteId);
+            if ($saved === null) {
+                throw new LogicException('Quote disappeared immediately after creation.');
+            }
 
-        $this->audit->record($actorUserId, $organizationId, 'quote.created', 'quote', $quoteId, null, QuoteResponse::toArray($saved, $lines));
+            return new QuoteWithLines($saved, $lineItems->findByParent(LineItemParent::Quote, $quoteId));
+        });
 
-        return new QuoteWithLines($saved, $lines);
+        $this->audit->record($actorUserId, $organizationId, 'quote.created', 'quote', $result->quote->id, null, QuoteResponse::toArray($result->quote, $result->lines));
+
+        return $result;
     }
 }

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Quote;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -17,6 +18,7 @@ use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\PdoLineItemRepository;
 use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Quote\Pdf\QuotePdfGenerator;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -46,16 +48,21 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
             ->set(TaxCalculator::class, static fn (ContainerInterface $c): TaxCalculator => new TaxCalculator())
             ->set(
                 CreateQuoteUseCase::class,
-                static fn (ContainerInterface $c): CreateQuoteUseCase => new CreateQuoteUseCase(
-                    self::quotes($c),
-                    self::resolve($c, LineItemRepositoryInterface::class),
-                    self::resolve($c, ClientRepositoryInterface::class),
-                    self::resolve($c, CompanySettingsRepositoryInterface::class),
-                    self::resolve($c, DocumentNumberGenerator::class),
-                    self::resolve($c, TaxCalculator::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): CreateQuoteUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new CreateQuoteUseCase(
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): QuoteRepositoryInterface => new PdoQuoteRepository($exec, $orgHolder),
+                        static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                        self::resolve($c, ClientRepositoryInterface::class),
+                        self::resolve($c, CompanySettingsRepositoryInterface::class),
+                        self::resolve($c, DocumentNumberGenerator::class),
+                        self::resolve($c, TaxCalculator::class),
+                        self::resolve($c, AuditRecorderInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 ChangeQuoteStatusUseCase::class,

--- a/src/Template/CreateTemplateUseCase.php
+++ b/src/Template/CreateTemplateUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItem;
@@ -14,39 +17,50 @@ use NeneInvoice\LineItem\LineItemRepositoryInterface;
 final readonly class CreateTemplateUseCase
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private TemplateRepositoryInterface $templates,
-        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $templatesFactory,
+        private Closure $lineItemsFactory,
         private AuditRecorderInterface $audit,
         private RequestScopedHolder $orgId,
     ) {
     }
 
-    /** Creates a template (header + line presets) in the resolved organization. */
+    /** Creates a template (header + line presets) atomically in the resolved organization. */
     public function execute(?int $actorUserId, CreateTemplateInput $input): TemplateWithLines
     {
         $organizationId = $this->orgId->get();
 
-        $id = $this->templates->save(new Template(
-            organizationId: $organizationId,
-            name: $input->name,
-            notes: $input->notes,
-        ));
+        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $organizationId,
+            $input,
+        ): TemplateWithLines {
+            $templates = ($this->templatesFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
 
-        $this->lineItems->replaceForParent(LineItemParent::Template, $id, self::toLineEntities($id, $input->lines));
+            $id = $templates->save(new Template(
+                organizationId: $organizationId,
+                name: $input->name,
+                notes: $input->notes,
+            ));
 
-        $created = $this->templates->findById($id);
-        if ($created === null) {
-            throw new LogicException('Template disappeared immediately after creation.');
-        }
+            $lineItems->replaceForParent(LineItemParent::Template, $id, self::toLineEntities($id, $input->lines));
 
-        $lines = $this->lineItems->findByParent(LineItemParent::Template, $id);
+            $created = $templates->findById($id);
+            if ($created === null) {
+                throw new LogicException('Template disappeared immediately after creation.');
+            }
 
-        $this->audit->record($actorUserId, $organizationId, 'template.created', 'template', $id, null, TemplateResponse::toArray($created, $lines));
+            return new TemplateWithLines($created, $lineItems->findByParent(LineItemParent::Template, $id));
+        });
 
-        return new TemplateWithLines($created, $lines);
+        $this->audit->record($actorUserId, $organizationId, 'template.created', 'template', $result->template->id, null, TemplateResponse::toArray($result->template, $result->lines));
+
+        return $result;
     }
 
     /**

--- a/src/Template/TemplateServiceProvider.php
+++ b/src/Template/TemplateServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Template;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -14,6 +15,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\PdoLineItemRepository;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -40,8 +42,28 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
             )
             ->set(ListTemplatesUseCase::class, static fn (ContainerInterface $c): ListTemplatesUseCase => new ListTemplatesUseCase(self::repository($c)))
             ->set(GetTemplateByIdUseCase::class, static fn (ContainerInterface $c): GetTemplateByIdUseCase => new GetTemplateByIdUseCase(self::repository($c), self::lineItems($c)))
-            ->set(CreateTemplateUseCase::class, static fn (ContainerInterface $c): CreateTemplateUseCase => new CreateTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateTemplateUseCase::class, static fn (ContainerInterface $c): UpdateTemplateUseCase => new UpdateTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
+            ->set(CreateTemplateUseCase::class, static function (ContainerInterface $c): CreateTemplateUseCase {
+                $orgHolder = self::orgHolder($c);
+
+                return new CreateTemplateUseCase(
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): TemplateRepositoryInterface => new PdoTemplateRepository($exec, $orgHolder),
+                    static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                    self::audit($c),
+                    $orgHolder,
+                );
+            })
+            ->set(UpdateTemplateUseCase::class, static function (ContainerInterface $c): UpdateTemplateUseCase {
+                $orgHolder = self::orgHolder($c);
+
+                return new UpdateTemplateUseCase(
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): TemplateRepositoryInterface => new PdoTemplateRepository($exec, $orgHolder),
+                    static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                    self::audit($c),
+                    $orgHolder,
+                );
+            })
             ->set(DeleteTemplateUseCase::class, static fn (ContainerInterface $c): DeleteTemplateUseCase => new DeleteTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListTemplatesHandler::class,

--- a/src/Template/UpdateTemplateUseCase.php
+++ b/src/Template/UpdateTemplateUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItem;
@@ -14,63 +17,79 @@ use NeneInvoice\LineItem\LineItemRepositoryInterface;
 final readonly class UpdateTemplateUseCase
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private TemplateRepositoryInterface $templates,
-        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $templatesFactory,
+        private Closure $lineItemsFactory,
         private AuditRecorderInterface $audit,
         private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
-     * Updates a template (header + line presets) in the resolved organization.
+     * Updates a template (header + line presets) atomically in the resolved
+     * organization.
      *
      * @throws TemplateNotFoundException
      */
     public function execute(?int $actorUserId, int $id, UpdateTemplateInput $input): TemplateWithLines
     {
-        $existing = $this->templates->findById($id);
-        if ($existing === null) {
-            throw new TemplateNotFoundException($id);
-        }
+        /** @var array<string, mixed> $before */
+        $before = [];
 
-        $before = TemplateResponse::toArray($existing, $this->lineItems->findByParent(LineItemParent::Template, $id));
+        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $id,
+            $input,
+            &$before,
+        ): TemplateWithLines {
+            $templates = ($this->templatesFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
 
-        $this->templates->update(new Template(
-            organizationId: $existing->organizationId,
-            name: $input->name,
-            notes: $input->notes,
-            isDeleted: false,
-            id: $existing->id,
-            createdAt: $existing->createdAt,
-            updatedAt: $existing->updatedAt,
-        ));
+            $existing = $templates->findById($id);
+            if ($existing === null) {
+                throw new TemplateNotFoundException($id);
+            }
 
-        $entities = [];
-        foreach ($input->lines as $index => $line) {
-            $entities[] = new LineItem(
-                parentType: LineItemParent::Template,
-                parentId: $id,
-                description: $line->description,
-                quantity: $line->quantity,
-                unitPriceCents: $line->unitPriceCents,
-                taxRateBps: $line->taxRateBps,
-                sortOrder: $index,
-            );
-        }
-        $this->lineItems->replaceForParent(LineItemParent::Template, $id, $entities);
+            $before = TemplateResponse::toArray($existing, $lineItems->findByParent(LineItemParent::Template, $id));
 
-        $updated = $this->templates->findById($id);
-        if ($updated === null) {
-            throw new LogicException('Template disappeared immediately after update.');
-        }
+            $templates->update(new Template(
+                organizationId: $existing->organizationId,
+                name: $input->name,
+                notes: $input->notes,
+                isDeleted: false,
+                id: $existing->id,
+                createdAt: $existing->createdAt,
+                updatedAt: $existing->updatedAt,
+            ));
 
-        $lines = $this->lineItems->findByParent(LineItemParent::Template, $id);
+            $entities = [];
+            foreach ($input->lines as $index => $line) {
+                $entities[] = new LineItem(
+                    parentType: LineItemParent::Template,
+                    parentId: $id,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $index,
+                );
+            }
+            $lineItems->replaceForParent(LineItemParent::Template, $id, $entities);
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'template.updated', 'template', $id, $before, TemplateResponse::toArray($updated, $lines));
+            $updated = $templates->findById($id);
+            if ($updated === null) {
+                throw new LogicException('Template disappeared immediately after update.');
+            }
 
-        return new TemplateWithLines($updated, $lines);
+            return new TemplateWithLines($updated, $lineItems->findByParent(LineItemParent::Template, $id));
+        });
+
+        $this->audit->record($actorUserId, $this->orgId->get(), 'template.updated', 'template', $id, $before, TemplateResponse::toArray($result->template, $result->lines));
+
+        return $result;
     }
 }

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Quote\Quote;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteStatus;
 use NeneInvoice\Quote\QuoteValidationException;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
@@ -37,7 +38,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, $this->invoices, $this->lineItems, $this->audit, $this->holder);
+        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, new ImmediateTransactionManager(), fn () => $this->invoices, fn () => $this->lineItems, $this->audit, $this->holder);
     }
 
     private function quote(QuoteStatus $status): int

--- a/tests/Invoice/CreateInvoiceUseCaseTest.php
+++ b/tests/Invoice/CreateInvoiceUseCaseTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Invoice\InvoiceValidationException;
 use NeneInvoice\LineItem\LineItemInput;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
@@ -38,8 +39,9 @@ final class CreateInvoiceUseCaseTest extends TestCase
         $this->clients = new InMemoryClientRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
         $this->useCase = new CreateInvoiceUseCase(
-            $this->invoices,
-            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->invoices,
+            fn () => $this->lineItems,
             $this->clients,
             new TaxCalculator(),
             $this->audit,

--- a/tests/Invoice/InvoiceQueryUseCasesTest.php
+++ b/tests/Invoice/InvoiceQueryUseCasesTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\ListInvoicesUseCase;
 use NeneInvoice\LineItem\LineItemInput;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
@@ -46,8 +47,9 @@ final class InvoiceQueryUseCasesTest extends TestCase
         $this->clientId  = $this->clients->save(new Client(organizationId: 1, name: 'Buyer KK'));
 
         $this->create = new CreateInvoiceUseCase(
-            $this->invoices,
-            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->invoices,
+            fn () => $this->lineItems,
             $this->clients,
             new TaxCalculator(),
             new RecordingAuditRecorder(),

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -16,6 +16,7 @@ use NeneInvoice\Quote\CreateQuoteInput;
 use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\QuoteStatus;
 use NeneInvoice\Quote\QuoteValidationException;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
@@ -48,8 +49,9 @@ final class CreateQuoteUseCaseTest extends TestCase
         $this->clientId = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
 
         $this->useCase = new CreateQuoteUseCase(
-            $this->quotes,
-            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->quotes,
+            fn () => $this->lineItems,
             $this->clients,
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),

--- a/tests/Quote/GenerateQuotePdfUseCaseTest.php
+++ b/tests/Quote/GenerateQuotePdfUseCaseTest.php
@@ -14,6 +14,7 @@ use NeneInvoice\Quote\CreateQuoteInput;
 use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\GenerateQuotePdfUseCase;
 use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
@@ -63,8 +64,9 @@ final class GenerateQuotePdfUseCaseTest extends TestCase
     private function createQuote(): int
     {
         $create = new CreateQuoteUseCase(
-            $this->quotes,
-            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->quotes,
+            fn () => $this->lineItems,
             $this->clients,
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -16,6 +16,7 @@ use NeneInvoice\Quote\ListQuotesUseCase;
 use NeneInvoice\Quote\QuoteListFilter;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteSort;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
@@ -49,8 +50,9 @@ final class QuoteQueryUseCasesTest extends TestCase
         $this->clientId  = $this->clients->save(new Client(organizationId: 1, name: 'Acme'));
 
         $this->create = new CreateQuoteUseCase(
-            $this->quotes,
-            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->quotes,
+            fn () => $this->lineItems,
             $this->clients,
             new InMemoryCompanySettingsRepository($this->holder),
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),

--- a/tests/Support/ImmediateTransactionManager.php
+++ b/tests/Support/ImmediateTransactionManager.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+/**
+ * Test double that runs the unit of work immediately (no real transaction).
+ * The callback receives a {@see NoopQueryExecutor}; use-case tests pass repo
+ * factories that ignore the executor and return their in-memory repositories.
+ */
+final class ImmediateTransactionManager implements DatabaseTransactionManagerInterface
+{
+    private DatabaseQueryExecutorInterface $executor;
+
+    public function __construct(?DatabaseQueryExecutorInterface $executor = null)
+    {
+        $this->executor = $executor ?? new NoopQueryExecutor();
+    }
+
+    public function transactional(callable $callback): mixed
+    {
+        return $callback($this->executor);
+    }
+}

--- a/tests/Support/NoopQueryExecutor.php
+++ b/tests/Support/NoopQueryExecutor.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * A do-nothing query executor for unit tests. Use-case tests drive in-memory
+ * repositories, so the executor handed to {@see ImmediateTransactionManager}'s
+ * callback is never actually queried — every method here fails loudly if it is,
+ * surfacing a test that forgot to wire its repository factory to the fake.
+ */
+final class NoopQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    /** @param array<string, mixed> $parameters */
+    public function execute(string $sql, array $parameters = []): int
+    {
+        throw new LogicException('NoopQueryExecutor must not be queried in unit tests.');
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function insert(string $sql, array $parameters = []): int
+    {
+        throw new LogicException('NoopQueryExecutor must not be queried in unit tests.');
+    }
+
+    public function lastInsertId(): int
+    {
+        throw new LogicException('NoopQueryExecutor must not be queried in unit tests.');
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @return array<string, mixed>|null
+     */
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        throw new LogicException('NoopQueryExecutor must not be queried in unit tests.');
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @return list<array<string, mixed>>
+     */
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        throw new LogicException('NoopQueryExecutor must not be queried in unit tests.');
+    }
+}

--- a/tests/Template/TemplateWriteUseCasesTest.php
+++ b/tests/Template/TemplateWriteUseCasesTest.php
@@ -15,6 +15,7 @@ use NeneInvoice\Template\Template;
 use NeneInvoice\Template\TemplateNotFoundException;
 use NeneInvoice\Template\UpdateTemplateInput;
 use NeneInvoice\Template\UpdateTemplateUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryTemplateRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -104,7 +105,7 @@ final class TemplateWriteUseCasesTest extends TestCase
 
     private function create(): CreateTemplateUseCase
     {
-        return new CreateTemplateUseCase($this->templates, $this->lines, $this->audit, $this->holder);
+        return new CreateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, $this->audit, $this->holder);
     }
 
     private function get(): GetTemplateByIdUseCase
@@ -114,7 +115,7 @@ final class TemplateWriteUseCasesTest extends TestCase
 
     private function update(): UpdateTemplateUseCase
     {
-        return new UpdateTemplateUseCase($this->templates, $this->lines, $this->audit, $this->holder);
+        return new UpdateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, $this->audit, $this->holder);
     }
 
     private function delete(): DeleteTemplateUseCase


### PR DESCRIPTION
Closes #338（監査 D-1・データ整合性）

## 概要
ヘッダ＋明細を別々に書いていた作成系を、フレームワークの `DatabaseTransactionManager` で**1トランザクション**に統一。途中失敗時の半保存（壊れたレコード）を解消。

## 重要な実装ポイント
`PdoConnectionFactory` は呼ぶたび**新規コネクション**を作り、`transactional()` は**別コネクション**でトランザクションを張ります。そのため**注入済みリポジトリをそのまま囲っても書き込みはトランザクション外に漏れる**（rollback無効＝偽の安全）。本PRは各ユースケースを **リポジトリ・ファクトリ（`Closure(executor): Repository`）** 依存に変更し、`transactional()` のコールバック内で**渡された executor からリポジトリを再生成**して書き込みます（フレームワーク仕様準拠）。

- 検証・採番はトランザクション外（採番ギャップは許容）、監査はコミット後。
- 対象: `CreateQuote` / `CreateInvoice` / `ConvertQuoteToInvoice` / `CreateTemplate` / `UpdateTemplate`。
- `RuntimeServiceProvider` に `DatabaseTransactionManagerInterface` を登録。
- テスト支援: `ImmediateTransactionManager`＋`NoopQueryExecutor`、該当テストをファクトリ方式に更新。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev サーバーで**実トランザクション経路**の create-quote を実機確認（合計・明細整合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)