### PR TITLE
fix(frontend): u（一覧へ戻る）を作成/編集フォームでも有効化 (#374)

### DIFF
--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -78,16 +78,31 @@ describe('KeyboardShortcuts', () => {
     expect(getByTestId('loc').textContent).toBe('/invoices')
   })
 
-  it('does NOT leave a create/edit form on u (avoids losing input) (#362)', () => {
+  it('returns to the parent list with u from an edit form when no field is focused (#374)', () => {
     const { getByTestId } = render(
-      <MemoryRouter initialEntries={['/invoices/new']}>
+      <MemoryRouter initialEntries={['/clients/42/edit']}>
         <KeyboardShortcuts />
         <LocationProbe />
       </MemoryRouter>,
     )
 
     fireEvent.keyDown(document.body, { key: 'u' })
-    expect(getByTestId('loc').textContent).toBe('/invoices/new')
+    expect(getByTestId('loc').textContent).toBe('/clients')
+  })
+
+  it('does not fire u while a form field is focused (typing wins) (#374)', () => {
+    const { getByTestId, container } = render(
+      <MemoryRouter initialEntries={['/clients/42/edit']}>
+        <KeyboardShortcuts />
+        <LocationProbe />
+        <input data-testid="field" />
+      </MemoryRouter>,
+    )
+    const field = container.querySelector('[data-testid="field"]') as HTMLInputElement
+    field.focus()
+
+    fireEvent.keyDown(field, { key: 'u' })
+    expect(getByTestId('loc').textContent).toBe('/clients/42/edit')
   })
 
   it('blurs the search field on Esc so j/k work again (#362)', () => {

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.tsx
@@ -47,13 +47,13 @@ const LIST_ROOTS = [
 ]
 
 /**
- * The parent list for `u` (back to list) — but only from a **detail** view, not
- * a create/edit form. Firing `u` on `/new` or `/edit` would navigate away mid-edit
- * and lose unsaved input (e.g. when focus sits on a form button), so forms opt out
- * (#362). Detail routes like `/invoices/123` still resolve to their list.
+ * The parent list for `u` (back to list), from detail / create / edit views.
+ * Whether `u` fires at all is left to the editable-field guard: while a form
+ * field is focused, single keys (incl. `u`) never fire, so it can't steal typed
+ * input; once focus leaves the field (e.g. via Esc, #364), `u` returns to the
+ * list — including from an edit form (#374).
  */
 function parentListOf(path: string): string | null {
-  if (path.endsWith('/new') || path.endsWith('/edit')) return null
   return LIST_ROOTS.find((root) => path.startsWith(`${root}/`)) ?? null
 }
 


### PR DESCRIPTION
Closes #374

## 症状
取引先の編集画面（`/clients/{id}/edit`）で `u` を押しても一覧に戻れない。

## 原因
#362 で「入力中の誤遷移＝データ消失」を防ぐため `parentListOf` が `/new`・`/edit` で `null` を返し、フォームページ全体で `u` を無効化していた。だが**入力欄にフォーカスがある間は元々 `isEditableTarget` ガードで単一キー（`u` 含む）は発火しない**。よってフォーム全体での無効化は過剰で、欄から外れている時すら編集画面から戻れなくなっていた。

## 修正
`parentListOf` の `/new`・`/edit` 除外を撤回。`u` は詳細・作成・編集いずれでも有効にし、発火可否は `isEditableTarget` ガードに一任する。

- フォーム欄を編集中 → `u` は文字入力を奪わない（発火しない）
- 欄から外れている → `u` で一覧へ戻る（編集画面からも）
- `Esc` で欄を blur できる（#364）ので「入力 → Esc → u」で安全に戻れる

> データ消失が気になる場合の本来の対策は「未保存変更ガード（beforeunload / route guard）」で、`u` 無効化は手段として過剰でした。必要なら別途対応します。

## 確認
- [x] type-check / lint / format / test（**216**）green（編集フォームで欄非フォーカス時 `u`→一覧／欄フォーカス中は `u` 不発、の回帰テストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)