### PR TITLE
fix(frontend): 取引先コンボボックスがIME変換中のキーを横取りする問題を修正 (#360)

### DIFF
--- a/frontend/src/shared/ui/components/ClientCombobox.test.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.test.tsx
@@ -118,6 +118,33 @@ describe('ClientCombobox', () => {
     expect(getByRole('option', { name: /Acme Foods/ })).toBeTruthy()
   })
 
+  it('ignores the IME conversion-confirm Enter, then acts on the committed Enter (#360)', () => {
+    const onChange = vi.fn()
+    const onCreate = vi.fn(() => Promise.resolve(99))
+    const { container } = renderWithProviders(
+      <ClientCombobox
+        id="c"
+        clients={CLIENTS}
+        value={0}
+        onChange={onChange}
+        onCreate={onCreate}
+        createLabel={(name) => `「${name}」を登録`}
+        createConfirmLabel="登録"
+      />,
+    )
+    const input = container.querySelector('#c') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '新規取引先' } })
+
+    // Enter that confirms the IME conversion (keyCode 229) must NOT open the
+    // create form — it belongs to the IME.
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })
+    expect(container.querySelector('.combo-createform')).toBeNull()
+
+    // The next Enter (composition done) opens the inline-create form.
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(container.querySelector('.combo-createform')).not.toBeNull()
+  })
+
   it('shows the selected client name when value is set', () => {
     const { container } = renderWithProviders(
       <ClientCombobox id="c" clients={CLIENTS} value={2} onChange={vi.fn()} />,

--- a/frontend/src/shared/ui/components/ClientCombobox.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.tsx
@@ -148,6 +148,14 @@ export function ClientCombobox({
   }
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    // Let the IME own keys while composing — the Enter that confirms a Japanese
+    // conversion (and ↑↓ that move candidates) must not be hijacked into picking
+    // a suggestion or opening the create form (#360). keyCode 229 is the legacy
+    // IME signal some browsers emit before isComposing flips, mirroring the
+    // global dispatcher's guard.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return
+
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       if (!open) {
@@ -177,6 +185,11 @@ export function ClientCombobox({
   }
 
   const onKanaKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    // Same IME guard as the name field: the conversion-confirming Enter on the
+    // furigana input must reach the IME, not trigger the create (#360).
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return
+
     if (e.key === 'Enter') {
       e.preventDefault()
       void runCreate()


### PR DESCRIPTION
Closes #360

## 症状
見積/請求の取引先入力でサジェストは出るが、**日本語入力（IME）変換中**に ↑↓ で候補選択が変えられず、「〇〇を新規取引先として登録」が出た後も入力の継続も新規登録もできず、マウスに持ち替えるしかなかった。

## 原因
`ClientCombobox` の `onKeyDown` / `onKanaKeyDown` に **IME 合成中ガードが無い**。IME 変換確定の Enter（`isComposing` / `keyCode === 229`）や変換候補移動の ↑↓ を combobox が横取りし、`preventDefault` ＋ 候補 pick / 作成モード移行を実行していた。グローバル dispatcher・DatePicker・line-grid には同ガードがあるが、combobox だけ抜けていた。

> jsdom/fireEvent は composition を再現しないため自動テストは緑（単体・dispatcher＋form 統合の手元検証でも矢印/Enter は動作）。**実機の日本語入力でのみ再現**。

## 修正
両ハンドラ先頭で `e.nativeEvent.isComposing || e.keyCode === 229` の時は早期 return（IME に委ねる）。既存の確立済みパターンに合わせた。

→ 変換確定の Enter は IME に通り、確定後の Enter / ↑↓ で候補選択・新規登録ができる。

## 確認
- [x] type-check / lint / format / test（**206**）green（keyCode 229 Enter で作成フォームを開かず、続く通常 Enter で開く回帰テストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)