### PR TITLE
feat(backend): タイムスタンプをUTC保存・JST表示に統一＋Clock注入 (#342 part1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "autoload": {
         "psr-4": {
             "NeneInvoice\\": "src/"
-        }
+        },
+        "files": [
+            "src/bootstrap.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/adr/0010-utc-storage-jst-display.md
+++ b/docs/adr/0010-utc-storage-jst-display.md
@@ -1,0 +1,65 @@
+# ADR 0010: Store timestamps in UTC, display in JST
+
+## Status
+
+accepted
+
+## Context
+
+Timestamps were generated with ambient `date()` / `new DateTimeImmutable()` and
+stored as naive `Y-m-d H:i:s` strings in the server's local timezone (deployments
+assumed `Asia/Tokyo`). This has two problems:
+
+- **No canonical timezone.** A deployment whose server clock is not JST would
+  silently store and display wrong times. Nothing in the code declared the
+  intended zone, so the correctness of 発行日 / 入金日 depended on host config.
+- **Time source is implicit and untestable.** Use cases read the wall clock
+  directly, so time-dependent logic (issue date, due-date math, dashboard month
+  buckets, token expiry, login throttling) could not be exercised deterministically.
+
+The qualified-invoice **交付年月日 (issue date)** is statutory and, once issued,
+**immutable** (`docs/explanation/accounting-compliance.md` §2, §5). It must be the
+**Japan calendar date** of issuance regardless of where the server runs. We are
+pre-launch with no customer data, so this is the moment to fix the model with no
+migration risk.
+
+## Decision
+
+1. **Canonical storage is UTC.** The process timezone is forced to UTC at
+   bootstrap (`src/bootstrap.php`, wired via Composer `autoload.files`), so every
+   ambient `date()` and repository `created_at`/`updated_at`/`issued_at`/`paid_at`
+   write produces a UTC instant. The JSON API returns these stored UTC strings
+   as-is; **UTC is the documented convention** for all instant fields.
+
+2. **The authoritative clock is the server, via `ClockInterface` (UtcClock).**
+   Client-supplied time is never trusted for stored instants. Use cases that need
+   "now" depend on the framework `Nene2\Http\ClockInterface`, registered to
+   `UtcClock`, so time is injectable and tests pin a fixed instant.
+
+3. **Display is JST.** All user-facing output converts UTC → JST via
+   `NeneInvoice\Support\Jst`: PDF (発行日), CSV exports, and the admin frontend.
+
+4. **Calendar-date fields are computed in JST.** `due_at` (支払期限),
+   `valid_until` (有効期限), the document-number fiscal year, the "today" used by
+   list filters / overdue checks, and dashboard month boundaries are derived from
+   the **JST** wall clock (the clock's UTC instant re-zoned to JST), so the
+   Japanese calendar day/month/year is correct around the UTC midnight boundary.
+   These fields are stored as JST calendar dates and need no display conversion.
+
+## Consequences
+
+- 発行日 / 支払期限 / 有効期限 remain correct Japan dates independent of host
+  timezone; the rule is now explicit and enforced in code, not host config.
+- Time-dependent use cases are deterministically testable (fixed-instant clock).
+- Instant fields in API responses are UTC; the admin frontend converts to JST for
+  display (separate change). External read-only consumers (ServiceApi) receive UTC.
+- Tax-compliance impact: none to the statutory figures or the displayed issue
+  date — only the storage zone and the (previously implicit) derivation rule
+  change. No deviation from `docs/explanation/accounting-compliance.md`.
+
+## Related
+
+- Issue: `#342`
+- PR: `#350`
+- Supersedes: none
+- Superseded by: none

--- a/src/Audit/ExportAuditLogsCsvHandler.php
+++ b/src/Audit/ExportAuditLogsCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Audit;
 
+use NeneInvoice\Support\Jst;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,7 +27,7 @@ final readonly class ExportAuditLogsCsvHandler implements RequestHandlerInterfac
     {
         $filter   = AuditLogFilterFactory::fromQueryParams($request->getQueryParams());
         $csv      = $this->useCase->execute($filter);
-        $filename = 'audit-logs-' . date('Y-m-d') . '.csv';
+        $filename = 'audit-logs-' . Jst::today() . '.csv';
         $stream   = $this->psr17->createStream($csv);
 
         return $this->psr17->createResponse(200)

--- a/src/Audit/ExportAuditLogsCsvUseCase.php
+++ b/src/Audit/ExportAuditLogsCsvUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Audit;
 
+use NeneInvoice\Support\Jst;
+
 /**
  * Assembles CSV bytes for the audit trail (filtered, newest first). UTF-8 BOM is
  * prepended so Excel opens the file without encoding issues. before/after are
@@ -42,7 +44,7 @@ final readonly class ExportAuditLogsCsvUseCase implements ExportAuditLogsCsvUseC
 
         foreach ($rows as $log) {
             fputcsv($handle, [
-                $log->createdAt,
+                $log->createdAt !== null ? Jst::dateTime($log->createdAt) : '',
                 $log->action,
                 $log->entityType,
                 $log->entityId,

--- a/src/Dashboard/DashboardServiceProvider.php
+++ b/src/Dashboard/DashboardServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Dashboard;
 use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
@@ -22,6 +23,7 @@ final readonly class DashboardServiceProvider implements ServiceProviderInterfac
                 static fn (ContainerInterface $c): GetDashboardSummaryUseCase => new GetDashboardSummaryUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, ClockInterface::class),
                 ),
             )
             ->set(

--- a/src/Dashboard/GetDashboardSummaryUseCase.php
+++ b/src/Dashboard/GetDashboardSummaryUseCase.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace NeneInvoice\Dashboard;
 
 use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
+use NeneInvoice\Support\Jst;
 
 /**
  * Assembles the dashboard summary: unpaid/overdue counts, outstanding balance,
@@ -18,37 +20,42 @@ final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUs
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
         private PaymentRepositoryInterface $payments,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(): DashboardSummary
     {
-        // All time boundaries follow the application timezone (deploy with
-        // TZ=Asia/Tokyo), consistent with how paid_at / due_at are written.
-        $nowDt = new DateTimeImmutable();
-        $now   = $nowDt->format('Y-m-d H:i:s');
-        $data  = $this->invoices->getDashboardData($now);
+        // Months are Japanese calendar months: boundaries are computed on the JST
+        // wall clock, then converted to the UTC values stored in instant columns
+        // (issued_at, paid_at) for range queries. The overdue check compares the
+        // JST-calendar due_at against the current JST day. (ADR 0010)
+        $nowJst = Jst::of($this->clock->now());
+        $now    = $nowJst->format('Y-m-d H:i:s');
+        $data   = $this->invoices->getDashboardData($now);
 
         $outstandingTotalCents = $this->payments->outstandingTotal();
 
-        $thisMonthStart = $nowDt->format('Y-m-01 00:00:00');
-        $nextMonthStart = $nowDt->modify('first day of next month')->format('Y-m-01 00:00:00');
-        $lastMonthStart = $nowDt->modify('first day of last month')->format('Y-m-01 00:00:00');
-        $thirtyDaysAgo  = $nowDt->modify('-30 days')->format('Y-m-d H:i:s');
+        $firstThisMonthJst = $nowJst->modify('first day of this month')->setTime(0, 0);
+        $thisMonthStart = Jst::toUtcString($firstThisMonthJst);
+        $nextMonthStart = Jst::toUtcString($firstThisMonthJst->modify('+1 month'));
+        $lastMonthStart = Jst::toUtcString($firstThisMonthJst->modify('-1 month'));
+        // Aging compares the JST-calendar due_at, so its boundary stays in JST.
+        $thirtyDaysAgo  = $nowJst->modify('-30 days')->format('Y-m-d H:i:s');
 
         $billedThisMonth = $this->invoices->billedTotalBetween($thisMonthStart, $nextMonthStart);
         $billedLastMonth = $this->invoices->billedTotalBetween($lastMonthStart, $thisMonthStart);
 
         // Prior-year same month (YoY hero).
-        $prevYearStart = $nowDt->modify('first day of this month')->modify('-1 year');
+        $prevYearStart = $firstThisMonthJst->modify('-1 year');
         $billedPrevYearMonth = $this->invoices->billedTotalBetween(
-            $prevYearStart->format('Y-m-01 00:00:00'),
-            $prevYearStart->modify('first day of next month')->format('Y-m-01 00:00:00'),
+            Jst::toUtcString($prevYearStart),
+            Jst::toUtcString($prevYearStart->modify('+1 month')),
         );
 
         // Daily cumulative pace — current month (1..today) and the full prior month.
-        $today = (int) $nowDt->format('j');
-        $prevMonthLen = (int) $nowDt->modify('first day of last month')->format('t');
+        $today = (int) $nowJst->format('j');
+        $prevMonthLen = (int) $firstThisMonthJst->modify('-1 month')->format('t');
         $dailyCurrent = $this->dailyCumulative(
             $this->invoices->billedRowsBetween($thisMonthStart, $nextMonthStart),
             $today,
@@ -68,7 +75,7 @@ final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUs
             aging: $this->payments->agingBuckets($now, $thirtyDaysAgo),
             billedThisMonthCents: $billedThisMonth['cents'],
             billedLastMonthCents: $billedLastMonth['cents'],
-            monthlyBilled: $this->monthlyBilled($nowDt),
+            monthlyBilled: $this->monthlyBilled($firstThisMonthJst),
             billedPrevYearMonthCents: $billedPrevYearMonth['cents'],
             billedDailyCurrent: $dailyCurrent,
             billedDailyPrevMonth: $dailyPrev,
@@ -88,8 +95,9 @@ final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUs
         $perDay = array_fill(1, max($daysCount, 1), 0);
 
         foreach ($rows as $row) {
-            $day = (int) substr($row['issued_at'], 8, 2);
-            if ($day >= 1 && $day <= $daysCount) {
+            // issued_at is stored in UTC; bucket by the JST calendar day.
+            $day = (int) Jst::of(new DateTimeImmutable($row['issued_at']))->format('j');
+            if ($day <= $daysCount) {
                 $perDay[$day] += $row['total_cents'];
             }
         }
@@ -105,21 +113,24 @@ final readonly class GetDashboardSummaryUseCase implements GetDashboardSummaryUs
     }
 
     /**
-     * Issued-invoice totals for the last 6 calendar months (oldest→newest).
+     * Issued-invoice totals for the last 6 JST calendar months (oldest→newest).
+     * Month boundaries are JST wall-clock times converted to the UTC issued_at
+     * values used by the range query (ADR 0010).
+     *
+     * @param DateTimeImmutable $firstThisMonthJst first day of this JST month (00:00 JST)
      *
      * @return list<array{month: string, billed_cents: int, count: int}>
      */
-    private function monthlyBilled(DateTimeImmutable $nowDt): array
+    private function monthlyBilled(DateTimeImmutable $firstThisMonthJst): array
     {
-        $firstOfThisMonth = $nowDt->modify('first day of this month')->setTime(0, 0, 0);
         $months = [];
 
         for ($k = 5; $k >= 0; --$k) {
-            $start  = $firstOfThisMonth->modify("-{$k} month");
+            $start  = $firstThisMonthJst->modify("-{$k} month");
             $end    = $start->modify('+1 month');
             $bucket = $this->invoices->billedTotalBetween(
-                $start->format('Y-m-d H:i:s'),
-                $end->format('Y-m-d H:i:s'),
+                Jst::toUtcString($start),
+                Jst::toUtcString($end),
             );
 
             $months[] = [

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -18,9 +18,11 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditServiceProvider;
@@ -134,6 +136,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 
                     return new PdoDatabaseQueryExecutor($connectionFactory);
                 },
+            )
+            ->set(
+                ClockInterface::class,
+                static fn (): ClockInterface => new UtcClock(),
             )
             ->set(
                 DatabaseTransactionManagerInterface::class,

--- a/src/Invoice/ExportInvoicesCsvHandler.php
+++ b/src/Invoice/ExportInvoicesCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use NeneInvoice\Support\Jst;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,7 +25,7 @@ final readonly class ExportInvoicesCsvHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $csv      = $this->useCase->execute();
-        $filename = 'invoices-' . date('Y-m-d') . '.csv';
+        $filename = 'invoices-' . Jst::today() . '.csv';
         $stream   = $this->psr17->createStream($csv);
 
         return $this->psr17->createResponse(200)

--- a/src/Invoice/ExportInvoicesCsvUseCase.php
+++ b/src/Invoice/ExportInvoicesCsvUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use NeneInvoice\Support\Jst;
+
 /**
  * Assembles CSV bytes for all issued invoices in the organization.
  * UTF-8 BOM is prepended so Excel opens the file without encoding issues.
@@ -45,7 +47,7 @@ final readonly class ExportInvoicesCsvUseCase implements ExportInvoicesCsvUseCas
         foreach ($rows as $row) {
             fputcsv($handle, [
                 $row['invoice_number'],
-                $row['issued_at'],
+                $row['issued_at'] !== null ? Jst::date($row['issued_at']) : '',
                 $row['due_at'],
                 $row['client_name'],
                 $row['subtotal_cents'],

--- a/src/Invoice/InvoiceListFilter.php
+++ b/src/Invoice/InvoiceListFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use NeneInvoice\Support\Jst;
+
 /**
  * Read filters for listing invoices (service API §2.1). All predicates resolve
  * against the invoices table alone — `overdueOnly` / `outstandingOnly` are
@@ -52,6 +54,6 @@ final readonly class InvoiceListFilter
 
     public function todayOrNow(): string
     {
-        return $this->today ?? date('Y-m-d');
+        return $this->today ?? Jst::today();
     }
 }

--- a/src/Invoice/InvoiceResponse.php
+++ b/src/Invoice/InvoiceResponse.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use DateTimeImmutable;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemResponse;
+use NeneInvoice\Support\Jst;
 
 /**
  * Serializes an {@see Invoice} to its snake_case JSON representation. Line items
@@ -65,6 +65,6 @@ final class InvoiceResponse
             return false;
         }
 
-        return $invoice->dueAt < (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        return $invoice->dueAt < Jst::nowString();
     }
 }

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -87,6 +88,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                     self::resolve($c, CompanySettingsRepositoryInterface::class),
                     self::resolve($c, DocumentNumberGenerator::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::resolve($c, ClockInterface::class),
                     self::orgHolder($c),
                 ),
             )

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
-use DateTimeImmutable;
 use LogicException;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
@@ -13,6 +13,7 @@ use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
 use NeneInvoice\DocumentSequence\DocumentType;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\Support\Jst;
 
 /**
  * Issues a draft invoice: validates qualified-invoice requirements, allocates an
@@ -31,6 +32,7 @@ final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
         private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
         private AuditRecorderInterface $audit,
+        private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -68,9 +70,13 @@ final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
             }
         }
 
-        $number = $this->numbers->next(DocumentType::Invoice, (int) date('Y'));
+        // The issue instant is stored in UTC; the 交付年月日 and all calendar math
+        // (fiscal year, due date) use the JST wall clock (ADR 0010).
+        $now       = $this->clock->now();
+        $issuedAt  = $now->format('Y-m-d H:i:s');
+        $issuedJst = Jst::of($now);
 
-        $issuedAt = date('Y-m-d H:i:s');
+        $number = $this->numbers->next(DocumentType::Invoice, (int) $issuedJst->format('Y'));
 
         // Due date: explicit input wins, then any pre-set value, else the
         // company payment-terms default (締め日＋支払サイト) from the issue date.
@@ -79,7 +85,7 @@ final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
         if ($dueAt === null) {
             $terms = $settings?->paymentTerms();
             if ($terms !== null) {
-                $dueAt = $terms->dueDateFrom(new DateTimeImmutable($issuedAt));
+                $dueAt = $terms->dueDateFrom($issuedJst);
             }
         }
 

--- a/src/Invoice/Pdf/InvoicePdfGenerator.php
+++ b/src/Invoice/Pdf/InvoicePdfGenerator.php
@@ -8,6 +8,7 @@ use Mpdf\Mpdf;
 use Mpdf\MpdfException;
 use NeneInvoice\LineItem\TaxBreakdownLine;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Support\Jst;
 use RuntimeException;
 
 /**
@@ -36,7 +37,7 @@ final readonly class InvoicePdfGenerator implements InvoicePdfGeneratorInterface
 
         $html = $this->buildHtml(
             invoiceNumber: $invoice->invoiceNumber ?? '（下書き）',
-            issuedAt: $invoice->issuedAt ? substr($invoice->issuedAt, 0, 10) : '—',
+            issuedAt: $invoice->issuedAt ? Jst::date($invoice->issuedAt) : '—',
             dueAt: $invoice->dueAt ? substr($invoice->dueAt, 0, 10) : '—',
             isQualified: $invoice->isQualifiedInvoice,
             clientName: $client->name,

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\InvoiceDownloadToken;
 
-use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\SecureTokenHelper;
 use NeneInvoice\Audit\AuditRecorderInterface;
@@ -27,6 +27,7 @@ final readonly class GenerateDownloadTokenUseCase implements GenerateDownloadTok
         private InvoiceRepositoryInterface $invoices,
         private InvoiceDownloadTokenRepositoryInterface $tokens,
         private AuditRecorderInterface $audit,
+        private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -51,7 +52,7 @@ final readonly class GenerateDownloadTokenUseCase implements GenerateDownloadTok
 
         // 256-bit token; only its SHA-256 hash is persisted (see SecureTokenHelper).
         [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
-        $now       = new DateTimeImmutable();
+        $now       = $this->clock->now();
         $expiresAt = $now->modify('+' . self::TTL_DAYS . ' days')->format('Y-m-d H:i:s');
         $createdAt = $now->format('Y-m-d H:i:s');
 

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -42,6 +43,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::resolve($c, ClockInterface::class),
                     self::orgHolder($c),
                 ),
             )

--- a/src/Payment/ExportPaymentsCsvHandler.php
+++ b/src/Payment/ExportPaymentsCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
+use NeneInvoice\Support\Jst;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,7 +25,7 @@ final readonly class ExportPaymentsCsvHandler implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $csv      = $this->useCase->execute();
-        $filename = 'payments-' . date('Y-m-d') . '.csv';
+        $filename = 'payments-' . Jst::today() . '.csv';
         $stream   = $this->psr17->createStream($csv);
 
         return $this->psr17->createResponse(200)

--- a/src/Payment/ExportPaymentsCsvUseCase.php
+++ b/src/Payment/ExportPaymentsCsvUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
+use NeneInvoice\Support\Jst;
+
 /**
  * Assembles CSV bytes for all valid (non-voided) payments in the organization.
  * UTF-8 BOM is prepended so Excel opens the file without encoding issues.
@@ -43,7 +45,7 @@ final readonly class ExportPaymentsCsvUseCase implements ExportPaymentsCsvUseCas
             fputcsv($handle, [
                 $row['invoice_number'],
                 $row['client_name'],
-                $row['paid_at'],
+                Jst::date($row['paid_at']),
                 $row['amount_cents'],
                 self::METHOD_LABELS[$row['method']] ?? $row['method'],
                 $row['note'],

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -44,6 +45,7 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
                     self::resolve($c, PaymentRepositoryInterface::class),
                     self::resolve($c, InvoiceRepositoryInterface::class),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::resolve($c, ClockInterface::class),
                     self::orgHolder($c),
                 ),
             )

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Payment;
 
 use LogicException;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\Invoice;
@@ -12,6 +13,7 @@ use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\InvoiceResponse;
 use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Support\Jst;
 
 /**
  * Records a payment against an issued invoice and advances the invoice status:
@@ -31,6 +33,7 @@ final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterfa
         private PaymentRepositoryInterface $payments,
         private InvoiceRepositoryInterface $invoices,
         private AuditRecorderInterface $audit,
+        private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -74,7 +77,9 @@ final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterfa
                 throw new PaymentValidationException('A payment date must be a valid date (YYYY-MM-DD).');
             }
 
-            if ($parsed > new \DateTimeImmutable('now')) {
+            // The supplied value is a JST calendar date; reject anything after the
+            // current JST day (compare calendar dates, zone-independent — ADR 0010).
+            if ($parsed->format('Y-m-d') > Jst::of($this->clock->now())->format('Y-m-d')) {
                 throw new PaymentValidationException('A payment date cannot be in the future.');
             }
         }
@@ -91,7 +96,7 @@ final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterfa
 
         $before = InvoiceResponse::toArray($invoice);
 
-        $paidAt = $input->paidAt ?? date('Y-m-d H:i:s');
+        $paidAt = $input->paidAt ?? $this->clock->now()->format('Y-m-d H:i:s');
 
         $paymentId = $this->payments->save(new Payment(
             organizationId: $organizationId,

--- a/src/Quote/ChangeQuoteStatusUseCase.php
+++ b/src/Quote/ChangeQuoteStatusUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use LogicException;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
@@ -16,6 +17,7 @@ final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCas
     public function __construct(
         private QuoteRepositoryInterface $quotes,
         private AuditRecorderInterface $audit,
+        private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -38,7 +40,7 @@ final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCas
 
         // A quote is considered issued when first sent.
         $issuedAt = $target === QuoteStatus::Sent && $quote->issuedAt === null
-            ? date('Y-m-d H:i:s')
+            ? $this->clock->now()->format('Y-m-d H:i:s')
             : $quote->issuedAt;
 
         $this->quotes->update(new Quote(

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace NeneInvoice\Quote;
 
 use Closure;
-use DateTimeImmutable;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Client\ClientRepositoryInterface;
@@ -19,6 +19,7 @@ use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Support\Jst;
 
 /**
  * Creates a draft quote: validates the client and lines, computes totals
@@ -49,6 +50,7 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
         private DocumentNumberGenerator $numbers,
         private TaxCalculator $taxCalculator,
         private AuditRecorderInterface $audit,
+        private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -84,12 +86,16 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
         }
 
         $totals = $this->taxCalculator->calculate($input->lines);
-        $number = $this->numbers->next(DocumentType::Quote, (int) date('Y'));
+
+        // Fiscal year and the "today" the validity period is measured from use the
+        // JST wall clock so the Japanese calendar date is correct (ADR 0010).
+        $todayJst = Jst::of($this->clock->now())->setTime(0, 0);
+        $number   = $this->numbers->next(DocumentType::Quote, (int) $todayJst->format('Y'));
 
         // Validity: explicit input wins, else the company default period (有効期限)
         // measured from today (the draft's creation date).
         $validUntil = $input->validUntil
-            ?? $this->companySettings->find()?->quoteValidUntilFrom(new DateTimeImmutable('today'));
+            ?? $this->companySettings->find()?->quoteValidUntilFrom($todayJst);
 
         $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
             $organizationId,

--- a/src/Quote/Pdf/QuotePdfGenerator.php
+++ b/src/Quote/Pdf/QuotePdfGenerator.php
@@ -8,6 +8,7 @@ use Mpdf\Mpdf;
 use Mpdf\MpdfException;
 use NeneInvoice\LineItem\TaxBreakdownLine;
 use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Support\Jst;
 use RuntimeException;
 
 /**
@@ -35,7 +36,7 @@ final readonly class QuotePdfGenerator
 
         $html = $this->buildHtml(
             quoteNumber: $quote->quoteNumber,
-            issuedAt: $quote->issuedAt ? substr($quote->issuedAt, 0, 10) : '—',
+            issuedAt: $quote->issuedAt ? Jst::date($quote->issuedAt) : '—',
             validUntil: $quote->validUntil ? substr($quote->validUntil, 0, 10) : '—',
             clientName: $client->name,
             clientAddress: $client->billingAddress ?? '',

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -60,6 +61,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                         self::resolve($c, DocumentNumberGenerator::class),
                         self::resolve($c, TaxCalculator::class),
                         self::resolve($c, AuditRecorderInterface::class),
+                        self::resolve($c, ClockInterface::class),
                         $orgHolder,
                     );
                 },
@@ -69,6 +71,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ChangeQuoteStatusUseCase => new ChangeQuoteStatusUseCase(
                     self::quotes($c),
                     self::resolve($c, AuditRecorderInterface::class),
+                    self::resolve($c, ClockInterface::class),
                     self::orgHolder($c),
                 ),
             )

--- a/src/Support/Jst.php
+++ b/src/Support/Jst.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Japan Standard Time conversion helpers.
+ *
+ * The application stores instant timestamps in UTC (see
+ * docs/adr/0010-utc-storage-jst-display.md). User-facing output — PDFs, CSV
+ * exports, the admin UI — must show those instants in JST, and calendar-date
+ * fields (発行日, 支払期限, 有効期限) must be derived from the **JST** wall clock,
+ * never UTC, so the Japanese calendar day is correct around midnight.
+ */
+final class Jst
+{
+    public const ZONE = 'Asia/Tokyo';
+
+    private static ?DateTimeZone $jst = null;
+    private static ?DateTimeZone $utc = null;
+
+    /**
+     * Current JST calendar date (`Y-m-d`). For list-filter defaults and overdue
+     * checks where the comparison column holds a JST calendar date.
+     */
+    public static function today(): string
+    {
+        return self::of(new DateTimeImmutable('now', self::utc()))->format('Y-m-d');
+    }
+
+    /** Current JST wall-clock datetime (`Y-m-d H:i:s`). */
+    public static function nowString(): string
+    {
+        return self::of(new DateTimeImmutable('now', self::utc()))->format('Y-m-d H:i:s');
+    }
+
+    /** Parses a stored UTC datetime string and returns it as a JST instant. */
+    public static function fromUtc(string $utcDateTime): DateTimeImmutable
+    {
+        return (new DateTimeImmutable($utcDateTime, self::utc()))->setTimezone(self::jst());
+    }
+
+    /** JST calendar date (`Y-m-d`) of a stored UTC datetime string. */
+    public static function date(string $utcDateTime): string
+    {
+        return self::fromUtc($utcDateTime)->format('Y-m-d');
+    }
+
+    /** JST wall-clock datetime (`Y-m-d H:i:s`) of a stored UTC datetime string. */
+    public static function dateTime(string $utcDateTime): string
+    {
+        return self::fromUtc($utcDateTime)->format('Y-m-d H:i:s');
+    }
+
+    /** Re-zones a UTC instant to JST (for calendar math on a known instant). */
+    public static function of(DateTimeImmutable $utcInstant): DateTimeImmutable
+    {
+        return $utcInstant->setTimezone(self::jst());
+    }
+
+    /**
+     * Renders any instant as a UTC `Y-m-d H:i:s` string. Used to turn a JST
+     * wall-clock boundary into the UTC value stored in instant columns
+     * (issued_at, paid_at) for range queries.
+     */
+    public static function toUtcString(DateTimeImmutable $instant): string
+    {
+        return $instant->setTimezone(self::utc())->format('Y-m-d H:i:s');
+    }
+
+    private static function jst(): DateTimeZone
+    {
+        return self::$jst ??= new DateTimeZone(self::ZONE);
+    }
+
+    private static function utc(): DateTimeZone
+    {
+        return self::$utc ??= new DateTimeZone('UTC');
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Process-wide timezone. The application stores all instant timestamps
+ * (created_at, updated_at, issued_at, paid_at, audit/token/login times) in
+ * **UTC** and converts to JST only at display edges (PDF, CSV, frontend).
+ * Forcing the process timezone to UTC makes every ambient date()/DateTimeImmutable
+ * produce UTC consistently across web, CLI, and test contexts.
+ *
+ * Calendar-date fields (due_at, valid_until) are computed in JST — see
+ * docs/adr/0010-utc-storage-jst-display.md and NeneInvoice\Support\Jst.
+ */
+date_default_timezone_set('UTC');

--- a/tests/Dashboard/GetDashboardHandlerTest.php
+++ b/tests/Dashboard/GetDashboardHandlerTest.php
@@ -10,6 +10,7 @@ use NeneInvoice\Dashboard\GetDashboardHandler;
 use NeneInvoice\Dashboard\GetDashboardSummaryUseCase;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -31,7 +32,7 @@ final class GetDashboardHandlerTest extends TestCase
         $this->payments = new InMemoryPaymentRepository($holder);
 
         $this->handler = new GetDashboardHandler(
-            new GetDashboardSummaryUseCase($this->invoices, $this->payments),
+            new GetDashboardSummaryUseCase($this->invoices, $this->payments, new FixedClock()),
             $this->payments,
             new JsonResponseFactory($this->psr17, $this->psr17),
         );

--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\Dashboard;
 use NeneInvoice\Dashboard\GetDashboardSummaryUseCase;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($holder);
         $this->payments = new InMemoryPaymentRepository($holder);
-        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, $this->payments);
+        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, $this->payments, new FixedClock());
     }
 
     public function test_empty_organization_returns_zeros(): void

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -18,6 +18,7 @@ use NeneInvoice\Invoice\IssueInvoiceUseCase;
 use NeneInvoice\Invoice\QualifiedInvoiceIncompleteException;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
@@ -49,6 +50,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             $this->audit,
+            new FixedClock(),
             $this->holder,
         );
     }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
@@ -11,6 +11,7 @@ use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenHandler;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -44,7 +45,7 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
         ));
 
         $this->handler = new GenerateDownloadTokenHandler(
-            new GenerateDownloadTokenUseCase($this->invoices, $tokens, new RecordingAuditRecorder(), $this->holder),
+            new GenerateDownloadTokenUseCase($this->invoices, $tokens, new RecordingAuditRecorder(), new FixedClock(), $this->holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
         );
     }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
