### PR TITLE
refactor(backend): 監査トランザクション統一を全ミューテーションに拡大 (#354)

### DIFF
--- a/src/Client/ClientServiceProvider.php
+++ b/src/Client/ClientServiceProvider.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use Closure;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -38,9 +40,9 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
             )
             ->set(ListClientsUseCaseInterface::class, static fn (ContainerInterface $c): ListClientsUseCase => new ListClientsUseCase(self::repository($c)))
             ->set(GetClientByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetClientByIdUseCase => new GetClientByIdUseCase(self::repository($c)))
-            ->set(CreateClientUseCaseInterface::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateClientUseCaseInterface::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteClientUseCaseInterface::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(CreateClientUseCaseInterface::class, static fn (ContainerInterface $c): CreateClientUseCase => new CreateClientUseCase(self::tx($c), self::clientsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(UpdateClientUseCaseInterface::class, static fn (ContainerInterface $c): UpdateClientUseCase => new UpdateClientUseCase(self::repository($c), self::tx($c), self::clientsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(DeleteClientUseCaseInterface::class, static fn (ContainerInterface $c): DeleteClientUseCase => new DeleteClientUseCase(self::repository($c), self::tx($c), self::clientsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
             ->set(
                 ListClientsHandler::class,
                 static fn (ContainerInterface $c): ListClientsHandler => new ListClientsHandler(
@@ -163,15 +165,23 @@ final readonly class ClientServiceProvider implements ServiceProviderInterface
         return $holder;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    private static function tx(ContainerInterface $c): DatabaseTransactionManagerInterface
     {
-        $recorder = $c->get(AuditRecorderInterface::class);
+        $tx = $c->get(DatabaseTransactionManagerInterface::class);
 
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
+        if (!$tx instanceof DatabaseTransactionManagerInterface) {
+            throw new LogicException('Transaction manager service is invalid.');
         }
 
-        return $recorder;
+        return $tx;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): ClientRepositoryInterface */
+    private static function clientsFactory(ContainerInterface $c): Closure
+    {
+        $orgHolder = self::orgHolder($c);
+
+        return static fn (DatabaseQueryExecutorInterface $exec): ClientRepositoryInterface => new PdoClientRepository($exec, $orgHolder);
     }
 
     private static function listUseCase(ContainerInterface $c): ListClientsUseCase

--- a/src/Client/CreateClientUseCase.php
+++ b/src/Client/CreateClientUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
@@ -12,18 +15,22 @@ use NeneInvoice\Compliance\RegistrationNumber;
 final readonly class CreateClientUseCase implements CreateClientUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ClientRepositoryInterface $clientsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private ClientRepositoryInterface $clients,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $clientsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
      * Creates a client in the resolved organization (the repository forces the
-     * org from the request-scoped holder, never from request input).
+     * org from the request-scoped holder, never from request input). The write
+     * and its audit record commit atomically (Issue #352).
      *
      * @throws InvalidRegistrationNumberException
      */
@@ -35,24 +42,28 @@ final readonly class CreateClientUseCase implements CreateClientUseCaseInterface
 
         $organizationId = $this->orgId->get();
 
-        $id = $this->clients->save(new Client(
-            organizationId: $organizationId,
-            name: $input->name,
-            nameKana: $input->nameKana,
-            contactName: $input->contactName,
-            email: $input->email,
-            billingAddress: $input->billingAddress,
-            registrationNumber: $input->registrationNumber,
-        ));
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $input): Client {
+            $clients = ($this->clientsFactory)($exec);
 
-        $created = $this->clients->findById($id);
+            $id = $clients->save(new Client(
+                organizationId: $organizationId,
+                name: $input->name,
+                nameKana: $input->nameKana,
+                contactName: $input->contactName,
+                email: $input->email,
+                billingAddress: $input->billingAddress,
+                registrationNumber: $input->registrationNumber,
+            ));
 
-        if ($created === null) {
-            throw new LogicException('Client disappeared immediately after creation.');
-        }
+            $created = $clients->findById($id);
 
-        $this->audit->record($actorUserId, $organizationId, 'client.created', 'client', $id, null, ClientResponse::toArray($created));
+            if ($created === null) {
+                throw new LogicException('Client disappeared immediately after creation.');
+            }
 
-        return $created;
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'client.created', 'client', $id, null, ClientResponse::toArray($created));
+
+            return $created;
+        });
     }
 }

--- a/src/Client/DeleteClientUseCase.php
+++ b/src/Client/DeleteClientUseCase.php
@@ -4,17 +4,24 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteClientUseCase implements DeleteClientUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ClientRepositoryInterface $clientsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private ClientRepositoryInterface $clients,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $clientsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -22,7 +29,8 @@ final readonly class DeleteClientUseCase implements DeleteClientUseCaseInterface
     /**
      * Soft-deletes a client in the resolved organization. The repository scopes
      * the lookup/delete to the request org, so cross-organization targets
-     * surface as not found.
+     * surface as not found. The delete and its audit record commit atomically
+     * (Issue #352).
      *
      * @throws ClientNotFoundException
      */
@@ -34,8 +42,14 @@ final readonly class DeleteClientUseCase implements DeleteClientUseCaseInterface
             throw new ClientNotFoundException($id);
         }
 
-        $this->clients->delete($id);
+        $organizationId = $this->orgId->get();
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'client.deleted', 'client', $id, ClientResponse::toArray($existing), null);
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $existing): null {
+            ($this->clientsFactory)($exec)->delete($id);
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'client.deleted', 'client', $id, ClientResponse::toArray($existing), null);
+
+            return null;
+        });
     }
 }

