### PR TITLE
fix(frontend): 閉じた DatePicker がTabフォーカスを奪う問題を修正 (#358)

### DIFF
--- a/frontend/src/shared/ui/components/DatePicker.test.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.test.tsx
@@ -71,4 +71,16 @@ describe('DatePicker', () => {
     expect(onChange).not.toHaveBeenCalled()
     expect(input.value).toBe('2026/06/15')
   })
+
+  it('keeps the closed calendar out of the tab order via inert (#358)', () => {
+    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
+    const pop = container.querySelector('.dp-pop') as HTMLElement
+
+    // Closed: inert so its ~45 buttons cannot trap Tab focus.
+    expect(pop.hasAttribute('inert')).toBe(true)
+
+    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
+    // Open: interactive again.
+    expect(pop.hasAttribute('inert')).toBe(false)
+  })
 })

--- a/frontend/src/shared/ui/components/DatePicker.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.tsx
@@ -199,6 +199,10 @@ export function DatePicker({
         ref={popRef}
         className={cn('dp-pop', flip.up && 'up', flip.right && 'right')}
         role="dialog"
+        // Closed popover stays in the DOM for the fade transition, but must be
+        // removed from the tab order / a11y tree — otherwise tabbing into a
+        // closed field is trapped in its ~45 hidden calendar buttons (#358).
+        inert={!open}
       >
         <div className="dp-head">
           <button


### PR DESCRIPTION
Closes #358

## 症状
一覧フィルタで `/` → 検索欄 → Tab と進むと、状態 → 有効期限(開始)のカレンダーアイコン まで行くが、その先の **有効期限(終了)へ進めず Tab がどこにも移動しない**（不可視の要素に吸い込まれる）。

## 原因
`DatePicker` は閉状態でも popup（`.dp-pop`）を常時 DOM に描画している。閉状態の CSS は `opacity: 0; pointer-events: none;` のみで `display:none` / `visibility:hidden` ではないため、popup 内の**約45個のボタン**（前月/翌月＋42日セル＋今日/クリア）が **Tab 順に残る**。閉じた日付欄に Tab で入るとその不可視ボタン群にフォーカスが吸い込まれ、次フィールドへ進めなくなっていた。

## 修正
閉状態の popup に **`inert`（React 19）** を付与し、Tab・クリック・支援技術（AT）の対象から除外。開いている時のみ操作可能。フェードのトランジションは従来どおり維持。

→ Tab 順が `検索 → 状態 → 有効期限(開始) → 有効期限(終了) → 最小 → 最大` と正しく通ります。

## 確認
- [x] type-check / lint / format / test（**205**）green（閉=inert / 開=非inert の回帰テスト追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)