### PR TITLE
refactor(backend): 全ユースケースにインターフェースを導入 (#339)

### DIFF
--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -47,18 +47,18 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                ListAuditLogsUseCase::class,
+                ListAuditLogsUseCaseInterface::class,
                 static fn (ContainerInterface $c): ListAuditLogsUseCase => new ListAuditLogsUseCase(self::resolve($c, AuditLogRepositoryInterface::class)),
             )
             ->set(
                 ListAuditLogsHandler::class,
                 static fn (ContainerInterface $c): ListAuditLogsHandler => new ListAuditLogsHandler(
-                    self::resolve($c, ListAuditLogsUseCase::class),
+                    self::resolve($c, ListAuditLogsUseCaseInterface::class),
                     self::resolve($c, JsonResponseFactory::class),
                 ),
             )
             ->set(
-                ExportAuditLogsCsvUseCase::class,
+                ExportAuditLogsCsvUseCaseInterface::class,
                 static fn (ContainerInterface $c): ExportAuditLogsCsvUseCase => new ExportAuditLogsCsvUseCase(
                     self::resolve($c, AuditLogRepositoryInterface::class),
                 ),
@@ -66,7 +66,7 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
             ->set(
                 ExportAuditLogsCsvHandler::class,
                 static fn (ContainerInterface $c): ExportAuditLogsCsvHandler => new ExportAuditLogsCsvHandler(
-                    self::resolve($c, ExportAuditLogsCsvUseCase::class),
+                    self::resolve($c, ExportAuditLogsCsvUseCaseInterface::class),
                     self::resolve($c, Psr17Factory::class),
                 ),
             )

--- a/src/Audit/ExportAuditLogsCsvHandler.php
+++ b/src/Audit/ExportAuditLogsCsvHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ExportAuditLogsCsvHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ExportAuditLogsCsvUseCase $useCase,
+        private ExportAuditLogsCsvUseCaseInterface $useCase,
         private Psr17Factory $psr17,
     ) {
     }

--- a/src/Audit/ExportAuditLogsCsvUseCase.php
+++ b/src/Audit/ExportAuditLogsCsvUseCase.php
@@ -9,7 +9,7 @@ namespace NeneInvoice\Audit;
  * prepended so Excel opens the file without encoding issues. before/after are
  * emitted as JSON so the full snapshot is preserved for compliance.
  */
