### PR TITLE
fix(frontend): フォームでの u 誤遷移を防止＋検索欄を Esc で blur (#362)

### DIFF
--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -1,5 +1,5 @@
-import { act, fireEvent, waitFor } from '@testing-library/react'
-import { useLocation } from 'react-router-dom'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { KeyboardShortcuts } from './KeyboardShortcuts'
@@ -66,25 +66,57 @@ describe('KeyboardShortcuts', () => {
     })
   })
 
-  it('returns to the parent list with u', async () => {
-    const { getByTestId } = renderWithProviders(
-      <>
+  it('returns to the parent list with u from a detail view', () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/invoices/42']}>
         <KeyboardShortcuts />
         <LocationProbe />
-      </>,
+      </MemoryRouter>,
     )
 
-    fireEvent.keyDown(document.body, { key: 'g' })
-    fireEvent.keyDown(document.body, { key: 'i' })
-    fireEvent.keyDown(document.body, { key: 'n' })
-    await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/invoices/new')
-    })
+    fireEvent.keyDown(document.body, { key: 'u' })
+    expect(getByTestId('loc').textContent).toBe('/invoices')
+  })
+
+  it('does NOT leave a create/edit form on u (avoids losing input) (#362)', () => {
+    const { getByTestId } = render(
+      <MemoryRouter initialEntries={['/invoices/new']}>
+        <KeyboardShortcuts />
+        <LocationProbe />
+      </MemoryRouter>,
+    )
 
     fireEvent.keyDown(document.body, { key: 'u' })
-    await waitFor(() => {
-      expect(getByTestId('loc').textContent).toBe('/invoices')
-    })
+    expect(getByTestId('loc').textContent).toBe('/invoices/new')
+  })
+
+  it('blurs the search field on Esc so j/k work again (#362)', () => {
+    const { container } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <input data-kbd="search" />
+      </>,
+    )
+    const search = container.querySelector('[data-kbd="search"]') as HTMLInputElement
+    search.focus()
+    expect(document.activeElement).toBe(search)
+
+    fireEvent.keyDown(search, { key: 'Escape' })
+    expect(document.activeElement).not.toBe(search)
+  })
+
+  it('keeps focus on Esc while composing in the search field (IME cancel) (#362)', () => {
+    const { container } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <input data-kbd="search" />
+      </>,
+    )
+    const search = container.querySelector('[data-kbd="search"]') as HTMLInputElement
+    search.focus()
+
+    fireEvent.keyDown(search, { key: 'Escape', isComposing: true })
+    expect(document.activeElement).toBe(search)
   })
 
   it('opens the cheat-sheet via openShortcutsOverlay()', () => {

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -45,7 +45,14 @@ const LIST_ROOTS = [
   '/audit-logs',
 ]
 
+/**
+ * The parent list for `u` (back to list) — but only from a **detail** view, not
+ * a create/edit form. Firing `u` on `/new` or `/edit` would navigate away mid-edit
+ * and lose unsaved input (e.g. when focus sits on a form button), so forms opt out
+ * (#362). Detail routes like `/invoices/123` still resolve to their list.
+ */
 function parentListOf(path: string): string | null {
+  if (path.endsWith('/new') || path.endsWith('/edit')) return null
   return LIST_ROOTS.find((root) => path.startsWith(`${root}/`)) ?? null
 }
 
@@ -120,6 +127,16 @@ export function KeyboardShortcuts() {
       if (e.key === 'Escape') {
         if (overlayRef.current) setOverlayOpen(false)
         else if (pendingRef.current) clearPending()
+        // Esc leaves the search box (so j/k work again) without reaching for the
+        // mouse. Scoped to the search field only — combobox / date picker own
+        // their Esc — and skipped while composing, where Esc cancels the IME (#362).
+        else if (
+          !e.isComposing &&
+          e.target instanceof HTMLElement &&
+          e.target.matches('[data-kbd="search"]')
+        ) {
+          e.target.blur()
+        }
         return
       }
 


### PR DESCRIPTION
Closes #362

## 1. フォーム作成/編集中に `u` で一覧へ戻ってしまう
`u`（一覧へ戻る）は detail だけでなく作成/編集フォーム（`/{root}/new`・`/{root}/{id}/edit`）でも有効だったため、フォーム上でボタン等にフォーカスがある状態で `u` を押すと一覧へ遷移し、**入力中の内容を失うリスク**があった。

→ `parentListOf` がフォームパス（`/new`・`/edit`）では `null` を返すようにし、`u` を **detail ビュー専用**に。

## 2. `/` で検索にフォーカス後、キーボードで抜けられない
Esc で検索欄を blur できるようにした（→ 一覧に戻って j/k が使える）。

- 対象は検索欄（`[data-kbd="search"]`）に限定（combobox / DatePicker は各自の Esc 挙動があるため不干渉）
- **IME 変換中（`isComposing`）は対象外**（Esc は変換取消に使うため）— ご質問の「不都合」はこの一点で、ガード済み

## 確認
- [x] type-check / lint / format / test（**209**）green（detail の `u` / フォームでの `u` 無効 / 検索欄 Esc blur / IME 中 Esc 維持 の各テストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)