### PR TITLE
fix(service-api): client 読みモデルに client_id を公開（契約整合）

### DIFF
--- a/docs/openapi/service-api.yaml
+++ b/docs/openapi/service-api.yaml
@@ -267,8 +267,17 @@ components:
         Client (取引先) contact data for dunning. `recipient_email` maps to the
         client's billing email in NeNe Invoice.
       properties:
+        client_id:
+          type: integer
+          description: >
+            Canonical client identifier on the service surface (matches the invoice
+            read model's `client_id` and upstream contract §2.3).
         id:
           type: integer
+          deprecated: true
+          description: >
+            Deprecated alias of `client_id` (ADR 0009 §5: deprecate, never rename).
+            Read `client_id` instead.
         name:
           type: string
           description: Client company name.
@@ -283,7 +292,7 @@ components:
         registration_number:
           type: [string, 'null']
           description: Buyer's invoice registration number (T + 13 digits), if set.
-      required: [id, name]
+      required: [client_id, id, name]
     ServiceInvoice:
       type: object
       properties:

--- a/src/ServiceApi/GetServiceClientHandler.php
+++ b/src/ServiceApi/GetServiceClientHandler.php
@@ -47,6 +47,11 @@ final readonly class GetServiceClientHandler implements RequestHandlerInterface
         }
 
         return $this->json->create([
+            // `client_id` is the canonical identifier on the service surface — it
+            // matches the invoice read model's `client_id` and the upstream contract
+            // (§2.3). `id` is retained but deprecated (ADR 0009 §5: deprecate, never
+            // rename); consumers should read `client_id`.
+            'client_id'           => $client->id,
             'id'                  => $client->id,
             'name'                => $client->name,
             'contact_name'        => $client->contactName,

--- a/tests/ServiceApi/GetServiceClientHandlerTest.php
+++ b/tests/ServiceApi/GetServiceClientHandlerTest.php
@@ -52,6 +52,10 @@ final class GetServiceClientHandlerTest extends TestCase
 
         /** @var array<string, mixed> $body */
         $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        // `client_id` is the canonical identifier the upstream contract / NeNe Clear
+        // reads (C2); `id` is retained as a deprecated alias.
+        self::assertSame($id, $body['client_id']);
+        self::assertSame($id, $body['id']);
         self::assertSame('株式会社テスト', $body['name']);
         self::assertSame('山田太郎', $body['contact_name']);
         self::assertSame('yamada@example.com', $body['recipient_email']);


### PR DESCRIPTION
Closes #412

NeNe Clear との**実機契約テスト（Phase A）**で検出した契約ミスマッチ C2 の修正。

## 背景
`GET /api/clients/{id}` が `id` のみを返していたが、束縛契約 `invoice-upstream-contract.md` §2.3 と Clear の `InvoiceUpstreamHttpClient::getClient()` は **`client_id`** を期待。invoice 一覧の read モデルは既に `client_id` を使っており、client 詳細だけ `id` で不整合だった。

## 変更
- `GetServiceClientHandler`: 応答に **`client_id` を追加**（`id` は deprecated として併記 — ADR 0009 §5「deprecate, never rename」）。
- `service-api.yaml` の `ServiceClient`: `client_id` を追加・`required` 化、`id` を `deprecated` 記述。
- テストに `client_id` アサート追加。

## 検証
- `composer check`: 407 テスト・PHPStan・cs・OpenAPI・MCP すべて green。
- ライブ: `GET /api/clients/{id}` が `client_id` と `id` の両方を返すことを確認。

## 連携の残タスク（別repo / 別Issue）
Phase A で検出した他の3件は **消費側(NeNe Clear)** に起票済み:
- nene-clear #163: `listInvoices` の `limit=200` → 契約上限100以内＋ページング（**連携ブロッカー**）
- nene-clear #164: 契約テストの `due_at` を nullable 許容に緩和（契約は nullable）
- nene-clear #165: `ext-curl` を実行前提として明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)