### PR TITLE
refactor(backend): 監査記録をトランザクション内＋Clock注入に統一 (#352)

### DIFF
--- a/src/Audit/AuditRecorder.php
+++ b/src/Audit/AuditRecorder.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Audit;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class AuditRecorder implements AuditRecorderInterface
 {
     public function __construct(
         private AuditLogRepositoryInterface $repository,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -20,6 +23,8 @@ final readonly class AuditRecorder implements AuditRecorderInterface
         ?array $before,
         ?array $after,
     ): void {
+        // The audit timestamp comes from the injected clock (UTC), so it is
+        // deterministic in tests and consistent with every other "now" (ADR 0010).
         $this->repository->append(new AuditLog(
             action: $action,
             entityType: $entityType,
@@ -28,6 +33,7 @@ final readonly class AuditRecorder implements AuditRecorderInterface
             entityId: $entityId,
             before: $before,
             after: $after,
+            createdAt: $this->clock->now()->format('Y-m-d H:i:s'),
         ));
     }
 }

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Audit;
 
+use Closure;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -43,7 +45,7 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Audit log repository service is invalid.');
                     }
 
-                    return new AuditRecorder($repo);
+                    return new AuditRecorder($repo, self::clock($c));
                 },
             )
             ->set(
@@ -111,5 +113,33 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
         }
 
         return $holder;
+    }
+
+    private static function clock(ContainerInterface $c): ClockInterface
+    {
+        $clock = $c->get(ClockInterface::class);
+
+        if (!$clock instanceof ClockInterface) {
+            throw new LogicException('Clock service is invalid.');
+        }
+
+        return $clock;
+    }
+
+    /**
+     * Builds a recorder factory bound to a transaction's executor, so the audit
+     * write commits or rolls back together with the business writes (Issue #352).
+     * Use cases that mutate inside {@see DatabaseTransactionManagerInterface} take
+     * this closure and build the recorder from the transaction-bound executor.
+     *
+     * @return Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface
+     */
+    public static function recorderFactory(ContainerInterface $c): Closure
+    {
+        $orgHolder = self::orgHolder($c);
+        $clock     = self::clock($c);
+
+        return static fn (DatabaseQueryExecutorInterface $exec): AuditRecorderInterface
+            => new AuditRecorder(new PdoAuditLogRepository($exec, $orgHolder), $clock);
     }
 }

--- a/src/Audit/PdoAuditLogRepository.php
+++ b/src/Audit/PdoAuditLogRepository.php
@@ -33,7 +33,7 @@ final readonly class PdoAuditLogRepository implements AuditLogRepositoryInterfac
                 $log->entityId,
                 self::encode($log->before),
                 self::encode($log->after),
-                date('Y-m-d H:i:s'),
+                $log->createdAt ?? date('Y-m-d H:i:s'),
             ],
         );
 

