### PR TITLE
feat(frontend): 取引先サジェストの先頭自動選択をやめ ↑↓で明示選択に (#366)

### DIFF
--- a/frontend/src/shared/ui/components/ClientCombobox.test.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.test.tsx
@@ -135,14 +135,40 @@ describe('ClientCombobox', () => {
     const input = container.querySelector('#c') as HTMLInputElement
     fireEvent.change(input, { target: { value: '新規取引先' } })
 
-    // Enter that confirms the IME conversion (keyCode 229) must NOT open the
-    // create form — it belongs to the IME.
+    // Enter that confirms the IME conversion (keyCode 229) must NOT act — it
+    // belongs to the IME.
     fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })
     expect(container.querySelector('.combo-createform')).toBeNull()
 
-    // The next Enter (composition done) opens the inline-create form.
+    // Nothing is auto-highlighted (#366): the committed Enter alone does nothing.
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(container.querySelector('.combo-createform')).toBeNull()
+
+    // Move to the create row with ↓, then Enter opens the inline-create form.
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
     fireEvent.keyDown(input, { key: 'Enter' })
     expect(container.querySelector('.combo-createform')).not.toBeNull()
+  })
+
+  it('does not auto-highlight a suggestion; ↓ enters the list, Enter picks (#366)', () => {
+    const onChange = vi.fn()
+    const { container } = renderWithProviders(
+      <ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />,
+    )
+    const input = container.querySelector('#c') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'a' } }) // matches Acme Foods
+
+    // Suggestions are shown but nothing is highlighted — the field keeps the cursor.
+    expect(container.querySelector('.combo-opt.hl')).toBeNull()
+    // A bare Enter does not pick anything.
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).not.toHaveBeenCalled()
+
+    // ↓ highlights the first suggestion, Enter picks it.
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(container.querySelector('.combo-opt.hl')).not.toBeNull()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith(2)
   })
 
   it('shows the selected client name when value is set', () => {

--- a/frontend/src/shared/ui/components/ClientCombobox.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.tsx
@@ -79,7 +79,10 @@ export function ClientCombobox({
   }
 
   const [open, setOpen] = useState(false)
-  const [highlight, setHighlight] = useState(0)
+  // -1 = nothing highlighted: suggestions appear but the field keeps the "cursor",
+  // so a user who knows their text isn't in the list is never auto-committed to a
+  // suggestion. ↑↓ move into the list explicitly (#366).
+  const [highlight, setHighlight] = useState(-1)
   const [creating, setCreating] = useState(false)
   // Inline-create sub-form (name is the typed text; capture an optional reading).
   const [createMode, setCreateMode] = useState(false)
@@ -166,10 +169,12 @@ export function ClientCombobox({
       }
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
-      setHighlight((h) => Math.max(h - 1, 0))
+      // Down to -1 returns to the field with nothing selected.
+      setHighlight((h) => Math.max(h - 1, -1))
     } else if (e.key === 'Enter') {
       e.preventDefault() // never submit the surrounding form
-      if (!open) return
+      // Nothing highlighted → let the user keep typing; never auto-pick / auto-create.
+      if (!open || highlight < 0) return
       if (highlight < matches.length) {
         const m = matches[highlight]
         if (m !== undefined) pick(m)
@@ -225,7 +230,7 @@ export function ClientCombobox({
         onChange={(e) => {
           setText(e.target.value)
           setOpen(true)
-          setHighlight(0)
+          setHighlight(-1)
           resetCreate()
           onQueryChange?.(e.target.value)
         }}


### PR DESCRIPTION
Closes #366

## 要望
取引先サジェストが出ると先頭候補が自動でハイライト（選択状態）になり、目的の候補が無いと分かって入力している時に Enter で先頭を拾ってしまい邪魔。サジェストが出ても**フォーカス（選択）はフォームのまま**にし、**↑↓ で明示的に**サジェストへ入りたい。

## 変更
- `highlight` の初期値／入力変更時を **-1（未選択）** に。サジェストは表示されるがどの候補もハイライトされず、フィールドにカーソルが残る。
- **↑↓ で初めてリストへ入る**（ArrowDown: -1→0、ArrowUp は -1 まで戻れる＝未選択へ）。
- **Enter は何も選択されていない（highlight<0）時は何もしない**（誤確定・誤作成を防止）。新規登録行も ↓ で選んでから Enter。
- マウス hover の一時ハイライト、IME ガード（#360）は維持。

## 確認
- [x] type-check / lint / format / test（**211**）green（自動ハイライトされない／↓で入って Enter で確定、の回帰テスト追加。IME テストは新挙動に更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)