### PR TITLE
fix(frontend): 一覧のホバー色を中立にし選択カーソルと分離 (#376)

### DIFF
--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -103,8 +103,11 @@
   .data-table tbody tr:nth-child(even) {
     background: var(--color-surface-overlay);
   }
+  /* Hover is a neutral tint — the accent-soft green is reserved for the keyboard
+     row cursor (.is-cursor), so a hovered row never reads as a selection (e.g. the
+     stationary pointer landing on a row after the in-place login swap). */
   .data-table tbody tr:hover {
-    background: var(--color-accent-soft);
+    background: var(--color-neutral-soft);
   }
 
   /* Case C — square status badge */


### PR DESCRIPTION
Closes #376

## 症状
アイドルでログイン画面に戻され、再ログインで前回の一覧が表示された直後、**選択していない行が緑**に見える。

## 原因
`AuthGate` はトークン失効時に同じ画面位置へ `LoginPage` を差し替え、ログイン成功でその場にアプリ＋前回URLの一覧を戻す（URL据え置き）。マウスで「ログイン」を押すと**ポインタが止まったまま**画面が一覧に差し替わり、ポインタ直下の行に CSS `:hover` が当たる（マウス移動不要）。

その `.data-table tbody tr:hover` の背景が `--color-accent-soft`（緑）で、**キーボード行カーソル `.is-cursor` と同色**だったため、ホバー行が「選択」のように見えていた（行カーソルは未選択=-1）。

## 修正
`tr:hover` の背景を中立色 **`--color-neutral-soft`** に変更。緑（accent-soft＋左アクセント罫）は `.is-cursor`（キーボード選択行）専用にし、ホバーと選択を視覚的に分離。モバイルのカード表示は従来どおりホバー透明。

## 確認
- [x] format / test（**216**）green（CSS のみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)