--- a/src/Invoice/ConvertQuoteToInvoiceUseCase.php
+++ b/src/Invoice/ConvertQuoteToInvoiceUseCase.php
@@ -31,6 +31,7 @@ final readonly class ConvertQuoteToInvoiceUseCase implements ConvertQuoteToInvoi
     /**
      * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
      * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
@@ -38,7 +39,7 @@ final readonly class ConvertQuoteToInvoiceUseCase implements ConvertQuoteToInvoi
         private DatabaseTransactionManagerInterface $tx,
         private Closure $invoicesFactory,
         private Closure $lineItemsFactory,
-        private AuditRecorderInterface $audit,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -62,7 +63,8 @@ final readonly class ConvertQuoteToInvoiceUseCase implements ConvertQuoteToInvoi
             throw new QuoteValidationException('Only an accepted quote can be converted to an invoice.');
         }
 
-        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
             $organizationId,
             $quote,
             $quoteId,
@@ -108,11 +110,12 @@ final readonly class ConvertQuoteToInvoiceUseCase implements ConvertQuoteToInvoi
                 throw new LogicException('Invoice disappeared immediately after conversion.');
             }
 
-            return new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+            $result = new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+
+            // Audit inside the transaction (Issue #352).
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
+
+            return $result;
         });
-
-        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
-
-        return $result;
     }
 }

--- a/src/Invoice/CreateInvoiceUseCase.php
+++ b/src/Invoice/CreateInvoiceUseCase.php
@@ -34,6 +34,7 @@ final readonly class CreateInvoiceUseCase implements CreateInvoiceUseCaseInterfa
     /**
      * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
      * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
@@ -42,7 +43,7 @@ final readonly class CreateInvoiceUseCase implements CreateInvoiceUseCaseInterfa
         private Closure $lineItemsFactory,
         private ClientRepositoryInterface $clients,
         private TaxCalculator $taxCalculator,
-        private AuditRecorderInterface $audit,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -79,7 +80,8 @@ final readonly class CreateInvoiceUseCase implements CreateInvoiceUseCaseInterfa
 
         $totals = $this->taxCalculator->calculate($input->lines);
 
-        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
             $organizationId,
             $input,
             $totals,
@@ -118,11 +120,12 @@ final readonly class CreateInvoiceUseCase implements CreateInvoiceUseCaseInterfa
                 throw new LogicException('Invoice disappeared immediately after creation.');
             }
 
-            return new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+            $result = new InvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+
+            // Audit inside the transaction (Issue #352).
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
+
+            return $result;
         });
-
-        $this->audit->record($actorUserId, $organizationId, 'invoice.created', 'invoice', $result->invoice->id, null, InvoiceResponse::toArray($result->invoice, $result->lines));
-
-        return $result;
     }
 }

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -15,6 +15,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
@@ -59,7 +60,7 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                         self::resolve($c, DatabaseTransactionManagerInterface::class),
                         static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
                         static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
-                        self::resolve($c, AuditRecorderInterface::class),
+                        AuditServiceProvider::recorderFactory($c),
                         $orgHolder,
                     );
                 },
@@ -75,22 +76,28 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
                         static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
                         self::resolve($c, ClientRepositoryInterface::class),
                         self::resolve($c, TaxCalculator::class),
-                        self::resolve($c, AuditRecorderInterface::class),
+                        AuditServiceProvider::recorderFactory($c),
                         $orgHolder,
                     );
                 },
             )
             ->set(
                 IssueInvoiceUseCaseInterface::class,
-                static fn (ContainerInterface $c): IssueInvoiceUseCase => new IssueInvoiceUseCase(
-                    self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, LineItemRepositoryInterface::class),
-                    self::resolve($c, CompanySettingsRepositoryInterface::class),
-                    self::resolve($c, DocumentNumberGenerator::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::resolve($c, ClockInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): IssueInvoiceUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new IssueInvoiceUseCase(
+                        self::resolve($c, InvoiceRepositoryInterface::class),
+                        self::resolve($c, LineItemRepositoryInterface::class),
+                        self::resolve($c, CompanySettingsRepositoryInterface::class),
+                        self::resolve($c, DocumentNumberGenerator::class),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        self::resolve($c, ClockInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 ListInvoicesUseCaseInterface::class,

--- a/src/Invoice/IssueInvoiceUseCase.php
+++ b/src/Invoice/IssueInvoiceUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
@@ -24,6 +27,8 @@ use NeneInvoice\Support\Jst;
 final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
@@ -31,7 +36,9 @@ final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
         private LineItemRepositoryInterface $lineItems,
         private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $invoicesFactory,
+        private Closure $auditFactory,
         private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
@@ -89,31 +96,48 @@ final readonly class IssueInvoiceUseCase implements IssueInvoiceUseCaseInterface
             }
         }
 
-        $this->invoices->update(new Invoice(
-            organizationId: $invoice->organizationId,
-            clientId: $invoice->clientId,
-            status: InvoiceStatus::Issued,
-            subtotalCents: $invoice->subtotalCents,
-            taxCents: $invoice->taxCents,
-            totalCents: $invoice->totalCents,
-            isQualifiedInvoice: $input->qualified,
-            quoteId: $invoice->quoteId,
-            invoiceNumber: $number,
-            issuedAt: $issuedAt,
-            dueAt: $dueAt,
-            notes: $invoice->notes,
-            id: $invoice->id,
-            createdAt: $invoice->createdAt,
-            updatedAt: $invoice->updatedAt,
-        ));
+        // The update and its audit record commit atomically (Issue #352).
+        $issued = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
+            $organizationId,
+            $id,
+            $input,
+            $invoice,
+            $lines,
+            $number,
+            $issuedAt,
+            $dueAt,
+        ): Invoice {
+            $invoices = ($this->invoicesFactory)($exec);
 
-        $issued = $this->invoices->findById($id);
+            $invoices->update(new Invoice(
+                organizationId: $invoice->organizationId,
+                clientId: $invoice->clientId,
+                status: InvoiceStatus::Issued,
+                subtotalCents: $invoice->subtotalCents,
+                taxCents: $invoice->taxCents,
+                totalCents: $invoice->totalCents,
+                isQualifiedInvoice: $input->qualified,
+                quoteId: $invoice->quoteId,
+                invoiceNumber: $number,
+                issuedAt: $issuedAt,
+                dueAt: $dueAt,
+                notes: $invoice->notes,
+                id: $invoice->id,
+                createdAt: $invoice->createdAt,
+                updatedAt: $invoice->updatedAt,
+            ));
 
-        if ($issued === null) {
-            throw new LogicException('Invoice disappeared immediately after issue.');
-        }
+            $issued = $invoices->findById($id);
 
-        $this->audit->record($actorUserId, $organizationId, 'invoice.issued', 'invoice', $id, InvoiceResponse::toArray($invoice, $lines), InvoiceResponse::toArray($issued, $lines));
+            if ($issued === null) {
+                throw new LogicException('Invoice disappeared immediately after issue.');
+            }
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'invoice.issued', 'invoice', $id, InvoiceResponse::toArray($invoice, $lines), InvoiceResponse::toArray($issued, $lines));
+
+            return $issued;
+        });
 
         return new InvoiceWithLines($issued, $lines);
     }

--- a/src/Payment/PaymentServiceProvider.php
+++ b/src/Payment/PaymentServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Payment;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -13,8 +14,9 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\PdoInvoiceRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 
@@ -41,13 +43,20 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 RecordPaymentUseCaseInterface::class,
-                static fn (ContainerInterface $c): RecordPaymentUseCase => new RecordPaymentUseCase(
-                    self::resolve($c, PaymentRepositoryInterface::class),
-                    self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::resolve($c, ClockInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): RecordPaymentUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new RecordPaymentUseCase(
+                        self::resolve($c, PaymentRepositoryInterface::class),
+                        self::resolve($c, InvoiceRepositoryInterface::class),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): PaymentRepositoryInterface => new PdoPaymentRepository($exec, $orgHolder),
+                        static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        self::resolve($c, ClockInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 ListPaymentsUseCaseInterface::class,
@@ -58,12 +67,19 @@ final readonly class PaymentServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 VoidPaymentUseCaseInterface::class,
-                static fn (ContainerInterface $c): VoidPaymentUseCase => new VoidPaymentUseCase(
-                    self::resolve($c, PaymentRepositoryInterface::class),
-                    self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): VoidPaymentUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new VoidPaymentUseCase(
+                        self::resolve($c, PaymentRepositoryInterface::class),
+                        self::resolve($c, InvoiceRepositoryInterface::class),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): PaymentRepositoryInterface => new PdoPaymentRepository($exec, $orgHolder),
+                        static fn (DatabaseQueryExecutorInterface $exec): InvoiceRepositoryInterface => new PdoInvoiceRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(
                 RecordPaymentHandler::class,

--- a/src/Payment/RecordPaymentUseCase.php
+++ b/src/Payment/RecordPaymentUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
@@ -27,12 +30,18 @@ use NeneInvoice\Support\Jst;
 final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): PaymentRepositoryInterface $paymentsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private PaymentRepositoryInterface $payments,
         private InvoiceRepositoryInterface $invoices,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $paymentsFactory,
+        private Closure $invoicesFactory,
+        private Closure $auditFactory,
         private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
@@ -96,19 +105,7 @@ final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterfa
 
         $before = InvoiceResponse::toArray($invoice);
 
-        $paidAt = $input->paidAt ?? $this->clock->now()->format('Y-m-d H:i:s');
-
-        $paymentId = $this->payments->save(new Payment(
-            organizationId: $organizationId,
-            invoiceId: $invoiceId,
-            amountCents: $input->amountCents,
-            paidAt: $paidAt,
-            method: $input->method,
-            note: $input->note,
-            externalReference: $input->externalReference,
-            idempotencyKey: $input->idempotencyKey,
-        ));
-
+        $paidAt    = $input->paidAt ?? $this->clock->now()->format('Y-m-d H:i:s');
         $totalPaid = $alreadyPaid + $input->amountCents;
         $newStatus = $totalPaid >= $invoice->totalCents ? InvoiceStatus::Paid : InvoiceStatus::PartiallyPaid;
 
@@ -130,32 +127,58 @@ final readonly class RecordPaymentUseCase implements RecordPaymentUseCaseInterfa
             updatedAt: $invoice->updatedAt,
         );
 
-        $this->invoices->update($updatedInvoice);
-
-        $stored = $this->payments->findByInvoice($invoiceId);
-        $payment = null;
-
-        foreach ($stored as $candidate) {
-            if ($candidate->id === $paymentId) {
-                $payment = $candidate;
-
-                break;
-            }
-        }
-
-        if ($payment === null) {
-            throw new LogicException('Payment disappeared immediately after recording.');
-        }
-
-        $this->audit->record(
+        // The payment insert, the invoice status update, and the audit record all
+        // commit atomically — a partial write (e.g. payment saved but status stale)
+        // can no longer occur (Issue #352).
+        $payment = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
             $actorUserId,
             $organizationId,
-            'payment.recorded',
-            'invoice',
             $invoiceId,
+            $input,
+            $paidAt,
+            $updatedInvoice,
             $before,
-            InvoiceResponse::toArray($updatedInvoice),
-        );
+        ): Payment {
+            $payments = ($this->paymentsFactory)($exec);
+
+            $paymentId = $payments->save(new Payment(
+                organizationId: $organizationId,
+                invoiceId: $invoiceId,
+                amountCents: $input->amountCents,
+                paidAt: $paidAt,
+                method: $input->method,
+                note: $input->note,
+                externalReference: $input->externalReference,
+                idempotencyKey: $input->idempotencyKey,
+            ));
+
+            ($this->invoicesFactory)($exec)->update($updatedInvoice);
+
+            $payment = null;
+            foreach ($payments->findByInvoice($invoiceId) as $candidate) {
+                if ($candidate->id === $paymentId) {
+                    $payment = $candidate;
+
+                    break;
+                }
+            }
+
+            if ($payment === null) {
+                throw new LogicException('Payment disappeared immediately after recording.');
+            }
+
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'payment.recorded',
+                'invoice',
+                $invoiceId,
+                $before,
+                InvoiceResponse::toArray($updatedInvoice),
+            );
+
+            return $payment;
+        });
 
         return new RecordPaymentResult($payment, $updatedInvoice, $totalPaid);
     }

--- a/src/Payment/VoidPaymentUseCase.php
+++ b/src/Payment/VoidPaymentUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Payment;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Invoice\Invoice;
@@ -22,12 +25,18 @@ use NeneInvoice\Invoice\InvoiceStatus;
 final readonly class VoidPaymentUseCase implements VoidPaymentUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): PaymentRepositoryInterface $paymentsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private PaymentRepositoryInterface $payments,
         private InvoiceRepositoryInterface $invoices,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $paymentsFactory,
+        private Closure $invoicesFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -62,42 +71,58 @@ final readonly class VoidPaymentUseCase implements VoidPaymentUseCaseInterface
             return new RecordPaymentResult($payment, $invoice, $this->payments->totalPaidForInvoice($invoiceId));
         }
 
-        $before = InvoiceResponse::toArray($invoice);
+        $before          = InvoiceResponse::toArray($invoice);
+        $organizationId  = $this->orgId->get();
 
-        $this->payments->markVoided($paymentId);
+        // The void, the recomputed invoice status, and the audit record commit
+        // atomically — the two writes can no longer diverge (Issue #352).
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
+            $organizationId,
+            $invoiceId,
+            $paymentId,
+            $invoice,
+            $payment,
+            $reason,
+            $before,
+        ): RecordPaymentResult {
+            $payments = ($this->paymentsFactory)($exec);
 
-        $totalPaid = $this->payments->totalPaidForInvoice($invoiceId);
-        $newStatus = $this->recomputeStatus($invoice, $totalPaid);
+            $payments->markVoided($paymentId);
 
-        $updatedInvoice = new Invoice(
-            organizationId: $invoice->organizationId,
-            clientId: $invoice->clientId,
-            status: $newStatus,
-            subtotalCents: $invoice->subtotalCents,
-            taxCents: $invoice->taxCents,
-            totalCents: $invoice->totalCents,
-            isQualifiedInvoice: $invoice->isQualifiedInvoice,
-            quoteId: $invoice->quoteId,
-            invoiceNumber: $invoice->invoiceNumber,
-            issuedAt: $invoice->issuedAt,
-            dueAt: $invoice->dueAt,
-            notes: $invoice->notes,
-            id: $invoice->id,
-            createdAt: $invoice->createdAt,
-            updatedAt: $invoice->updatedAt,
-        );
+            $totalPaid = $payments->totalPaidForInvoice($invoiceId);
+            $newStatus = $this->recomputeStatus($invoice, $totalPaid);
 
-        $this->invoices->update($updatedInvoice);
+            $updatedInvoice = new Invoice(
+                organizationId: $invoice->organizationId,
+                clientId: $invoice->clientId,
+                status: $newStatus,
+                subtotalCents: $invoice->subtotalCents,
+                taxCents: $invoice->taxCents,
+                totalCents: $invoice->totalCents,
+                isQualifiedInvoice: $invoice->isQualifiedInvoice,
+                quoteId: $invoice->quoteId,
+                invoiceNumber: $invoice->invoiceNumber,
+                issuedAt: $invoice->issuedAt,
+                dueAt: $invoice->dueAt,
+                notes: $invoice->notes,
+                id: $invoice->id,
+                createdAt: $invoice->createdAt,
+                updatedAt: $invoice->updatedAt,
+            );
 
-        $after = InvoiceResponse::toArray($updatedInvoice);
-        $after['voided_payment_id'] = $paymentId;
-        $after['void_reason'] = $reason;
+            ($this->invoicesFactory)($exec)->update($updatedInvoice);
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'payment.voided', 'invoice', $invoiceId, $before, $after);
+            $after = InvoiceResponse::toArray($updatedInvoice);
+            $after['voided_payment_id'] = $paymentId;
+            $after['void_reason'] = $reason;
 
-        $voided = $this->payments->findById($paymentId) ?? $payment;
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'payment.voided', 'invoice', $invoiceId, $before, $after);
 
-        return new RecordPaymentResult($voided, $updatedInvoice, $totalPaid);
+            $voided = $payments->findById($paymentId) ?? $payment;
+
+            return new RecordPaymentResult($voided, $updatedInvoice, $totalPaid);
+        });
     }
 
     /**

--- a/src/Quote/ChangeQuoteStatusUseCase.php
+++ b/src/Quote/ChangeQuoteStatusUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Quote;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
@@ -12,11 +15,15 @@ use NeneInvoice\Audit\AuditRecorderInterface;
 final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): QuoteRepositoryInterface $quotesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private QuoteRepositoryInterface $quotes,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $quotesFactory,
+        private Closure $auditFactory,
         private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
@@ -28,6 +35,8 @@ final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCas
      */
     public function execute(?int $actorUserId, int $id, QuoteStatus $target): Quote
     {
+        $organizationId = $this->orgId->get();
+
         $quote = $this->quotes->findById($id);
 
         if ($quote === null) {
@@ -43,38 +52,50 @@ final readonly class ChangeQuoteStatusUseCase implements ChangeQuoteStatusUseCas
             ? $this->clock->now()->format('Y-m-d H:i:s')
             : $quote->issuedAt;
 
-        $this->quotes->update(new Quote(
-            organizationId: $quote->organizationId,
-            clientId: $quote->clientId,
-            quoteNumber: $quote->quoteNumber,
-            status: $target,
-            subtotalCents: $quote->subtotalCents,
-            taxCents: $quote->taxCents,
-            totalCents: $quote->totalCents,
-            issuedAt: $issuedAt,
-            validUntil: $quote->validUntil,
-            notes: $quote->notes,
-            id: $quote->id,
-            createdAt: $quote->createdAt,
-            updatedAt: $quote->updatedAt,
-        ));
-
-        $updated = $this->quotes->findById($id);
-
-        if ($updated === null) {
-            throw new LogicException('Quote disappeared immediately after status change.');
-        }
-
-        $this->audit->record(
+        // The update and its audit record commit atomically (Issue #352).
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
             $actorUserId,
-            $this->orgId->get(),
-            'quote.status_changed',
-            'quote',
+            $organizationId,
             $id,
-            QuoteResponse::toArray($quote),
-            QuoteResponse::toArray($updated),
-        );
+            $target,
+            $quote,
+            $issuedAt,
+        ): Quote {
+            $quotes = ($this->quotesFactory)($exec);
 
-        return $updated;
+            $quotes->update(new Quote(
+                organizationId: $quote->organizationId,
+                clientId: $quote->clientId,
+                quoteNumber: $quote->quoteNumber,
+                status: $target,
+                subtotalCents: $quote->subtotalCents,
+                taxCents: $quote->taxCents,
+                totalCents: $quote->totalCents,
+                issuedAt: $issuedAt,
+                validUntil: $quote->validUntil,
+                notes: $quote->notes,
+                id: $quote->id,
+                createdAt: $quote->createdAt,
+                updatedAt: $quote->updatedAt,
+            ));
+
+            $updated = $quotes->findById($id);
+
+            if ($updated === null) {
+                throw new LogicException('Quote disappeared immediately after status change.');
+            }
+
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'quote.status_changed',
+                'quote',
+                $id,
+                QuoteResponse::toArray($quote),
+                QuoteResponse::toArray($updated),
+            );
+
+            return $updated;
+        });
     }
 }