@@ -9,6 +9,7 @@ use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -34,7 +35,7 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->tokens   = new InMemoryInvoiceDownloadTokenRepository();
         $this->audit    = new RecordingAuditRecorder();
-        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->audit, $this->holder);
+        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->audit, new FixedClock(), $this->holder);
     }
 
     public function test_generates_token_for_invoice_in_org(): void

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -12,6 +12,7 @@ use NeneInvoice\Payment\PaymentExceedsOutstandingException;
 use NeneInvoice\Payment\PaymentValidationException;
 use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -33,7 +34,7 @@ final class RecordPaymentUseCaseTest extends TestCase
         $this->payments = new InMemoryPaymentRepository($this->holder);
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
+        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, new FixedClock(), $this->holder);
     }
 
     private function issuedInvoice(int $totalCents = 2200): int

--- a/tests/Payment/VoidPaymentUseCaseTest.php
+++ b/tests/Payment/VoidPaymentUseCaseTest.php
@@ -11,6 +11,7 @@ use NeneInvoice\Payment\PaymentNotFoundException;
 use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use NeneInvoice\Payment\VoidPaymentUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -34,7 +35,7 @@ final class VoidPaymentUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->payments = new InMemoryPaymentRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
+        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, new FixedClock(), $this->holder);
         $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
 
         $this->invoiceId = $this->invoices->save(new Invoice(

--- a/tests/Quote/ChangeQuoteStatusUseCaseTest.php
+++ b/tests/Quote/ChangeQuoteStatusUseCaseTest.php
@@ -10,6 +10,7 @@ use NeneInvoice\Quote\InvalidStateTransitionException;
 use NeneInvoice\Quote\Quote;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteStatus;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +29,7 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
         $this->holder->set(1);
         $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit, $this->holder);
+        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit, new FixedClock(), $this->holder);
     }
 
     private function draft(): int

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -16,6 +16,7 @@ use NeneInvoice\Quote\CreateQuoteInput;
 use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\QuoteStatus;
 use NeneInvoice\Quote\QuoteValidationException;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
