### PR TITLE
feat(backend): PostgreSQL 対応 — リポジトリSQLの方言非依存化 (#396)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ BASE_DOMAIN=localhost
 NENE2_LOCAL_JWT_SECRET=
 
 # --- Database (host / PHPUnit default: SQLite) ---
+# DB_ADAPTER: sqlite | mysql | pgsql （3アダプタ対応 — repository SQL は方言非依存）
 DB_ADAPTER=sqlite
 DB_NAME=var/nene_invoice.sqlite
 DB_HOST=127.0.0.1

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,3 +45,87 @@ jobs:
 
       - name: Run checks
         run: composer check
+
+  # Runs the repository SQL against the real production engines (MySQL +
+  # PostgreSQL — issue #396). SQLite cannot catch PG's strict boolean typing, so
+  # this is what guards the dialect-portable SQL from regressing.
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: nene_invoice_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: nene_invoice_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_sqlite, pdo_mysql, pdo_pgsql
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Apply schema (MySQL via Phinx)
+        env:
+          APP_ENV: test
+          DB_ADAPTER: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: '3306'
+          DB_NAME: nene_invoice_test
+          DB_USER: root
+          DB_PASSWORD: root
+          DB_CHARSET: utf8mb4
+        run: php vendor/bin/phinx migrate -c phinx.php
+
+      - name: Apply schema (PostgreSQL via Phinx)
+        env:
+          APP_ENV: test
+          DB_ADAPTER: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: '5432'
+          DB_NAME: nene_invoice_test
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+          DB_CHARSET: utf8
+        run: php vendor/bin/phinx migrate -c phinx.php
+
+      - name: Integration tests (MySQL + PostgreSQL)
+        env:
+          MYSQL_TEST_HOST: 127.0.0.1
+          MYSQL_TEST_PORT: '3306'
+          MYSQL_TEST_DB: nene_invoice_test
+          MYSQL_TEST_USER: root
+          MYSQL_TEST_PASSWORD: root
+          PGSQL_TEST_HOST: 127.0.0.1
+          PGSQL_TEST_PORT: '5432'
+          PGSQL_TEST_DB: nene_invoice_test
+          PGSQL_TEST_USER: postgres
+          PGSQL_TEST_PASSWORD: postgres
+        run: composer test:integration

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "scripts": {
         "test": "phpunit --testsuite NeneInvoice",
+        "test:integration": "phpunit --testsuite integration",
         "analyse": "phpstan analyse --memory-limit 512M",
         "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,10 @@
   <testsuites>
     <testsuite name="NeneInvoice">
       <directory>tests</directory>
+      <exclude>tests/Integration</exclude>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>tests/Integration</directory>
     </testsuite>
   </testsuites>
   <source>

--- a/src/Client/PdoClientRepository.php
+++ b/src/Client/PdoClientRepository.php
@@ -24,7 +24,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
     public function findById(int $id): ?Client
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM clients WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM clients WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$id, $this->orgId->get()],
         );
 