--- a/src/Quote/CreateQuoteUseCase.php
+++ b/src/Quote/CreateQuoteUseCase.php
@@ -39,6 +39,7 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
     /**
      * @param Closure(DatabaseQueryExecutorInterface): QuoteRepositoryInterface $quotesFactory
      * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
@@ -49,7 +50,7 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
         private CompanySettingsRepositoryInterface $companySettings,
         private DocumentNumberGenerator $numbers,
         private TaxCalculator $taxCalculator,
-        private AuditRecorderInterface $audit,
+        private Closure $auditFactory,
         private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
@@ -97,7 +98,8 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
         $validUntil = $input->validUntil
             ?? $this->companySettings->find()?->quoteValidUntilFrom($todayJst);
 
-        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
             $organizationId,
             $input,
             $number,
@@ -140,11 +142,13 @@ final readonly class CreateQuoteUseCase implements CreateQuoteUseCaseInterface
                 throw new LogicException('Quote disappeared immediately after creation.');
             }
 
-            return new QuoteWithLines($saved, $lineItems->findByParent(LineItemParent::Quote, $quoteId));
+            $result = new QuoteWithLines($saved, $lineItems->findByParent(LineItemParent::Quote, $quoteId));
+
+            // Audit inside the transaction: the record commits or rolls back with
+            // the quote, so an unaudited creation cannot occur (Issue #352).
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'quote.created', 'quote', $result->quote->id, null, QuoteResponse::toArray($result->quote, $result->lines));
+
+            return $result;
         });
-
-        $this->audit->record($actorUserId, $organizationId, 'quote.created', 'quote', $result->quote->id, null, QuoteResponse::toArray($result->quote, $result->lines));
-
-        return $result;
     }
 }

--- a/src/Quote/QuoteServiceProvider.php
+++ b/src/Quote/QuoteServiceProvider.php
@@ -14,7 +14,7 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Client\ClientRepositoryInterface;
 use NeneInvoice\Company\CompanySettingsRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
@@ -60,7 +60,7 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
                         self::resolve($c, CompanySettingsRepositoryInterface::class),
                         self::resolve($c, DocumentNumberGenerator::class),
                         self::resolve($c, TaxCalculator::class),
-                        self::resolve($c, AuditRecorderInterface::class),
+                        AuditServiceProvider::recorderFactory($c),
                         self::resolve($c, ClockInterface::class),
                         $orgHolder,
                     );
@@ -68,12 +68,18 @@ final readonly class QuoteServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 ChangeQuoteStatusUseCaseInterface::class,
-                static fn (ContainerInterface $c): ChangeQuoteStatusUseCase => new ChangeQuoteStatusUseCase(
-                    self::quotes($c),
-                    self::resolve($c, AuditRecorderInterface::class),
-                    self::resolve($c, ClockInterface::class),
-                    self::orgHolder($c),
-                ),
+                static function (ContainerInterface $c): ChangeQuoteStatusUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new ChangeQuoteStatusUseCase(
+                        self::quotes($c),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): QuoteRepositoryInterface => new PdoQuoteRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        self::resolve($c, ClockInterface::class),
+                        $orgHolder,
+                    );
+                },
             )
             ->set(ListQuotesUseCaseInterface::class, static fn (ContainerInterface $c): ListQuotesUseCase => new ListQuotesUseCase(self::quotes($c)))
             ->set(

--- a/src/Template/CreateTemplateUseCase.php
+++ b/src/Template/CreateTemplateUseCase.php
@@ -19,13 +19,14 @@ final readonly class CreateTemplateUseCase implements CreateTemplateUseCaseInter
     /**
      * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory
      * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $tx,
         private Closure $templatesFactory,
         private Closure $lineItemsFactory,
-        private AuditRecorderInterface $audit,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -35,7 +36,8 @@ final readonly class CreateTemplateUseCase implements CreateTemplateUseCaseInter
     {
         $organizationId = $this->orgId->get();
 
-        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
             $organizationId,
             $input,
         ): TemplateWithLines {
@@ -55,12 +57,13 @@ final readonly class CreateTemplateUseCase implements CreateTemplateUseCaseInter
                 throw new LogicException('Template disappeared immediately after creation.');
             }
 
-            return new TemplateWithLines($created, $lineItems->findByParent(LineItemParent::Template, $id));
+            $result = new TemplateWithLines($created, $lineItems->findByParent(LineItemParent::Template, $id));
+
+            // Audit inside the transaction (Issue #352).
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'template.created', 'template', $result->template->id, null, TemplateResponse::toArray($result->template, $result->lines));
+
+            return $result;
         });
-
-        $this->audit->record($actorUserId, $organizationId, 'template.created', 'template', $result->template->id, null, TemplateResponse::toArray($result->template, $result->lines));
-
-        return $result;
     }
 
     /**

--- a/src/Template/TemplateServiceProvider.php
+++ b/src/Template/TemplateServiceProvider.php
@@ -14,6 +14,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\LineItem\PdoLineItemRepository;
 use Psr\Container\ContainerInterface;
@@ -49,7 +50,7 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     self::resolve($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $exec): TemplateRepositoryInterface => new PdoTemplateRepository($exec, $orgHolder),
                     static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
-                    self::audit($c),
+                    AuditServiceProvider::recorderFactory($c),
                     $orgHolder,
                 );
             })
@@ -60,7 +61,7 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     self::resolve($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $exec): TemplateRepositoryInterface => new PdoTemplateRepository($exec, $orgHolder),
                     static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
-                    self::audit($c),
+                    AuditServiceProvider::recorderFactory($c),
                     $orgHolder,
                 );
             })

--- a/src/Template/UpdateTemplateUseCase.php
+++ b/src/Template/UpdateTemplateUseCase.php
@@ -19,13 +19,14 @@ final readonly class UpdateTemplateUseCase implements UpdateTemplateUseCaseInter
     /**
      * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory
      * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $tx,
         private Closure $templatesFactory,
         private Closure $lineItemsFactory,
-        private AuditRecorderInterface $audit,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -38,13 +39,13 @@ final readonly class UpdateTemplateUseCase implements UpdateTemplateUseCaseInter
      */
     public function execute(?int $actorUserId, int $id, UpdateTemplateInput $input): TemplateWithLines
     {
-        /** @var array<string, mixed> $before */
-        $before = [];
+        $organizationId = $this->orgId->get();
 
-        $result = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
+            $organizationId,
             $id,
             $input,
-            &$before,
         ): TemplateWithLines {
             $templates = ($this->templatesFactory)($exec);
             $lineItems = ($this->lineItemsFactory)($exec);
@@ -55,6 +56,7 @@ final readonly class UpdateTemplateUseCase implements UpdateTemplateUseCaseInter
             }
 
             $before = TemplateResponse::toArray($existing, $lineItems->findByParent(LineItemParent::Template, $id));