--- a/src/Client/UpdateClientUseCase.php
+++ b/src/Client/UpdateClientUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Client;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
@@ -12,11 +15,15 @@ use NeneInvoice\Compliance\RegistrationNumber;
 final readonly class UpdateClientUseCase implements UpdateClientUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ClientRepositoryInterface $clientsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private ClientRepositoryInterface $clients,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $clientsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -24,7 +31,8 @@ final readonly class UpdateClientUseCase implements UpdateClientUseCaseInterface
     /**
      * Updates a client in the resolved organization. The repository scopes the
      * read/write to the request org, so a client from another organization (or
-     * soft-deleted) surfaces as not found.
+     * soft-deleted) surfaces as not found. The write and its audit record commit
+     * atomically (Issue #352).
      *
      * @throws ClientNotFoundException
      * @throws InvalidRegistrationNumberException
@@ -41,28 +49,34 @@ final readonly class UpdateClientUseCase implements UpdateClientUseCaseInterface
             throw new InvalidRegistrationNumberException($input->registrationNumber);
         }
 
-        $this->clients->update(new Client(
-            organizationId: $existing->organizationId,
-            name: $input->name,
-            nameKana: $input->nameKana,
-            contactName: $input->contactName,
-            email: $input->email,
-            billingAddress: $input->billingAddress,
-            registrationNumber: $input->registrationNumber,
-            isDeleted: false,
-            id: $existing->id,
-            createdAt: $existing->createdAt,
-            updatedAt: $existing->updatedAt,
-        ));
+        $organizationId = $this->orgId->get();
 
-        $updated = $this->clients->findById($id);
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $input, $existing): Client {
+            $clients = ($this->clientsFactory)($exec);
 
-        if ($updated === null) {
-            throw new LogicException('Client disappeared immediately after update.');
-        }
+            $clients->update(new Client(
+                organizationId: $existing->organizationId,
+                name: $input->name,
+                nameKana: $input->nameKana,
+                contactName: $input->contactName,
+                email: $input->email,
+                billingAddress: $input->billingAddress,
+                registrationNumber: $input->registrationNumber,
+                isDeleted: false,
+                id: $existing->id,
+                createdAt: $existing->createdAt,
+                updatedAt: $existing->updatedAt,
+            ));
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'client.updated', 'client', $id, ClientResponse::toArray($existing), ClientResponse::toArray($updated));
+            $updated = $clients->findById($id);
 
-        return $updated;
+            if ($updated === null) {
+                throw new LogicException('Client disappeared immediately after update.');
+            }
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'client.updated', 'client', $id, ClientResponse::toArray($existing), ClientResponse::toArray($updated));
+
+            return $updated;
+        });
     }
 }

--- a/src/Company/CompanyServiceProvider.php
+++ b/src/Company/CompanyServiceProvider.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
+use Closure;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -37,7 +39,7 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(GetCompanySettingsUseCaseInterface::class, static fn (ContainerInterface $c): GetCompanySettingsUseCase => new GetCompanySettingsUseCase(self::repository($c), self::orgHolder($c)))
-            ->set(UpdateCompanySettingsUseCaseInterface::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(UpdateCompanySettingsUseCaseInterface::class, static fn (ContainerInterface $c): UpdateCompanySettingsUseCase => new UpdateCompanySettingsUseCase(self::repository($c), self::tx($c), self::repositoryFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
             ->set(
                 GetCompanySettingsHandler::class,
                 static fn (ContainerInterface $c): GetCompanySettingsHandler => new GetCompanySettingsHandler(
@@ -86,15 +88,23 @@ final readonly class CompanyServiceProvider implements ServiceProviderInterface
         return $repo;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    private static function tx(ContainerInterface $c): DatabaseTransactionManagerInterface
     {
-        $recorder = $c->get(AuditRecorderInterface::class);
+        $tx = $c->get(DatabaseTransactionManagerInterface::class);
 
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
+        if (!$tx instanceof DatabaseTransactionManagerInterface) {
+            throw new LogicException('Transaction manager service is invalid.');
         }
 
-        return $recorder;
+        return $tx;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): CompanySettingsRepositoryInterface */
+    private static function repositoryFactory(ContainerInterface $c): Closure
+    {
+        $orgHolder = self::orgHolder($c);
+
+        return static fn (DatabaseQueryExecutorInterface $exec): CompanySettingsRepositoryInterface => new PdoCompanySettingsRepository($exec, $orgHolder);
     }
 
     private static function getUseCase(ContainerInterface $c): GetCompanySettingsUseCase

--- a/src/Company/UpdateCompanySettingsUseCase.php
+++ b/src/Company/UpdateCompanySettingsUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Company;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Compliance\RegistrationNumber;
@@ -12,11 +15,15 @@ use NeneInvoice\Compliance\RegistrationNumber;
 final readonly class UpdateCompanySettingsUseCase implements UpdateCompanySettingsUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): CompanySettingsRepositoryInterface $repositoryFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private CompanySettingsRepositoryInterface $repository,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $repositoryFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -35,40 +42,44 @@ final readonly class UpdateCompanySettingsUseCase implements UpdateCompanySettin
         $organizationId = $this->orgId->get();
         $existing = $this->repository->find();
 
-        $this->repository->save(new CompanySettings(
-            organizationId: $organizationId,
-            legalName: $input->legalName,
-            address: $input->address,
-            phone: $input->phone,
-            email: $input->email,
-            registrationNumber: $input->registrationNumber,
-            bankName: $input->bankName,
-            bankBranch: $input->bankBranch,
-            accountType: $input->accountType,
-            accountNumber: $input->accountNumber,
-            logoUrl: $input->logoUrl,
-            defaultQuoteValidityDays: $input->defaultQuoteValidityDays,
-            defaultPaymentClosingDay: $input->defaultPaymentClosingDay,
-            defaultPaymentMonthOffset: $input->defaultPaymentMonthOffset,
-            defaultPaymentPayDay: $input->defaultPaymentPayDay,
-        ));
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $input, $existing): CompanySettings {
+            $repository = ($this->repositoryFactory)($exec);
 
-        $saved = $this->repository->find();
+            $repository->save(new CompanySettings(
+                organizationId: $organizationId,
+                legalName: $input->legalName,
+                address: $input->address,
+                phone: $input->phone,
+                email: $input->email,
+                registrationNumber: $input->registrationNumber,
+                bankName: $input->bankName,
+                bankBranch: $input->bankBranch,
+                accountType: $input->accountType,
+                accountNumber: $input->accountNumber,
+                logoUrl: $input->logoUrl,
+                defaultQuoteValidityDays: $input->defaultQuoteValidityDays,
+                defaultPaymentClosingDay: $input->defaultPaymentClosingDay,
+                defaultPaymentMonthOffset: $input->defaultPaymentMonthOffset,
+                defaultPaymentPayDay: $input->defaultPaymentPayDay,
+            ));
 
-        if ($saved === null) {
-            throw new LogicException('Company settings disappeared immediately after save.');
-        }
+            $saved = $repository->find();
 
-        $this->audit->record(
-            $actorUserId,
-            $organizationId,
-            $existing === null ? 'company_settings.created' : 'company_settings.updated',
-            'company_settings',
-            $organizationId,
-            $existing !== null ? CompanySettingsResponse::toArray($existing) : null,
-            CompanySettingsResponse::toArray($saved),
-        );
+            if ($saved === null) {
+                throw new LogicException('Company settings disappeared immediately after save.');
+            }
 
-        return $saved;
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                $existing === null ? 'company_settings.created' : 'company_settings.updated',
+                'company_settings',
+                $organizationId,
+                $existing !== null ? CompanySettingsResponse::toArray($existing) : null,
+                CompanySettingsResponse::toArray($saved),
+            );
+
+            return $saved;
+        });
     }
 }