@@ -57,6 +58,7 @@ final class CreateQuoteUseCaseTest extends TestCase
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             $this->audit,
+            new FixedClock(),
             $this->holder,
         );
     }

--- a/tests/Quote/GenerateQuotePdfUseCaseTest.php
+++ b/tests/Quote/GenerateQuotePdfUseCaseTest.php
@@ -14,6 +14,7 @@ use NeneInvoice\Quote\CreateQuoteInput;
 use NeneInvoice\Quote\CreateQuoteUseCase;
 use NeneInvoice\Quote\GenerateQuotePdfUseCase;
 use NeneInvoice\Quote\QuoteNotFoundException;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
@@ -72,6 +73,7 @@ final class GenerateQuotePdfUseCaseTest extends TestCase
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             new RecordingAuditRecorder(),
+            new FixedClock(),
             $this->holder,
         );
 

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -16,6 +16,7 @@ use NeneInvoice\Quote\ListQuotesUseCase;
 use NeneInvoice\Quote\QuoteListFilter;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteSort;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
@@ -58,6 +59,7 @@ final class QuoteQueryUseCasesTest extends TestCase
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
             new RecordingAuditRecorder(),
+            new FixedClock(),
             $this->holder,
         );
 

--- a/tests/ServiceApi/RecordServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/RecordServicePaymentHandlerTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Payment\PaymentExceedsOutstandingException;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use NeneInvoice\ServiceApi\RecordServicePaymentHandler;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -48,7 +49,7 @@ final class RecordServicePaymentHandlerTest extends TestCase
         ));
 
         $this->handler = new RecordServicePaymentHandler(
-            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), $holder),
+            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), new FixedClock(), $holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );

--- a/tests/Support/FixedClock.php
+++ b/tests/Support/FixedClock.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Nene2\Http\ClockInterface;
+
+/**
+ * Deterministic {@see ClockInterface} for tests: always returns the same UTC
+ * instant so time-dependent use cases (issue date, due-date math, dashboard
+ * buckets, token expiry) can be asserted without real-time drift.
+ */
+final class FixedClock implements ClockInterface
+{
+    private DateTimeImmutable $now;
+
+    /** Defaults to a fixed UTC instant; pass an ISO-8601 string to override. */
+    public function __construct(string $instant = '2026-06-06T03:00:00Z')
+    {
+        $this->now = new DateTimeImmutable($instant, new DateTimeZone('UTC'));
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}


### PR DESCRIPTION
Refs #342（part 1 / バックエンド。フロント表示変換は part 2 で対応）

## 概要
ADR 0010 に基づき、**インスタント系**タイムスタンプ（created_at / updated_at / issued_at / paid_at / 監査・トークン・ログイン）を **UTC 保存**、表示（PDF / CSV / フロント）で **JST 変換**に統一。**暦日系**（due_at / valid_until / 発行日 / 採番年 / today / 月境界）は **JST で算出**します。権威時刻は常にサーバ（`ClockInterface`）で、クライアント時刻は採用しません。

## 基盤
- `src/bootstrap.php`（composer `autoload.files`）でプロセス TZ を UTC 固定 → web / CLI / test 全コンテキストで `date()` が UTC。
- `NeneInvoice\Support\Jst`：UTC↔JST 変換、JST today/now、UTC 文字列化。
- DI に `ClockInterface → UtcClock` を登録。
- `docs/adr/0010-utc-storage-jst-display.md`。

## ユースケース（Clock 注入＋JST 算出）
- **IssueInvoice**: issued_at=UTC、交付年月日 / 採番年 / 支払期限は JST。
- **CreateQuote**: 採番年 / 有効期限は JST today。
- **RecordPayment**: paid_at デフォルト=UTC、未来日チェックは JST 暦日比較。
- **ChangeQuoteStatus / GenerateDownloadToken**: now=Clock(UTC)。
- **Dashboard**: 月境界を JST 算出→issued_at(UTC) クエリ用に UTC 変換、overdue は due_at(JST) を JST now と比較、日次バケットは JST 日で集計。

## 表示（UTC→JST）
- Invoice / Quote PDF の発行日を `Jst::date` で変換（**従来の `substr` は UTC 日付を切り出す不具合**＝適格請求書の交付年月日が深夜帯にずれる）。
- Invoices / Payments / AuditLogs CSV の日付列、一覧フィルタ / overdue 判定を JST 化。

## コンプライアンス
`docs/explanation/accounting-compliance.md` の交付年月日（法定・発行後不変）に影響なし — 表示される JST 日付は不変、保存ゾーンと（従来暗黙だった）算出規則を明示化しただけ。プレローンチ・顧客データなしのためデータ移行リスクなし。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev サーバーで `issued_at`=UTC・`due_at`=JST 暦日・dashboard 200 を実機確認
- 補足: API はインスタントを UTC で返す。フロント表示変換は **part 2**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)