+            // (captured for the in-transaction audit below)
 
             $templates->update(new Template(
                 organizationId: $existing->organizationId,
@@ -85,11 +87,12 @@ final readonly class UpdateTemplateUseCase implements UpdateTemplateUseCaseInter
                 throw new LogicException('Template disappeared immediately after update.');
             }
 
-            return new TemplateWithLines($updated, $lineItems->findByParent(LineItemParent::Template, $id));
+            $result = new TemplateWithLines($updated, $lineItems->findByParent(LineItemParent::Template, $id));
+
+            // Audit inside the transaction (Issue #352).
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'template.updated', 'template', $id, $before, TemplateResponse::toArray($result->template, $result->lines));
+
+            return $result;
         });
-
-        $this->audit->record($actorUserId, $this->orgId->get(), 'template.updated', 'template', $id, $before, TemplateResponse::toArray($result->template, $result->lines));
-
-        return $result;
     }
 }

--- a/tests/Audit/AuditLogTest.php
+++ b/tests/Audit/AuditLogTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeneInvoice\Audit\AuditLogFilter;
 use NeneInvoice\Audit\AuditRecorder;
 use NeneInvoice\Audit\PdoAuditLogRepository;
@@ -63,7 +64,7 @@ final class AuditLogTest extends TestCase
 
     public function test_recorder_persists_before_and_after_snapshots(): void
     {
-        $recorder = new AuditRecorder($this->repository);
+        $recorder = new AuditRecorder($this->repository, new UtcClock());
 
         $recorder->record(7, 1, 'client.updated', 'client', 42, ['name' => '前'], ['name' => '後']);
 
@@ -80,7 +81,7 @@ final class AuditLogTest extends TestCase
     {
         $this->insertUser(7, 'operator@example.com');
 
-        $recorder = new AuditRecorder($this->repository);
+        $recorder = new AuditRecorder($this->repository, new UtcClock());
         $recorder->record(7, 1, 'invoice.issued', 'invoice', 5, null, ['status' => 'issued']);
         // Actor 99 has no users row → email stays null (caller shows #id).
         $recorder->record(99, 1, 'invoice.created', 'invoice', 6, null, ['status' => 'draft']);
@@ -95,7 +96,7 @@ final class AuditLogTest extends TestCase
     {
         // append keeps the organization on the log itself, so it is recorded
         // with an explicit org regardless of the read-side holder.
-        $recorder = new AuditRecorder($this->repository);
+        $recorder = new AuditRecorder($this->repository, new UtcClock());
         $recorder->record(1, 1, 'client.created', 'client', 1, null, ['name' => 'A']);
         $recorder->record(1, 1, 'client.deleted', 'client', 1, ['name' => 'A'], null);
         $recorder->record(1, 2, 'client.created', 'client', 9, null, ['name' => 'B']);
@@ -113,7 +114,7 @@ final class AuditLogTest extends TestCase
 
     public function test_filters_by_entity_type_action_actor_and_date_range(): void
     {
-        $recorder = new AuditRecorder($this->repository);
+        $recorder = new AuditRecorder($this->repository, new UtcClock());
         $recorder->record(5, 1, 'invoice.created', 'invoice', 1, null, ['status' => 'draft']);
         $recorder->record(6, 1, 'invoice.issued', 'invoice', 1, null, ['status' => 'issued']);
         $recorder->record(5, 1, 'client.created', 'client', 2, null, ['name' => 'A']);

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -38,7 +38,7 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->lineItems = new InMemoryLineItemRepository();
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, new ImmediateTransactionManager(), fn () => $this->invoices, fn () => $this->lineItems, $this->audit, $this->holder);
+        $this->useCase = new ConvertQuoteToInvoiceUseCase($this->quotes, new ImmediateTransactionManager(), fn () => $this->invoices, fn () => $this->lineItems, fn () => $this->audit, $this->holder);
     }
 
     private function quote(QuoteStatus $status): int

--- a/tests/Invoice/CreateInvoiceUseCaseTest.php
+++ b/tests/Invoice/CreateInvoiceUseCaseTest.php
@@ -44,7 +44,7 @@ final class CreateInvoiceUseCaseTest extends TestCase
             fn () => $this->lineItems,
             $this->clients,
             new TaxCalculator(),
-            $this->audit,
+            fn () => $this->audit,
             $this->holder,
         );
     }