--- a/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
+++ b/src/InvoiceDownloadToken/GenerateDownloadTokenUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\InvoiceDownloadToken;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\SecureTokenHelper;
@@ -21,12 +24,15 @@ final readonly class GenerateDownloadTokenUseCase implements GenerateDownloadTok
     private const TTL_DAYS = 7;
 
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceDownloadTokenRepositoryInterface $tokensFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private InvoiceRepositoryInterface $invoices,
-        private InvoiceDownloadTokenRepositoryInterface $tokens,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $tokensFactory,
+        private Closure $auditFactory,
         private ClockInterface $clock,
         private RequestScopedHolder $orgId,
     ) {
@@ -56,26 +62,31 @@ final readonly class GenerateDownloadTokenUseCase implements GenerateDownloadTok
         $expiresAt = $now->modify('+' . self::TTL_DAYS . ' days')->format('Y-m-d H:i:s');
         $createdAt = $now->format('Y-m-d H:i:s');
 
-        $this->tokens->save(new InvoiceDownloadToken(
-            invoiceId: $invoiceId,
-            organizationId: $organizationId,
-            tokenHash: $tokenHash,
-            expiresAt: $expiresAt,
-            createdAt: $createdAt,
-        ));
+        // The token insert and its audit record commit atomically (Issue #352).
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $invoiceId, $tokenHash, $expiresAt, $createdAt): null {
+            ($this->tokensFactory)($exec)->save(new InvoiceDownloadToken(
+                invoiceId: $invoiceId,
+                organizationId: $organizationId,
+                tokenHash: $tokenHash,
+                expiresAt: $expiresAt,
+                createdAt: $createdAt,
+            ));
 
-        // Audit (ADR 0008): issuing a public download link is an auditable event.
-        // `after` carries only the non-secret expiry — the raw token and its hash
-        // are never written to the audit trail.
-        $this->audit->record(
-            $actorUserId,
-            $organizationId,
-            'invoice.download_token_issued',
-            'invoice',
-            $invoiceId,
-            null,
-            ['expires_at' => $expiresAt],
-        );
+            // Audit (ADR 0008): issuing a public download link is an auditable event.
+            // `after` carries only the non-secret expiry — the raw token and its hash
+            // are never written to the audit trail.
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'invoice.download_token_issued',
+                'invoice',
+                $invoiceId,
+                null,
+                ['expires_at' => $expiresAt],
+            );
+
+            return null;
+        });
 
         return ['rawToken' => $rawToken, 'expiresAt' => $expiresAt];
     }

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\InvoiceDownloadToken;
 
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -13,7 +14,7 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Invoice\GenerateInvoicePdfUseCaseInterface;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Invoice\Pdf\InvoicePdfGenerator;
@@ -41,8 +42,9 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                 GenerateDownloadTokenUseCaseInterface::class,
                 static fn (ContainerInterface $c): GenerateDownloadTokenUseCase => new GenerateDownloadTokenUseCase(
                     self::resolve($c, InvoiceRepositoryInterface::class),
-                    self::resolve($c, InvoiceDownloadTokenRepositoryInterface::class),
-                    self::resolve($c, AuditRecorderInterface::class),
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): InvoiceDownloadTokenRepositoryInterface => new PdoInvoiceDownloadTokenRepository($exec),
+                    AuditServiceProvider::recorderFactory($c),
                     self::resolve($c, ClockInterface::class),
                     self::orgHolder($c),
                 ),

--- a/src/Item/CreateItemUseCase.php
+++ b/src/Item/CreateItemUseCase.php
@@ -4,45 +4,56 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class CreateItemUseCase implements CreateItemUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ItemRepositoryInterface $itemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private ItemRepositoryInterface $items,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $itemsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
      * Creates an item in the resolved organization (the repository forces the
-     * org from the request-scoped holder, never from request input).
+     * org from the request-scoped holder, never from request input). The write
+     * and its audit record commit atomically (Issue #352).
      */
     public function execute(?int $actorUserId, CreateItemInput $input): Item
     {
         $organizationId = $this->orgId->get();
 
-        $id = $this->items->save(new Item(
-            organizationId: $organizationId,
-            description: $input->description,
-            defaultUnitPriceCents: $input->defaultUnitPriceCents,
-            defaultTaxRateBps: $input->defaultTaxRateBps,
-        ));
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $input): Item {
+            $items = ($this->itemsFactory)($exec);
 
-        $created = $this->items->findById($id);
+            $id = $items->save(new Item(
+                organizationId: $organizationId,
+                description: $input->description,
+                defaultUnitPriceCents: $input->defaultUnitPriceCents,
+                defaultTaxRateBps: $input->defaultTaxRateBps,
+            ));
 
-        if ($created === null) {
-            throw new LogicException('Item disappeared immediately after creation.');
-        }
+            $created = $items->findById($id);
 
-        $this->audit->record($actorUserId, $organizationId, 'item.created', 'item', $id, null, ItemResponse::toArray($created));
+            if ($created === null) {
+                throw new LogicException('Item disappeared immediately after creation.');
+            }
 
-        return $created;
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'item.created', 'item', $id, null, ItemResponse::toArray($created));
+
+            return $created;
+        });
     }
 }

--- a/src/Item/DeleteItemUseCase.php
+++ b/src/Item/DeleteItemUseCase.php
@@ -4,17 +4,24 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteItemUseCase implements DeleteItemUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ItemRepositoryInterface $itemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private ItemRepositoryInterface $items,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $itemsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -22,7 +29,8 @@ final readonly class DeleteItemUseCase implements DeleteItemUseCaseInterface
     /**
      * Soft-deletes an item in the resolved organization. The repository scopes
      * the lookup/delete to the request org, so cross-organization targets
-     * surface as not found.
+     * surface as not found. The delete and its audit record commit atomically
+     * (Issue #352).
      *
      * @throws ItemNotFoundException
      */
@@ -34,8 +42,14 @@ final readonly class DeleteItemUseCase implements DeleteItemUseCaseInterface
             throw new ItemNotFoundException($id);
         }
 
-        $this->items->delete($id);
+        $organizationId = $this->orgId->get();
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'item.deleted', 'item', $id, ItemResponse::toArray($existing), null);
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $existing): null {
+            ($this->itemsFactory)($exec)->delete($id);
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'item.deleted', 'item', $id, ItemResponse::toArray($existing), null);
+
+            return null;
+        });
     }
 }

--- a/src/Item/ItemServiceProvider.php
+++ b/src/Item/ItemServiceProvider.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
+use Closure;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -38,9 +40,9 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
             )
             ->set(ListItemsUseCaseInterface::class, static fn (ContainerInterface $c): ListItemsUseCase => new ListItemsUseCase(self::repository($c)))
             ->set(GetItemByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetItemByIdUseCase => new GetItemByIdUseCase(self::repository($c)))
