### PR TITLE
feat(frontend): インスタント日時をJST表示に変換 (#342 part2)

### DIFF
--- a/frontend/src/features/list-audit-logs/ui/ListAuditLogs.tsx
+++ b/frontend/src/features/list-audit-logs/ui/ListAuditLogs.tsx
@@ -10,6 +10,7 @@ import {
   type AuditLogFilters,
 } from '@/entities/audit'
 import { useTranslation } from '@/shared/i18n'
+import { formatJstDateTime } from '@/shared/lib/format-date'
 import {
   Button,
   DatePicker,
@@ -224,7 +225,9 @@ function AuditRow({ log, expanded, onToggle }: AuditRowProps) {
   return (
     <>
       <tr>
-        <td data-label={t('admin.audit.col.createdAt')}>{log.created_at ?? '—'}</td>
+        <td data-label={t('admin.audit.col.createdAt')}>
+          {log.created_at !== null ? formatJstDateTime(log.created_at) : '—'}
+        </td>
         <td data-label={t('admin.audit.col.action')}>
           {/* Accounting-term label; the raw code stays available on hover. */}
           <span title={log.action}>{actionLabel}</span>

--- a/frontend/src/features/list-invoices/ui/ListInvoices.tsx
+++ b/frontend/src/features/list-invoices/ui/ListInvoices.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
 import { KbdHint, useRowCursor } from '@/shared/keyboard'
+import { formatCalendarDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -259,7 +260,7 @@ export function ListInvoices() {
                       {invoice.client_name ?? `#${String(invoice.client_id)}`}
                     </td>
                     <td className="num" data-label={t('admin.invoices.col.due')}>
-                      {invoice.due_at ?? '—'}
+                      {invoice.due_at !== null ? formatCalendarDate(invoice.due_at) : '—'}
                     </td>
                     <td className="tr num" data-label={t('admin.invoices.col.total')}>
                       {formatYen(invoice.total_cents)}

--- a/frontend/src/features/list-quotes/ui/ListQuotes.tsx
+++ b/frontend/src/features/list-quotes/ui/ListQuotes.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
 import { KbdHint, useRowCursor } from '@/shared/keyboard'
+import { formatCalendarDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -201,7 +202,7 @@ export function ListQuotes() {
                       {quote.client_name ?? `#${String(quote.client_id)}`}
                     </td>
                     <td className="num" data-label={t('admin.quotes.col.validUntil')}>
-                      {quote.valid_until ?? '—'}
+                      {quote.valid_until !== null ? formatCalendarDate(quote.valid_until) : '—'}
                     </td>
                     <td className="tr num" data-label={t('admin.quotes.col.total')}>
                       {formatYen(quote.total_cents)}

--- a/frontend/src/features/manage-payments/ui/ManagePayments.tsx
+++ b/frontend/src/features/manage-payments/ui/ManagePayments.tsx
@@ -1,5 +1,6 @@
 import type { InvoiceId } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
+import { formatJstDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Button,
@@ -73,7 +74,7 @@ export function ManagePayments({ invoiceId }: ManagePaymentsProps) {
               {payments.map((payment) => (
                 <tr key={payment.id}>
                   <td className="num" data-label={t('admin.payments.col.paidAt')}>
-                    {payment.paid_at}
+                    {formatJstDate(payment.paid_at)}
                   </td>
                   <td data-label={t('admin.payments.col.method')}>
                     {payment.method === null ? '—' : t(`admin.payments.method.${payment.method}`)}

--- a/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
+++ b/frontend/src/features/view-dashboard/ui/ViewDashboard.tsx
@@ -4,6 +4,7 @@ import type { DailyBilled, MonthlyBilled } from '@/entities/dashboard'
 import { invoiceStatusTone } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
 import { cn } from '@/shared/lib/cn'
+import { formatCalendarDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import { Badge, EmptyState, ErrorState, LinkButton, LoadingState, Stack } from '@/shared/ui'
 import { useViewDashboard } from '../hooks/use-view-dashboard'
@@ -185,7 +186,7 @@ export function ViewDashboard() {
                     </div>
                     <div className="text-caption text-fg-muted">
                       {invoice.due_at !== null
-                        ? t('admin.dashboard.due', { date: invoice.due_at.slice(0, 10) })
+                        ? t('admin.dashboard.due', { date: formatCalendarDate(invoice.due_at) })
                         : '—'}
                     </div>
                   </div>

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -7,6 +7,7 @@ import {
   type InvoiceId,
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
+import { formatCalendarDate, formatJstDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   ActionError,
@@ -196,12 +197,12 @@ export function ViewInvoice({ invoiceId }: ViewInvoiceProps) {
           )}
           {invoice.issued_at !== null && (
             <Text variant="muted">
-              {t('admin.invoices.detail.issuedAt')}: {invoice.issued_at}
+              {t('admin.invoices.detail.issuedAt')}: {formatJstDate(invoice.issued_at)}
             </Text>
           )}
           {invoice.due_at !== null && (
             <Text variant="muted">
-              {t('admin.invoices.detail.dueAt')}: {invoice.due_at}
+              {t('admin.invoices.detail.dueAt')}: {formatCalendarDate(invoice.due_at)}
             </Text>
           )}
         </Stack>

--- a/frontend/src/features/view-quote/ui/ViewQuote.tsx
+++ b/frontend/src/features/view-quote/ui/ViewQuote.tsx
@@ -6,6 +6,7 @@ import {
   type QuoteId,
 } from '@/entities/quote'
 import { useTranslation } from '@/shared/i18n'
+import { formatCalendarDate, formatJstDate } from '@/shared/lib/format-date'
 import { formatYen } from '@/shared/lib/format-money'
 import {
   Badge,
@@ -147,12 +148,12 @@ export function ViewQuote({ quoteId }: ViewQuoteProps) {
           </Badge>
           {quote.issued_at !== null && (
             <Text variant="muted">
-              {t('admin.quotes.detail.issuedAt')}: {quote.issued_at.slice(0, 10)}
+              {t('admin.quotes.detail.issuedAt')}: {formatJstDate(quote.issued_at)}
             </Text>
           )}
           {quote.valid_until !== null && (
             <Text variant="muted">
-              {t('admin.quotes.detail.validUntil')}: {quote.valid_until.slice(0, 10)}
+              {t('admin.quotes.detail.validUntil')}: {formatCalendarDate(quote.valid_until)}
             </Text>
           )}
         </Stack>

--- a/frontend/src/shared/lib/format-date.test.ts
+++ b/frontend/src/shared/lib/format-date.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { formatCalendarDate, formatJstDate, formatJstDateTime } from './format-date'
+
+describe('formatJstDate', () => {
+  it('converts a UTC instant to the JST calendar date (+9h)', () => {
+    // 2026-06-06 21:00 UTC → 2026-06-07 06:00 JST (date rolls forward).
+    expect(formatJstDate('2026-06-06 21:00:00')).toBe('2026-06-07')
+    // 2026-06-06 12:33 UTC → 2026-06-06 21:33 JST (same day).
+    expect(formatJstDate('2026-06-06 12:33:33')).toBe('2026-06-06')
+  })
+
+  it('honours an explicit zone suffix', () => {
+    expect(formatJstDate('2026-06-06T21:00:00Z')).toBe('2026-06-07')
+  })
+
+  it('returns the input unchanged when unparseable', () => {
+    expect(formatJstDate('not-a-date')).toBe('not-a-date')
+  })
+})
+
+describe('formatJstDateTime', () => {
+  it('converts a UTC instant to JST date and time', () => {
+    expect(formatJstDateTime('2026-06-06 12:33:33')).toBe('2026-06-06 21:33')
+  })
+})
+
+describe('formatCalendarDate', () => {
+  it('trims to the date portion without any timezone shift', () => {
+    expect(formatCalendarDate('2026-07-31')).toBe('2026-07-31')
+    expect(formatCalendarDate('2026-07-31 00:00:00')).toBe('2026-07-31')
+  })
+})

--- a/frontend/src/shared/lib/format-date.ts
+++ b/frontend/src/shared/lib/format-date.ts
@@ -1,0 +1,53 @@
+/**
+ * Date formatting at the UI edge.
+ *
+ * The API returns **instant** fields (issued_at, paid_at, created_at, updated_at)
+ * as UTC timestamps in `YYYY-MM-DD HH:MM:SS` form (no zone suffix; UTC by
+ * convention — see backend ADR 0010). These must be converted to JST for display.
+ *
+ * **Calendar-date** fields (due_at, valid_until) are already JST calendar dates
+ * and must NOT be timezone-shifted — only trimmed to the date portion.
+ */
+
+const JST = 'Asia/Tokyo'
+
+/** Parses a backend instant string (UTC, with or without an explicit zone) to a Date. */
+function parseInstant(value: string): Date {
+  const trimmed = value.trim()
+  const hasZone = /([zZ]|[+-]\d\d:?\d\d)$/.test(trimmed)
+  const iso = trimmed.includes('T') ? trimmed : trimmed.replace(' ', 'T')
+
+  return new Date(hasZone ? iso : `${iso}Z`)
+}
+
+/** A UTC instant as the JST calendar date, `YYYY-MM-DD`. */
+export function formatJstDate(value: string): string {
+  const date = parseInstant(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: JST }).format(date)
+}
+
+/** A UTC instant as JST date and time, `YYYY-MM-DD HH:MM`. */
+export function formatJstDateTime(value: string): string {
+  const date = parseInstant(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: JST,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date)
+}
+
+/**
+ * A calendar-date field (already JST) trimmed to `YYYY-MM-DD`. No timezone shift —
+ * the stored value is the intended Japan calendar date.
+ */
+export function formatCalendarDate(value: string): string {
+  return value.slice(0, 10)
+}


### PR DESCRIPTION
Closes #342（part 2 / フロント表示変換。バックエンドは #350 で対応済み）

## 概要
バックエンド（#342 part1）で API がインスタント系（`issued_at` / `paid_at` / `created_at`）を **UTC 文字列**で返すようになったため、表示側で **JST** に変換します。

## 変更
- `shared/lib/format-date.ts` を追加：
  - `formatJstDate` / `formatJstDateTime`：UTC 文字列（`YYYY-MM-DD HH:MM:SS`、Z なし）を `Asia/Tokyo` で解釈・整形（`Intl`, `sv-SE`）。
  - `formatCalendarDate`：暦日系（`due_at` / `valid_until`、既に JST）は日付のみ整形・**TZ 非変換**。
- 適用箇所：
  - 発行日（`issued_at`）: ViewInvoice / ViewQuote → `formatJstDate`。
  - 入金日（`paid_at`）: ManagePayments → `formatJstDate`。
  - 監査 `created_at`: ListAuditLogs → `formatJstDateTime`。
  - `due_at` / `valid_until`: 一覧・詳細・ダッシュボードを `formatCalendarDate` に統一。

## 確認
- [x] vitest **203** / lint / format / knip green
- [x] 新 util に +9h 境界変換テスト（21:00 UTC → 翌日 JST）を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)