--- a/tests/Invoice/InvoiceQueryUseCasesTest.php
+++ b/tests/Invoice/InvoiceQueryUseCasesTest.php
@@ -52,7 +52,7 @@ final class InvoiceQueryUseCasesTest extends TestCase
             fn () => $this->lineItems,
             $this->clients,
             new TaxCalculator(),
-            new RecordingAuditRecorder(),
+            fn () => new RecordingAuditRecorder(),
             $this->holder,
         );
     }

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -19,6 +19,7 @@ use NeneInvoice\Invoice\QualifiedInvoiceIncompleteException;
 use NeneInvoice\LineItem\LineItem;
 use NeneInvoice\LineItem\LineItemParent;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
 use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
@@ -49,7 +50,9 @@ final class IssueInvoiceUseCaseTest extends TestCase
             $this->lineItems,
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
-            $this->audit,
+            new ImmediateTransactionManager(),
+            fn () => $this->invoices,
+            fn () => $this->audit,
             new FixedClock(),
             $this->holder,
         );

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Payment\PaymentValidationException;
 use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -34,7 +35,7 @@ final class RecordPaymentUseCaseTest extends TestCase
         $this->payments = new InMemoryPaymentRepository($this->holder);
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, new FixedClock(), $this->holder);
+        $this->useCase = new RecordPaymentUseCase($this->payments, $this->invoices, new ImmediateTransactionManager(), fn () => $this->payments, fn () => $this->invoices, fn () => $this->audit, new FixedClock(), $this->holder);
     }
 
     private function issuedInvoice(int $totalCents = 2200): int