-            ->set(CreateItemUseCaseInterface::class, static fn (ContainerInterface $c): CreateItemUseCase => new CreateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateItemUseCaseInterface::class, static fn (ContainerInterface $c): UpdateItemUseCase => new UpdateItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteItemUseCaseInterface::class, static fn (ContainerInterface $c): DeleteItemUseCase => new DeleteItemUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(CreateItemUseCaseInterface::class, static fn (ContainerInterface $c): CreateItemUseCase => new CreateItemUseCase(self::tx($c), self::itemsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(UpdateItemUseCaseInterface::class, static fn (ContainerInterface $c): UpdateItemUseCase => new UpdateItemUseCase(self::repository($c), self::tx($c), self::itemsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(DeleteItemUseCaseInterface::class, static fn (ContainerInterface $c): DeleteItemUseCase => new DeleteItemUseCase(self::repository($c), self::tx($c), self::itemsFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
             ->set(
                 ListItemsHandler::class,
                 static fn (ContainerInterface $c): ListItemsHandler => new ListItemsHandler(
@@ -159,15 +161,23 @@ final readonly class ItemServiceProvider implements ServiceProviderInterface
         return $holder;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    private static function tx(ContainerInterface $c): DatabaseTransactionManagerInterface
     {
-        $recorder = $c->get(AuditRecorderInterface::class);
+        $tx = $c->get(DatabaseTransactionManagerInterface::class);
 
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
+        if (!$tx instanceof DatabaseTransactionManagerInterface) {
+            throw new LogicException('Transaction manager service is invalid.');
         }
 
-        return $recorder;
+        return $tx;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): ItemRepositoryInterface */
+    private static function itemsFactory(ContainerInterface $c): Closure
+    {
+        $orgHolder = self::orgHolder($c);
+
+        return static fn (DatabaseQueryExecutorInterface $exec): ItemRepositoryInterface => new PdoItemRepository($exec, $orgHolder);
     }
 
     private static function listUseCase(ContainerInterface $c): ListItemsUseCase

--- a/src/Item/UpdateItemUseCase.php
+++ b/src/Item/UpdateItemUseCase.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Item;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class UpdateItemUseCase implements UpdateItemUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): ItemRepositoryInterface $itemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private ItemRepositoryInterface $items,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $itemsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -23,7 +30,8 @@ final readonly class UpdateItemUseCase implements UpdateItemUseCaseInterface
     /**
      * Updates an item in the resolved organization. The repository scopes the
      * read/write to the request org, so an item from another organization (or
-     * soft-deleted) surfaces as not found.
+     * soft-deleted) surfaces as not found. The write and its audit record commit
+     * atomically (Issue #352).
      *
      * @throws ItemNotFoundException
      */
@@ -35,25 +43,31 @@ final readonly class UpdateItemUseCase implements UpdateItemUseCaseInterface
             throw new ItemNotFoundException($id);
         }
 
-        $this->items->update(new Item(
-            organizationId: $existing->organizationId,
-            description: $input->description,
-            defaultUnitPriceCents: $input->defaultUnitPriceCents,
-            defaultTaxRateBps: $input->defaultTaxRateBps,
-            isDeleted: false,
-            id: $existing->id,
-            createdAt: $existing->createdAt,
-            updatedAt: $existing->updatedAt,
-        ));
+        $organizationId = $this->orgId->get();
 
-        $updated = $this->items->findById($id);
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $input, $existing): Item {
+            $items = ($this->itemsFactory)($exec);
 
-        if ($updated === null) {
-            throw new LogicException('Item disappeared immediately after update.');
-        }
+            $items->update(new Item(
+                organizationId: $existing->organizationId,
+                description: $input->description,
+                defaultUnitPriceCents: $input->defaultUnitPriceCents,
+                defaultTaxRateBps: $input->defaultTaxRateBps,
+                isDeleted: false,
+                id: $existing->id,
+                createdAt: $existing->createdAt,
+                updatedAt: $existing->updatedAt,
+            ));
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'item.updated', 'item', $id, ItemResponse::toArray($existing), ItemResponse::toArray($updated));
+            $updated = $items->findById($id);
 
-        return $updated;
+            if ($updated === null) {
+                throw new LogicException('Item disappeared immediately after update.');
+            }
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'item.updated', 'item', $id, ItemResponse::toArray($existing), ItemResponse::toArray($updated));
+
+            return $updated;
+        });
     }
 }

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -4,35 +4,47 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizationsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     */
     public function __construct(
-        private OrganizationRepositoryInterface $organizations,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $organizationsFactory,
+        private Closure $auditFactory,
     ) {
     }
 
     /** @throws OrganizationSlugConflictException */
     public function execute(?int $actorUserId, CreateOrganizationInput $input): Organization
     {
-        $id = $this->organizations->save(new Organization(
-            name: $input->name,
-            slug: $input->slug,
-            plan: $input->plan,
-            isActive: true,
-        ));
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $input): Organization {
+            $organizations = ($this->organizationsFactory)($exec);
 
-        $created = $this->organizations->findById($id);
+            $id = $organizations->save(new Organization(
+                name: $input->name,
+                slug: $input->slug,
+                plan: $input->plan,
+                isActive: true,
+            ));
 
-        if ($created === null) {
-            throw new LogicException('Organization disappeared immediately after creation.');
-        }
+            $created = $organizations->findById($id);
 
-        $this->audit->record($actorUserId, $id, 'organization.created', 'organization', $id, null, OrganizationResponse::toArray($created));
+            if ($created === null) {
+                throw new LogicException('Organization disappeared immediately after creation.');
+            }
 
-        return $created;
+            ($this->auditFactory)($exec)->record($actorUserId, $id, 'organization.created', 'organization', $id, null, OrganizationResponse::toArray($created));
+
+            return $created;
+        });
     }
 }

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizationsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     */
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $organizationsFactory,
+        private Closure $auditFactory,
     ) {
     }
 
@@ -23,8 +32,12 @@ final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseC
             throw new OrganizationNotFoundException($id);
         }
 
-        $this->organizations->delete($id);
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $id, $existing): null {
+            ($this->organizationsFactory)($exec)->delete($id);
 
-        $this->audit->record($actorUserId, $id, 'organization.deleted', 'organization', $id, OrganizationResponse::toArray($existing), null);
+            ($this->auditFactory)($exec)->record($actorUserId, $id, 'organization.deleted', 'organization', $id, OrganizationResponse::toArray($existing), null);
+
+            return null;
+        });
     }
 }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Organization;
 
+use Closure;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -36,8 +38,8 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
             )
             ->set(ListOrganizationsUseCaseInterface::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
             ->set(GetOrganizationByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
-            ->set(CreateOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::repository($c), self::audit($c)))
-            ->set(DeleteOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::audit($c)))
+            ->set(CreateOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::tx($c), self::organizationsFactory(), AuditServiceProvider::recorderFactory($c)))
+            ->set(DeleteOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::tx($c), self::organizationsFactory(), AuditServiceProvider::recorderFactory($c)))
             ->set(
                 ListOrganizationsHandler::class,
                 static fn (ContainerInterface $c): ListOrganizationsHandler => new ListOrganizationsHandler(
@@ -106,15 +108,21 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
         return $repo;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    private static function tx(ContainerInterface $c): DatabaseTransactionManagerInterface
     {
-        $recorder = $c->get(AuditRecorderInterface::class);
+        $tx = $c->get(DatabaseTransactionManagerInterface::class);
 
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
+        if (!$tx instanceof DatabaseTransactionManagerInterface) {
+            throw new LogicException('Transaction manager service is invalid.');
         }
 
-        return $recorder;
+        return $tx;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface */
+    private static function organizationsFactory(): Closure
+    {
+        return static fn (DatabaseQueryExecutorInterface $exec): OrganizationRepositoryInterface => new PdoOrganizationRepository($exec);
     }
 
     private static function listUseCase(ContainerInterface $c): ListOrganizationsUseCase

--- a/src/Template/DeleteTemplateUseCase.php
+++ b/src/Template/DeleteTemplateUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Template;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\LineItem\LineItemParent;
@@ -12,12 +15,18 @@ use NeneInvoice\LineItem\LineItemRepositoryInterface;
 final readonly class DeleteTemplateUseCase implements DeleteTemplateUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): TemplateRepositoryInterface $templatesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private TemplateRepositoryInterface $templates,
         private LineItemRepositoryInterface $lineItems,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $templatesFactory,
+        private Closure $lineItemsFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -25,6 +34,7 @@ final readonly class DeleteTemplateUseCase implements DeleteTemplateUseCaseInter
     /**
      * Soft-deletes a template and clears its line presets, in the resolved
      * organization (the repository scopes the lookup/delete to the request org).
+     * The two deletes and the audit record commit atomically (Issue #352).
      *
      * @throws TemplateNotFoundException
      */
@@ -35,11 +45,16 @@ final readonly class DeleteTemplateUseCase implements DeleteTemplateUseCaseInter
             throw new TemplateNotFoundException($id);
         }
 
-        $before = TemplateResponse::toArray($existing, $this->lineItems->findByParent(LineItemParent::Template, $id));
+        $before         = TemplateResponse::toArray($existing, $this->lineItems->findByParent(LineItemParent::Template, $id));
+        $organizationId = $this->orgId->get();
 
-        $this->templates->delete($id);
-        $this->lineItems->deleteForParent(LineItemParent::Template, $id);
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $before): null {
+            ($this->templatesFactory)($exec)->delete($id);
+            ($this->lineItemsFactory)($exec)->deleteForParent(LineItemParent::Template, $id);
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'template.deleted', 'template', $id, $before, null);
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'template.deleted', 'template', $id, $before, null);
+
+            return null;
+        });
     }
 }

