### PR TITLE
fix(frontend): 取引先検索でキー変更ごとに入力欄が無効化される問題を修正 (#368)

### DIFF
--- a/frontend/src/entities/client/queries.test.ts
+++ b/frontend/src/entities/client/queries.test.ts
@@ -1,0 +1,44 @@
+import { act, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useClientList } from './queries'
+
+/**
+ * The client picker drives a per-keystroke server search, so the query key
+ * changes on every character. Without `placeholderData: keepPreviousData` the
+ * status flips to 'pending' on each change, which disabled the picker input
+ * mid-typing (#368). This pins that the status stays settled across key changes.
+ */
+function useProbe() {
+  const [q, setQ] = useState<string | null>(null)
+  const query = useClientList({
+    limit: 100,
+    offset: 0,
+    filters: { q },
+    sort: { field: null, order: 'asc' },
+  })
+  return { setQ, query }
+}
+
+describe('useClientList', () => {
+  it('does not return to isPending when the search query changes (#368)', async () => {
+    const { result } = renderHookWithProviders(() => useProbe())
+
+    await waitFor(() => {
+      expect(result.current.query.isPending).toBe(false)
+    })
+
+    // Changing the query key (a keystroke) must not flip back to pending —
+    // keepPreviousData holds the prior page while the new one loads.
+    act(() => {
+      result.current.setQ('c')
+    })
+    expect(result.current.query.isPending).toBe(false)
+
+    act(() => {
+      result.current.setQ('cr')
+    })
+    expect(result.current.query.isPending).toBe(false)
+  })
+})

--- a/frontend/src/entities/client/queries.ts
+++ b/frontend/src/entities/client/queries.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { keepPreviousData, useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { apiClient } from '@/shared/api/client'
 import type { AppError } from '@/shared/api/errors'
 import type { ClientDto, ClientListDto } from './api-types'
@@ -11,6 +11,11 @@ import { clientKeys, type ClientListParams } from './query-keys'
 export function useClientList(params: ClientListParams): UseQueryResult<ClientPage, AppError> {
   return useQuery<ClientPage, AppError>({
     queryKey: clientKeys.list(params),
+    // Keep the previous page while a new query (e.g. the combobox's per-keystroke
+    // server search) loads, so status stays 'success' instead of flipping to
+    // 'pending'. Without this, `isPending` toggling true on every keystroke
+    // disabled the client picker input mid-typing (#368).
+    placeholderData: keepPreviousData,
     queryFn: async () => {
       const search = new URLSearchParams({
         limit: String(params.limit),


### PR DESCRIPTION
Closes #368

## 症状
請求書/見積の取引先入力で英字（例: `crud`）を打つと、最初の「c」でサジェストが出た後、**それ以降の文字が入力できない**。

## 原因
`useClientList`（逐次サーバー検索）に `placeholderData` が無いため、入力ごとに `q` が変わってクエリキーが変わるたび **status='pending'（`isPending=true`）** になる。これが `clientsLoading = clientList.isPending` → ClientCombobox の `disabled={loading}` に伝わり、**1文字打つたびに入力欄が `disabled` 化**してフォーカスを失い、以降のキーが落ちていた。

## 修正
`useClientList` に **`placeholderData: keepPreviousData`** を付与。クエリキーが変わっても直前ページを保持して status は success のまま（`isFetching` のみ true）になり、初回ロード以後は `isPending` が true にならず入力欄が無効化されない。一覧フィルタのちらつき低減にも有効。

## 確認
- [x] lint / format / test（**212**）green（検索クエリ変更後も `isPending=false` を保つ回帰テストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)