--- a/tests/Payment/VoidPaymentUseCaseTest.php
+++ b/tests/Payment/VoidPaymentUseCaseTest.php
@@ -12,6 +12,7 @@ use NeneInvoice\Payment\RecordPaymentInput;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use NeneInvoice\Payment\VoidPaymentUseCase;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -35,8 +36,8 @@ final class VoidPaymentUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->payments = new InMemoryPaymentRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, $this->audit, new FixedClock(), $this->holder);
-        $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, $this->audit, $this->holder);
+        $this->record = new RecordPaymentUseCase($this->payments, $this->invoices, new ImmediateTransactionManager(), fn () => $this->payments, fn () => $this->invoices, fn () => $this->audit, new FixedClock(), $this->holder);
+        $this->void = new VoidPaymentUseCase($this->payments, $this->invoices, new ImmediateTransactionManager(), fn () => $this->payments, fn () => $this->invoices, fn () => $this->audit, $this->holder);
 
         $this->invoiceId = $this->invoices->save(new Invoice(
             organizationId: 1,

--- a/tests/Quote/ChangeQuoteStatusUseCaseTest.php
+++ b/tests/Quote/ChangeQuoteStatusUseCaseTest.php
@@ -11,6 +11,7 @@ use NeneInvoice\Quote\Quote;
 use NeneInvoice\Quote\QuoteNotFoundException;
 use NeneInvoice\Quote\QuoteStatus;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +30,7 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
         $this->holder->set(1);
         $this->quotes = new InMemoryQuoteRepository($this->holder);
         $this->audit = new RecordingAuditRecorder();
-        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, $this->audit, new FixedClock(), $this->holder);
+        $this->useCase = new ChangeQuoteStatusUseCase($this->quotes, new ImmediateTransactionManager(), fn () => $this->quotes, fn () => $this->audit, new FixedClock(), $this->holder);
     }
 
     private function draft(): int

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -57,7 +57,7 @@ final class CreateQuoteUseCaseTest extends TestCase
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
-            $this->audit,
+            fn () => $this->audit,
             new FixedClock(),
             $this->holder,
         );