-final readonly class ExportAuditLogsCsvUseCase
+final readonly class ExportAuditLogsCsvUseCase implements ExportAuditLogsCsvUseCaseInterface
 {
     /** Safety cap on exported rows (a single CSV should stay bounded). */
     private const MAX_ROWS = 10000;

--- a/src/Audit/ExportAuditLogsCsvUseCaseInterface.php
+++ b/src/Audit/ExportAuditLogsCsvUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+interface ExportAuditLogsCsvUseCaseInterface
+{
+    public function execute(AuditLogFilter $filter): string;
+}

--- a/src/Audit/ListAuditLogsHandler.php
+++ b/src/Audit/ListAuditLogsHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListAuditLogsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListAuditLogsUseCase $useCase,
+        private ListAuditLogsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Audit/ListAuditLogsUseCase.php
+++ b/src/Audit/ListAuditLogsUseCase.php
@@ -8,7 +8,7 @@ namespace NeneInvoice\Audit;
  * Lists the audit trail for the resolved organization, most recent first. The
  * organization is read from the request-scoped org holder by the repository.
  */
-final readonly class ListAuditLogsUseCase
+final readonly class ListAuditLogsUseCase implements ListAuditLogsUseCaseInterface
 {
     public function __construct(
         private AuditLogRepositoryInterface $logs,

--- a/src/Audit/ListAuditLogsUseCaseInterface.php
+++ b/src/Audit/ListAuditLogsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Audit;
+
+interface ListAuditLogsUseCaseInterface
+{
+    public function execute(AuditLogFilter $filter, int $limit, int $offset): ListAuditLogsResult;
+}

--- a/src/Auth/LoginUseCaseInterface.php
+++ b/src/Auth/LoginUseCaseInterface.php
@@ -6,6 +6,5 @@ namespace NeneInvoice\Auth;
 
 interface LoginUseCaseInterface
 {
-    /** @throws InvalidCredentialsException */
     public function execute(LoginInput $input): LoginOutput;
 }

--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -36,11 +36,11 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
                     return new PdoClientRepository($query, self::orgHolder($c));
                 },
             )
-            ->set(ListClientsUseCase::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
-            ->set(GetClientByIdUseCase::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
-            ->set(CreateClientUseCase::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateClientUseCase::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteClientUseCase::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(ListClientsUseCaseInterface::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
+            ->set(GetClientByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
+            ->set(CreateClientUseCaseInterface::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateClientUseCaseInterface::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteClientUseCaseInterface::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListClientsHandler::class,
                 static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
@@ -109,7 +109,7 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
 
     private static function createUseCase(ContainerInterface $c): CreateClientUseCase
     {
-        $u = $c->get(CreateClientUseCase::class);
+        $u = $c->get(CreateClientUseCaseInterface::class);
 
         if (!$u instanceof CreateClientUseCase) {
             throw new LogicException('Create client use case service is invalid.');
@@ -120,7 +120,7 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
 
     private static function updateUseCase(ContainerInterface $c): UpdateClientUseCase
     {
-        $u = $c->get(UpdateClientUseCase::class);
+        $u = $c->get(UpdateClientUseCaseInterface::class);
 
         if (!$u instanceof UpdateClientUseCase) {
             throw new LogicException('Update client use case service is invalid.');
@@ -131,7 +131,7 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
 
     private static function deleteUseCase(ContainerInterface $c): DeleteClientUseCase
     {
-        $u = $c->get(DeleteClientUseCase::class);
+        $u = $c->get(DeleteClientUseCaseInterface::class);
 
         if (!$u instanceof DeleteClientUseCase) {
             throw new LogicException('Delete client use case service is invalid.');
@@ -176,7 +176,7 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
 
     private static function listUseCase(ContainerInterface $c): ListClientsUseCase
     {
-        $u = $c->get(ListClientsUseCase::class);
+        $u = $c->get(ListClientsUseCaseInterface::class);
 
         if (!$u instanceof ListClientsUseCase) {
             throw new LogicException('List clients use case service is invalid.');
@@ -187,7 +187,7 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
 
     private static function getUseCase(ContainerInterface $c): GetClientByIdUseCase
     {
-        $u = $c->get(GetClientByIdUseCase::class);
+        $u = $c->get(GetClientByIdUseCaseInterface::class);
 
         if (!$u instanceof GetClientByIdUseCase) {
             throw new LogicException('Get client use case service is invalid.');

--- a/src/Client/CreateClientHandler.php
+++ b/src/Client/CreateClientHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateClientHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateClientUseCase $useCase,
+        private CreateClientUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
-final readonly class CreateClientUseCase
+final readonly class CreateClientUseCase implements CreateClientUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Client/CreateClientUseCaseInterface.php
+++ b/src/Client/CreateClientUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+interface CreateClientUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateClientInput $input): Client;
+}

--- a/src/Client/DeleteClientHandler.php
+++ b/src/Client/DeleteClientHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class DeleteClientHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DeleteClientUseCase $useCase,
+        private DeleteClientUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Client/DeleteClientUseCase.php
+++ b/src/Client/DeleteClientUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\Client;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class DeleteClientUseCase
+final readonly class DeleteClientUseCase implements DeleteClientUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Client/DeleteClientUseCaseInterface.php
+++ b/src/Client/DeleteClientUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+interface DeleteClientUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id): void;
+}

--- a/src/Client/GetClientByIdHandler.php
+++ b/src/Client/GetClientByIdHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetClientByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetClientByIdUseCase $useCase,
+        private GetClientByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Client/GetClientByIdUseCase.php
+++ b/src/Client/GetClientByIdUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-final readonly class GetClientByIdUseCase
+final readonly class GetClientByIdUseCase implements GetClientByIdUseCaseInterface
 {
     public function __construct(
         private ClientRepositoryInterface $clients,

--- a/src/Client/GetClientByIdUseCaseInterface.php
+++ b/src/Client/GetClientByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+interface GetClientByIdUseCaseInterface
+{
+    public function execute(int $id): Client;
+}

--- a/src/Client/ListClientsHandler.php
+++ b/src/Client/ListClientsHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListClientsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListClientsUseCase $useCase,
+        private ListClientsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Client/ListClientsUseCase.php
+++ b/src/Client/ListClientsUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
-final readonly class ListClientsUseCase
+final readonly class ListClientsUseCase implements ListClientsUseCaseInterface
 {
     public function __construct(
         private ClientRepositoryInterface $clients,

--- a/src/Client/ListClientsUseCaseInterface.php
+++ b/src/Client/ListClientsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+interface ListClientsUseCaseInterface
+{
+    public function executeAdmin(ClientListFilter $filter, ClientSort $sort, int $limit, int $offset): ListClientsResult;
+}

--- a/src/Client/UpdateClientHandler.php
+++ b/src/Client/UpdateClientHandler.php
@@ -21,7 +21,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class UpdateClientHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private UpdateClientUseCase $useCase,
+        private UpdateClientUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
-final readonly class UpdateClientUseCase
+final readonly class UpdateClientUseCase implements UpdateClientUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Client/UpdateClientUseCaseInterface.php
+++ b/src/Client/UpdateClientUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Client;
+
+interface UpdateClientUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id, UpdateClientInput $input): Client;
+}

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -36,8 +36,8 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
                     return new PdoCompanySettingsRepository($query, self::orgHolder($c));
                 },
             )
-            ->set(GetCompanySettingsUseCase::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c), self::orgHolder($c)))
-            ->set(UpdateCompanySettingsUseCase::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(GetCompanySettingsUseCaseInterface::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c), self::orgHolder($c)))
+            ->set(UpdateCompanySettingsUseCaseInterface::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 GetCompanySettingsHandler::class,
                 static fn (ContainerInterface $c): GetCompanySettingsHandler => new GetCompanySettingsHandler(
@@ -99,7 +99,7 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
 
     private static function getUseCase(ContainerInterface $c): GetCompanySettingsUseCase
     {
-        $u = $c->get(GetCompanySettingsUseCase::class);
+        $u = $c->get(GetCompanySettingsUseCaseInterface::class);
 
         if (!$u instanceof GetCompanySettingsUseCase) {
             throw new LogicException('Get company settings use case service is invalid.');
@@ -110,7 +110,7 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
 
     private static function updateUseCase(ContainerInterface $c): UpdateCompanySettingsUseCase
     {
-        $u = $c->get(UpdateCompanySettingsUseCase::class);
+        $u = $c->get(UpdateCompanySettingsUseCaseInterface::class);
 
         if (!$u instanceof UpdateCompanySettingsUseCase) {
             throw new LogicException('Update company settings use case service is invalid.');

--- a/src/Company/GetCompanySettingsHandler.php
+++ b/src/Company/GetCompanySettingsHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetCompanySettingsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetCompanySettingsUseCase $useCase,
+        private GetCompanySettingsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Company/GetCompanySettingsUseCase.php
+++ b/src/Company/GetCompanySettingsUseCase.php
@@ -6,7 +6,7 @@ namespace NeneInvoice\Company;
 
 use Nene2\Http\RequestScopedHolder;
 
-final readonly class GetCompanySettingsUseCase
+final readonly class GetCompanySettingsUseCase implements GetCompanySettingsUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Company/GetCompanySettingsUseCaseInterface.php
+++ b/src/Company/GetCompanySettingsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+interface GetCompanySettingsUseCaseInterface
+{
+    public function execute(): CompanySettings;
+}

--- a/src/Company/UpdateCompanySettingsHandler.php
+++ b/src/Company/UpdateCompanySettingsHandler.php
@@ -21,7 +21,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class UpdateCompanySettingsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private UpdateCompanySettingsUseCase $useCase,
+        private UpdateCompanySettingsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
 
-final readonly class UpdateCompanySettingsUseCase
+final readonly class UpdateCompanySettingsUseCase implements UpdateCompanySettingsUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Company/UpdateCompanySettingsUseCaseInterface.php
+++ b/src/Company/UpdateCompanySettingsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Company;
+
+interface UpdateCompanySettingsUseCaseInterface
+{
+    public function execute(?int $actorUserId, UpdateCompanySettingsInput $input): CompanySettings;
+}

--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -18,7 +18,7 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
     {
         $builder
             ->set(
-                GetDashboardSummaryUseCase::class,
+                GetDashboardSummaryUseCaseInterface::class,
                 static fn (ContainerInterface $c): GetDashboardSummaryUseCase => new GetDashboardSummaryUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
@@ -27,7 +27,7 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
             ->set(
                 GetDashboardHandler::class,
                 static fn (ContainerInterface $c): GetDashboardHandler => new GetDashboardHandler(
-                    self::resolve($c, GetDashboardSummaryUseCase::class),
+                    self::resolve($c, GetDashboardSummaryUseCaseInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, JsonResponseFactory::class),
                 ),

--- a/src/Dashboard/GetDashboardHandler.php
+++ b/src/Dashboard/GetDashboardHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetDashboardHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetDashboardSummaryUseCase $useCase,
+        private GetDashboardSummaryUseCaseInterface $useCase,
         private PaymentRepositoryInterface $payments,
         private JsonResponseFactory $json,
     ) {

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -13,7 +13,7 @@ use NeneInvoice\Payment\PaymentRepositoryInterface;
  * and the most recent 5 unpaid invoices. Both repositories are org-scoped via
  * the request holder, so no organization id is threaded here (ADR 0006).
  */
-final readonly class GetDashboardSummaryUseCase
+final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUseCaseInterface
 {
     public function __construct(
         private InvoiceRepositoryInterface $invoices,

--- a/src/Dashboard/GetDashboardSummaryUseCaseInterface.php
+++ b/src/Dashboard/GetDashboardSummaryUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Dashboard;
+
+interface GetDashboardSummaryUseCaseInterface
+{
+    public function execute(): DashboardSummary;
+}

--- a/src/Invoice/ConvertQuoteToInvoiceHandler.php
+++ b/src/Invoice/ConvertQuoteToInvoiceHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ConvertQuoteToInvoiceHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ConvertQuoteToInvoiceUseCase $useCase,
+        private ConvertQuoteToInvoiceUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -26,7 +26,7 @@ use NeneInvoice\Quote\QuoteValidationException;
  * rebuilt from the transaction-bound executor via the injected factories), so a
  * failure leaves no half-converted invoice.
  */
-final readonly class ConvertQuoteToInvoiceUseCase
+final readonly class ConvertQuoteToInvoiceUseCase implements ConvertQuoteToInvoiceUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory

--- a/src/Invoice/ConvertQuoteToInvoiceUseCaseInterface.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface ConvertQuoteToInvoiceUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $quoteId): InvoiceWithLines;
+}

--- a/src/Invoice/CreateInvoiceHandler.php
+++ b/src/Invoice/CreateInvoiceHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateInvoiceHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateInvoiceUseCase $useCase,
+        private CreateInvoiceUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Invoice/CreateInvoiceUseCase.php
+++ b/src/Invoice/CreateInvoiceUseCase.php
@@ -26,7 +26,7 @@ use NeneInvoice\LineItem\TaxCalculator;
  * header + line writes run inside the transaction manager, so the repositories are
  * rebuilt from the transaction-bound executor via the injected factories.
  */
-final readonly class CreateInvoiceUseCase
+final readonly class CreateInvoiceUseCase implements CreateInvoiceUseCaseInterface
 {
     /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];

--- a/src/Invoice/CreateInvoiceUseCaseInterface.php
+++ b/src/Invoice/CreateInvoiceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface CreateInvoiceUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateInvoiceInput $input): InvoiceWithLines;
+}

--- a/src/Invoice/ExportInvoicesCsvHandler.php
+++ b/src/Invoice/ExportInvoicesCsvHandler.php
@@ -16,7 +16,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ExportInvoicesCsvHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ExportInvoicesCsvUseCase $useCase,
+        private ExportInvoicesCsvUseCaseInterface $useCase,
         private Psr17Factory $psr17,
     ) {
     }

--- a/src/Invoice/ExportInvoicesCsvUseCase.php
+++ b/src/Invoice/ExportInvoicesCsvUseCase.php
@@ -8,7 +8,7 @@ namespace NeneInvoice\Invoice;
  * Assembles CSV bytes for all issued invoices in the organization.
  * UTF-8 BOM is prepended so Excel opens the file without encoding issues.
  */
-final readonly class ExportInvoicesCsvUseCase
+final readonly class ExportInvoicesCsvUseCase implements ExportInvoicesCsvUseCaseInterface
 {
     private const STATUS_LABELS = [
         'issued'         => '発行済み',

--- a/src/Invoice/ExportInvoicesCsvUseCaseInterface.php
+++ b/src/Invoice/ExportInvoicesCsvUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface ExportInvoicesCsvUseCaseInterface
+{
+    public function execute(): string;
+}

--- a/src/Invoice/GenerateInvoicePdfUseCase.php
+++ b/src/Invoice/GenerateInvoicePdfUseCase.php
@@ -16,7 +16,7 @@ use NeneInvoice\Payment\PaymentRepositoryInterface;
  * Assembles all data needed to render an invoice PDF: invoice with lines,
  * company settings (issuer), and client (buyer).
  */
-final readonly class GenerateInvoicePdfUseCase
+final readonly class GenerateInvoicePdfUseCase implements GenerateInvoicePdfUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Invoice/GenerateInvoicePdfUseCaseInterface.php
+++ b/src/Invoice/GenerateInvoicePdfUseCaseInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\Invoice\Pdf\InvoicePdfData;
+
+interface GenerateInvoicePdfUseCaseInterface
+{
+    public function execute(int $invoiceId): InvoicePdfData;
+}

--- a/src/Invoice/GetInvoiceByIdHandler.php
+++ b/src/Invoice/GetInvoiceByIdHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetInvoiceByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetInvoiceByIdUseCase $useCase,
+        private GetInvoiceByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Invoice/GetInvoiceByIdUseCase.php
+++ b/src/Invoice/GetInvoiceByIdUseCase.php
@@ -8,7 +8,7 @@ use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 
-final readonly class GetInvoiceByIdUseCase
+final readonly class GetInvoiceByIdUseCase implements GetInvoiceByIdUseCaseInterface
 {
     public function __construct(
         private InvoiceRepositoryInterface $invoices,

--- a/src/Invoice/GetInvoiceByIdUseCaseInterface.php
+++ b/src/Invoice/GetInvoiceByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface GetInvoiceByIdUseCaseInterface
+{
+    public function execute(int $id): InvoiceWithLines;
+}

--- a/src/Invoice/GetInvoicePdfHandler.php
+++ b/src/Invoice/GetInvoicePdfHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetInvoicePdfHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GenerateInvoicePdfUseCase $useCase,
+        private GenerateInvoicePdfUseCaseInterface $useCase,
         private InvoicePdfGenerator $generator,
         private Psr17Factory $psr17,
     ) {

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -49,7 +49,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                ConvertQuoteToInvoiceUseCase::class,
+                ConvertQuoteToInvoiceUseCaseInterface::class,
                 static function (ContainerInterface $c): ConvertQuoteToInvoiceUseCase {
                     $orgHolder = self::orgHolder($c);
 
@@ -64,7 +64,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                CreateInvoiceUseCase::class,
+                CreateInvoiceUseCaseInterface::class,
                 static function (ContainerInterface $c): CreateInvoiceUseCase {
                     $orgHolder = self::orgHolder($c);
 
@@ -80,7 +80,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                IssueInvoiceUseCase::class,
+                IssueInvoiceUseCaseInterface::class,
                 static fn (ContainerInterface $c): IssueInvoiceUseCase => new IssueInvoiceUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -91,14 +91,14 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
-                ListInvoicesUseCase::class,
+                ListInvoicesUseCaseInterface::class,
                 static fn (ContainerInterface $c): ListInvoicesUseCase => new ListInvoicesUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
                 ),
             )
             ->set(
-                GetInvoiceByIdUseCase::class,
+                GetInvoiceByIdUseCaseInterface::class,
                 static fn (ContainerInterface $c): GetInvoiceByIdUseCase => new GetInvoiceByIdUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -108,35 +108,35 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             ->set(
                 ConvertQuoteToInvoiceHandler::class,
                 static fn (ContainerInterface $c): ConvertQuoteToInvoiceHandler => new ConvertQuoteToInvoiceHandler(
-                    self::resolve($c, ConvertQuoteToInvoiceUseCase::class),
+                    self::resolve($c, ConvertQuoteToInvoiceUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 ListInvoicesHandler::class,
                 static fn (ContainerInterface $c): ListInvoicesHandler => new ListInvoicesHandler(
-                    self::resolve($c, ListInvoicesUseCase::class),
+                    self::resolve($c, ListInvoicesUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 GetInvoiceByIdHandler::class,
                 static fn (ContainerInterface $c): GetInvoiceByIdHandler => new GetInvoiceByIdHandler(
-                    self::resolve($c, GetInvoiceByIdUseCase::class),
+                    self::resolve($c, GetInvoiceByIdUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 CreateInvoiceHandler::class,
                 static fn (ContainerInterface $c): CreateInvoiceHandler => new CreateInvoiceHandler(
-                    self::resolve($c, CreateInvoiceUseCase::class),
+                    self::resolve($c, CreateInvoiceUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 IssueInvoiceHandler::class,
                 static fn (ContainerInterface $c): IssueInvoiceHandler => new IssueInvoiceHandler(
-                    self::resolve($c, IssueInvoiceUseCase::class),
+                    self::resolve($c, IssueInvoiceUseCaseInterface::class),
                     self::json($c),
                 ),
             )
@@ -159,7 +159,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
-                GenerateInvoicePdfUseCase::class,
+                GenerateInvoicePdfUseCaseInterface::class,
                 static fn (ContainerInterface $c): GenerateInvoicePdfUseCase => new GenerateInvoicePdfUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -172,13 +172,13 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             ->set(
                 GetInvoicePdfHandler::class,
                 static fn (ContainerInterface $c): GetInvoicePdfHandler => new GetInvoicePdfHandler(
-                    self::resolve($c, GenerateInvoicePdfUseCase::class),
+                    self::resolve($c, GenerateInvoicePdfUseCaseInterface::class),
                     self::resolve($c, InvoicePdfGenerator::class),
                     self::resolve($c, Psr17Factory::class),
                 ),
             )
             ->set(
-                ExportInvoicesCsvUseCase::class,
+                ExportInvoicesCsvUseCaseInterface::class,
                 static fn (ContainerInterface $c): ExportInvoicesCsvUseCase => new ExportInvoicesCsvUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                 ),
@@ -186,12 +186,12 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             ->set(
                 ExportInvoicesCsvHandler::class,
                 static fn (ContainerInterface $c): ExportInvoicesCsvHandler => new ExportInvoicesCsvHandler(
-                    self::resolve($c, ExportInvoicesCsvUseCase::class),
+                    self::resolve($c, ExportInvoicesCsvUseCaseInterface::class),
                     self::resolve($c, Psr17Factory::class),
                 ),
             )
             ->set(
-                SendInvoiceEmailUseCase::class,
+                SendInvoiceEmailUseCaseInterface::class,
                 static fn (ContainerInterface $c): SendInvoiceEmailUseCase => new SendInvoiceEmailUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -207,7 +207,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             ->set(
                 SendInvoiceEmailHandler::class,
                 static fn (ContainerInterface $c): SendInvoiceEmailHandler => new SendInvoiceEmailHandler(
-                    self::resolve($c, SendInvoiceEmailUseCase::class),
+                    self::resolve($c, SendInvoiceEmailUseCaseInterface::class),
                     self::resolve($c, Psr17Factory::class),
                 ),
             )

--- a/src/Invoice/IssueInvoiceHandler.php
+++ b/src/Invoice/IssueInvoiceHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class IssueInvoiceHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private IssueInvoiceUseCase $useCase,
+        private IssueInvoiceUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -20,7 +20,7 @@ use NeneInvoice\LineItem\LineItemRepositoryInterface;
  * issued without an issuer registration number (accounting-compliance §2/§4),
  * and only draft invoices can be issued (issued documents are immutable).
  */
-final readonly class IssueInvoiceUseCase
+final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Invoice/IssueInvoiceUseCaseInterface.php
+++ b/src/Invoice/IssueInvoiceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface IssueInvoiceUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id, IssueInvoiceInput $input): InvoiceWithLines;
+}

--- a/src/Invoice/ListInvoicesHandler.php
+++ b/src/Invoice/ListInvoicesHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListInvoicesHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListInvoicesUseCase $useCase,
+        private ListInvoicesUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Invoice/ListInvoicesUseCase.php
+++ b/src/Invoice/ListInvoicesUseCase.php
@@ -6,7 +6,7 @@ namespace NeneInvoice\Invoice;
 
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 
-final readonly class ListInvoicesUseCase
+final readonly class ListInvoicesUseCase implements ListInvoicesUseCaseInterface
 {
     public function __construct(
         private InvoiceRepositoryInterface $invoices,

--- a/src/Invoice/ListInvoicesUseCaseInterface.php
+++ b/src/Invoice/ListInvoicesUseCaseInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface ListInvoicesUseCaseInterface
+{
+    public function execute(int $limit, int $offset, ?InvoiceListFilter $filter = null): ListInvoicesResult;
+
+    public function executeAdmin(InvoiceListFilter $filter, InvoiceSort $sort, int $limit, int $offset): ListInvoicesResult;
+}

--- a/src/Invoice/SendInvoiceEmailHandler.php
+++ b/src/Invoice/SendInvoiceEmailHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class SendInvoiceEmailHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private SendInvoiceEmailUseCase $useCase,
+        private SendInvoiceEmailUseCaseInterface $useCase,
         private Psr17Factory $psr17,
     ) {
     }

--- a/src/Invoice/SendInvoiceEmailUseCase.php
+++ b/src/Invoice/SendInvoiceEmailUseCase.php
@@ -22,7 +22,7 @@ use NeneInvoice\Mailer\MailMessage;
  * Only issued / partially_paid invoices can be sent (draft has no number).
  * Requires the client to have an email address.
  */
-final readonly class SendInvoiceEmailUseCase
+final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Invoice/SendInvoiceEmailUseCaseInterface.php
+++ b/src/Invoice/SendInvoiceEmailUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+interface SendInvoiceEmailUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $invoiceId): void;
+}

--- a/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
+++ b/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
@@ -9,7 +9,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\SecureTokenHelper;
 use Nene2\Routing\Router;
-use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
+use NeneInvoice\Invoice\GenerateInvoicePdfUseCaseInterface;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -33,7 +33,7 @@ final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterfac
      */
     public function __construct(
         private InvoiceDownloadTokenRepositoryInterface $tokens,
-        private GenerateInvoicePdfUseCase $pdfData,
+        private GenerateInvoicePdfUseCaseInterface $pdfData,
         private InvoicePdfGenerator $pdfGenerator,
         private Psr17Factory $psr17,
         private ProblemDetailsResponseFactory $problemDetails,

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GenerateDownloadTokenHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GenerateDownloadTokenUseCase $useCase,
+        private GenerateDownloadTokenUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -16,7 +16,7 @@ use NeneInvoice\Invoice\InvoiceRepositoryInterface;
  * Returns the raw (un-hashed) token so the caller can embed it in the URL.
  * The raw token is never stored — only its SHA-256 hash is kept in the DB.
  */
-final readonly class GenerateDownloadTokenUseCase
+final readonly class GenerateDownloadTokenUseCase implements GenerateDownloadTokenUseCaseInterface
 {
     private const TTL_DAYS = 7;
 

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCaseInterface.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\InvoiceDownloadToken;
+
+interface GenerateDownloadTokenUseCaseInterface
+{
+    /** @return array{rawToken: string, expiresAt: string} */
+    public function execute(?int $actorUserId, int $invoiceId): array;
+}

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -13,7 +13,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
-use NeneInvoice\Invoice\GenerateInvoicePdfUseCase;
+use NeneInvoice\Invoice\GenerateInvoicePdfUseCaseInterface;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -37,7 +37,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 },
             )
             ->set(
-                GenerateDownloadTokenUseCase::class,
+                GenerateDownloadTokenUseCaseInterface::class,
                 static fn (ContainerInterface $c): GenerateDownloadTokenUseCase => new GenerateDownloadTokenUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
@@ -48,7 +48,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
             ->set(
                 GenerateDownloadTokenHandler::class,
                 static fn (ContainerInterface $c): GenerateDownloadTokenHandler => new GenerateDownloadTokenHandler(
-                    self::resolve($c, GenerateDownloadTokenUseCase::class),
+                    self::resolve($c, GenerateDownloadTokenUseCaseInterface::class),
                     self::resolve($c, JsonResponseFactory::class),
                 ),
             )
@@ -56,7 +56,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 DownloadInvoicePdfHandler::class,
                 static fn (ContainerInterface $c): DownloadInvoicePdfHandler => new DownloadInvoicePdfHandler(
                     self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
-                    self::resolve($c, GenerateInvoicePdfUseCase::class),
+                    self::resolve($c, GenerateInvoicePdfUseCaseInterface::class),
                     self::resolve($c, InvoicePdfGenerator::class),
                     self::resolve($c, Psr17Factory::class),
                     self::resolve($c, ProblemDetailsResponseFactory::class),

--- a/src/Item/CreateItemHandler.php
+++ b/src/Item/CreateItemHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateItemHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateItemUseCase $useCase,
+        private CreateItemUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Item/CreateItemUseCase.php
+++ b/src/Item/CreateItemUseCase.php
@@ -8,7 +8,7 @@ use LogicException;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class CreateItemUseCase
+final readonly class CreateItemUseCase implements CreateItemUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Item/CreateItemUseCaseInterface.php
+++ b/src/Item/CreateItemUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Item;
+
+interface CreateItemUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateItemInput $input): Item;
+}

--- a/src/Item/DeleteItemHandler.php
+++ b/src/Item/DeleteItemHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class DeleteItemHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DeleteItemUseCase $useCase,
+        private DeleteItemUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Item/DeleteItemUseCase.php
+++ b/src/Item/DeleteItemUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\Item;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class DeleteItemUseCase
+final readonly class DeleteItemUseCase implements DeleteItemUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Item/DeleteItemUseCaseInterface.php
+++ b/src/Item/DeleteItemUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Item;
+
+interface DeleteItemUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id): void;
+}

--- a/src/Item/GetItemByIdHandler.php
+++ b/src/Item/GetItemByIdHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetItemByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetItemByIdUseCase $useCase,
+        private GetItemByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Item/GetItemByIdUseCase.php
+++ b/src/Item/GetItemByIdUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
-final readonly class GetItemByIdUseCase
+final readonly class GetItemByIdUseCase implements GetItemByIdUseCaseInterface
 {
     public function __construct(
         private ItemRepositoryInterface $items,

--- a/src/Item/GetItemByIdUseCaseInterface.php
+++ b/src/Item/GetItemByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Item;
+
+interface GetItemByIdUseCaseInterface
+{
+    public function execute(int $id): Item;
+}

--- a/src/Item/ItemServiceProvider.php
+++ b/src/Item/ItemServiceProvider.php
@@ -36,11 +36,11 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
                     return new PdoItemRepository($query, self::orgHolder($c));
                 },
             )
-            ->set(ListItemsUseCase::class, static fn (ContainerInterface $c): ListItemsUseCase => new ListItemsUseCase(self::repository($c)))
-            ->set(GetItemByIdUseCase::class, static fn (ContainerInterface $c): GetItemByIdUseCase => new GetItemByIdUseCase(self::repository($c)))
-            ->set(CreateItemUseCase::class, static fn (ContainerInterface $c): CreateItemUseCase => new CreateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateItemUseCase::class, static fn (ContainerInterface $c): UpdateItemUseCase => new UpdateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteItemUseCase::class, static fn (ContainerInterface $c): DeleteItemUseCase => new DeleteItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(ListItemsUseCaseInterface::class, static fn (ContainerInterface $c): ListItemsUseCase => new ListItemsUseCase(self::repository($c)))
+            ->set(GetItemByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetItemByIdUseCase => new GetItemByIdUseCase(self::repository($c)))
+            ->set(CreateItemUseCaseInterface::class, static fn (ContainerInterface $c): CreateItemUseCase => new CreateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateItemUseCaseInterface::class, static fn (ContainerInterface $c): UpdateItemUseCase => new UpdateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteItemUseCaseInterface::class, static fn (ContainerInterface $c): DeleteItemUseCase => new DeleteItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListItemsHandler::class,
                 static fn (ContainerInterface $c): ListItemsHandler => new ListItemsHandler(
@@ -105,7 +105,7 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
 
     private static function createUseCase(ContainerInterface $c): CreateItemUseCase
     {
-        $u = $c->get(CreateItemUseCase::class);
+        $u = $c->get(CreateItemUseCaseInterface::class);
 
         if (!$u instanceof CreateItemUseCase) {
             throw new LogicException('Create item use case service is invalid.');
@@ -116,7 +116,7 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
 
     private static function updateUseCase(ContainerInterface $c): UpdateItemUseCase
     {
-        $u = $c->get(UpdateItemUseCase::class);
+        $u = $c->get(UpdateItemUseCaseInterface::class);
 
         if (!$u instanceof UpdateItemUseCase) {
             throw new LogicException('Update item use case service is invalid.');
@@ -127,7 +127,7 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
 
     private static function deleteUseCase(ContainerInterface $c): DeleteItemUseCase
     {
-        $u = $c->get(DeleteItemUseCase::class);
+        $u = $c->get(DeleteItemUseCaseInterface::class);
 
         if (!$u instanceof DeleteItemUseCase) {
             throw new LogicException('Delete item use case service is invalid.');
@@ -172,7 +172,7 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
 
     private static function listUseCase(ContainerInterface $c): ListItemsUseCase
     {
-        $u = $c->get(ListItemsUseCase::class);
+        $u = $c->get(ListItemsUseCaseInterface::class);
 
         if (!$u instanceof ListItemsUseCase) {
             throw new LogicException('List items use case service is invalid.');
@@ -183,7 +183,7 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
 
     private static function getUseCase(ContainerInterface $c): GetItemByIdUseCase
     {
-        $u = $c->get(GetItemByIdUseCase::class);
+        $u = $c->get(GetItemByIdUseCaseInterface::class);
 
         if (!$u instanceof GetItemByIdUseCase) {
             throw new LogicException('Get item use case service is invalid.');

--- a/src/Item/ListItemsHandler.php
+++ b/src/Item/ListItemsHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListItemsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListItemsUseCase $useCase,
+        private ListItemsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Item/ListItemsUseCase.php
+++ b/src/Item/ListItemsUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
-final readonly class ListItemsUseCase
+final readonly class ListItemsUseCase implements ListItemsUseCaseInterface
 {
     public function __construct(
         private ItemRepositoryInterface $items,

--- a/src/Item/ListItemsUseCaseInterface.php
+++ b/src/Item/ListItemsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Item;
+
+interface ListItemsUseCaseInterface
+{
+    public function executeAdmin(ItemListFilter $filter, ItemSort $sort, int $limit, int $offset): ListItemsResult;
+}

--- a/src/Item/UpdateItemHandler.php
+++ b/src/Item/UpdateItemHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class UpdateItemHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private UpdateItemUseCase $useCase,
+        private UpdateItemUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Item/UpdateItemUseCase.php
+++ b/src/Item/UpdateItemUseCase.php
@@ -8,7 +8,7 @@ use LogicException;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class UpdateItemUseCase
+final readonly class UpdateItemUseCase implements UpdateItemUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Item/UpdateItemUseCaseInterface.php
+++ b/src/Item/UpdateItemUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Item;
+
+interface UpdateItemUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id, UpdateItemInput $input): Item;
+}

--- a/src/LineItem/LineItemServiceProvider.php
+++ b/src/LineItem/LineItemServiceProvider.php
@@ -36,7 +36,7 @@ final readonly class LineItemServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                ListLineItemSuggestionsUseCase::class,
+                ListLineItemSuggestionsUseCaseInterface::class,
                 static fn (ContainerInterface $c): ListLineItemSuggestionsUseCase => new ListLineItemSuggestionsUseCase(
                     self::resolve($c, LineItemRepositoryInterface::class),
                     self::resolve($c, ItemRepositoryInterface::class),
@@ -45,7 +45,7 @@ final readonly class LineItemServiceProvider implements ServiceProviderInterface
             ->set(
                 ListLineItemSuggestionsHandler::class,
                 static fn (ContainerInterface $c): ListLineItemSuggestionsHandler => new ListLineItemSuggestionsHandler(
-                    self::resolve($c, ListLineItemSuggestionsUseCase::class),
+                    self::resolve($c, ListLineItemSuggestionsUseCaseInterface::class),
                     self::resolve($c, JsonResponseFactory::class),
                 ),
             )

--- a/src/LineItem/ListLineItemSuggestionsHandler.php
+++ b/src/LineItem/ListLineItemSuggestionsHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListLineItemSuggestionsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListLineItemSuggestionsUseCase $useCase,
+        private ListLineItemSuggestionsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/LineItem/ListLineItemSuggestionsUseCase.php
+++ b/src/LineItem/ListLineItemSuggestionsUseCase.php
@@ -15,7 +15,7 @@ use NeneInvoice\Item\ItemRepositoryInterface;
  * defaults (the master is the source of truth) and the history usage count for
  * the same description, so a frequently-used master item still sorts high.
  */
-final readonly class ListLineItemSuggestionsUseCase
+final readonly class ListLineItemSuggestionsUseCase implements ListLineItemSuggestionsUseCaseInterface
 {
     /**
      * How many recent rows to scan. Generous enough to surface real repeats

--- a/src/LineItem/ListLineItemSuggestionsUseCaseInterface.php
+++ b/src/LineItem/ListLineItemSuggestionsUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\LineItem;
+
+interface ListLineItemSuggestionsUseCaseInterface
+{
+    /** @return list<LineItemSuggestion> */
+    public function execute(): array;
+}

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateOrganizationHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateOrganizationUseCase $useCase,
+        private CreateOrganizationUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\Organization;
 use LogicException;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class CreateOrganizationUseCase
+final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,

--- a/src/Organization/CreateOrganizationUseCaseInterface.php
+++ b/src/Organization/CreateOrganizationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface CreateOrganizationUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateOrganizationInput $input): Organization;
+}

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class DeleteOrganizationHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DeleteOrganizationUseCase $useCase,
+        private DeleteOrganizationUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -6,7 +6,7 @@ namespace NeneInvoice\Organization;
 
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class DeleteOrganizationUseCase
+final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,

--- a/src/Organization/DeleteOrganizationUseCaseInterface.php
+++ b/src/Organization/DeleteOrganizationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface DeleteOrganizationUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id): void;
+}

--- a/src/Organization/GetOrganizationByIdHandler.php
+++ b/src/Organization/GetOrganizationByIdHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetOrganizationByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetOrganizationByIdUseCase $useCase,
+        private GetOrganizationByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Organization/GetOrganizationByIdUseCase.php
+++ b/src/Organization/GetOrganizationByIdUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
-final readonly class GetOrganizationByIdUseCase
+final readonly class GetOrganizationByIdUseCase implements GetOrganizationByIdUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,

--- a/src/Organization/GetOrganizationByIdUseCaseInterface.php
+++ b/src/Organization/GetOrganizationByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface GetOrganizationByIdUseCaseInterface
+{
+    public function execute(int $id): Organization;
+}

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListOrganizationsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListOrganizationsUseCase $useCase,
+        private ListOrganizationsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Organization/ListOrganizationsUseCase.php
+++ b/src/Organization/ListOrganizationsUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
-final readonly class ListOrganizationsUseCase
+final readonly class ListOrganizationsUseCase implements ListOrganizationsUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,

--- a/src/Organization/ListOrganizationsUseCaseInterface.php
+++ b/src/Organization/ListOrganizationsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface ListOrganizationsUseCaseInterface
+{
+    public function execute(int $limit, int $offset): ListOrganizationsResult;
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -34,10 +34,10 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                     return new PdoOrganizationRepository($query);
                 },
             )
-            ->set(ListOrganizationsUseCase::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
-            ->set(GetOrganizationByIdUseCase::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
-            ->set(CreateOrganizationUseCase::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c), self::audit($c)))
-            ->set(DeleteOrganizationUseCase::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::audit($c)))
+            ->set(ListOrganizationsUseCaseInterface::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
+            ->set(GetOrganizationByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
+            ->set(CreateOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c), self::audit($c)))
+            ->set(DeleteOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::audit($c)))
             ->set(
                 ListOrganizationsHandler::class,
                 static fn (ContainerInterface $c): ListOrganizationsHandler => new ListOrganizationsHandler(
@@ -119,7 +119,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
     private static function listUseCase(ContainerInterface $c): ListOrganizationsUseCase
     {
-        $u = $c->get(ListOrganizationsUseCase::class);
+        $u = $c->get(ListOrganizationsUseCaseInterface::class);
 
         if (!$u instanceof ListOrganizationsUseCase) {
             throw new LogicException('List organizations use case service is invalid.');
@@ -130,7 +130,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
     private static function getUseCase(ContainerInterface $c): GetOrganizationByIdUseCase
     {
-        $u = $c->get(GetOrganizationByIdUseCase::class);
+        $u = $c->get(GetOrganizationByIdUseCaseInterface::class);
 
         if (!$u instanceof GetOrganizationByIdUseCase) {
             throw new LogicException('Get organization use case service is invalid.');
@@ -141,7 +141,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
     private static function createUseCase(ContainerInterface $c): CreateOrganizationUseCase
     {
-        $u = $c->get(CreateOrganizationUseCase::class);
+        $u = $c->get(CreateOrganizationUseCaseInterface::class);
 
         if (!$u instanceof CreateOrganizationUseCase) {
             throw new LogicException('Create organization use case service is invalid.');
@@ -152,7 +152,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
     private static function deleteUseCase(ContainerInterface $c): DeleteOrganizationUseCase
     {
-        $u = $c->get(DeleteOrganizationUseCase::class);
+        $u = $c->get(DeleteOrganizationUseCaseInterface::class);
 
         if (!$u instanceof DeleteOrganizationUseCase) {
             throw new LogicException('Delete organization use case service is invalid.');

--- a/src/Payment/ExportPaymentsCsvHandler.php
+++ b/src/Payment/ExportPaymentsCsvHandler.php
@@ -16,7 +16,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ExportPaymentsCsvHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ExportPaymentsCsvUseCase $useCase,
+        private ExportPaymentsCsvUseCaseInterface $useCase,
         private Psr17Factory $psr17,
     ) {
     }

--- a/src/Payment/ExportPaymentsCsvUseCase.php
+++ b/src/Payment/ExportPaymentsCsvUseCase.php
@@ -8,7 +8,7 @@ namespace NeneInvoice\Payment;
  * Assembles CSV bytes for all valid (non-voided) payments in the organization.
  * UTF-8 BOM is prepended so Excel opens the file without encoding issues.
  */
-final readonly class ExportPaymentsCsvUseCase
+final readonly class ExportPaymentsCsvUseCase implements ExportPaymentsCsvUseCaseInterface
 {
     private const METHOD_LABELS = [
         'bank_transfer' => '銀行振込',

--- a/src/Payment/ExportPaymentsCsvUseCaseInterface.php
+++ b/src/Payment/ExportPaymentsCsvUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+interface ExportPaymentsCsvUseCaseInterface
+{
+    public function execute(): string;
+}

--- a/src/Payment/ListPaymentsHandler.php
+++ b/src/Payment/ListPaymentsHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListPaymentsHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListPaymentsUseCase $useCase,
+        private ListPaymentsUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Payment/ListPaymentsUseCase.php
+++ b/src/Payment/ListPaymentsUseCase.php
@@ -11,7 +11,7 @@ use NeneInvoice\Invoice\InvoiceRepositoryInterface;
  * Lists the payments recorded against an invoice, scoped to the caller's
  * organization (cross-org access surfaces as not-found, never a leak).
  */
-final readonly class ListPaymentsUseCase
+final readonly class ListPaymentsUseCase implements ListPaymentsUseCaseInterface
 {
     public function __construct(
         private PaymentRepositoryInterface $payments,

--- a/src/Payment/ListPaymentsUseCaseInterface.php
+++ b/src/Payment/ListPaymentsUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+interface ListPaymentsUseCaseInterface
+{
+    /** @return list<Payment> */
+    public function execute(int $invoiceId): array;
+}

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -39,7 +39,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                RecordPaymentUseCase::class,
+                RecordPaymentUseCaseInterface::class,
                 static fn (ContainerInterface $c): RecordPaymentUseCase => new RecordPaymentUseCase(
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
@@ -48,14 +48,14 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
-                ListPaymentsUseCase::class,
+                ListPaymentsUseCaseInterface::class,
                 static fn (ContainerInterface $c): ListPaymentsUseCase => new ListPaymentsUseCase(
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                 ),
             )
             ->set(
-                VoidPaymentUseCase::class,
+                VoidPaymentUseCaseInterface::class,
                 static fn (ContainerInterface $c): VoidPaymentUseCase => new VoidPaymentUseCase(
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
@@ -66,14 +66,14 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
             ->set(
                 RecordPaymentHandler::class,
                 static fn (ContainerInterface $c): RecordPaymentHandler => new RecordPaymentHandler(
-                    self::resolve($c, RecordPaymentUseCase::class),
+                    self::resolve($c, RecordPaymentUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 ListPaymentsHandler::class,
                 static fn (ContainerInterface $c): ListPaymentsHandler => new ListPaymentsHandler(
-                    self::resolve($c, ListPaymentsUseCase::class),
+                    self::resolve($c, ListPaymentsUseCaseInterface::class),
                     self::json($c),
                 ),
             )
@@ -90,7 +90,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): PaymentNotFoundExceptionHandler => new PaymentNotFoundExceptionHandler(self::problemDetails($c)),
             )
             ->set(
-                ExportPaymentsCsvUseCase::class,
+                ExportPaymentsCsvUseCaseInterface::class,
                 static fn (ContainerInterface $c): ExportPaymentsCsvUseCase => new ExportPaymentsCsvUseCase(
                     self::payments($c),
                 ),
@@ -98,7 +98,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
             ->set(
                 ExportPaymentsCsvHandler::class,
                 static fn (ContainerInterface $c): ExportPaymentsCsvHandler => new ExportPaymentsCsvHandler(
-                    self::resolve($c, ExportPaymentsCsvUseCase::class),
+                    self::resolve($c, ExportPaymentsCsvUseCaseInterface::class),
                     self::resolve($c, Psr17Factory::class),
                 ),
             )

--- a/src/Payment/RecordPaymentHandler.php
+++ b/src/Payment/RecordPaymentHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class RecordPaymentHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private RecordPaymentUseCase $useCase,
+        private RecordPaymentUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -22,7 +22,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
  * Over-payment is rejected: the recorded total may not exceed the invoice total
  * (refunds / over-receipts are a separate operation, deliberately not handled here).
  */
-final readonly class RecordPaymentUseCase
+final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Payment/RecordPaymentUseCaseInterface.php
+++ b/src/Payment/RecordPaymentUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+interface RecordPaymentUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $invoiceId, RecordPaymentInput $input): RecordPaymentResult;
+}

--- a/src/Payment/VoidPaymentUseCase.php
+++ b/src/Payment/VoidPaymentUseCase.php
@@ -19,7 +19,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
  * remaining valid payments. Idempotent: voiding an already-voided payment is a
  * no-op success.
  */
-final readonly class VoidPaymentUseCase
+final readonly class VoidPaymentUseCase implements VoidPaymentUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Payment/VoidPaymentUseCaseInterface.php
+++ b/src/Payment/VoidPaymentUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment;
+
+interface VoidPaymentUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $invoiceId, int $paymentId, ?string $reason): RecordPaymentResult;
+}

--- a/src/Quote/ChangeQuoteStatusHandler.php
+++ b/src/Quote/ChangeQuoteStatusHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ChangeQuoteStatusHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ChangeQuoteStatusUseCase $useCase,
+        private ChangeQuoteStatusUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Quote/ChangeQuoteStatusUseCase.php
+++ b/src/Quote/ChangeQuoteStatusUseCase.php
@@ -8,7 +8,7 @@ use LogicException;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class ChangeQuoteStatusUseCase
+final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Quote/ChangeQuoteStatusUseCaseInterface.php
+++ b/src/Quote/ChangeQuoteStatusUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+interface ChangeQuoteStatusUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id, QuoteStatus $target): Quote;
+}

--- a/src/Quote/CreateQuoteHandler.php
+++ b/src/Quote/CreateQuoteHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateQuoteHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateQuoteUseCase $useCase,
+        private CreateQuoteUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -30,7 +30,7 @@ use NeneInvoice\LineItem\TaxCalculator;
  * injected factories (a pre-built repository would use a different connection and
  * escape the transaction). Reads/validation and audit stay outside.
  */
-final readonly class CreateQuoteUseCase
+final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
 {
     /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
     private const ALLOWED_TAX_RATES_BPS = [800, 1000];

--- a/src/Quote/CreateQuoteUseCaseInterface.php
+++ b/src/Quote/CreateQuoteUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+interface CreateQuoteUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateQuoteInput $input): QuoteWithLines;
+}

--- a/src/Quote/GenerateQuotePdfUseCase.php
+++ b/src/Quote/GenerateQuotePdfUseCase.php
@@ -17,7 +17,7 @@ use NeneInvoice\Quote\Pdf\QuotePdfData;
  * Assembles all data needed to render a quote PDF: quote with lines,
  * company settings (issuer), and client (buyer).
  */
-final readonly class GenerateQuotePdfUseCase
+final readonly class GenerateQuotePdfUseCase implements GenerateQuotePdfUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Quote/GenerateQuotePdfUseCaseInterface.php
+++ b/src/Quote/GenerateQuotePdfUseCaseInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+use NeneInvoice\Quote\Pdf\QuotePdfData;
+
+interface GenerateQuotePdfUseCaseInterface
+{
+    public function execute(int $quoteId): QuotePdfData;
+}

--- a/src/Quote/GetQuoteByIdHandler.php
+++ b/src/Quote/GetQuoteByIdHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetQuoteByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetQuoteByIdUseCase $useCase,
+        private GetQuoteByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Quote/GetQuoteByIdUseCase.php
+++ b/src/Quote/GetQuoteByIdUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\Quote;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 
-final readonly class GetQuoteByIdUseCase
+final readonly class GetQuoteByIdUseCase implements GetQuoteByIdUseCaseInterface
 {
     public function __construct(
         private QuoteRepositoryInterface $quotes,

--- a/src/Quote/GetQuoteByIdUseCaseInterface.php
+++ b/src/Quote/GetQuoteByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+interface GetQuoteByIdUseCaseInterface
+{
+    public function execute(int $id): QuoteWithLines;
+}

--- a/src/Quote/GetQuotePdfHandler.php
+++ b/src/Quote/GetQuotePdfHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetQuotePdfHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GenerateQuotePdfUseCase $useCase,
+        private GenerateQuotePdfUseCaseInterface $useCase,
         private QuotePdfGenerator $generator,
         private Psr17Factory $psr17,
     ) {

--- a/src/Quote/ListQuotesHandler.php
+++ b/src/Quote/ListQuotesHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListQuotesHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListQuotesUseCase $useCase,
+        private ListQuotesUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Quote/ListQuotesUseCase.php
+++ b/src/Quote/ListQuotesUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
-final readonly class ListQuotesUseCase
+final readonly class ListQuotesUseCase implements ListQuotesUseCaseInterface
 {
     public function __construct(
         private QuoteRepositoryInterface $quotes,

--- a/src/Quote/ListQuotesUseCaseInterface.php
+++ b/src/Quote/ListQuotesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Quote;
+
+interface ListQuotesUseCaseInterface
+{
+    public function executeAdmin(QuoteListFilter $filter, QuoteSort $sort, int $limit, int $offset): ListQuotesResult;
+}

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -47,7 +47,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
             )
             ->set(TaxCalculator::class, static fn (ContainerInterface $c): TaxCalculator => new TaxCalculator())
             ->set(
-                CreateQuoteUseCase::class,
+                CreateQuoteUseCaseInterface::class,
                 static function (ContainerInterface $c): CreateQuoteUseCase {
                     $orgHolder = self::orgHolder($c);
 
@@ -65,16 +65,16 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                ChangeQuoteStatusUseCase::class,
+                ChangeQuoteStatusUseCaseInterface::class,
                 static fn (ContainerInterface $c): ChangeQuoteStatusUseCase => new ChangeQuoteStatusUseCase(
                     self::quotes($c),
                     self::resolve($c, AuditRecorderInterface::class),
                     self::orgHolder($c),
                 ),
             )
-            ->set(ListQuotesUseCase::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
+            ->set(ListQuotesUseCaseInterface::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
             ->set(
-                GetQuoteByIdUseCase::class,
+                GetQuoteByIdUseCaseInterface::class,
                 static fn (ContainerInterface $c): GetQuoteByIdUseCase => new GetQuoteByIdUseCase(
                     self::quotes($c),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -83,33 +83,33 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
             ->set(
                 CreateQuoteHandler::class,
                 static fn (ContainerInterface $c): CreateQuoteHandler => new CreateQuoteHandler(
-                    self::resolve($c, CreateQuoteUseCase::class),
+                    self::resolve($c, CreateQuoteUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 ListQuotesHandler::class,
                 static fn (ContainerInterface $c): ListQuotesHandler => new ListQuotesHandler(
-                    self::resolve($c, ListQuotesUseCase::class),
+                    self::resolve($c, ListQuotesUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 GetQuoteByIdHandler::class,
                 static fn (ContainerInterface $c): GetQuoteByIdHandler => new GetQuoteByIdHandler(
-                    self::resolve($c, GetQuoteByIdUseCase::class),
+                    self::resolve($c, GetQuoteByIdUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
                 ChangeQuoteStatusHandler::class,
                 static fn (ContainerInterface $c): ChangeQuoteStatusHandler => new ChangeQuoteStatusHandler(
-                    self::resolve($c, ChangeQuoteStatusUseCase::class),
+                    self::resolve($c, ChangeQuoteStatusUseCaseInterface::class),
                     self::json($c),
                 ),
             )
             ->set(
-                GenerateQuotePdfUseCase::class,
+                GenerateQuotePdfUseCaseInterface::class,
                 static fn (ContainerInterface $c): GenerateQuotePdfUseCase => new GenerateQuotePdfUseCase(
                     self::quotes($c),
                     self::resolve($c, LineItemRepositoryInterface::class),
@@ -127,7 +127,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
             ->set(
                 GetQuotePdfHandler::class,
                 static fn (ContainerInterface $c): GetQuotePdfHandler => new GetQuotePdfHandler(
-                    self::resolve($c, GenerateQuotePdfUseCase::class),
+                    self::resolve($c, GenerateQuotePdfUseCaseInterface::class),
                     self::resolve($c, QuotePdfGenerator::class),
                     self::resolve($c, Psr17Factory::class),
                 ),

--- a/src/ServiceApi/GetServiceInvoiceHandler.php
+++ b/src/ServiceApi/GetServiceInvoiceHandler.php
@@ -7,8 +7,8 @@ namespace NeneInvoice\ServiceApi;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
-use NeneInvoice\Payment\ListPaymentsUseCase;
+use NeneInvoice\Invoice\GetInvoiceByIdUseCaseInterface;
+use NeneInvoice\Payment\ListPaymentsUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -21,8 +21,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetServiceInvoiceHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetInvoiceByIdUseCase $getInvoice,
-        private ListPaymentsUseCase $listPayments,
+        private GetInvoiceByIdUseCaseInterface $getInvoice,
+        private ListPaymentsUseCaseInterface $listPayments,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {

--- a/src/ServiceApi/ListServiceInvoicesHandler.php
+++ b/src/ServiceApi/ListServiceInvoicesHandler.php
@@ -11,7 +11,7 @@ use Nene2\Http\PaginationResponse;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceStatus;
-use NeneInvoice\Invoice\ListInvoicesUseCase;
+use NeneInvoice\Invoice\ListInvoicesUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -25,7 +25,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListServiceInvoicesHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListInvoicesUseCase $useCase,
+        private ListInvoicesUseCaseInterface $useCase,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {

--- a/src/ServiceApi/RecordServicePaymentHandler.php
+++ b/src/ServiceApi/RecordServicePaymentHandler.php
@@ -11,7 +11,7 @@ use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneInvoice\Payment\RecordPaymentInput;
-use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
 use NeneInvoice\Support\RequestField;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,7 +27,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class RecordServicePaymentHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private RecordPaymentUseCase $useCase,
+        private RecordPaymentUseCaseInterface $useCase,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -12,11 +12,11 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Client\ClientRepositoryInterface;
-use NeneInvoice\Invoice\GetInvoiceByIdUseCase;
-use NeneInvoice\Invoice\ListInvoicesUseCase;
-use NeneInvoice\Payment\ListPaymentsUseCase;
-use NeneInvoice\Payment\RecordPaymentUseCase;
-use NeneInvoice\Payment\VoidPaymentUseCase;
+use NeneInvoice\Invoice\GetInvoiceByIdUseCaseInterface;
+use NeneInvoice\Invoice\ListInvoicesUseCaseInterface;
+use NeneInvoice\Payment\ListPaymentsUseCaseInterface;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
+use NeneInvoice\Payment\VoidPaymentUseCaseInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -35,7 +35,7 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
             ->set(
                 ListServiceInvoicesHandler::class,
                 static fn (ContainerInterface $c): ListServiceInvoicesHandler => new ListServiceInvoicesHandler(
-                    self::resolve($c, ListInvoicesUseCase::class),
+                    self::resolve($c, ListInvoicesUseCaseInterface::class),
                     self::json($c),
                     self::problemDetails($c),
                 ),
@@ -43,8 +43,8 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
             ->set(
                 GetServiceInvoiceHandler::class,
                 static fn (ContainerInterface $c): GetServiceInvoiceHandler => new GetServiceInvoiceHandler(
-                    self::resolve($c, GetInvoiceByIdUseCase::class),
-                    self::resolve($c, ListPaymentsUseCase::class),
+                    self::resolve($c, GetInvoiceByIdUseCaseInterface::class),
+                    self::resolve($c, ListPaymentsUseCaseInterface::class),
                     self::json($c),
                     self::problemDetails($c),
                 ),
@@ -52,7 +52,7 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
             ->set(
                 RecordServicePaymentHandler::class,
                 static fn (ContainerInterface $c): RecordServicePaymentHandler => new RecordServicePaymentHandler(
-                    self::resolve($c, RecordPaymentUseCase::class),
+                    self::resolve($c, RecordPaymentUseCaseInterface::class),
                     self::json($c),
                     self::problemDetails($c),
                 ),
@@ -60,7 +60,7 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
             ->set(
                 VoidServicePaymentHandler::class,
                 static fn (ContainerInterface $c): VoidServicePaymentHandler => new VoidServicePaymentHandler(
-                    self::resolve($c, VoidPaymentUseCase::class),
+                    self::resolve($c, VoidPaymentUseCaseInterface::class),
                     self::json($c),
                     self::problemDetails($c),
                 ),

--- a/src/ServiceApi/VoidServicePaymentHandler.php
+++ b/src/ServiceApi/VoidServicePaymentHandler.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\ServiceApi;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneInvoice\Payment\VoidPaymentUseCase;
+use NeneInvoice\Payment\VoidPaymentUseCaseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class VoidServicePaymentHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private VoidPaymentUseCase $useCase,
+        private VoidPaymentUseCaseInterface $useCase,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {

--- a/src/Template/CreateTemplateHandler.php
+++ b/src/Template/CreateTemplateHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateTemplateHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateTemplateUseCase $useCase,
+        private CreateTemplateUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Template/CreateTemplateUseCase.php
+++ b/src/Template/CreateTemplateUseCase.php
@@ -14,7 +14,7 @@ use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 
-final readonly class CreateTemplateUseCase
+final readonly class CreateTemplateUseCase implements CreateTemplateUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory

--- a/src/Template/CreateTemplateUseCaseInterface.php
+++ b/src/Template/CreateTemplateUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Template;
+
+interface CreateTemplateUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateTemplateInput $input): TemplateWithLines;
+}

--- a/src/Template/DeleteTemplateHandler.php
+++ b/src/Template/DeleteTemplateHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class DeleteTemplateHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DeleteTemplateUseCase $useCase,
+        private DeleteTemplateUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Template/DeleteTemplateUseCase.php
+++ b/src/Template/DeleteTemplateUseCase.php
@@ -9,7 +9,7 @@ use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 
-final readonly class DeleteTemplateUseCase
+final readonly class DeleteTemplateUseCase implements DeleteTemplateUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/Template/DeleteTemplateUseCaseInterface.php
+++ b/src/Template/DeleteTemplateUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Template;
+
+interface DeleteTemplateUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id): void;
+}

--- a/src/Template/GetTemplateByIdHandler.php
+++ b/src/Template/GetTemplateByIdHandler.php
@@ -17,7 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetTemplateByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetTemplateByIdUseCase $useCase,
+        private GetTemplateByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Template/GetTemplateByIdUseCase.php
+++ b/src/Template/GetTemplateByIdUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\Template;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 
-final readonly class GetTemplateByIdUseCase
+final readonly class GetTemplateByIdUseCase implements GetTemplateByIdUseCaseInterface
 {
     public function __construct(
         private TemplateRepositoryInterface $templates,

--- a/src/Template/GetTemplateByIdUseCaseInterface.php
+++ b/src/Template/GetTemplateByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Template;
+
+interface GetTemplateByIdUseCaseInterface
+{
+    public function execute(int $id): TemplateWithLines;
+}

--- a/src/Template/ListTemplatesHandler.php
+++ b/src/Template/ListTemplatesHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListTemplatesHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListTemplatesUseCase $useCase,
+        private ListTemplatesUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Template/ListTemplatesUseCase.php
+++ b/src/Template/ListTemplatesUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
-final readonly class ListTemplatesUseCase
+final readonly class ListTemplatesUseCase implements ListTemplatesUseCaseInterface
 {
     public function __construct(
         private TemplateRepositoryInterface $templates,

--- a/src/Template/ListTemplatesUseCaseInterface.php
+++ b/src/Template/ListTemplatesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Template;
+
+interface ListTemplatesUseCaseInterface
+{
+    public function execute(int $limit, int $offset): ListTemplatesResult;
+}

--- a/src/Template/TemplateServiceProvider.php
+++ b/src/Template/TemplateServiceProvider.php
@@ -40,9 +40,9 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     return new PdoTemplateRepository($query, self::orgHolder($c));
                 },
             )
-            ->set(ListTemplatesUseCase::class, static fn (ContainerInterface $c): ListTemplatesUseCase => new ListTemplatesUseCase(self::repository($c)))
-            ->set(GetTemplateByIdUseCase::class, static fn (ContainerInterface $c): GetTemplateByIdUseCase => new GetTemplateByIdUseCase(self::repository($c), self::lineItems($c)))
-            ->set(CreateTemplateUseCase::class, static function (ContainerInterface $c): CreateTemplateUseCase {
+            ->set(ListTemplatesUseCaseInterface::class, static fn (ContainerInterface $c): ListTemplatesUseCase => new ListTemplatesUseCase(self::repository($c)))
+            ->set(GetTemplateByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetTemplateByIdUseCase => new GetTemplateByIdUseCase(self::repository($c), self::lineItems($c)))
+            ->set(CreateTemplateUseCaseInterface::class, static function (ContainerInterface $c): CreateTemplateUseCase {
                 $orgHolder = self::orgHolder($c);
 
                 return new CreateTemplateUseCase(
@@ -53,7 +53,7 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     $orgHolder,
                 );
             })
-            ->set(UpdateTemplateUseCase::class, static function (ContainerInterface $c): UpdateTemplateUseCase {
+            ->set(UpdateTemplateUseCaseInterface::class, static function (ContainerInterface $c): UpdateTemplateUseCase {
                 $orgHolder = self::orgHolder($c);
 
                 return new UpdateTemplateUseCase(
@@ -64,26 +64,26 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     $orgHolder,
                 );
             })
-            ->set(DeleteTemplateUseCase::class, static fn (ContainerInterface $c): DeleteTemplateUseCase => new DeleteTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteTemplateUseCaseInterface::class, static fn (ContainerInterface $c): DeleteTemplateUseCase => new DeleteTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListTemplatesHandler::class,
-                static fn (ContainerInterface $c): ListTemplatesHandler => new ListTemplatesHandler(self::resolve($c, ListTemplatesUseCase::class), self::json($c)),
+                static fn (ContainerInterface $c): ListTemplatesHandler => new ListTemplatesHandler(self::resolve($c, ListTemplatesUseCaseInterface::class), self::json($c)),
             )
             ->set(
                 GetTemplateByIdHandler::class,
-                static fn (ContainerInterface $c): GetTemplateByIdHandler => new GetTemplateByIdHandler(self::resolve($c, GetTemplateByIdUseCase::class), self::json($c)),
+                static fn (ContainerInterface $c): GetTemplateByIdHandler => new GetTemplateByIdHandler(self::resolve($c, GetTemplateByIdUseCaseInterface::class), self::json($c)),
             )
             ->set(
                 CreateTemplateHandler::class,
-                static fn (ContainerInterface $c): CreateTemplateHandler => new CreateTemplateHandler(self::resolve($c, CreateTemplateUseCase::class), self::json($c)),
+                static fn (ContainerInterface $c): CreateTemplateHandler => new CreateTemplateHandler(self::resolve($c, CreateTemplateUseCaseInterface::class), self::json($c)),
             )
             ->set(
                 UpdateTemplateHandler::class,
-                static fn (ContainerInterface $c): UpdateTemplateHandler => new UpdateTemplateHandler(self::resolve($c, UpdateTemplateUseCase::class), self::json($c)),
+                static fn (ContainerInterface $c): UpdateTemplateHandler => new UpdateTemplateHandler(self::resolve($c, UpdateTemplateUseCaseInterface::class), self::json($c)),
             )
             ->set(
                 DeleteTemplateHandler::class,
-                static fn (ContainerInterface $c): DeleteTemplateHandler => new DeleteTemplateHandler(self::resolve($c, DeleteTemplateUseCase::class), self::json($c)),
+                static fn (ContainerInterface $c): DeleteTemplateHandler => new DeleteTemplateHandler(self::resolve($c, DeleteTemplateUseCaseInterface::class), self::json($c)),
             )
             ->set(
                 TemplateNotFoundExceptionHandler::class,

--- a/src/Template/UpdateTemplateHandler.php
+++ b/src/Template/UpdateTemplateHandler.php
@@ -18,7 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class UpdateTemplateHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private UpdateTemplateUseCase $useCase,
+        private UpdateTemplateUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/Template/UpdateTemplateUseCase.php
+++ b/src/Template/UpdateTemplateUseCase.php
@@ -14,7 +14,7 @@ use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 
-final readonly class UpdateTemplateUseCase
+final readonly class UpdateTemplateUseCase implements UpdateTemplateUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory

--- a/src/Template/UpdateTemplateUseCaseInterface.php
+++ b/src/Template/UpdateTemplateUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Template;
+
+interface UpdateTemplateUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $id, UpdateTemplateInput $input): TemplateWithLines;
+}

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -20,7 +20,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class CreateUserHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private CreateUserUseCase $useCase,
+        private CreateUserUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
-final readonly class CreateUserUseCase
+final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/User/CreateUserUseCaseInterface.php
+++ b/src/User/CreateUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface CreateUserUseCaseInterface
+{
+    public function execute(?int $actorUserId, CreateUserInput $input): User;
+}

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class DeleteUserHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private DeleteUserUseCase $useCase,
+        private DeleteUserUseCaseInterface $useCase,
         private JsonResponseFactory $json,
         private ProblemDetailsResponseFactory $problemDetails,
     ) {

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -7,7 +7,7 @@ namespace NeneInvoice\User;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
-final readonly class DeleteUserUseCase
+final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/User/DeleteUserUseCaseInterface.php
+++ b/src/User/DeleteUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface DeleteUserUseCaseInterface
+{
+    public function execute(int $callerUserId, int $userId): void;
+}

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class GetUserByIdHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private GetUserByIdUseCase $useCase,
+        private GetUserByIdUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-final readonly class GetUserByIdUseCase
+final readonly class GetUserByIdUseCase implements GetUserByIdUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,

--- a/src/User/GetUserByIdUseCaseInterface.php
+++ b/src/User/GetUserByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface GetUserByIdUseCaseInterface
+{
+    public function execute(int $id): User;
+}

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -19,7 +19,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 final readonly class ListUsersHandler implements RequestHandlerInterface
 {
     public function __construct(
-        private ListUsersUseCase $useCase,
+        private ListUsersUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
-final readonly class ListUsersUseCase
+final readonly class ListUsersUseCase implements ListUsersUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,

--- a/src/User/ListUsersUseCaseInterface.php
+++ b/src/User/ListUsersUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface ListUsersUseCaseInterface
+{
+    public function execute(int $limit, int $offset): ListUsersResult;
+}

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -24,7 +24,7 @@ final readonly class UpdateUserHandler implements RequestHandlerInterface
     private const ALLOWED_STATUSES = ['active', 'invited'];
 
     public function __construct(
-        private UpdateUserUseCase $useCase,
+        private UpdateUserUseCaseInterface $useCase,
         private JsonResponseFactory $json,
     ) {
     }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -9,7 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
 
-final readonly class UpdateUserUseCase
+final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 {
     /**
      * @param RequestScopedHolder<int> $orgId resolved organization for this request

--- a/src/User/UpdateUserUseCaseInterface.php
+++ b/src/User/UpdateUserUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\User;
+
+interface UpdateUserUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $userId, UpdateUserInput $input): User;
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -24,11 +24,11 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
     public function register(ContainerBuilder $builder): void
     {
         $builder
-            ->set(ListUsersUseCase::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
-            ->set(GetUserByIdUseCase::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
-            ->set(CreateUserUseCase::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateUserUseCase::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteUserUseCase::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(ListUsersUseCaseInterface::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
+            ->set(GetUserByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
+            ->set(CreateUserUseCaseInterface::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateUserUseCaseInterface::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteUserUseCaseInterface::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
             ->set(
                 ListUsersHandler::class,
                 static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
@@ -140,7 +140,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
     private static function listUseCase(ContainerInterface $c): ListUsersUseCase
     {
-        $u = $c->get(ListUsersUseCase::class);
+        $u = $c->get(ListUsersUseCaseInterface::class);
 
         if (!$u instanceof ListUsersUseCase) {
             throw new LogicException('List users use case service is invalid.');
@@ -151,7 +151,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
     private static function getUseCase(ContainerInterface $c): GetUserByIdUseCase
     {
-        $u = $c->get(GetUserByIdUseCase::class);
+        $u = $c->get(GetUserByIdUseCaseInterface::class);
 
         if (!$u instanceof GetUserByIdUseCase) {
             throw new LogicException('Get user use case service is invalid.');
@@ -162,7 +162,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
     private static function createUseCase(ContainerInterface $c): CreateUserUseCase
     {
-        $u = $c->get(CreateUserUseCase::class);
+        $u = $c->get(CreateUserUseCaseInterface::class);
 
         if (!$u instanceof CreateUserUseCase) {
             throw new LogicException('Create user use case service is invalid.');
@@ -173,7 +173,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
     private static function updateUseCase(ContainerInterface $c): UpdateUserUseCase
     {
-        $u = $c->get(UpdateUserUseCase::class);
+        $u = $c->get(UpdateUserUseCaseInterface::class);
 
         if (!$u instanceof UpdateUserUseCase) {
             throw new LogicException('Update user use case service is invalid.');
@@ -184,7 +184,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
 
     private static function deleteUseCase(ContainerInterface $c): DeleteUserUseCase
     {
-        $u = $c->get(DeleteUserUseCase::class);
+        $u = $c->get(DeleteUserUseCaseInterface::class);
 
         if (!$u instanceof DeleteUserUseCase) {
             throw new LogicException('Delete user use case service is invalid.');


### PR DESCRIPTION
Closes #339（監査 C-2・レイヤリング規約準拠）

## 概要
NENE2 のレイヤリング規約（`Handler → UseCaseInterface → UseCase`）に合わせ、**50個すべてのユースケース**に `XxxUseCaseInterface` を追加。ハンドラは具象ではなくインターフェースに依存し、各 `ServiceProvider` はインターフェースID で DI 登録/解決します。

## 変更
- `src/*/＊UseCaseInterface.php` を **50個**新規作成（`execute` / `executeAdmin` の公開シグネチャをリフレクションで正確に抽出）。
- 各ユースケースを `implements XxxUseCaseInterface` に変更。
- 全ハンドラのコンストラクタ型を具象 → インターフェースへ。
- 14 ServiceProvider の `->set()` / `resolve()` をインターフェースID に統一（ServiceApi・InvoiceDownloadToken のクロスドメイン解決も含む）。

機能変更はありません（純粋なリファクタリング）。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev サーバーで一覧API 200 を実機確認（interface 経由の DI 解決）

🤖 Generated with [Claude Code](https://claude.com/claude-code)