### PR TITLE
docs: CSVインポートの設計方針を ADR 0011 ＋設計メモとして策定 (#384)

### DIFF
--- a/docs/adr/0011-csv-import-template-only.md
+++ b/docs/adr/0011-csv-import-template-only.md
@@ -1,0 +1,113 @@
+# ADR 0011: CSV import is template-only, fully re-validated, with stated reasons
+
+## Status
+
+proposed
+
+## Context
+
+We ship CSV **export** for clients, quotes, invoices, payments, and the audit log
+(#378 / #379 / #382). The next request is CSV **import** — bulk-loading master
+data, primarily clients (取引先) and items (品目マスタ), e.g. when onboarding or
+migrating from another tool.
+
+Import is fundamentally harder and riskier than export, and the risk is partly
+a **compliance** risk (binding per CLAUDE.md and
+`docs/explanation/accounting-compliance.md`):
+
+- **Content validity is statutory.** A client's `registration_number` must be
+  `T` + 13 digits; a bad value flows into qualified-invoice PDFs. Import must not
+  weaken the validation that `CreateClient` / `CreateItem` already enforce.
+- **Arbitrary-file parsing is unbounded.** Column mapping, column order, extra
+  or missing columns, header synonyms, and locale-specific Excel quirks make
+  "intelligently interpret any CSV" an open-ended, error-prone problem.
+- **Encoding.** Excel on Windows frequently re-saves CSV as Shift_JIS; silently
+  guessing the encoding risks corrupting names/addresses.
+- **Failure semantics & dedup.** What happens on a partially-invalid file? How do
+  we tell "create a new record" from "update an existing one"?
+
+Trying to accept any CSV multiplies all of the above. We would rather constrain
+the input than build a fragile heuristic importer.
+
+## Decision
+
+Adopt a **template-only** import model with explicit, stated rejection reasons.
+
+1. **Template-only intake.** The system accepts only files that match a template
+   it distributes. The user must **download the template, add rows to that exact
+   structure, and upload it**. Anything else is rejected.
+
+2. **Two-layer acceptance, both with stated reasons** — and the content layer is
+   never bypassed:
+   - **① Format gate (per file).** Reject unless the header row matches the
+     template **exactly** (column names and order), the template **version**
+     matches, and the file is **UTF-8**. The rejection message names the precise
+     cause (e.g. unknown column `電話`, wrong/missing version, non-UTF-8).
+   - **② Content validation (per row).** Every row is validated through the
+     **same UseCase** as interactive creation/update (`CreateClient` /
+     `CreateItem` rules, including `registration_number` = T+13 digits). No
+     import-only "lenient" path exists. Each invalid row is reported with its
+     line number and reason.
+
+3. **`id` column drives create vs. update.** The template includes an `id`
+   column: **blank = create, present = update an existing record** (scoped to the
+   caller's organization, ADR 0006). Because exports already carry the `id`, an
+   exported CSV round-trips: export → edit → import updates in place; new rows
+   leave `id` blank. For v1, an update is a **full overwrite** of the editable
+   columns (a blank optional cell clears that field); required columns must be
+   non-empty.
+
+4. **All-or-nothing with a row-level error report.** Validate the whole file
+   first; if **any** row fails, write **nothing** and return a per-row error
+   report (a dry-run preview is the same code path). This keeps the master data
+   consistent and makes fixes obvious.
+
+5. **UTF-8 only.** The template is UTF-8 (BOM). Non-UTF-8 input is rejected with
+   an explicit "save as UTF-8" reason plus help, rather than guessed.
+
+6. **Audited.** Bulk create/update is recorded in the audit log (ADR 0008).
+
+7. **Scope.** Import covers **clients (取引先) and items (品目マスタ) only.**
+   Invoices and quotes are **out of scope** — they involve numbering (採番),
+   revenue timing (計上), and qualified-invoice rules that must not be bulk-loaded
+   from a spreadsheet.
+
+## Consequences
+
+**Benefits**
+- The input space is **bounded and verifiable**: we accept exactly one known
+  shape and re-validate every value, so import cannot become a backdoor around
+  the compliance rules.
+- **Export ↔ import round-trip** via the shared `id` column gives a natural
+  edit-in-Excel workflow and removes the dedup/matching ambiguity.
+- Failures are **legible**: the user always gets a concrete reason (file-level or
+  row-level), satisfying the "state the reason" policy.
+
+**Costs / trade-offs**
+- Users **must** start from our template; free-form CSVs are rejected. This is a
+  deliberate friction trade for safety and is mitigated by a one-click template
+  download and clear messaging.
+- Encoding friction is reduced but not eliminated (Excel re-saving); we mitigate
+  with explicit rejection + help, not silent conversion.
+- Template **versioning** is required so the format can evolve (a `__template`
+  marker column pins `clients/v1`, `items/v1`).
+
+**Follow-up work** (separate implementation epic, governed by this ADR)
+- Template definitions, format-gate spec, and error-report shape:
+  `docs/explanation/csv-import-design.md`.
+- New endpoints/operationIds (e.g. `importClientsCsv`, `importItemsCsv`,
+  `getClientsImportTemplate`) to be added to the OpenAPI spec, the contract test,
+  and the terminology registry **when implemented** (not before).
+- Decide the v2 question of partial-update ("blank = clear" vs "blank = leave
+  unchanged") if the full-overwrite v1 semantics prove insufficient.
+- No tax-rule change is introduced; import reuses existing validation. If a
+  future template touches statutory fields beyond what `CreateClient` /
+  `CreateItem` already validate, that change needs 税理士 confirmation per
+  CLAUDE.md.
+
+## Related
+
+- Issue: `#384`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/explanation/csv-import-design.md
+++ b/docs/explanation/csv-import-design.md
@@ -1,0 +1,141 @@
+# CSV import — design (template-only)
+
+> Governed by [ADR 0011](../adr/0011-csv-import-template-only.md). This document
+> specifies the templates, the format gate, the error report, and the
+> create/update semantics. **Not yet implemented** — it defines the contract a
+> future implementation epic must follow.
+
+Scope: **clients (取引先)** and **items (品目マスタ)** only. Invoices and quotes
+are out of scope (numbering / 計上 / qualified-invoice rules).
+
+---
+
+## 1. Principles (recap)
+
+1. Accept **only** a file produced from our template (download → add rows →
+   upload). Reject anything else **with a stated reason**.
+2. Acceptance is two layers, both giving reasons; the content layer is never
+   skipped:
+   - **① format gate** (per file) — header + version + encoding.
+   - **② content validation** (per row) — the *same* UseCase validation as
+     interactive create/update.
+3. `id` column: **blank = create, present = update**. Exported CSV round-trips.
+4. **All-or-nothing**: validate everything first; on any error, write nothing and
+   return a per-row report. Dry-run is the same path.
+
+---
+
+## 2. Format gate (① — per file)
+
+A file is rejected before any row is processed unless **all** hold. Each failure
+yields a specific, user-facing reason.
+
+| Check | Rule | Example rejection reason |
+| --- | --- | --- |
+| Encoding | Must be UTF-8 (BOM optional) | 「ファイルが UTF-8 ではありません。テンプレートを UTF-8 で保存し直してください。」 |
+| Version marker | First column is `__template` with value `clients/v1` (or `items/v1`) | 「テンプレートのバージョンが一致しません（期待: clients/v1、検出: なし）。最新テンプレートをダウンロードしてください。」 |
+| Header exact match | Header row equals the template header **exactly** (names + order), after the version column | 「不明な列『電話』があります。テンプレート以外の列は追加できません。」 / 「列『登録番号』が見つかりません。」 |
+| Row width | Every data row has the same column count as the header | 「8行目: 列数がヘッダーと一致しません。」 |
+
+The `__template` marker is a real column (not a comment line) so Excel does not
+mangle it; it pins the version and lets the format evolve (`clients/v2` …).
+
+---
+
+## 3. Templates (v1)
+
+Money is integer yen on screen but stored as **cents**; tax rate is shown as a
+**percent** in the sheet and converted to **basis points** internally
+(10 → 1000 bps, 8 → 800 bps). Empty optional cells are allowed; required cells
+must be non-empty.
+
+### 3.1 clients/v1
+
+| Column | Required | Maps to | Validation |
+| --- | --- | --- | --- |
+| `__template` | yes | — | literal `clients/v1` |
+| `id` | no | `clients.id` | blank = create; if present, an existing **own-org** client id |
+| `取引先名` | yes | `name` | non-empty |
+| `カナ` | no | `name_kana` | — |
+| `担当者` | no | `contact_name` | — |
+| `メール` | no | `email` | email format if present |
+| `請求先住所` | no | `billing_address` | — |
+| `登録番号` | no | `registration_number` | if present, `T` + 13 digits (same rule as CreateClient) |
+
+### 3.2 items/v1
+
+| Column | Required | Maps to | Validation |
+| --- | --- | --- | --- |
+| `__template` | yes | — | literal `items/v1` |
+| `id` | no | `items.id` | blank = create; if present, an existing **own-org** item id |
+| `品目名` | yes | `description` | non-empty |
+| `標準単価` | yes | `default_unit_price_cents` | integer yen ≥ 0 → ×100 to cents |
+| `標準税率` | yes | `default_tax_rate_bps` | one of `10` or `8` (percent) → 1000 / 800 bps |
+
+> Note: clients export today does **not** emit `id` / `__template`. To make
+> export ↔ import round-trip, the export must be extended to emit those columns
+> (follow-up in the implementation epic). Items have no export yet; it would be
+> added alongside import.
+
+---
+
+## 4. Create / update semantics
+
+- `id` **blank** → **create** a new record (org forced from the holder, ADR 0006).
+- `id` **present** → **update** the existing record in the caller's org. For v1
+  this is a **full overwrite** of the editable columns: a blank optional cell
+  **clears** that field; required columns must be non-empty. (A future v2 may add
+  "blank = leave unchanged" semantics if needed.)
+- An `id` that does not exist in the caller's org is a **row error** (not a
+  silent create), so a typo'd id cannot fork the data.
+
+---
+
+## 5. Content validation & error report (② — per row)
+
+Every row is run through the same validation the interactive UseCase uses; there
+is no lenient import path. The whole file is validated first.
+
+- **All valid** → apply all rows in one transaction; return a summary
+  (`created`, `updated` counts).
+- **Any invalid** → apply **nothing**; return a row-level report.
+
+Error report shape (illustrative):
+
+```json
+{
+  "accepted": false,
+  "summary": { "rows": 50, "created": 0, "updated": 0, "errors": 2 },
+  "errors": [
+    { "row": 12, "column": "登録番号", "code": "invalid_registration_number",
+      "message": "登録番号は T+13桁である必要があります。" },
+    { "row": 31, "column": "取引先名", "code": "required",
+      "message": "取引先名は必須です。" }
+  ]
+}
+```
+
+`row` is the 1-based spreadsheet row (header = row 1, first data row = row 2) so
+the user can jump straight to the cell. Codes reuse the existing
+snake_case validation codes (see `docs/explanation/terminology.md` §4).
+
+---
+
+## 6. Endpoints / naming (when implemented)
+
+To be registered in OpenAPI, `OpenApiContractTest`, and the terminology registry
+**at implementation time, not before**:
+
+- `getClientsImportTemplate` — `GET /admin/clients/import-template` (download).
+- `importClientsCsv` — `POST /admin/clients/import` (multipart upload).
+- `getItemsImportTemplate` / `importItemsCsv` — items equivalents.
+- A `?dry_run=1` parameter returns the same report without writing.
+
+---
+
+## 7. Out of scope
+
+- Invoices / quotes import (numbering, 計上 timing, qualified-invoice rules).
+- Encoding auto-detection / Shift_JIS conversion (rejected with a reason instead).
+- Any relaxation of statutory validation. A template that touched statutory
+  fields beyond current validation would require 税理士 confirmation (CLAUDE.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,7 +72,8 @@ Goal: Japan SMB install path.
 
 Goal: connect to sibling products.
 
-- CSV export (invoices, payments, audit) ✅
+- CSV export (clients, quotes, invoices, payments, audit; list-filter aware; formula-injection safe) ✅
+- CSV import (template-only, clients + items) — design first, see ADR 0011 / `explanation/csv-import-design.md`
 - NeNe Records product catalog import
 - NeNe Concierge lead → draft client / quote webhook
 - MCP tool catalog


### PR DESCRIPTION
Closes #384

## 概要
CSV インポートを実装する前に、設計を **ADR 0011 ＋設計メモ**として確定。**ドキュメントのみ**（コード・実装なし）。

## 追加ドキュメント
- `docs/adr/0011-csv-import-template-only.md` — 決定（proposed）
- `docs/explanation/csv-import-design.md` — テンプレ列定義・形式ゲート・エラーレポート仕様
- `docs/roadmap.md` — エクスポート現状の反映＋インポート（設計先行）の行を追加

## 決定の骨子
1. **テンプレート限定**インポート（download → 行追加 → upload 以外は受理しない）。
2. **2層で理由明記**：①形式ゲート（ヘッダー完全一致＋`__template`バージョン＋UTF-8）②内容検証（CreateXxx と同一 UseCase 検証。検証バイパス無し）。
3. **`id` 列で create/update**（空=新規/値あり=更新）。エクスポートCSVが往復可能。
4. **UTF-8限定・all-or-nothing＋行別エラーレポート・監査記録**。
5. **対象＝取引先・品目マスタのみ**。請求書/見積は対象外。

## 非対象
- 実装（本ADRに従って別エピックで着手。実装時に operationId を OpenAPI/契約テスト/用語レジストリへ追加）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)