--- a/tests/Quote/GenerateQuotePdfUseCaseTest.php
+++ b/tests/Quote/GenerateQuotePdfUseCaseTest.php
@@ -72,7 +72,7 @@ final class GenerateQuotePdfUseCaseTest extends TestCase
             $this->companySettings,
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
-            new RecordingAuditRecorder(),
+            fn () => new RecordingAuditRecorder(),
             new FixedClock(),
             $this->holder,
         );

--- a/tests/Quote/QuoteQueryUseCasesTest.php
+++ b/tests/Quote/QuoteQueryUseCasesTest.php
@@ -58,7 +58,7 @@ final class QuoteQueryUseCasesTest extends TestCase
             new InMemoryCompanySettingsRepository($this->holder),
             new DocumentNumberGenerator(new InMemoryDocumentSequenceRepository()),
             new TaxCalculator(),
-            new RecordingAuditRecorder(),
+            fn () => new RecordingAuditRecorder(),
             new FixedClock(),
             $this->holder,
         );

--- a/tests/ServiceApi/RecordServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/RecordServicePaymentHandlerTest.php
@@ -14,6 +14,7 @@ use NeneInvoice\Payment\PaymentExceedsOutstandingException;
 use NeneInvoice\Payment\RecordPaymentUseCase;
 use NeneInvoice\ServiceApi\RecordServicePaymentHandler;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -49,7 +50,7 @@ final class RecordServicePaymentHandlerTest extends TestCase
         ));
 
         $this->handler = new RecordServicePaymentHandler(
-            new RecordPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), new FixedClock(), $holder),
+            new RecordPaymentUseCase($this->payments, $this->invoices, new ImmediateTransactionManager(), fn () => $this->payments, fn () => $this->invoices, fn () => new RecordingAuditRecorder(), new FixedClock(), $holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );

--- a/tests/ServiceApi/VoidServicePaymentHandlerTest.php
+++ b/tests/ServiceApi/VoidServicePaymentHandlerTest.php
@@ -12,6 +12,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\Payment\Payment;
 use NeneInvoice\Payment\VoidPaymentUseCase;
 use NeneInvoice\ServiceApi\VoidServicePaymentHandler;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -57,7 +58,7 @@ final class VoidServicePaymentHandlerTest extends TestCase
         ));
 
         $this->handler = new VoidServicePaymentHandler(
-            new VoidPaymentUseCase($this->payments, $this->invoices, new RecordingAuditRecorder(), $holder),
+            new VoidPaymentUseCase($this->payments, $this->invoices, new ImmediateTransactionManager(), fn () => $this->payments, fn () => $this->invoices, fn () => new RecordingAuditRecorder(), $holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
         );

--- a/tests/Template/TemplateWriteUseCasesTest.php
+++ b/tests/Template/TemplateWriteUseCasesTest.php
@@ -105,7 +105,7 @@ final class TemplateWriteUseCasesTest extends TestCase
 
     private function create(): CreateTemplateUseCase
     {
-        return new CreateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, $this->audit, $this->holder);
+        return new CreateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, fn () => $this->audit, $this->holder);
     }
 
     private function get(): GetTemplateByIdUseCase
@@ -115,7 +115,7 @@ final class TemplateWriteUseCasesTest extends TestCase
 
     private function update(): UpdateTemplateUseCase
     {
-        return new UpdateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, $this->audit, $this->holder);
+        return new UpdateTemplateUseCase(new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, fn () => $this->audit, $this->holder);
     }
 
     private function delete(): DeleteTemplateUseCase


### PR DESCRIPTION
Closes #352（sibling 製品 nene-clear の `audit_events` 実装を参考）

## 概要
監査証跡の **原子性** と **時刻ソース** を改善。nene-clear（当方 ADR 0008 を採用・発展）の設計を取り込む。

## ① Clock 注入
- `AuditRecorder` に `ClockInterface` を注入し `created_at` を Clock(UTC) 由来に。
- `PdoAuditLogRepository` の `date()` 直書きを除去（#342 と一貫・決定論的にテスト可能）。

## ② トランザクション内監査（財務・コンプライアンス系9件）
- `AuditServiceProvider::recorderFactory()` を追加（tx 実行子から Recorder を生成）。
- 既トランザクション5件は監査呼び出しを **tx 内へ移動**: CreateQuote / CreateInvoice / ConvertQuoteToInvoice / CreateTemplate / UpdateTemplate。
- 法定記録の単一書込みを **tx 化**: IssueInvoice / ChangeQuoteStatus。
- **#338 の取りこぼし修正**: RecordPayment（payment保存＋invoice更新）/ VoidPayment（void＋invoice更新）は**複数書込みが非トランザクション**だったため tx 化。業務書込みと監査を原子的にコミット。

→ 「発行済み記録なのに監査が無い」「入金は保存されたが請求書ステータスが古い」といった部分書込みが原理的に発生しなくなる（`accounting-compliance.md` §5）。

## 範囲（境界）
非財務の管理CRUD（client / item / user / organization / company settings / template削除 / メール送信 / DLトークン）は単一書込み・非法定のため **①のみ** 適用。`SendInvoiceEmail` は外部副作用（メール送信）のため tx 内監査の対象外。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev サーバーで入金記録（2書込み＋監査）の原子コミットと Clock 由来 `created_at`(UTC) を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)