--- a/src/Template/TemplateServiceProvider.php
+++ b/src/Template/TemplateServiceProvider.php
@@ -13,7 +13,6 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\LineItem\LineItemRepositoryInterface;
 use NeneInvoice\LineItem\PdoLineItemRepository;
@@ -65,7 +64,19 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
                     $orgHolder,
                 );
             })
-            ->set(DeleteTemplateUseCaseInterface::class, static fn (ContainerInterface $c): DeleteTemplateUseCase => new DeleteTemplateUseCase(self::repository($c), self::lineItems($c), self::audit($c), self::orgHolder($c)))
+            ->set(DeleteTemplateUseCaseInterface::class, static function (ContainerInterface $c): DeleteTemplateUseCase {
+                $orgHolder = self::orgHolder($c);
+
+                return new DeleteTemplateUseCase(
+                    self::repository($c),
+                    self::lineItems($c),
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): TemplateRepositoryInterface => new PdoTemplateRepository($exec, $orgHolder),
+                    static fn (DatabaseQueryExecutorInterface $exec): LineItemRepositoryInterface => new PdoLineItemRepository($exec, $orgHolder),
+                    AuditServiceProvider::recorderFactory($c),
+                    $orgHolder,
+                );
+            })
             ->set(
                 ListTemplatesHandler::class,
                 static fn (ContainerInterface $c): ListTemplatesHandler => new ListTemplatesHandler(self::resolve($c, ListTemplatesUseCaseInterface::class), self::json($c)),
@@ -144,15 +155,6 @@ final readonly class TemplateServiceProvider implements ServiceProviderInterface
         return $holder;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
-    {
-        $recorder = $c->get(AuditRecorderInterface::class);
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
-        }
-
-        return $recorder;
-    }
 
     private static function json(ContainerInterface $c): JsonResponseFactory
     {

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
@@ -12,11 +15,14 @@ use NeneInvoice\Auth\Role;
 final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $usersFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
-        private UserRepositoryInterface $users,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $usersFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -24,7 +30,8 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
     /**
      * Creates a user in the caller's organization. The organization is taken
      * from the resolved org holder, never from request input, so a user cannot
-     * be created in another tenant.
+     * be created in another tenant. The write and its audit record commit
+     * atomically (Issue #352).
      *
      * @throws RoleNotAssignableException   when attempting to assign superadmin
      * @throws UserEmailConflictException   when the email is already in use
@@ -36,23 +43,28 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
         }
 
         $organizationId = $this->orgId->get();
+        $passwordHash   = password_hash($input->password, PASSWORD_DEFAULT);
 
-        $id = $this->users->save(new User(
-            email: $input->email,
-            passwordHash: password_hash($input->password, PASSWORD_DEFAULT),
-            role: $input->role,
-            organizationId: $organizationId,
-            status: 'active',
-        ));
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $input, $passwordHash): User {
+            $users = ($this->usersFactory)($exec);
 
-        $created = $this->users->findById($id);
+            $id = $users->save(new User(
+                email: $input->email,
+                passwordHash: $passwordHash,
+                role: $input->role,
+                organizationId: $organizationId,
+                status: 'active',
+            ));
 
-        if ($created === null) {
-            throw new LogicException('User disappeared immediately after creation.');
-        }
+            $created = $users->findById($id);
 
-        $this->audit->record($actorUserId, $organizationId, 'user.created', 'user', $id, null, UserResponse::toArray($created));
+            if ($created === null) {
+                throw new LogicException('User disappeared immediately after creation.');
+            }
 
-        return $created;
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'user.created', 'user', $id, null, UserResponse::toArray($created));
+
+            return $created;
+        });
     }
 }

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -4,24 +4,32 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 
 final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $usersFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private UserRepositoryInterface $users,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $usersFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
 
     /**
      * Deletes a user within the caller's organization. Cross-organization targets
-     * are reported as not found, and a caller cannot delete their own account.
+     * are reported as not found, and a caller cannot delete their own account. The
+     * delete and its audit record commit atomically (Issue #352).
      *
      * @throws CannotDeleteSelfException
      * @throws UserNotFoundException
@@ -38,8 +46,14 @@ final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
             throw new UserNotFoundException($userId);
         }
 
-        $this->users->delete($userId);
+        $organizationId = $this->orgId->get();
 
-        $this->audit->record($callerUserId, $this->orgId->get(), 'user.deleted', 'user', $userId, UserResponse::toArray($existing), null);
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($callerUserId, $organizationId, $userId, $existing): null {
+            ($this->usersFactory)($exec)->delete($userId);
+
+            ($this->auditFactory)($exec)->record($callerUserId, $organizationId, 'user.deleted', 'user', $userId, UserResponse::toArray($existing), null);
+
+            return null;
+        });
     }
 }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Audit\AuditRecorderInterface;
 use NeneInvoice\Auth\Role;
@@ -12,11 +15,15 @@ use NeneInvoice\Auth\Role;
 final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 {
     /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $usersFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
      * @param RequestScopedHolder<int> $orgId resolved organization for this request
      */
     public function __construct(
         private UserRepositoryInterface $users,
-        private AuditRecorderInterface $audit,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $usersFactory,
+        private Closure $auditFactory,
         private RequestScopedHolder $orgId,
     ) {
     }
@@ -24,7 +31,8 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
     /**
      * Updates a user's role, status, and (optionally) password — only within the
      * caller's organization. A user from another organization is reported as not
-     * found. Email is immutable here.
+     * found. Email is immutable here. The write and its audit record commit
+     * atomically (Issue #352).
      *
      * @throws UserNotFoundException        when the user is missing or in another org
      * @throws RoleNotAssignableException   when attempting to assign superadmin
@@ -41,25 +49,32 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
             throw new RoleNotAssignableException($input->role);
         }
 
-        $this->users->update(new User(
-            email: $existing->email,
-            passwordHash: $input->password !== null ? password_hash($input->password, PASSWORD_DEFAULT) : $existing->passwordHash,
-            role: $input->role,
-            organizationId: $existing->organizationId,
-            status: $input->status,
-            id: $existing->id,
-            createdAt: $existing->createdAt,
-            updatedAt: $existing->updatedAt,
-        ));
+        $organizationId = $this->orgId->get();
+        $passwordHash   = $input->password !== null ? password_hash($input->password, PASSWORD_DEFAULT) : $existing->passwordHash;
 
-        $updated = $this->users->findById($userId);
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $userId, $input, $existing, $passwordHash): User {
+            $users = ($this->usersFactory)($exec);
 
-        if ($updated === null) {
-            throw new LogicException('User disappeared immediately after update.');
-        }
+            $users->update(new User(
+                email: $existing->email,
+                passwordHash: $passwordHash,
+                role: $input->role,
+                organizationId: $existing->organizationId,
+                status: $input->status,
+                id: $existing->id,
+                createdAt: $existing->createdAt,
+                updatedAt: $existing->updatedAt,
+            ));
 
-        $this->audit->record($actorUserId, $this->orgId->get(), 'user.updated', 'user', $userId, UserResponse::toArray($existing), UserResponse::toArray($updated));
+            $updated = $users->findById($userId);
 
-        return $updated;
+            if ($updated === null) {
+                throw new LogicException('User disappeared immediately after update.');
+            }
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'user.updated', 'user', $userId, UserResponse::toArray($existing), UserResponse::toArray($updated));
+
+            return $updated;
+        });
     }
 }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace NeneInvoice\User;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
-use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Audit\AuditServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -26,9 +29,9 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         $builder
             ->set(ListUsersUseCaseInterface::class, static fn (ContainerInterface $c): ListUsersUseCase => new ListUsersUseCase(self::repository($c)))
             ->set(GetUserByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetUserByIdUseCase => new GetUserByIdUseCase(self::repository($c)))
-            ->set(CreateUserUseCaseInterface::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(UpdateUserUseCaseInterface::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
-            ->set(DeleteUserUseCaseInterface::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::audit($c), self::orgHolder($c)))
+            ->set(CreateUserUseCaseInterface::class, static fn (ContainerInterface $c): CreateUserUseCase => new CreateUserUseCase(self::tx($c), self::usersFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(UpdateUserUseCaseInterface::class, static fn (ContainerInterface $c): UpdateUserUseCase => new UpdateUserUseCase(self::repository($c), self::tx($c), self::usersFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
+            ->set(DeleteUserUseCaseInterface::class, static fn (ContainerInterface $c): DeleteUserUseCase => new DeleteUserUseCase(self::repository($c), self::tx($c), self::usersFactory($c), AuditServiceProvider::recorderFactory($c), self::orgHolder($c)))
             ->set(
                 ListUsersHandler::class,
                 static fn (ContainerInterface $c): ListUsersHandler => new ListUsersHandler(
@@ -115,15 +118,23 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
         return $repo;
     }
 
-    private static function audit(ContainerInterface $c): AuditRecorderInterface
+    private static function tx(ContainerInterface $c): DatabaseTransactionManagerInterface
     {
-        $recorder = $c->get(AuditRecorderInterface::class);
+        $tx = $c->get(DatabaseTransactionManagerInterface::class);
 
-        if (!$recorder instanceof AuditRecorderInterface) {
-            throw new LogicException('Audit recorder service is invalid.');
+        if (!$tx instanceof DatabaseTransactionManagerInterface) {
+            throw new LogicException('Transaction manager service is invalid.');
         }
 
-        return $recorder;
+        return $tx;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface */
+    private static function usersFactory(ContainerInterface $c): Closure
+    {
+        $orgHolder = self::orgHolder($c);
+
+        return static fn (DatabaseQueryExecutorInterface $exec): UserRepositoryInterface => new PdoUserRepository($exec, $orgHolder);
     }
 
     /** @return RequestScopedHolder<int> */

--- a/tests/Client/ClientWriteUseCasesTest.php
+++ b/tests/Client/ClientWriteUseCasesTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Client\DeleteClientUseCase;
 use NeneInvoice\Client\InvalidRegistrationNumberException;
 use NeneInvoice\Client\UpdateClientInput;
 use NeneInvoice\Client\UpdateClientUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
@@ -37,7 +38,7 @@ final class ClientWriteUseCasesTest extends TestCase
         // The org comes from the request-scoped holder, never from input.
         $this->holder->set(7);
 
-        $client = (new CreateClientUseCase($this->repo, $this->audit, $this->holder))->execute(42, new CreateClientInput(name: 'Acme'));
+        $client = (new CreateClientUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(42, new CreateClientInput(name: 'Acme'));
 
         self::assertSame(7, $client->organizationId);
 
@@ -54,14 +55,14 @@ final class ClientWriteUseCasesTest extends TestCase
     public function test_create_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new CreateClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
+        (new CreateClientUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, new CreateClientInput(name: 'Acme', registrationNumber: '12345'));
     }
 
     public function test_update_records_before_and_after(): void
     {
         $id = $this->repo->save(new Client(organizationId: 1, name: 'Before'));
 
-        (new UpdateClientUseCase($this->repo, $this->audit, $this->holder))->execute(9, $id, new UpdateClientInput(name: 'After'));
+        (new UpdateClientUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(9, $id, new UpdateClientInput(name: 'After'));
 
         self::assertCount(1, $this->audit->records);
         $record = $this->audit->records[0];
@@ -75,14 +76,14 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new UpdateClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
+        (new UpdateClientUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, $otherOrg, new UpdateClientInput(name: 'Hacked'));
     }
 
     public function test_delete_soft_deletes_and_records_before_only(): void
     {
         $id = $this->repo->save(new Client(organizationId: 1, name: 'Temp'));
 
-        (new DeleteClientUseCase($this->repo, $this->audit, $this->holder))->execute(5, $id);
+        (new DeleteClientUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(5, $id);
 
         self::assertNull($this->repo->findById($id));
 
@@ -97,6 +98,6 @@ final class ClientWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Client(organizationId: 2, name: 'Other'));
 
         $this->expectException(ClientNotFoundException::class);
-        (new DeleteClientUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrg);
+        (new DeleteClientUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, $otherOrg);
     }
 }

--- a/tests/Company/CompanySettingsTest.php
+++ b/tests/Company/CompanySettingsTest.php
@@ -14,6 +14,7 @@ use NeneInvoice\Company\InvalidRegistrationNumberException;
 use NeneInvoice\Company\PdoCompanySettingsRepository;
 use NeneInvoice\Company\UpdateCompanySettingsInput;
 use NeneInvoice\Company\UpdateCompanySettingsUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
 
@@ -59,7 +60,7 @@ final class CompanySettingsTest extends TestCase
 
     public function test_update_upserts_and_get_returns_settings(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder);
+        $update = new UpdateCompanySettingsUseCase($this->repository, new ImmediateTransactionManager(), fn () => $this->repository, fn () => $this->audit, $this->holder);
 
         $created = $update->execute(5, new UpdateCompanySettingsInput(
             legalName: '株式会社あやね',
@@ -80,7 +81,7 @@ final class CompanySettingsTest extends TestCase
     public function test_update_rejects_malformed_registration_number(): void
     {
         $this->expectException(InvalidRegistrationNumberException::class);
-        (new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder))->execute(5, new UpdateCompanySettingsInput(
+        (new UpdateCompanySettingsUseCase($this->repository, new ImmediateTransactionManager(), fn () => $this->repository, fn () => $this->audit, $this->holder))->execute(5, new UpdateCompanySettingsInput(
             legalName: 'X',
             registrationNumber: 'bad',
         ));
@@ -88,7 +89,7 @@ final class CompanySettingsTest extends TestCase
 
     public function test_settings_are_scoped_per_organization(): void
     {
-        $update = new UpdateCompanySettingsUseCase($this->repository, $this->audit, $this->holder);
+        $update = new UpdateCompanySettingsUseCase($this->repository, new ImmediateTransactionManager(), fn () => $this->repository, fn () => $this->audit, $this->holder);
         $this->holder->set(1);
         $update->execute(5, new UpdateCompanySettingsInput(legalName: 'Org One'));
         $this->holder->set(2);

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenHandlerTest.php
@@ -12,6 +12,7 @@ use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenHandler;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -45,7 +46,7 @@ final class GenerateDownloadTokenHandlerTest extends TestCase
         ));
 
         $this->handler = new GenerateDownloadTokenHandler(
-            new GenerateDownloadTokenUseCase($this->invoices, $tokens, new RecordingAuditRecorder(), new FixedClock(), $this->holder),
+            new GenerateDownloadTokenUseCase($this->invoices, new ImmediateTransactionManager(), fn () => $tokens, fn () => new RecordingAuditRecorder(), new FixedClock(), $this->holder),
             new JsonResponseFactory($this->psr17, $this->psr17),
         );
     }

--- a/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
+++ b/tests/InvoiceDownloadToken/GenerateDownloadTokenUseCaseTest.php
@@ -10,6 +10,7 @@ use NeneInvoice\Invoice\InvoiceNotFoundException;
 use NeneInvoice\Invoice\InvoiceStatus;
 use NeneInvoice\InvoiceDownloadToken\GenerateDownloadTokenUseCase;
 use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInvoiceDownloadTokenRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
@@ -35,7 +36,7 @@ final class GenerateDownloadTokenUseCaseTest extends TestCase
         $this->invoices = new InMemoryInvoiceRepository($this->holder);
         $this->tokens   = new InMemoryInvoiceDownloadTokenRepository();
         $this->audit    = new RecordingAuditRecorder();
-        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, $this->tokens, $this->audit, new FixedClock(), $this->holder);
+        $this->useCase  = new GenerateDownloadTokenUseCase($this->invoices, new ImmediateTransactionManager(), fn () => $this->tokens, fn () => $this->audit, new FixedClock(), $this->holder);
     }
 
     public function test_generates_token_for_invoice_in_org(): void

--- a/tests/Item/ItemWriteUseCasesTest.php
+++ b/tests/Item/ItemWriteUseCasesTest.php
@@ -13,6 +13,7 @@ use NeneInvoice\Item\Item;
 use NeneInvoice\Item\ItemNotFoundException;
 use NeneInvoice\Item\UpdateItemInput;
 use NeneInvoice\Item\UpdateItemUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryItemRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +37,7 @@ final class ItemWriteUseCasesTest extends TestCase
     {
         $this->holder->set(7);
 
-        $item = (new CreateItemUseCase($this->repo, $this->audit, $this->holder))
+        $item = (new CreateItemUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))
             ->execute(42, new CreateItemInput(description: '保守', defaultUnitPriceCents: 50000, defaultTaxRateBps: 1000));
 
         self::assertSame(7, $item->organizationId);
@@ -63,7 +64,7 @@ final class ItemWriteUseCasesTest extends TestCase
     {
         $id = $this->repo->save(new Item(organizationId: 1, description: 'Before', defaultUnitPriceCents: 1000, defaultTaxRateBps: 1000));
 
-        (new UpdateItemUseCase($this->repo, $this->audit, $this->holder))
+        (new UpdateItemUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))
             ->execute(9, $id, new UpdateItemInput(description: 'After', defaultUnitPriceCents: 2000, defaultTaxRateBps: 800));
 
         self::assertCount(1, $this->audit->records);
@@ -79,7 +80,7 @@ final class ItemWriteUseCasesTest extends TestCase
         $otherOrg = $this->repo->save(new Item(organizationId: 2, description: 'Other', defaultUnitPriceCents: 1, defaultTaxRateBps: 1000));
 
         $this->expectException(ItemNotFoundException::class);
-        (new UpdateItemUseCase($this->repo, $this->audit, $this->holder))
+        (new UpdateItemUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))
             ->execute(1, $otherOrg, new UpdateItemInput(description: 'Hacked', defaultUnitPriceCents: 1, defaultTaxRateBps: 1000));
     }
 
