### PR TITLE
fix(frontend): Esc を全フォーム欄で blur 対象にする (#364)

### DIFF
--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -105,6 +105,25 @@ describe('KeyboardShortcuts', () => {
     expect(document.activeElement).not.toBe(search)
   })
 
+  it('blurs any focused form field on Esc, not just search (#364)', () => {
+    const { container } = renderWithProviders(
+      <>
+        <KeyboardShortcuts />
+        <input id="plain" />
+        <textarea id="notes" />
+      </>,
+    )
+    const plain = container.querySelector('#plain') as HTMLInputElement
+    plain.focus()
+    fireEvent.keyDown(plain, { key: 'Escape' })
+    expect(document.activeElement).not.toBe(plain)
+
+    const notes = container.querySelector('#notes') as HTMLTextAreaElement
+    notes.focus()
+    fireEvent.keyDown(notes, { key: 'Escape' })
+    expect(document.activeElement).not.toBe(notes)
+  })
+
   it('keeps focus on Esc while composing in the search field (IME cancel) (#362)', () => {
     const { container } = renderWithProviders(
       <>

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -127,15 +127,13 @@ export function KeyboardShortcuts() {
       if (e.key === 'Escape') {
         if (overlayRef.current) setOverlayOpen(false)
         else if (pendingRef.current) clearPending()
-        // Esc leaves the search box (so j/k work again) without reaching for the
-        // mouse. Scoped to the search field only — combobox / date picker own
-        // their Esc — and skipped while composing, where Esc cancels the IME (#362).
-        else if (
-          !e.isComposing &&
-          e.target instanceof HTMLElement &&
-          e.target.matches('[data-kbd="search"]')
-        ) {
-          e.target.blur()
+        // Esc leaves any focused form field so navigation shortcuts work again
+        // without reaching for the mouse (single keys are suppressed while a field
+        // is focused — #364). Skipped while composing, where Esc cancels the IME.
+        // Combobox / date picker also close their popups on Esc (they don't stop
+        // propagation), so an open one closes and blurs together — fine.
+        else if (!e.isComposing && isEditableTarget(e.target)) {
+          ;(e.target as HTMLElement).blur()
         }
         return
       }


### PR DESCRIPTION
Closes #364

## 背景
#362 の Esc-blur は対象が検索欄（`[data-kbd="search"]`）限定だった。フォーム欄（取引先・有効期限・備考・明細など）にフォーカスがあると、入力欄では単一キーが無効化される仕様と相まって **「フォームにフォーカスがあるとショートカット遷移ができない」** 状態で、Esc でも抜けられなかった。

## 修正
dispatcher の Esc-blur 対象を **`isEditableTarget`（input / textarea / select / contenteditable）すべて** に拡大。→ 任意のフォーム欄で **Esc → blur → `g` 遷移等が即使える**。

- **IME 変換中（`isComposing`）は対象外**（Esc は変換取消）
- combobox / DatePicker は開いている時 Esc を自前で `preventDefault` するが `stopPropagation` しないため、開いていれば「ポップアップを閉じる＋blur」の一括動作（閉じていれば blur のみ）。Esc の独自挙動は壊れない。

## 確認
- [x] type-check / lint / format / test（**210**）green（data-kbd 無しの input / textarea が Esc で blur する回帰テストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)