@@ -63,14 +63,14 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
      */
     private function buildAdminWhere(ClientListFilter $filter): array
     {
-        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        $clauses = ['organization_id = ?', 'is_deleted = FALSE'];
         /** @var list<int|string> $params */
         $params = [$this->orgId->get()];
 
         if ($filter->search !== null) {
-            $clauses[] = "(name LIKE ? ESCAPE '!' OR name_kana LIKE ? ESCAPE '!'"
-                . " OR contact_name LIKE ? ESCAPE '!'"
-                . " OR email LIKE ? ESCAPE '!' OR registration_number LIKE ? ESCAPE '!')";
+            $clauses[] = "(LOWER(name) LIKE LOWER(?) ESCAPE '!' OR LOWER(name_kana) LIKE LOWER(?) ESCAPE '!'"
+                . " OR LOWER(contact_name) LIKE LOWER(?) ESCAPE '!'"
+                . " OR LOWER(email) LIKE LOWER(?) ESCAPE '!' OR LOWER(registration_number) LIKE LOWER(?) ESCAPE '!')";
             $like = '%' . SqlLike::escape($filter->search) . '%';
             $params[] = $like;
             $params[] = $like;
@@ -121,7 +121,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         // the entity — a write always lands in the caller's resolved org.
         $this->query->execute(
             'INSERT INTO clients (organization_id, name, name_kana, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, ?, ?, ?, ?, FALSE, ?, ?)',
             [
                 $this->orgId->get(),
                 $client->name,
@@ -147,7 +147,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE clients SET name = ?, name_kana = ?, contact_name = ?, email = ?, billing_address = ?, registration_number = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE clients SET name = ?, name_kana = ?, contact_name = ?, email = ?, billing_address = ?, registration_number = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [
                 $client->name,
                 $client->nameKana,
@@ -173,7 +173,7 @@ final readonly class PdoClientRepository implements ClientRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE clients SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE clients SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
             [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -24,7 +24,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     public function findById(int $id): ?Invoice
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$id, $this->orgId->get()],
         );
 
@@ -34,7 +34,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     public function existsForQuote(int $quoteId): bool
     {
         $row = $this->query->fetchOne(
-            'SELECT 1 AS hit FROM invoices WHERE quote_id = ? AND organization_id = ? AND is_deleted = 0 LIMIT 1',
+            'SELECT 1 AS hit FROM invoices WHERE quote_id = ? AND organization_id = ? AND is_deleted = FALSE LIMIT 1',
             [$quoteId, $this->orgId->get()],
         );
 
@@ -45,7 +45,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC LIMIT ? OFFSET ?',
+            'SELECT ' . self::COLUMNS . ' FROM invoices WHERE organization_id = ? AND is_deleted = FALSE ORDER BY id DESC LIMIT ? OFFSET ?',
             [$this->orgId->get(), $limit, $offset],
         );
 
@@ -55,7 +55,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
     public function count(): int
     {
         $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM invoices WHERE organization_id = ? AND is_deleted = 0',
+            'SELECT COUNT(*) AS cnt FROM invoices WHERE organization_id = ? AND is_deleted = FALSE',
             [$this->orgId->get()],
         );
 
@@ -99,7 +99,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
                     i.total_cents, i.notes, i.is_deleted, i.created_at, i.updated_at,
                     COALESCE(c.name, \'\') AS client_name
              FROM invoices i
-             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = FALSE
              WHERE ' . $where . '
              ORDER BY ' . self::orderByClause($sort) . '
              LIMIT ? OFFSET ?',
@@ -122,7 +122,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt
              FROM invoices i
-             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = FALSE
              WHERE ' . $where,
             $params,
         );
@@ -138,7 +138,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
      */
     private function buildAdminWhere(InvoiceListFilter $filter): array
     {
-        $clauses = ['i.organization_id = ?', 'i.is_deleted = 0'];
+        $clauses = ['i.organization_id = ?', 'i.is_deleted = FALSE'];
         /** @var list<int|string> $params */
         $params = [$this->orgId->get()];
 
@@ -151,7 +151,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         }
 
         if ($filter->search !== null) {
-            $clauses[] = "(i.invoice_number LIKE ? ESCAPE '!' OR c.name LIKE ? ESCAPE '!')";
+            $clauses[] = "(LOWER(i.invoice_number) LIKE LOWER(?) ESCAPE '!' OR LOWER(c.name) LIKE LOWER(?) ESCAPE '!')";
             $like = '%' . SqlLike::escape($filter->search) . '%';
             $params[] = $like;
             $params[] = $like;
@@ -222,7 +222,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
      */
     private function buildWhere(InvoiceListFilter $filter): array
     {
-        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        $clauses = ['organization_id = ?', 'is_deleted = FALSE'];
         /** @var list<int|string> $params */
         $params = [$this->orgId->get()];
 
@@ -270,7 +270,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $row = $this->query->fetchOne(
             'SELECT COALESCE(SUM(total_cents), 0) AS cents, COUNT(*) AS cnt
              FROM invoices
-             WHERE organization_id = ? AND is_deleted = 0
+             WHERE organization_id = ? AND is_deleted = FALSE
                AND issued_at IS NOT NULL AND issued_at >= ? AND issued_at < ?',
             [$this->orgId->get(), $startInclusive, $endExclusive],
         );
@@ -286,7 +286,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $rows = $this->query->fetchAll(
             'SELECT issued_at, total_cents
              FROM invoices
-             WHERE organization_id = ? AND is_deleted = 0
+             WHERE organization_id = ? AND is_deleted = FALSE
                AND issued_at IS NOT NULL AND issued_at >= ? AND issued_at < ?
              ORDER BY issued_at ASC',
             [$this->orgId->get(), $startInclusive, $endExclusive],
@@ -313,7 +313,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
                 SUM(CASE WHEN status IN (\'issued\', \'partially_paid\') THEN 1 ELSE 0 END) AS unpaid_count,
                 SUM(CASE WHEN status IN (\'issued\', \'partially_paid\') AND due_at IS NOT NULL AND due_at < ? THEN 1 ELSE 0 END) AS overdue_count
             FROM invoices
-            WHERE organization_id = ? AND is_deleted = 0',
+            WHERE organization_id = ? AND is_deleted = FALSE',
             [$now, $orgId],
         );
 
@@ -323,7 +323,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . '
             FROM invoices
-            WHERE organization_id = ? AND is_deleted = 0 AND status IN (\'issued\', \'partially_paid\')
+            WHERE organization_id = ? AND is_deleted = FALSE AND status IN (\'issued\', \'partially_paid\')
             ORDER BY id DESC
             LIMIT 5',
             [$orgId],
@@ -343,7 +343,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO invoices (organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, ?)',
             [
                 $this->orgId->get(),
                 $invoice->clientId,
@@ -374,7 +374,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE invoices SET client_id = ?, quote_id = ?, invoice_number = ?, status = ?, is_qualified_invoice = ?, issued_at = ?, due_at = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE invoices SET client_id = ?, quote_id = ?, invoice_number = ?, status = ?, is_qualified_invoice = ?, issued_at = ?, due_at = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [
                 $invoice->clientId,
                 $invoice->quoteId,
@@ -405,7 +405,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE invoices SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE invoices SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
             [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
@@ -422,7 +422,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
                     i.subtotal_cents, i.tax_cents, i.total_cents,
                     i.status, i.is_qualified_invoice
              FROM invoices i
-             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = FALSE
              WHERE ' . $where . '
                AND i.status != \'draft\'
              ORDER BY i.issued_at DESC, i.id DESC',

--- a/src/Item/PdoItemRepository.php
+++ b/src/Item/PdoItemRepository.php
@@ -24,7 +24,7 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
     public function findById(int $id): ?Item
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM items WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM items WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$id, $this->orgId->get()],
         );
 
@@ -35,7 +35,7 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM items WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT ' . self::COLUMNS . ' FROM items WHERE organization_id = ? AND is_deleted = FALSE ORDER BY id ASC LIMIT ? OFFSET ?',
             [$this->orgId->get(), $limit, $offset],
         );
 
@@ -74,12 +74,12 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
      */
     private function buildAdminWhere(ItemListFilter $filter): array
     {
-        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        $clauses = ['organization_id = ?', 'is_deleted = FALSE'];
         /** @var list<int|string> $params */
         $params = [$this->orgId->get()];
 
         if ($filter->search !== null) {
-            $clauses[] = "description LIKE ? ESCAPE '!'";
+            $clauses[] = "LOWER(description) LIKE LOWER(?) ESCAPE '!'";
             $params[] = '%' . SqlLike::escape($filter->search) . '%';
         }
 
@@ -124,7 +124,7 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
         // the entity — a write always lands in the caller's resolved org.
         $this->query->execute(
             'INSERT INTO items (organization_id, description, default_unit_price_cents, default_tax_rate_bps, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, ?, FALSE, ?, ?)',
             [
                 $this->orgId->get(),
                 $item->description,
@@ -147,7 +147,7 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE items SET description = ?, default_unit_price_cents = ?, default_tax_rate_bps = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE items SET description = ?, default_unit_price_cents = ?, default_tax_rate_bps = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [
                 $item->description,
                 $item->defaultUnitPriceCents,
@@ -170,7 +170,7 @@ final readonly class PdoItemRepository implements ItemRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE items SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE items SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
             [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }

--- a/src/LineItem/PdoLineItemRepository.php
+++ b/src/LineItem/PdoLineItemRepository.php
@@ -82,13 +82,13 @@ final readonly class PdoLineItemRepository implements LineItemRepositoryInterfac
                     li.tax_rate_bps AS tax_rate_bps, li.created_at AS created_at
                FROM line_items li
                JOIN invoices i ON li.parent_type = ? AND li.parent_id = i.id
-              WHERE i.organization_id = ? AND i.is_deleted = 0
+              WHERE i.organization_id = ? AND i.is_deleted = FALSE
              UNION ALL
              SELECT li.description AS description, li.unit_price_cents AS unit_price_cents,
                     li.tax_rate_bps AS tax_rate_bps, li.created_at AS created_at
                FROM line_items li
                JOIN quotes q ON li.parent_type = ? AND li.parent_id = q.id
-              WHERE q.organization_id = ? AND q.is_deleted = 0
+              WHERE q.organization_id = ? AND q.is_deleted = FALSE
              ORDER BY created_at DESC, description ASC
              LIMIT ?',
             [

--- a/src/Payment/PdoPaymentRepository.php
+++ b/src/Payment/PdoPaymentRepository.php
@@ -27,7 +27,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO payments (organization_id, invoice_id, amount_cents, paid_at, method, note, external_reference, idempotency_key, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, ?)',
             [
                 $this->orgId->get(),
                 $payment->invoiceId,
@@ -69,7 +69,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function markVoided(int $id): void
     {
         $this->query->execute(
-            'UPDATE payments SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE payments SET is_deleted = TRUE, deleted_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }
@@ -78,7 +78,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function findByInvoice(int $invoiceId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = 0 ORDER BY paid_at ASC, id ASC',
+            'SELECT ' . self::COLUMNS . ' FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = FALSE ORDER BY paid_at ASC, id ASC',
             [$invoiceId, $this->orgId->get()],
         );
 
@@ -88,7 +88,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     public function totalPaidForInvoice(int $invoiceId): int
     {
         $row = $this->query->fetchOne(
-            'SELECT COALESCE(SUM(amount_cents), 0) AS total FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT COALESCE(SUM(amount_cents), 0) AS total FROM payments WHERE invoice_id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$invoiceId, $this->orgId->get()],
         );
 
@@ -108,7 +108,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         $placeholders = implode(', ', array_fill(0, count($invoiceIds), '?'));
         $rows = $this->query->fetchAll(
             'SELECT invoice_id, COALESCE(SUM(amount_cents), 0) AS total
-             FROM payments WHERE is_deleted = 0 AND organization_id = ? AND invoice_id IN (' . $placeholders . ')
+             FROM payments WHERE is_deleted = FALSE AND organization_id = ? AND invoice_id IN (' . $placeholders . ')
              GROUP BY invoice_id',
             [$this->orgId->get(), ...$invoiceIds],
         );
@@ -125,10 +125,10 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
     {
         $row = $this->query->fetchOne(
             'SELECT
-                COALESCE(SUM(i.total_cents), 0) - COALESCE(SUM(CASE WHEN p.is_deleted = 0 THEN p.amount_cents ELSE 0 END), 0) AS outstanding
+                COALESCE(SUM(i.total_cents), 0) - COALESCE(SUM(CASE WHEN p.is_deleted = FALSE THEN p.amount_cents ELSE 0 END), 0) AS outstanding
             FROM invoices i
             LEFT JOIN payments p ON p.invoice_id = i.id
-            WHERE i.organization_id = ? AND i.is_deleted = 0 AND i.status IN (\'issued\', \'partially_paid\')',
+            WHERE i.organization_id = ? AND i.is_deleted = FALSE AND i.status IN (\'issued\', \'partially_paid\')',
             [$this->orgId->get()],
         );
 
@@ -143,8 +143,8 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
                     COALESCE(c.name, \'\') AS client_name
              FROM payments p
              LEFT JOIN invoices i ON i.id = p.invoice_id
-             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = 0
-             WHERE p.organization_id = ? AND p.is_deleted = 0
+             LEFT JOIN clients c ON c.id = i.client_id AND c.is_deleted = FALSE
+             WHERE p.organization_id = ? AND p.is_deleted = FALSE
              ORDER BY p.paid_at DESC, p.id DESC',
             [$this->orgId->get()],
         );
@@ -164,7 +164,7 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
         $row = $this->query->fetchOne(
             'SELECT COALESCE(SUM(amount_cents), 0) AS total
              FROM payments
-             WHERE organization_id = ? AND is_deleted = 0 AND paid_at >= ? AND paid_at < ?',
+             WHERE organization_id = ? AND is_deleted = FALSE AND paid_at >= ? AND paid_at < ?',
             [$this->orgId->get(), $startInclusive, $endExclusive],
         );
 
@@ -182,10 +182,10 @@ final readonly class PdoPaymentRepository implements PaymentRepositoryInterface
                 COALESCE(SUM(CASE WHEN t.due_at < ? THEN t.net ELSE 0 END), 0) AS overdue_31_plus
              FROM (
                 SELECT i.id, i.due_at,
-                       i.total_cents - COALESCE(SUM(CASE WHEN p.is_deleted = 0 THEN p.amount_cents ELSE 0 END), 0) AS net
+                       i.total_cents - COALESCE(SUM(CASE WHEN p.is_deleted = FALSE THEN p.amount_cents ELSE 0 END), 0) AS net
                 FROM invoices i
                 LEFT JOIN payments p ON p.invoice_id = i.id
-                WHERE i.organization_id = ? AND i.is_deleted = 0 AND i.status IN (\'issued\', \'partially_paid\')
+                WHERE i.organization_id = ? AND i.is_deleted = FALSE AND i.status IN (\'issued\', \'partially_paid\')
                 GROUP BY i.id, i.due_at, i.total_cents
              ) t
              WHERE t.net > 0',

--- a/src/Quote/PdoQuoteRepository.php
+++ b/src/Quote/PdoQuoteRepository.php
@@ -24,7 +24,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
     public function findById(int $id): ?Quote
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM quotes WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$id, $this->orgId->get()],
         );
 
@@ -46,7 +46,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
                     q.is_deleted, q.created_at, q.updated_at,
                     COALESCE(c.name, \'\') AS client_name
              FROM quotes q
-             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = FALSE
              WHERE ' . $where . '
              ORDER BY ' . self::orderByClause($sort) . '
              LIMIT ? OFFSET ?',
@@ -69,7 +69,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         $row = $this->query->fetchOne(
             'SELECT COUNT(*) AS cnt
              FROM quotes q
-             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = FALSE
              WHERE ' . $where,
             $params,
         );
@@ -85,7 +85,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
      */
     private function buildAdminWhere(QuoteListFilter $filter): array
     {
-        $clauses = ['q.organization_id = ?', 'q.is_deleted = 0'];
+        $clauses = ['q.organization_id = ?', 'q.is_deleted = FALSE'];
         /** @var list<int|string> $params */
         $params = [$this->orgId->get()];
 
@@ -98,7 +98,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         }
 
         if ($filter->search !== null) {
-            $clauses[] = "(q.quote_number LIKE ? ESCAPE '!' OR c.name LIKE ? ESCAPE '!')";
+            $clauses[] = "(LOWER(q.quote_number) LIKE LOWER(?) ESCAPE '!' OR LOWER(c.name) LIKE LOWER(?) ESCAPE '!')";
             $like = '%' . SqlLike::escape($filter->search) . '%';
             $params[] = $like;
             $params[] = $like;
@@ -138,7 +138,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
                     COALESCE(c.name, \'\') AS client_name,
                     q.subtotal_cents, q.tax_cents, q.total_cents, q.status
              FROM quotes q
-             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = 0
+             LEFT JOIN clients c ON c.id = q.client_id AND c.is_deleted = FALSE
              WHERE ' . $where . '
              ORDER BY q.issued_at DESC, q.id DESC',
             $params,
@@ -184,7 +184,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         // The organization is forced from the request-scoped holder.
         $this->query->execute(
             'INSERT INTO quotes (organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, ?)',
             [
                 $this->orgId->get(),
                 $quote->clientId,
@@ -213,7 +213,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE quotes SET client_id = ?, status = ?, issued_at = ?, valid_until = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE quotes SET client_id = ?, status = ?, issued_at = ?, valid_until = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [
                 $quote->clientId,
                 $quote->status->value,
@@ -241,7 +241,7 @@ final readonly class PdoQuoteRepository implements QuoteRepositoryInterface
         }
 
         $this->query->execute(
-            'UPDATE quotes SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE quotes SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
             [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }

--- a/src/Template/PdoTemplateRepository.php
+++ b/src/Template/PdoTemplateRepository.php
@@ -23,7 +23,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
     public function findById(int $id): ?Template
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM templates WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM templates WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$id, $this->orgId->get()],
         );
 
@@ -34,7 +34,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM templates WHERE organization_id = ? AND is_deleted = 0 ORDER BY name ASC, id ASC LIMIT ? OFFSET ?',
+            'SELECT ' . self::COLUMNS . ' FROM templates WHERE organization_id = ? AND is_deleted = FALSE ORDER BY name ASC, id ASC LIMIT ? OFFSET ?',
             [$this->orgId->get(), $limit, $offset],
         );
 
@@ -44,7 +44,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
     public function count(): int
     {
         $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM templates WHERE organization_id = ? AND is_deleted = 0',
+            'SELECT COUNT(*) AS cnt FROM templates WHERE organization_id = ? AND is_deleted = FALSE',
             [$this->orgId->get()],
         );
 
@@ -59,7 +59,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
         // the entity — a write always lands in the caller's resolved org.
         $this->query->execute(
             'INSERT INTO templates (organization_id, name, notes, is_deleted, created_at, updated_at)
-             VALUES (?, ?, ?, 0, ?, ?)',
+             VALUES (?, ?, ?, FALSE, ?, ?)',
             [$this->orgId->get(), $template->name, $template->notes, $now, $now],
         );
 
@@ -75,7 +75,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
         $now = date('Y-m-d H:i:s');
 
         $affected = $this->query->execute(
-            'UPDATE templates SET name = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            'UPDATE templates SET name = ?, notes = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
             [$template->name, $template->notes, $now, $template->id, $this->orgId->get()],
         );
 
@@ -91,7 +91,7 @@ final readonly class PdoTemplateRepository implements TemplateRepositoryInterfac
         }
 
         $this->query->execute(
-            'UPDATE templates SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            'UPDATE templates SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
             [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
         );
     }

--- a/tests/Integration/IntegrationDatabase.php
+++ b/tests/Integration/IntegrationDatabase.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Integration;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Throwable;
+
+/**
+ * Connects the integration suite to a real MySQL / PostgreSQL database (the two
+ * production targets — issue #396) with the production PDO settings (native
+ * prepared statements). The schema is applied out-of-band by CI via Phinx
+ * (`phinx migrate`) before the suite runs.
+ *
+ * Each adapter is configured from `<ADAPTER>_TEST_*` env vars and returns null
+ * when the adapter is not configured or its PDO driver is missing — so the tests
+ * skip and the default `composer test` stays serverless on SQLite.
+ */
+final class IntegrationDatabase
+{
+    public static function pgsql(): ?PdoDatabaseQueryExecutor
+    {
+        return self::fromEnv('PGSQL', 'pgsql', 'pdo_pgsql', 5432, 'utf8');
+    }
+
+    public static function mysql(): ?PdoDatabaseQueryExecutor
+    {
+        return self::fromEnv('MYSQL', 'mysql', 'pdo_mysql', 3306, 'utf8mb4');
+    }
+
+    private static function fromEnv(
+        string $prefix,
+        string $adapter,
+        string $driver,
+        int $defaultPort,
+        string $charset,
+    ): ?PdoDatabaseQueryExecutor {
+        $host = self::env($prefix . '_TEST_HOST');
+
+        if ($host === null || !extension_loaded($driver)) {
+            return null;
+        }
+
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: $adapter,
+            host: $host,
+            port: (int) (self::env($prefix . '_TEST_PORT') ?? (string) $defaultPort),
+            name: self::env($prefix . '_TEST_DB') ?? 'nene_invoice_test',
+            user: self::env($prefix . '_TEST_USER') ?? 'root',
+            password: self::env($prefix . '_TEST_PASSWORD') ?? '',
+            charset: $charset,
+        );
+
+        $executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory($config));
+
+        try {
+            $executor->fetchOne('SELECT 1');
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $executor;
+    }
+
+    private static function env(string $name): ?string
+    {
+        $value = getenv($name);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/tests/Integration/ItemRepositoryDialectTest.php
+++ b/tests/Integration/ItemRepositoryDialectTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Integration;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Item\Item;
+use NeneInvoice\Item\ItemListFilter;
+use NeneInvoice\Item\ItemSort;
+use NeneInvoice\Item\PdoItemRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the dialect-portable repository SQL on the real production engines
+ * (MySQL + PostgreSQL — issue #396): the boolean soft-delete predicates
+ * (`is_deleted = FALSE/TRUE`) and the case-insensitive search
+ * (`LOWER(col) LIKE LOWER(?)`). PostgreSQL is the strict case — it rejects
+ * `boolean = integer` — so this is what proves the fix on a real engine.
+ *
+ * Skips when the adapter is not configured (no `<ADAPTER>_TEST_HOST` / driver),
+ * so the default SQLite `composer test` is unaffected. CI applies the schema via
+ * `phinx migrate` before running `composer test:integration`.
+ */
+#[Group('integration')]
+final class ItemRepositoryDialectTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: callable(): ?PdoDatabaseQueryExecutor}>
+     */
+    public static function adapters(): iterable
+    {
+        yield 'postgresql' => [static fn (): ?PdoDatabaseQueryExecutor => IntegrationDatabase::pgsql()];
+        yield 'mysql' => [static fn (): ?PdoDatabaseQueryExecutor => IntegrationDatabase::mysql()];
+    }
+
+    /**
+     * @param callable(): ?PdoDatabaseQueryExecutor $connect
+     */
+    #[DataProvider('adapters')]
+    public function test_soft_delete_and_case_insensitive_search_round_trip(callable $connect): void
+    {
+        $db = $connect();
+
+        if ($db === null) {
+            self::markTestSkipped('Integration DB not configured for this adapter.');
+        }
+
+        // Isolate this run in its own organization so the suite is repeatable.
+        $organizationId = random_int(1_000_000, 9_999_999);
+        $orgHolder = new RequestScopedHolder();
+        $orgHolder->set($organizationId);
+        $repo = new PdoItemRepository($db, $orgHolder);
+
+        try {
+            // INSERT writes the inline boolean literal (is_deleted = FALSE).
+            $id = $repo->save(new Item(
+                organizationId: $organizationId,
+                description: 'Mixed Case Maintenance',
+                defaultUnitPriceCents: 50_000,
+                defaultTaxRateBps: 1_000,
+            ));
+
+            // SELECT … WHERE is_deleted = FALSE
+            self::assertNotNull($repo->findById($id));
+            self::assertSame(1, $repo->countForAdminList(new ItemListFilter()));
+
+            // LOWER(description) LIKE LOWER(?) — lowercase query matches mixed case.
+            $hits = $repo->findForAdminList(new ItemListFilter(search: 'maintenance'), new ItemSort(), 20, 0);
+            self::assertCount(1, $hits);
+
+            // UPDATE … SET is_deleted = TRUE … WHERE … is_deleted = FALSE
+            $repo->delete($id);
+            self::assertNull($repo->findById($id));
+            self::assertSame(0, $repo->countForAdminList(new ItemListFilter()));
+        } finally {
+            $db->execute('DELETE FROM items WHERE organization_id = ?', [$organizationId]);
+        }
+    }
+}


### PR DESCRIPTION
Closes #396

## 概要

接続層（NENE2 `PdoConnectionFactory`）とマイグレーション（Phinx）は元々 `sqlite`/`mysql`/`pgsql` に対応していたが、`Pdo*Repository` の手書き SQL が MySQL/SQLite 方言に依存しており、`DB_ADAPTER=pgsql` では**実際には起動・運用できなかった**。sibling 製品 **nene-serve**（MySQL+PG の実 DB で integration suite を回して PG 対応を保証）を参考に、方言非依存化した。

## 問題と修正

| 箇所 | 修正 | 理由 |
| --- | --- | --- |
| `is_deleted = 0/1`（述語・SET・INSERT インライン、7リポジトリ・約50箇所） | `= FALSE/TRUE` | PG は `boolean` 型に厳格で `operator does not exist: boolean = integer` になる |
| 検索 `col LIKE ?`（Client/Quote/Item/Invoice） | `LOWER(col) LIKE LOWER(?)` | PG の `LIKE` は case-sensitive。3 DB 共通で case-insensitive に統一 |
| 書き込み `? 1 : 0` バインド | **変更なし** | PG も `'1'`/`'0'` を boolean として受理（PDO のテキストバインドで検証済み） |
| `lastInsertId()` / 日付関数 | **変更なし** | PG でも `lastval()` 経由で機能。`DATE()` 等は未使用（範囲比較のみ） |

データモデル（`is_deleted` boolean 列）は変更していない。`= 0`→`= FALSE` は意味的に同値で、請求/税の**計算ロジックには非干渉**。検索の case-insensitive 化は会計非関連の挙動改善。

## 保証（nene-serve 参照）

- `tests/Integration/` に harness（`IntegrationDatabase`）+ 代表テスト（boolean ソフトデリート / case-insensitive 検索の往復）を追加。`<ADAPTER>_TEST_HOST` 未設定 or ドライバ無しで **skip** → 既定の SQLite `composer test` はサーバーレス維持。
- CI に MySQL + PostgreSQL サービスの `integration` ジョブを追加（Phinx でスキーマ適用 → `composer test:integration`）。

## 検証

- **SQLite**: `composer test` 390 件パス（cs / phpstan lv? green）
- **実 MySQL 8.4**: Phinx migrate + `PdoItemRepository` 往復（保存/検索/ソフトデリート）パス
- **実 PostgreSQL 16**: 変更後の全 SQL 形（`= FALSE` / `= TRUE` / インライン `FALSE` / `LOWER() LIKE` / untyped param の boolean 強制）を psql で確認。旧 `= 0` が `operator does not exist: boolean = integer` で落ちることも確認

## セルフレビュー

- 命名規則: 新規識別子なし（用語レジストリ変更不要）
- accounting-compliance: 計算ロジック非干渉、対象変更に非該当

🤖 Generated with [Claude Code](https://claude.com/claude-code)