@@ -87,7 +88,7 @@ final class ItemWriteUseCasesTest extends TestCase
     {
         $id = $this->repo->save(new Item(organizationId: 1, description: 'Doomed', defaultUnitPriceCents: 1000, defaultTaxRateBps: 1000));
 
-        (new DeleteItemUseCase($this->repo, $this->audit, $this->holder))->execute(5, $id);
+        (new DeleteItemUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(5, $id);
 
         self::assertNull($this->repo->findById($id));
         self::assertSame('item.deleted', $this->audit->records[0]['action']);

--- a/tests/Organization/OrganizationUseCasesTest.php
+++ b/tests/Organization/OrganizationUseCasesTest.php
@@ -11,6 +11,7 @@ use NeneInvoice\Organization\GetOrganizationByIdUseCase;
 use NeneInvoice\Organization\ListOrganizationsUseCase;
 use NeneInvoice\Organization\OrganizationNotFoundException;
 use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +29,7 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_create_persists_returns_with_id_and_audits(): void
     {
-        $useCase = new CreateOrganizationUseCase($this->repo, $this->audit);
+        $useCase = new CreateOrganizationUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit);
 
         $org = $useCase->execute(1, new CreateOrganizationInput('Acme', 'acme'));
 
@@ -44,7 +45,7 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_create_rejects_duplicate_slug(): void
     {
-        $useCase = new CreateOrganizationUseCase($this->repo, $this->audit);
+        $useCase = new CreateOrganizationUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit);
         $useCase->execute(1, new CreateOrganizationInput('First', 'dup'));
 
         $this->expectException(OrganizationSlugConflictException::class);
@@ -53,7 +54,7 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_list_returns_items_and_total(): void
     {
-        $create = new CreateOrganizationUseCase($this->repo, $this->audit);
+        $create = new CreateOrganizationUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit);
         $create->execute(1, new CreateOrganizationInput('A', 'a'));
         $create->execute(1, new CreateOrganizationInput('B', 'b'));
 
@@ -65,7 +66,7 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_get_returns_organization_or_throws(): void
     {
-        $id = (new CreateOrganizationUseCase($this->repo, $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
+        $id = (new CreateOrganizationUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
         self::assertNotNull($id);
 
         $get = new GetOrganizationByIdUseCase($this->repo);
@@ -77,10 +78,10 @@ final class OrganizationUseCasesTest extends TestCase
 
     public function test_delete_removes_audits_and_throws_when_missing(): void
     {
-        $id = (new CreateOrganizationUseCase($this->repo, $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
+        $id = (new CreateOrganizationUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit))->execute(1, new CreateOrganizationInput('A', 'a'))->id;
         self::assertNotNull($id);
 
-        $delete = new DeleteOrganizationUseCase($this->repo, $this->audit);
+        $delete = new DeleteOrganizationUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit);
         $delete->execute(1, $id);
         self::assertSame(0, $this->repo->count());
         self::assertSame('organization.deleted', $this->audit->records[1]['action']);

--- a/tests/Template/TemplateWriteUseCasesTest.php
+++ b/tests/Template/TemplateWriteUseCasesTest.php
@@ -120,6 +120,6 @@ final class TemplateWriteUseCasesTest extends TestCase
 
     private function delete(): DeleteTemplateUseCase
     {
-        return new DeleteTemplateUseCase($this->templates, $this->lines, $this->audit, $this->holder);
+        return new DeleteTemplateUseCase($this->templates, $this->lines, new ImmediateTransactionManager(), fn () => $this->templates, fn () => $this->lines, fn () => $this->audit, $this->holder);
     }
 }

--- a/tests/User/UserWriteUseCasesTest.php
+++ b/tests/User/UserWriteUseCasesTest.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Tests\User;
 
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Auth\Role;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryUserRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
 use NeneInvoice\User\CannotDeleteSelfException;
@@ -37,7 +38,7 @@ final class UserWriteUseCasesTest extends TestCase
 
     public function test_create_hashes_password_forces_org_and_audits(): void
     {
-        $user = (new CreateUserUseCase($this->repo, $this->audit, $this->holder))->execute(99, new CreateUserInput('m@org1', 'secret', Role::Member));
+        $user = (new CreateUserUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(99, new CreateUserInput('m@org1', 'secret', Role::Member));
 
         self::assertSame(1, $user->organizationId);
         self::assertSame(Role::Member, $user->role);
@@ -52,12 +53,12 @@ final class UserWriteUseCasesTest extends TestCase
     public function test_create_blocks_superadmin_role(): void
     {
         $this->expectException(RoleNotAssignableException::class);
-        (new CreateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
+        (new CreateUserUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, new CreateUserInput('x@org1', 'secret', Role::Superadmin));
     }
 
     public function test_create_rejects_duplicate_email(): void
     {
-        $create = new CreateUserUseCase($this->repo, $this->audit, $this->holder);
+        $create = new CreateUserUseCase(new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder);
         $create->execute(1, new CreateUserInput('dup@org1', 'secret', Role::Member));
 
         $this->expectException(UserEmailConflictException::class);
@@ -68,7 +69,7 @@ final class UserWriteUseCasesTest extends TestCase
     {
         $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
 
-        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(7, $id, new UpdateUserInput(Role::Admin, 'active'));
+        (new UpdateUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(7, $id, new UpdateUserInput(Role::Admin, 'active'));
 
         self::assertSame('user.updated', $this->audit->records[0]['action']);
         self::assertSame('member', $this->audit->records[0]['before']['role'] ?? null);
@@ -80,7 +81,7 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
+        (new UpdateUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, $otherOrgUser, new UpdateUserInput(Role::Admin, 'active'));
     }
 
     public function test_update_blocks_superadmin_escalation(): void
@@ -88,7 +89,7 @@ final class UserWriteUseCasesTest extends TestCase
         $id = $this->repo->save(new User('a@org1', 'h', Role::Member, 1));
 
         $this->expectException(RoleNotAssignableException::class);
-        (new UpdateUserUseCase($this->repo, $this->audit, $this->holder))->execute(1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
+        (new UpdateUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute(1, $id, new UpdateUserInput(Role::Superadmin, 'active'));
     }
 
     public function test_delete_blocks_self(): void
@@ -96,7 +97,7 @@ final class UserWriteUseCasesTest extends TestCase
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
 
         $this->expectException(CannotDeleteSelfException::class);
-        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $caller);
+        (new DeleteUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute($caller, $caller);
     }
 
     public function test_delete_blocks_cross_organization_target(): void
@@ -105,7 +106,7 @@ final class UserWriteUseCasesTest extends TestCase
         $otherOrgUser = $this->repo->save(new User('a@org2', 'h', Role::Member, 2));
 
         $this->expectException(UserNotFoundException::class);
-        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $otherOrgUser);
+        (new DeleteUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute($caller, $otherOrgUser);
     }
 
     public function test_delete_removes_user_and_audits(): void
@@ -113,7 +114,7 @@ final class UserWriteUseCasesTest extends TestCase
         $caller = $this->repo->save(new User('me@org1', 'h', Role::Admin, 1));
         $target = $this->repo->save(new User('t@org1', 'h', Role::Member, 1));
 
-        (new DeleteUserUseCase($this->repo, $this->audit, $this->holder))->execute($caller, $target);
+        (new DeleteUserUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit, $this->holder))->execute($caller, $target);
 
         self::assertNull($this->repo->findById($target));
         self::assertSame('user.deleted', $this->audit->records[0]['action']);


### PR DESCRIPTION
Closes #354（#352 の続き）

## 概要
#352 で財務系9件をトランザクション内監査にしたのに続き、**非財務の管理CRUDにも同パターンを適用**。これで全ての監査書き込みが業務書込みと**原子的にコミット**され、「部分書込み＝監査欠落」が一掃され方針が統一されます。

## 対象14件（tx＋リポジトリ/監査ファクトリ方式に統一）
- **Client**: Create / Update / Delete
- **Item**: Create / Update / Delete
- **User**: Create / Update / Delete
- **Organization**: Create / Delete
- **Company**: UpdateCompanySettings
- **Template**: Delete（templates削除＋line_items削除の**2書込みも原子化**）
- **InvoiceDownloadToken**: GenerateDownloadToken（token保存＋監査）

各 ServiceProvider に `tx()` / リポジトリファクトリのヘルパを追加し、監査は `AuditServiceProvider::recorderFactory()` を共通利用。検証・存在チェック・パスワードハッシュ化はトランザクション外（読み取り／純計算）に維持。

## 除外
`SendInvoiceEmail` は外部副作用（メール送信。ロールバック不能）のため tx 内監査の対象外。

## 確認
- [x] composer check（test **346** / phpstan 0 / cs / openapi / mcp）green
- [x] dev サーバーで取引先作成 → 監査（`client.created`・Clock 由来 `created_at`）を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)