### PR TITLE
feat(frontend): 品目・テンプレート一覧のキーボードショートカットを追加 (#356)

### DIFF
--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -40,6 +40,32 @@ describe('KeyboardShortcuts', () => {
     })
   })
 
+  it('navigates to items (g m) and templates (g t), and n opens new item', async () => {
+    const { getByTestId } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <LocationProbe />
+      </>,
+    )
+
+    fireEvent.keyDown(document.body, { key: 'g' })
+    fireEvent.keyDown(document.body, { key: 'm' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/items')
+    })
+
+    fireEvent.keyDown(document.body, { key: 'n' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/items/new')
+    })
+
+    fireEvent.keyDown(document.body, { key: 'g' })
+    fireEvent.keyDown(document.body, { key: 't' })
+    await waitFor(() => {
+      expect(getByTestId('loc')).toHaveTextContent('/templates')
+    })
+  })
+
   it('returns to the parent list with u', async () => {
     const { getByTestId } = renderWithProviders(
       <>

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -17,6 +17,8 @@ const GOTO: Record<string, string> = {
   q: '/quotes',
   i: '/invoices',
   c: '/clients',
+  m: '/items',
+  t: '/templates',
   u: '/users',
   s: '/settings',
   a: '/audit-logs',
@@ -27,11 +29,21 @@ const NEW_ROUTE: Record<string, string> = {
   '/quotes': '/quotes/new',
   '/invoices': '/invoices/new',
   '/clients': '/clients/new',
+  '/items': '/items/new',
+  '/templates': '/templates/new',
   '/users': '/users/new',
 }
 
 /** Parent list roots for `u` (back to list). */
-const LIST_ROOTS = ['/invoices', '/quotes', '/clients', '/users', '/audit-logs']
+const LIST_ROOTS = [
+  '/invoices',
+  '/quotes',
+  '/clients',
+  '/items',
+  '/templates',
+  '/users',
+  '/audit-logs',
+]
 
 function parentListOf(path: string): string | null {
   return LIST_ROOTS.find((root) => path.startsWith(`${root}/`)) ?? null

--- a/frontend/src/shared/keyboard/shortcuts-data.ts
+++ b/frontend/src/shared/keyboard/shortcuts-data.ts
@@ -37,6 +37,8 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { ja: '見積書', en: 'Quotes', combos: [{ caps: ['g', 'q'], join: 'then' }] },
       { ja: '請求書', en: 'Invoices', combos: [{ caps: ['g', 'i'], join: 'then' }] },
       { ja: '取引先', en: 'Clients', combos: [{ caps: ['g', 'c'], join: 'then' }] },
+      { ja: '品目マスタ', en: 'Items', combos: [{ caps: ['g', 'm'], join: 'then' }] },
+      { ja: 'テンプレート', en: 'Templates', combos: [{ caps: ['g', 't'], join: 'then' }] },
       { ja: 'ユーザー', en: 'Users', combos: [{ caps: ['g', 'u'], join: 'then' }] },
       { ja: '会社設定', en: 'Settings', combos: [{ caps: ['g', 's'], join: 'then' }] },
       { ja: '監査ログ', en: 'Audit log', combos: [{ caps: ['g', 'a'], join: 'then' }] },


### PR DESCRIPTION
Closes #356

## 概要
品目（/items）・テンプレート（/templates）一覧に g-prefix ナビ等のショートカットが無かったので追加。あわせて、両ページが `aria-keyshortcuts="n"` を表示していたのに dispatcher 未対応で **`n` が実際には効かなかった不整合**も解消。

## 変更
- **g m → 品目マスタ**（/items）、**g t → テンプレート**（/templates）
- **n（新規）**: /items→/items/new、/templates→/templates/new に対応
- **u（一覧へ戻る）**: LIST_ROOTS に /items・/templates を追加
- **? オーバーレイ**: 「品目マスタ g m」「テンプレート g t」を追記
- g m / g t / n の回帰テストを追加

## j/k 調査結果（別件のご報告）
「j/k のテーブル行移動が効かない気がする」を調査しました。**実際の ListItems を描画して `j` を押すとカーソルが row0→row1 と動く統合テストがパス**し、コード上は**全6一覧で正常動作**を確認（配線・CSS・dispatcher いずれも異常なし）。

実機で効かない場合に最も可能性が高いのは、**フィルタ検索欄などの入力欄にフォーカスがある状態**です。入力欄では単一キーのショートカット（j/k 等）は意図的に無効化される仕様（日本語入力・誤爆防止）のため、テーブル本体にフォーカスがある状態でお試しください。再現する具体的な画面・手順があれば追って深掘りします。

## 確認
- [x] type-check / lint / format / test（**204**）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)