### PR TITLE
feat(service-api): service token をレジストリ化し発行/一覧/失効 API を追加 (#416)

### DIFF
--- a/database/migrations/20260609000000_create_service_tokens_table.php
+++ b/database/migrations/20260609000000_create_service_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateServiceTokensTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('service_tokens')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('jti', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('subject', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('label', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('scopes', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('created_by', 'integer', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('expires_at', 'datetime', ['null' => false])
+            ->addColumn('revoked_at', 'datetime', ['null' => true])
+            ->addIndex(['jti'], ['unique' => true, 'name' => 'uniq_service_tokens_jti'])
+            ->addIndex(['organization_id'], ['name' => 'idx_service_tokens_organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -190,3 +190,22 @@ CREATE TABLE IF NOT EXISTS `login_attempts` (
     `created_at` DATETIME    NOT NULL,
     KEY `idx_login_attempts_ip_time` (`ip_address`, `created_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- service_tokens — registry of issued NeNe Clear service tokens (ADR 0009).
+-- Metadata only; the token value is never stored. `jti` keys revocation.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `service_tokens` (
+    `id`              INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id` INT          NOT NULL,
+    `jti`             VARCHAR(64)  NOT NULL,
+    `subject`         VARCHAR(255) NOT NULL,
+    `label`           VARCHAR(255) NOT NULL,
+    `scopes`          VARCHAR(255) NOT NULL,
+    `created_by`      INT          DEFAULT NULL,
+    `created_at`      DATETIME     NOT NULL,
+    `expires_at`      DATETIME     NOT NULL,
+    `revoked_at`      DATETIME     DEFAULT NULL,
+    UNIQUE KEY `uniq_service_tokens_jti` (`jti`),
+    KEY `idx_service_tokens_organization_id` (`organization_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/schema/service_tokens.sql
+++ b/database/schema/service_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS service_tokens (
+    id                INTEGER      NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id   INTEGER      NOT NULL,
+    jti               VARCHAR(64)  NOT NULL,
+    subject           VARCHAR(255) NOT NULL,
+    label             VARCHAR(255) NOT NULL,
+    scopes            VARCHAR(255) NOT NULL,
+    created_by        INTEGER,
+    created_at        DATETIME     NOT NULL,
+    expires_at        DATETIME     NOT NULL,
+    revoked_at        DATETIME,
+    CONSTRAINT uniq_service_tokens_jti UNIQUE (jti)
+);
+CREATE INDEX IF NOT EXISTS idx_service_tokens_organization_id ON service_tokens (organization_id);

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -43,6 +43,7 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 | Template | `Template` | `templates` | `template_id` |
 | Receipt | `Payment` | `payments` | `payment_id` |
 | Number generator | `DocumentSequence` | `document_sequences` | — |
+| Integration credential | `ServiceToken` | `service_tokens` | `service_token_id` |
 
 Domain folders are **PascalCase singular**; tables are **snake_case plural**.
 
@@ -62,6 +63,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `line_item_suggestion.source` | `master`, `history` |
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
 | `user.status` | `active`, `invited` |
+| service_token status (computed) | `active`, `revoked` |
 | Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
 | Org resolution mode | `single` (default), `path`, `subdomain`, `custom_domain` |
 
@@ -98,6 +100,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Billing defaults (issuer) | `default_quote_validity_days`, `default_payment_closing_day`, `default_payment_month_offset`, `default_payment_pay_day` | `quote_validity`, `closing_day`, `payment_site`, `pay_day`, `net_days` |
 | Client fields | `name_kana`, `contact_name`, `billing_address` | `kana`, `furigana`, `name_reading`, `contact`, `address` |
 | Item master defaults | `default_unit_price_cents`, `default_tax_rate_bps` | `default_price_cents`, `item_price_cents`, `default_rate`, `unit_price` |
+| Service-token fields | `jti`, `subject`, `label`, `scopes`, `created_by`, `expires_at`, `revoked_at`, `ttl_seconds` | `jwt_id`, `name`, `scope`, `created_user_id`, `expiry`, `revoked`, `ttl` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
@@ -142,6 +145,8 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `payment-exceeds-outstanding` | Payment would exceed the invoice outstanding balance (422; service API) |
 | `payment-not-found` | Payment id / external_reference not found (404; service API) |
 | `insufficient-scope` | Service token lacks the required scope (403; service API) |
+| `service-token-revoked` | Presented service token has been revoked (401; service API) |
+| `service-token-not-found` | Service-token id not found in the caller's org (404; operator API) |
 
 Add new slugs here before using them. Validation `errors[].field` uses
 snake_case paths (e.g. `body.registration_number`); `errors[].code` is
@@ -170,6 +175,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice`, `getInvoicePdf`, `generateDownloadToken`, `downloadInvoicePdf`, `sendInvoiceEmail` | Invoice |
 | `listPayments`, `recordPayment` | Payment (operator `/admin/*`) |
 | `listLineItemSuggestions` | LineItem (history-based suggestions) |
+| `listServiceTokens`, `issueServiceToken`, `revokeServiceToken` | ServiceToken (NeNe Clear integration credentials; admin oversight) |
 
 ### Service API (`/api/*`, NeNe Clear — ADR 0009)
 

--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -43,7 +43,13 @@ architecture: **ADR 0009**.
   `POST …/payments/{paymentId}/void` (void-with-audit, idempotent). All behind
   service-token auth; OpenAPI `docs/openapi/service-api.yaml`. Mint tokens:
   `php tools/issue-service-token.php --org=N --scopes=read:invoices,write:payments`.
-  Remaining: Clear-side contract tests; ops (multi-org tokens, issuance/revocation UI).
+- **Token registry + revocation (#416):** issued tokens are recorded in
+  `service_tokens` (metadata + `jti` only — the token value is never stored). The
+  operator API `/admin/service-tokens` (admin oversight) issues, lists, and revokes
+  them, and the CLI issuer registers too. A revoked token's `jti` is rejected at
+  request time by `ServiceScopeMiddleware` (`401 service-token-revoked`). Legacy
+  tokens issued before the registry carry no `jti` and rely on signature + `exp`.
+  Remaining: Clear-side contract tests; operator **UI** for the registry (#417).
 
 ## Environment variables (planned)
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Payments (入金) recorded against invoices.
   - name: LineItems
     description: Document line items (品目) and history-based suggestions.
+  - name: ServiceTokens
+    description: NeNe Clear integration credentials (machine tokens) — issue / list / revoke (admin oversight, ADR 0009).
 paths:
   /health:
     get:
@@ -1010,6 +1012,78 @@ paths:
       responses:
         '204':
           description: Template deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /admin/service-tokens:
+    get:
+      tags: [ServiceTokens]
+      summary: List service tokens
+      operationId: listServiceTokens
+      description: >
+        Lists the organization's NeNe Clear service-token registry records
+        (metadata only — the token value is never returned). Requires
+        ManageUsers (admin oversight).
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Service-token page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceTokenList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+    post:
+      tags: [ServiceTokens]
+      summary: Issue service token
+      operationId: issueServiceToken
+      description: >
+        Issues a NeNe Clear service token for the caller's organization. The
+        plaintext `token` is returned exactly once in this response and never
+        again. Requires ManageUsers.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueServiceTokenRequest'
+            example:
+              label: NeNe Clear (本番)
+              scopes: [read:invoices, write:payments]
+      responses:
+        '201':
+          description: Service token issued (plaintext token included once)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedServiceToken'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+  /admin/service-tokens/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    delete:
+      tags: [ServiceTokens]
+      summary: Revoke service token
+      operationId: revokeServiceToken
+      description: >
+        Revokes a service token by id (idempotent). Once revoked, the token's
+        `jti` is rejected at request time on `/api/*`. Requires ManageUsers.
+      responses:
+        '204':
+          description: Service token revoked
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2257,6 +2331,67 @@ components:
           items:
             $ref: '#/components/schemas/LineItemInput'
       required: [name]
+    ServiceToken:
+      type: object
+      description: >
+        Registry record for a NeNe Clear service token (ADR 0009). Metadata only —
+        the token value is never included here.
+      properties:
+        id:
+          type: integer
+        subject:
+          type: string
+          description: The token `sub` claim (machine principal, e.g. service:clear).
+        label:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+            enum: [read:invoices, write:payments]
+        created_by:
+          type: [integer, 'null']
+          description: Operator user id who issued the token (null for CLI-issued).
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        revoked_at:
+          type: [string, 'null']
+        status:
+          type: string
+          enum: [active, revoked]
+      required: [id, subject, label, scopes, created_at, expires_at, status]
+    ServiceTokenList:
+      $ref: '#/components/schemas/PageEnvelope'
+    IssueServiceTokenRequest:
+      type: object
+      properties:
+        label:
+          type: string
+          description: Human label for the token (required).
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            enum: [read:invoices, write:payments]
+        subject:
+          type: string
+          description: Machine principal `sub` claim. Defaults to service:clear.
+        ttl_seconds:
+          type: integer
+          description: Token lifetime in seconds (3600 … 31536000; default 2592000).
+      required: [label, scopes]
+    CreatedServiceToken:
+      allOf:
+        - $ref: '#/components/schemas/ServiceToken'
+        - type: object
+          properties:
+            token:
+              type: string
+              description: The signed bearer token, returned exactly once on issuance.
+          required: [token]
     LineItem:
       type: object
       description: A line on a quote or invoice. Money is integer cents.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -407,6 +407,7 @@ Phase 1–3 後の運用・UX 強化と Phase 4 着手分（すべて merged）:
 
 Phase 1–3・セキュリティ診断・上記 UX 強化は完了。Phase 4 の残り：
 
+- **NeNe Clear service token 運用（#416 backend / #417 frontend）** — 🔄 進行中。発行済みトークンを `service_tokens` レジストリに記録（メタデータ＋`jti` のみ・値は保存しない）し、`/admin/service-tokens`（admin）で発行・一覧・失効。失効は `ServiceScopeMiddleware` が `jti` 照合で即時拒否（`401 service-token-revoked`）。#416 が backend、#417 がオペレーター UI。
 - **NeNe Records 商品カタログ連携** — 明細行への商品インポート
 - **NeNe Concierge webhook** — リード → 取引先/見積下書き自動生成
 - **決済ゲートウェイ連携** — Stripe 等（任意）

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -37,6 +37,8 @@ use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
 use NeneInvoice\Quote\QuoteRouteRegistrar;
 use NeneInvoice\Quote\QuoteValidationExceptionHandler;
 use NeneInvoice\ServiceApi\ServiceApiRouteRegistrar;
+use NeneInvoice\ServiceToken\ServiceTokenNotFoundExceptionHandler;
+use NeneInvoice\ServiceToken\ServiceTokenRouteRegistrar;
 use NeneInvoice\Template\TemplateNotFoundExceptionHandler;
 use NeneInvoice\Template\TemplateRouteRegistrar;
 use NeneInvoice\User\CannotDeleteSelfExceptionHandler;
@@ -93,6 +95,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $lineItemRoutes = $container->get(LineItemRouteRegistrar::class);
                     $itemRoutes = $container->get(ItemRouteRegistrar::class);
                     $templateRoutes = $container->get(TemplateRouteRegistrar::class);
+                    $serviceTokenRoutes = $container->get(ServiceTokenRouteRegistrar::class);
 
                     if (!$dashboardRoutes instanceof DashboardRouteRegistrar) {
                         throw new LogicException('Dashboard route registrar service is invalid.');
@@ -154,7 +157,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Template route registrar service is invalid.');
                     }
 
-                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes];
+                    if (!$serviceTokenRoutes instanceof ServiceTokenRouteRegistrar) {
+                        throw new LogicException('Service token route registrar service is invalid.');
+                    }
+
+                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes, $serviceTokenRoutes];
                 },
             )
             ->set(
@@ -182,6 +189,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $paymentValidation = $container->get(PaymentValidationExceptionHandler::class);
                     $paymentExceeds = $container->get(PaymentExceedsOutstandingExceptionHandler::class);
                     $paymentNotFound = $container->get(PaymentNotFoundExceptionHandler::class);
+                    $serviceTokenNotFound = $container->get(ServiceTokenNotFoundExceptionHandler::class);
 
                     if (!$orgNotFound instanceof OrganizationNotFoundExceptionHandler) {
                         throw new LogicException('Organization not-found exception handler service is invalid.');
@@ -271,7 +279,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Payment not-found exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $itemNotFound, $templateNotFound, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $invoiceEmail, $paymentValidation, $paymentExceeds, $paymentNotFound];
+                    if (!$serviceTokenNotFound instanceof ServiceTokenNotFoundExceptionHandler) {
+                        throw new LogicException('Service token not-found exception handler service is invalid.');
+                    }
+
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $itemNotFound, $templateNotFound, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $invoiceEmail, $paymentValidation, $paymentExceeds, $paymentNotFound, $serviceTokenNotFound];
                 },
             );
     }

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -30,6 +30,13 @@ final class CapabilityResolver
             return Capability::ManageUsers;
         }
 
+        // Service-token management (NeNe Clear integration credentials) is admin
+        // oversight: issuing a machine principal that can write payments must not
+        // be available to billing operators (member / viewer). ADR 0009 ops.
+        if (str_starts_with($path, '/admin/service-tokens')) {
+            return Capability::ManageUsers;
+        }
+
         if (str_starts_with($path, '/admin/company-settings')) {
             return Capability::ManageCompanySettings;
         }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -49,6 +49,7 @@ use NeneInvoice\Payment\PaymentServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
 use NeneInvoice\ServiceApi\ServiceApiServiceProvider;
 use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
+use NeneInvoice\ServiceToken\ServiceTokenServiceProvider;
 use NeneInvoice\Template\TemplateServiceProvider;
 use NeneInvoice\User\UserServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -86,6 +87,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new InvoiceServiceProvider());
         $builder->addProvider(new PaymentServiceProvider());
         $builder->addProvider(new ServiceApiServiceProvider());
+        $builder->addProvider(new ServiceTokenServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/ServiceApi/ServiceApiServiceProvider.php
+++ b/src/ServiceApi/ServiceApiServiceProvider.php
@@ -17,6 +17,7 @@ use NeneInvoice\Invoice\ListInvoicesUseCaseInterface;
 use NeneInvoice\Payment\ListPaymentsUseCaseInterface;
 use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
 use NeneInvoice\Payment\VoidPaymentUseCaseInterface;
+use NeneInvoice\ServiceToken\ServiceTokenAuthorizerInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -30,7 +31,11 @@ final readonly class ServiceApiServiceProvider implements ServiceProviderInterfa
         $builder
             ->set(
                 ServiceScopeMiddleware::class,
-                static fn (ContainerInterface $c): ServiceScopeMiddleware => new ServiceScopeMiddleware(self::problemDetails($c), self::orgHolder($c)),
+                static fn (ContainerInterface $c): ServiceScopeMiddleware => new ServiceScopeMiddleware(
+                    self::problemDetails($c),
+                    self::orgHolder($c),
+                    self::resolve($c, ServiceTokenAuthorizerInterface::class),
+                ),
             )
             ->set(
                 ListServiceInvoicesHandler::class,

--- a/src/ServiceApi/ServiceAuthContext.php
+++ b/src/ServiceApi/ServiceAuthContext.php
@@ -25,6 +25,17 @@ final class ServiceAuthContext
         return is_int($value) ? $value : null;
     }
 
+    /**
+     * The token's `jti` (revocation key in the service-token registry), or null
+     * for a legacy token issued before the registry existed.
+     */
+    public static function tokenId(ServerRequestInterface $request): ?string
+    {
+        $value = self::claim($request, 'jti');
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
     /** @return list<string> */
     public static function scopes(ServerRequestInterface $request): array
     {

--- a/src/ServiceApi/ServiceScopeMiddleware.php
+++ b/src/ServiceApi/ServiceScopeMiddleware.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\ServiceApi;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ServiceToken\ServiceTokenAuthorizerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -21,6 +22,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  * `/api/*` bypasses OrgResolverMiddleware (org comes from the service token, not
  * the URL), so this middleware sets the request-scoped org holder from the
  * token's `org` claim — the same holder org-scoped repositories read (ADR 0006).
+ *
+ * It also enforces **revocation**: a token carrying a `jti` is rejected once its
+ * registry row is revoked (or missing). Legacy tokens without a `jti` predate the
+ * registry and rely on the JWT signature + `exp` only.
  */
 final readonly class ServiceScopeMiddleware implements MiddlewareInterface
 {
@@ -30,6 +35,7 @@ final readonly class ServiceScopeMiddleware implements MiddlewareInterface
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private RequestScopedHolder $orgId,
+        private ServiceTokenAuthorizerInterface $authorizer,
     ) {
     }
 
@@ -60,6 +66,20 @@ final readonly class ServiceScopeMiddleware implements MiddlewareInterface
                 'Forbidden',
                 403,
                 'The service token is not scoped to an organization.',
+            );
+        }
+
+        // Revocation: a registered token (carrying a jti) must still be active.
+        // Legacy tokens without a jti predate the registry and are not checked here.
+        $jti = ServiceAuthContext::tokenId($request);
+
+        if ($jti !== null && !$this->authorizer->isActive($jti)) {
+            return $this->problemDetails->create(
+                $request,
+                'service-token-revoked',
+                'Unauthorized',
+                401,
+                'The service token has been revoked.',
             );
         }
 

--- a/src/ServiceToken/IssueServiceTokenHandler.php
+++ b/src/ServiceToken/IssueServiceTokenHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/service-tokens` — issues a NeNe Clear service token for the
+ * caller's organization. The plaintext token is returned **once** in the 201
+ * response and never again. Requires ManageUsers (admin oversight).
+ */
+final readonly class IssueServiceTokenHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private IssueServiceTokenUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $input = ServiceTokenField::parse(JsonRequestBodyParser::parse($request));
+
+        $result = $this->useCase->execute(AuthContext::userId($request), $input);
+
+        return $this->json->create(ServiceTokenResponse::toCreatedArray($result), 201);
+    }
+}

--- a/src/ServiceToken/IssueServiceTokenInput.php
+++ b/src/ServiceToken/IssueServiceTokenInput.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Validated payload for issuing a service token.
+ *
+ * @param list<string> $scopes registered {@see \NeneInvoice\ServiceApi\ServiceScope} values
+ */
+final readonly class IssueServiceTokenInput
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public string $label,
+        public array $scopes,
+        public string $subject,
+        public int $ttlSeconds,
+    ) {
+    }
+}

--- a/src/ServiceToken/IssueServiceTokenResult.php
+++ b/src/ServiceToken/IssueServiceTokenResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Outcome of issuing a service token: the persisted registry record plus the
+ * **plaintext token**, which is returned exactly once (never stored) and must be
+ * shown to the operator immediately.
+ */
+final readonly class IssueServiceTokenResult
+{
+    public function __construct(
+        public ServiceToken $token,
+        public string $plaintextToken,
+    ) {
+    }
+}

--- a/src/ServiceToken/IssueServiceTokenUseCase.php
+++ b/src/ServiceToken/IssueServiceTokenUseCase.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Closure;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+/**
+ * Issues a NeNe Clear service token (ADR 0009): mints a stateless HMAC JWT and
+ * persists a registry row keyed by its `jti`, so the token can later be listed
+ * and revoked. The token value itself is never stored.
+ *
+ * The registry write and its audit record commit atomically (ADR 0008). The
+ * plaintext token is returned exactly once and never written to the audit trail.
+ */
+final readonly class IssueServiceTokenUseCase implements IssueServiceTokenUseCaseInterface
+{
+    /** Bytes of entropy for the `jti` (→ 32 hex chars). */
+    private const JTI_BYTES = 16;
+
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ServiceTokenRepositoryInterface $tokensFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private TokenIssuerInterface $issuer,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $tokensFactory,
+        private Closure $auditFactory,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(?int $actorUserId, IssueServiceTokenInput $input): IssueServiceTokenResult
+    {
+        $organizationId = $this->orgId->get();
+        $jti            = SecureTokenHelper::generate(self::JTI_BYTES);
+
+        $now      = $this->clock->now();
+        $issuedAt = $now->getTimestamp();
+        $expires  = $issuedAt + $input->ttlSeconds;
+
+        $plaintext = $this->issuer->issue([
+            'sub'    => $input->subject,
+            'org'    => $organizationId,
+            'scopes' => $input->scopes,
+            'jti'    => $jti,
+            'iat'    => $issuedAt,
+            'exp'    => $expires,
+        ]);
+
+        $token = new ServiceToken(
+            id: null,
+            organizationId: $organizationId,
+            jti: $jti,
+            subject: $input->subject,
+            label: $input->label,
+            scopes: $input->scopes,
+            createdBy: $actorUserId,
+            createdAt: $now->format('Y-m-d H:i:s'),
+            expiresAt: $now->modify('+' . $input->ttlSeconds . ' seconds')->format('Y-m-d H:i:s'),
+            revokedAt: null,
+        );
+
+        $id = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($token, $actorUserId, $organizationId): int {
+            $newId = ($this->tokensFactory)($exec)->save($token);
+
+            // Audit (ADR 0008): issuing a machine credential is security-relevant.
+            // `after` carries only non-secret metadata — never the token or its jti.
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'service_token.issued',
+                'service_token',
+                $newId,
+                null,
+                ['label' => $token->label, 'subject' => $token->subject, 'scopes' => $token->scopes, 'expires_at' => $token->expiresAt],
+            );
+
+            return $newId;
+        });
+
+        return new IssueServiceTokenResult(
+            token: new ServiceToken(
+                id: $id,
+                organizationId: $token->organizationId,
+                jti: $token->jti,
+                subject: $token->subject,
+                label: $token->label,
+                scopes: $token->scopes,
+                createdBy: $token->createdBy,
+                createdAt: $token->createdAt,
+                expiresAt: $token->expiresAt,
+                revokedAt: null,
+            ),
+            plaintextToken: $plaintext,
+        );
+    }
+}

--- a/src/ServiceToken/IssueServiceTokenUseCaseInterface.php
+++ b/src/ServiceToken/IssueServiceTokenUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+interface IssueServiceTokenUseCaseInterface
+{
+    /**
+     * @param int|null $actorUserId authenticated operator (null for the CLI issuer)
+     */
+    public function execute(?int $actorUserId, IssueServiceTokenInput $input): IssueServiceTokenResult;
+}

--- a/src/ServiceToken/ListServiceTokensHandler.php
+++ b/src/ServiceToken/ListServiceTokensHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /admin/service-tokens` — lists the org's service-token registry records
+ * (metadata only, never the token value). Requires ManageUsers.
+ */
+final readonly class ListServiceTokensHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ListServiceTokensUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $pagination = PaginationQueryParser::parse($request, 50);
+
+        $result = $this->useCase->execute($pagination->limit, $pagination->offset);
+
+        return $this->json->create((new PaginationResponse(
+            items: array_map(
+                static fn (ServiceToken $t): array => ServiceTokenResponse::toArray($t),
+                $result->items,
+            ),
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+            total: $result->total,
+        ))->toArray());
+    }
+}

--- a/src/ServiceToken/ListServiceTokensResult.php
+++ b/src/ServiceToken/ListServiceTokensResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Page of service-token registry records plus the total count for pagination.
+ */
+final readonly class ListServiceTokensResult
+{
+    /**
+     * @param list<ServiceToken> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/ServiceToken/ListServiceTokensUseCase.php
+++ b/src/ServiceToken/ListServiceTokensUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+final readonly class ListServiceTokensUseCase implements ListServiceTokensUseCaseInterface
+{
+    public function __construct(
+        private ServiceTokenRepositoryInterface $repository,
+    ) {
+    }
+
+    public function execute(int $limit, int $offset): ListServiceTokensResult
+    {
+        return new ListServiceTokensResult(
+            items: $this->repository->findAll($limit, $offset),
+            total: $this->repository->count(),
+        );
+    }
+}

--- a/src/ServiceToken/ListServiceTokensUseCaseInterface.php
+++ b/src/ServiceToken/ListServiceTokensUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+interface ListServiceTokensUseCaseInterface
+{
+    public function execute(int $limit, int $offset): ListServiceTokensResult;
+}

--- a/src/ServiceToken/PdoServiceTokenAuthorizer.php
+++ b/src/ServiceToken/PdoServiceTokenAuthorizer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * SQL-backed revocation check. A `jti` is active iff a registry row exists for
+ * it and `revoked_at` is null. Not org-scoped by design (see the interface).
+ */
+final readonly class PdoServiceTokenAuthorizer implements ServiceTokenAuthorizerInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function isActive(string $jti): bool
+    {
+        $row = $this->query->fetchOne(
+            'SELECT 1 AS ok FROM service_tokens WHERE jti = ? AND revoked_at IS NULL',
+            [$jti],
+        );
+
+        return $row !== null;
+    }
+}

--- a/src/ServiceToken/PdoServiceTokenRepository.php
+++ b/src/ServiceToken/PdoServiceTokenRepository.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * SQL-backed service-token registry, scoped to the resolved organization
+ * (ADR 0006). `scopes` is stored as a comma-separated string.
+ */
+final readonly class PdoServiceTokenRepository implements ServiceTokenRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, jti, subject, label, scopes, created_by, created_at, expires_at, revoked_at';
+
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for scoping
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function save(ServiceToken $token): int
+    {
+        $this->query->execute(
+            'INSERT INTO service_tokens (organization_id, jti, subject, label, scopes, created_by, created_at, expires_at, revoked_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->orgId->get(),
+                $token->jti,
+                $token->subject,
+                $token->label,
+                implode(',', $token->scopes),
+                $token->createdBy,
+                $token->createdAt,
+                $token->expiresAt,
+                $token->revokedAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findById(int $id): ?ServiceToken
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM service_tokens WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row === null ? null : self::mapRow($row);
+    }
+
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM service_tokens WHERE organization_id = ? ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$this->orgId->get(), $limit, $offset],
+        );
+
+        return array_map(static fn (array $row): ServiceToken => self::mapRow($row), $rows);
+    }
+
+    public function count(): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS total FROM service_tokens WHERE organization_id = ?',
+            [$this->orgId->get()],
+        );
+
+        return $row === null ? 0 : (int) $row['total'];
+    }
+
+    public function revoke(int $id, string $revokedAt): void
+    {
+        $affected = $this->query->execute(
+            'UPDATE service_tokens SET revoked_at = ? WHERE id = ? AND organization_id = ? AND revoked_at IS NULL',
+            [$revokedAt, $id, $this->orgId->get()],
+        );
+
+        if ($affected === 0 && $this->findById($id) === null) {
+            throw new ServiceTokenNotFoundException($id);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function mapRow(array $row): ServiceToken
+    {
+        $scopes = array_values(array_filter(
+            explode(',', (string) $row['scopes']),
+            static fn (string $s): bool => $s !== '',
+        ));
+
+        return new ServiceToken(
+            id: (int) $row['id'],
+            organizationId: (int) $row['organization_id'],
+            jti: (string) $row['jti'],
+            subject: (string) $row['subject'],
+            label: (string) $row['label'],
+            scopes: $scopes,
+            createdBy: $row['created_by'] !== null ? (int) $row['created_by'] : null,
+            createdAt: (string) $row['created_at'],
+            expiresAt: (string) $row['expires_at'],
+            revokedAt: $row['revoked_at'] !== null ? (string) $row['revoked_at'] : null,
+        );
+    }
+}

--- a/src/ServiceToken/RevokeServiceTokenHandler.php
+++ b/src/ServiceToken/RevokeServiceTokenHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `DELETE /admin/service-tokens/{id}` — revokes a service token in the caller's
+ * organization. Idempotent: re-revoking an already-revoked token still 204s.
+ * Requires ManageUsers.
+ */
+final readonly class RevokeServiceTokenHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private RevokeServiceTokenUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $this->useCase->execute(AuthContext::userId($request), $id);
+
+        return $this->json->createEmpty(204);
+    }
+}

--- a/src/ServiceToken/RevokeServiceTokenUseCase.php
+++ b/src/ServiceToken/RevokeServiceTokenUseCase.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+/**
+ * Revokes a service token by id (org-scoped). Sets `revoked_at` so the
+ * request-time {@see ServiceTokenAuthorizerInterface} rejects it immediately.
+ * The revoke write and its audit record commit atomically (ADR 0008).
+ */
+final readonly class RevokeServiceTokenUseCase implements RevokeServiceTokenUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ServiceTokenRepositoryInterface $tokensFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $tokensFactory,
+        private Closure $auditFactory,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(?int $actorUserId, int $id): void
+    {
+        $organizationId = $this->orgId->get();
+        $revokedAt      = $this->clock->now()->format('Y-m-d H:i:s');
+
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($id, $revokedAt, $actorUserId, $organizationId): null {
+            // Throws ServiceTokenNotFoundException for an unknown / foreign id.
+            ($this->tokensFactory)($exec)->revoke($id, $revokedAt);
+
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'service_token.revoked',
+                'service_token',
+                $id,
+                null,
+                ['revoked_at' => $revokedAt],
+            );
+
+            return null;
+        });
+    }
+}

--- a/src/ServiceToken/RevokeServiceTokenUseCaseInterface.php
+++ b/src/ServiceToken/RevokeServiceTokenUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+interface RevokeServiceTokenUseCaseInterface
+{
+    /**
+     * @throws ServiceTokenNotFoundException when the token does not exist in the caller's org
+     */
+    public function execute(?int $actorUserId, int $id): void;
+}

--- a/src/ServiceToken/ServiceToken.php
+++ b/src/ServiceToken/ServiceToken.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Registry record for an issued NeNe Clear service token (ADR 0009).
+ *
+ * The token itself is a stateless HMAC JWT and is **never** stored — this row
+ * holds only metadata plus the `jti` claim, which keys revocation. Reads/writes
+ * are scoped to `organization_id` (ADR 0006); the CLI issuer may set
+ * `createdBy = null`.
+ *
+ * @param list<string> $scopes registered {@see \NeneInvoice\ServiceApi\ServiceScope} values
+ */
+final readonly class ServiceToken
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public ?int $id,
+        public int $organizationId,
+        public string $jti,
+        public string $subject,
+        public string $label,
+        public array $scopes,
+        public ?int $createdBy,
+        public string $createdAt,
+        public string $expiresAt,
+        public ?string $revokedAt,
+    ) {
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revokedAt !== null;
+    }
+}

--- a/src/ServiceToken/ServiceTokenAuthorizerInterface.php
+++ b/src/ServiceToken/ServiceTokenAuthorizerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Checks a presented service token against the registry at request time.
+ *
+ * Unlike {@see ServiceTokenRepositoryInterface}, lookups here are **not**
+ * org-scoped: the `jti` is globally unique and the request org is derived from
+ * the token itself, so revocation must be enforceable before any org scoping is
+ * trusted. Tokens issued before the registry existed carry no `jti` and are not
+ * checked here (the JWT signature + `exp` remain authoritative for them).
+ */
+interface ServiceTokenAuthorizerInterface
+{
+    /**
+     * True when a non-revoked registry row exists for the `jti`. Returns false
+     * for an unknown or revoked `jti` (fail-closed).
+     */
+    public function isActive(string $jti): bool;
+}

--- a/src/ServiceToken/ServiceTokenField.php
+++ b/src/ServiceToken/ServiceTokenField.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneInvoice\ServiceApi\ServiceScope;
+use NeneInvoice\Support\TextLimit;
+
+/**
+ * Parses + validates the service-token issuance payload (`POST
+ * /admin/service-tokens`). Scopes must be a non-empty subset of the registered
+ * {@see ServiceScope} values; the subject defaults to the NeNe Clear principal.
+ */
+final class ServiceTokenField
+{
+    public const DEFAULT_SUBJECT = 'service:clear';
+
+    /** Issuance TTL bounds (seconds): 1 hour … 1 year, default 30 days. */
+    public const MIN_TTL_SECONDS = 3600;
+    public const MAX_TTL_SECONDS = 31_536_000;
+    public const DEFAULT_TTL_SECONDS = 2_592_000;
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @throws ValidationException
+     */
+    public static function parse(array $body): IssueServiceTokenInput
+    {
+        $errors = [];
+
+        $label = $body['label'] ?? null;
+        if (!is_string($label) || trim($label) === '') {
+            $errors[] = new ValidationError('body.label', 'Label is required.', 'required');
+            $label = '';
+        } elseif (mb_strlen($label) > TextLimit::NAME) {
+            $errors[] = new ValidationError('body.label', sprintf('Must be at most %d characters.', TextLimit::NAME), 'too_long');
+        }
+
+        $scopes = self::parseScopes($body['scopes'] ?? null, $errors);
+
+        $subject = $body['subject'] ?? self::DEFAULT_SUBJECT;
+        if (!is_string($subject) || trim($subject) === '') {
+            $errors[] = new ValidationError('body.subject', 'Subject must be a non-empty string.', 'invalid');
+            $subject = self::DEFAULT_SUBJECT;
+        } elseif (mb_strlen($subject) > TextLimit::NAME) {
+            $errors[] = new ValidationError('body.subject', sprintf('Must be at most %d characters.', TextLimit::NAME), 'too_long');
+        }
+
+        $ttl = $body['ttl_seconds'] ?? self::DEFAULT_TTL_SECONDS;
+        if (!is_int($ttl) || $ttl < self::MIN_TTL_SECONDS || $ttl > self::MAX_TTL_SECONDS) {
+            $errors[] = new ValidationError(
+                'body.ttl_seconds',
+                sprintf('TTL must be an integer between %d and %d seconds.', self::MIN_TTL_SECONDS, self::MAX_TTL_SECONDS),
+                'invalid',
+            );
+            $ttl = self::DEFAULT_TTL_SECONDS;
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        return new IssueServiceTokenInput(
+            label: trim($label),
+            scopes: $scopes,
+            subject: trim($subject),
+            ttlSeconds: $ttl,
+        );
+    }
+
+    /**
+     * @param list<ValidationError> $errors
+     * @return list<string>
+     */
+    private static function parseScopes(mixed $value, array &$errors): array
+    {
+        if (!is_array($value) || $value === []) {
+            $errors[] = new ValidationError('body.scopes', 'At least one scope is required.', 'required');
+
+            return [];
+        }
+
+        $allowed = array_map(static fn (ServiceScope $s): string => $s->value, ServiceScope::cases());
+        $scopes = [];
+
+        foreach ($value as $scope) {
+            if (!is_string($scope) || !in_array($scope, $allowed, true)) {
+                $errors[] = new ValidationError('body.scopes', sprintf('Each scope must be one of: %s.', implode(', ', $allowed)), 'invalid');
+
+                return [];
+            }
+
+            if (!in_array($scope, $scopes, true)) {
+                $scopes[] = $scope;
+            }
+        }
+
+        return $scopes;
+    }
+}

--- a/src/ServiceToken/ServiceTokenNotFoundException.php
+++ b/src/ServiceToken/ServiceTokenNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use RuntimeException;
+
+final class ServiceTokenNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Service token {$id} not found.");
+    }
+}

--- a/src/ServiceToken/ServiceTokenNotFoundExceptionHandler.php
+++ b/src/ServiceToken/ServiceTokenNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ServiceTokenNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ServiceTokenNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'service-token-not-found', 'Not Found', 404, 'The requested service token was not found.');
+    }
+}

--- a/src/ServiceToken/ServiceTokenRepositoryInterface.php
+++ b/src/ServiceToken/ServiceTokenRepositoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Persistence for the service-token registry. Every query is scoped to the
+ * organization held in the request-scoped org holder (ADR 0006). The token
+ * value is never persisted — only metadata + the `jti` revocation key.
+ */
+interface ServiceTokenRepositoryInterface
+{
+    public function save(ServiceToken $token): int;
+
+    public function findById(int $id): ?ServiceToken;
+
+    /** @return list<ServiceToken> newest first */
+    public function findAll(int $limit, int $offset): array;
+
+    public function count(): int;
+
+    /**
+     * Marks the token revoked at the given timestamp. No-op if already revoked.
+     *
+     * @throws ServiceTokenNotFoundException when no matching token exists in the org
+     */
+    public function revoke(int $id, string $revokedAt): void;
+}

--- a/src/ServiceToken/ServiceTokenResponse.php
+++ b/src/ServiceToken/ServiceTokenResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+/**
+ * Serialises service-token registry records for the operator API. The token
+ * value is **never** included here — only on the issuance response, exactly once
+ * (see {@see self::toCreatedArray()}).
+ */
+final class ServiceTokenResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ServiceToken $token): array
+    {
+        return [
+            'id'         => $token->id,
+            'subject'    => $token->subject,
+            'label'      => $token->label,
+            'scopes'     => $token->scopes,
+            'created_by' => $token->createdBy,
+            'created_at' => $token->createdAt,
+            'expires_at' => $token->expiresAt,
+            'revoked_at' => $token->revokedAt,
+            'status'     => $token->isRevoked() ? 'revoked' : 'active',
+        ];
+    }
+
+    /**
+     * Issuance response: metadata plus the plaintext `token`, shown to the
+     * operator once and never retrievable again.
+     *
+     * @return array<string, mixed>
+     */
+    public static function toCreatedArray(IssueServiceTokenResult $result): array
+    {
+        return self::toArray($result->token) + ['token' => $result->plaintextToken];
+    }
+}

--- a/src/ServiceToken/ServiceTokenRouteRegistrar.php
+++ b/src/ServiceToken/ServiceTokenRouteRegistrar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers service-token management routes (`/admin/service-tokens`). All
+ * require ManageUsers (admin oversight) via CapabilityMiddleware, scoped to the
+ * resolved organization (ADR 0006).
+ */
+final readonly class ServiceTokenRouteRegistrar
+{
+    public function __construct(
+        private ListServiceTokensHandler $listHandler,
+        private IssueServiceTokenHandler $issueHandler,
+        private RevokeServiceTokenHandler $revokeHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list = $this->listHandler;
+        $issue = $this->issueHandler;
+        $revoke = $this->revokeHandler;
+
+        $router->get('/admin/service-tokens', static fn (ServerRequestInterface $r) => $list->handle($r));
+        $router->post('/admin/service-tokens', static fn (ServerRequestInterface $r) => $issue->handle($r));
+        $router->delete('/admin/service-tokens/{id}', static fn (ServerRequestInterface $r) => $revoke->handle($r));
+    }
+}

--- a/src/ServiceToken/ServiceTokenServiceProvider.php
+++ b/src/ServiceToken/ServiceTokenServiceProvider.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\ServiceToken;
+
+use LogicException;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Audit\AuditServiceProvider;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the service-token management domain: registry repository, request-time
+ * revocation authorizer, issue/list/revoke use cases, handlers, not-found
+ * exception handler, and the route registrar (ADR 0009 ops follow-up).
+ */
+final readonly class ServiceTokenServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ServiceTokenRepositoryInterface::class,
+                static fn (ContainerInterface $c): ServiceTokenRepositoryInterface => new PdoServiceTokenRepository(self::executor($c), self::orgHolder($c)),
+            )
+            ->set(
+                ServiceTokenAuthorizerInterface::class,
+                static fn (ContainerInterface $c): ServiceTokenAuthorizerInterface => new PdoServiceTokenAuthorizer(self::executor($c)),
+            )
+            ->set(
+                ListServiceTokensUseCaseInterface::class,
+                static fn (ContainerInterface $c): ListServiceTokensUseCase => new ListServiceTokensUseCase(self::repository($c)),
+            )
+            ->set(
+                IssueServiceTokenUseCaseInterface::class,
+                static function (ContainerInterface $c): IssueServiceTokenUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new IssueServiceTokenUseCase(
+                        self::resolve($c, TokenIssuerInterface::class),
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): ServiceTokenRepositoryInterface => new PdoServiceTokenRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        self::clock($c),
+                        $orgHolder,
+                    );
+                },
+            )
+            ->set(
+                RevokeServiceTokenUseCaseInterface::class,
+                static function (ContainerInterface $c): RevokeServiceTokenUseCase {
+                    $orgHolder = self::orgHolder($c);
+
+                    return new RevokeServiceTokenUseCase(
+                        self::resolve($c, DatabaseTransactionManagerInterface::class),
+                        static fn (DatabaseQueryExecutorInterface $exec): ServiceTokenRepositoryInterface => new PdoServiceTokenRepository($exec, $orgHolder),
+                        AuditServiceProvider::recorderFactory($c),
+                        self::clock($c),
+                        $orgHolder,
+                    );
+                },
+            )
+            ->set(
+                ListServiceTokensHandler::class,
+                static fn (ContainerInterface $c): ListServiceTokensHandler => new ListServiceTokensHandler(self::resolve($c, ListServiceTokensUseCaseInterface::class), self::json($c)),
+            )
+            ->set(
+                IssueServiceTokenHandler::class,
+                static fn (ContainerInterface $c): IssueServiceTokenHandler => new IssueServiceTokenHandler(self::resolve($c, IssueServiceTokenUseCaseInterface::class), self::json($c)),
+            )
+            ->set(
+                RevokeServiceTokenHandler::class,
+                static fn (ContainerInterface $c): RevokeServiceTokenHandler => new RevokeServiceTokenHandler(self::resolve($c, RevokeServiceTokenUseCaseInterface::class), self::json($c)),
+            )
+            ->set(
+                ServiceTokenNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): ServiceTokenNotFoundExceptionHandler => new ServiceTokenNotFoundExceptionHandler(self::problemDetails($c)),
+            )
+            ->set(
+                ServiceTokenRouteRegistrar::class,
+                static function (ContainerInterface $c): ServiceTokenRouteRegistrar {
+                    $list = $c->get(ListServiceTokensHandler::class);
+                    $issue = $c->get(IssueServiceTokenHandler::class);
+                    $revoke = $c->get(RevokeServiceTokenHandler::class);
+
+                    if (!$list instanceof ListServiceTokensHandler || !$issue instanceof IssueServiceTokenHandler || !$revoke instanceof RevokeServiceTokenHandler) {
+                        throw new LogicException('Service token handler services are invalid.');
+                    }
+
+                    return new ServiceTokenRouteRegistrar($list, $issue, $revoke);
+                },
+            );
+    }
+
+    private static function repository(ContainerInterface $c): ServiceTokenRepositoryInterface
+    {
+        return self::resolve($c, ServiceTokenRepositoryInterface::class);
+    }
+
+    private static function executor(ContainerInterface $c): DatabaseQueryExecutorInterface
+    {
+        return self::resolve($c, DatabaseQueryExecutorInterface::class);
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
+    }
+
+    private static function clock(ContainerInterface $c): ClockInterface
+    {
+        return self::resolve($c, ClockInterface::class);
+    }
+
+    private static function json(ContainerInterface $c): JsonResponseFactory
+    {
+        return self::resolve($c, JsonResponseFactory::class);
+    }
+
+    private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
+    {
+        return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -80,6 +80,9 @@ final class OpenApiContractTest extends TestCase
         'sendInvoiceEmail',
         'exportInvoicesCsv',
         'exportPaymentsCsv',
+        'listServiceTokens',
+        'issueServiceToken',
+        'revokeServiceToken',
     ];
 
     /** @var array<string, mixed> */

--- a/tests/ServiceApi/ServiceScopeMiddlewareTest.php
+++ b/tests/ServiceApi/ServiceScopeMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace NeneInvoice\Tests\ServiceApi;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
+use NeneInvoice\ServiceToken\ServiceTokenAuthorizerInterface;
 use NeneInvoice\Tests\Support\RecordingRequestHandler;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -19,15 +20,32 @@ final class ServiceScopeMiddlewareTest extends TestCase
     private Psr17Factory $psr17;
     /** @var RequestScopedHolder<int> */
     private RequestScopedHolder $holder;
+    /** @var list<string> jtis the fake authorizer treats as revoked */
+    private array $revoked = [];
     private ServiceScopeMiddleware $middleware;
 
     protected function setUp(): void
     {
         $this->psr17 = new Psr17Factory();
         $this->holder = new RequestScopedHolder();
+
+        $revoked = &$this->revoked;
+        $authorizer = new class ($revoked) implements ServiceTokenAuthorizerInterface {
+            /** @param list<string> $revoked */
+            public function __construct(private array &$revoked)
+            {
+            }
+
+            public function isActive(string $jti): bool
+            {
+                return !in_array($jti, $this->revoked, true);
+            }
+        };
+
         $this->middleware = new ServiceScopeMiddleware(
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
             $this->holder,
+            $authorizer,
         );
     }
 
@@ -89,6 +107,43 @@ final class ServiceScopeMiddlewareTest extends TestCase
     {
         $response = $this->middleware->process(
             $this->request('/admin/invoices', ['sub' => 7, 'role' => 'admin', 'org' => 1]),
+            $this->handler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_active_registered_token_passes(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['org' => 4, 'scopes' => ['read:invoices'], 'jti' => 'live-jti']),
+            $this->handler(),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(4, $this->holder->get());
+    }
+
+    public function test_revoked_token_is_rejected_with_401(): void
+    {
+        $this->revoked = ['dead-jti'];
+
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['org' => 4, 'scopes' => ['read:invoices'], 'jti' => 'dead-jti']),
+            $this->handler(),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_legacy_token_without_jti_skips_revocation_check(): void
+    {
+        // Even with a non-empty revocation set, a token carrying no jti predates
+        // the registry and is accepted on signature + scope alone.
+        $this->revoked = ['anything'];
+
+        $response = $this->middleware->process(
+            $this->request('/api/invoices', ['org' => 4, 'scopes' => ['read:invoices']]),
             $this->handler(),
         );
 

--- a/tests/ServiceToken/IssueServiceTokenUseCaseTest.php
+++ b/tests/ServiceToken/IssueServiceTokenUseCaseTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceToken;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ServiceToken\IssueServiceTokenInput;
+use NeneInvoice\ServiceToken\IssueServiceTokenUseCase;
+use NeneInvoice\ServiceToken\PdoServiceTokenRepository;
+use NeneInvoice\ServiceToken\ServiceTokenRepositoryInterface;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use NeneInvoice\Tests\Support\RecordingTokenIssuer;
+use PHPUnit\Framework\TestCase;
+
+final class IssueServiceTokenUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+    private RecordingAuditRecorder $audit;
+    private PdoServiceTokenRepository $repository;
+    private RecordingTokenIssuer $issuer;
+    private IssueServiceTokenUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/service_tokens.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $executor = new PdoDatabaseQueryExecutor($factory, $pdo);
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(5);
+        $this->repository = new PdoServiceTokenRepository($executor, $this->orgId);
+        $this->audit = new RecordingAuditRecorder();
+
+        $this->issuer = new RecordingTokenIssuer();
+
+        $orgHolder = $this->orgId;
+        $audit = $this->audit;
+
+        $this->useCase = new IssueServiceTokenUseCase(
+            $this->issuer,
+            new ImmediateTransactionManager($executor),
+            static fn (DatabaseQueryExecutorInterface $exec): ServiceTokenRepositoryInterface => new PdoServiceTokenRepository($exec, $orgHolder),
+            static fn (DatabaseQueryExecutorInterface $exec) => $audit,
+            new FixedClock('2026-06-09T00:00:00Z'),
+            $orgHolder,
+        );
+    }
+
+    public function test_issue_persists_registry_row_and_returns_plaintext_once(): void
+    {
+        $result = $this->useCase->execute(7, new IssueServiceTokenInput(
+            label: 'NeNe Clear prod',
+            scopes: ['read:invoices', 'write:payments'],
+            subject: 'service:clear',
+            ttlSeconds: 2_592_000,
+        ));
+
+        // Plaintext token returned exactly once; jti embedded by the issuer.
+        self::assertNotNull($result->token->id);
+        self::assertSame('signed.' . $result->token->jti, $result->plaintextToken);
+        self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $result->token->jti);
+
+        // Persisted row carries metadata, org from the holder, and actor.
+        $stored = $this->repository->findById($result->token->id);
+        self::assertNotNull($stored);
+        self::assertSame(5, $stored->organizationId);
+        self::assertSame('NeNe Clear prod', $stored->label);
+        self::assertSame(['read:invoices', 'write:payments'], $stored->scopes);
+        self::assertSame(7, $stored->createdBy);
+        self::assertNull($stored->revokedAt);
+        // 30-day TTL from the fixed clock.
+        self::assertSame('2026-07-09 00:00:00', $stored->expiresAt);
+    }
+
+    public function test_issued_jwt_claims_carry_org_scopes_jti_and_expiry(): void
+    {
+        $this->useCase->execute(7, new IssueServiceTokenInput(
+            label: 'cli',
+            scopes: ['read:invoices'],
+            subject: 'service:clear',
+            ttlSeconds: 3600,
+        ));
+
+        $claims = $this->issuer->claims;
+        self::assertSame('service:clear', $claims['sub']);
+        self::assertSame(5, $claims['org']);
+        self::assertSame(['read:invoices'], $claims['scopes']);
+        self::assertArrayHasKey('jti', $claims);
+        $expectedIat = (new \DateTimeImmutable('2026-06-09T00:00:00Z'))->getTimestamp();
+        self::assertSame($expectedIat, $claims['iat']);
+        self::assertSame($expectedIat + 3600, $claims['exp']);
+    }
+
+    public function test_audit_record_excludes_secret_material(): void
+    {
+        $this->useCase->execute(7, new IssueServiceTokenInput(
+            label: 'audited',
+            scopes: ['read:invoices'],
+            subject: 'service:clear',
+            ttlSeconds: 3600,
+        ));
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame('service_token.issued', $record['action']);
+        self::assertSame('service_token', $record['entity_type']);
+        self::assertSame(5, $record['organization_id']);
+        self::assertSame(7, $record['actor_user_id']);
+        self::assertArrayNotHasKey('token', $record['after']);
+        self::assertArrayNotHasKey('jti', $record['after']);
+        self::assertSame('audited', $record['after']['label']);
+    }
+}

--- a/tests/ServiceToken/PdoServiceTokenAuthorizerTest.php
+++ b/tests/ServiceToken/PdoServiceTokenAuthorizerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceToken;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\ServiceToken\PdoServiceTokenAuthorizer;
+use PHPUnit\Framework\TestCase;
+
+final class PdoServiceTokenAuthorizerTest extends TestCase
+{
+    private \PDO $pdo;
+    private PdoServiceTokenAuthorizer $authorizer;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/service_tokens.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->pdo = $pdo;
+        $this->authorizer = new PdoServiceTokenAuthorizer(new PdoDatabaseQueryExecutor($factory, $pdo));
+    }
+
+    private function insert(string $jti, ?string $revokedAt): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO service_tokens (organization_id, jti, subject, label, scopes, created_by, created_at, expires_at, revoked_at)
+             VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+        $stmt->execute([$jti, 'service:clear', 'NeNe Clear', 'read:invoices', null, '2026-06-09 00:00:00', '2026-07-09 00:00:00', $revokedAt]);
+    }
+
+    public function test_active_token_is_active(): void
+    {
+        $this->insert('live', null);
+        self::assertTrue($this->authorizer->isActive('live'));
+    }
+
+    public function test_revoked_token_is_not_active(): void
+    {
+        $this->insert('dead', '2026-06-09 10:00:00');
+        self::assertFalse($this->authorizer->isActive('dead'));
+    }
+
+    public function test_unknown_jti_is_not_active(): void
+    {
+        self::assertFalse($this->authorizer->isActive('missing'));
+    }
+}

--- a/tests/ServiceToken/PdoServiceTokenRepositoryTest.php
+++ b/tests/ServiceToken/PdoServiceTokenRepositoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceToken;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ServiceToken\PdoServiceTokenRepository;
+use NeneInvoice\ServiceToken\ServiceToken;
+use NeneInvoice\ServiceToken\ServiceTokenNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class PdoServiceTokenRepositoryTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+    private PdoServiceTokenRepository $repository;
+    private \PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/service_tokens.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->pdo = $pdo;
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(1);
+        $this->repository = new PdoServiceTokenRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->orgId);
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    private function newToken(string $jti, array $scopes = ['read:invoices']): ServiceToken
+    {
+        return new ServiceToken(
+            id: null,
+            organizationId: 1,
+            jti: $jti,
+            subject: 'service:clear',
+            label: 'NeNe Clear',
+            scopes: $scopes,
+            createdBy: 7,
+            createdAt: '2026-06-09 00:00:00',
+            expiresAt: '2026-07-09 00:00:00',
+            revokedAt: null,
+        );
+    }
+
+    public function test_save_and_find_round_trips_all_fields(): void
+    {
+        $id = $this->repository->save($this->newToken('jti-a', ['read:invoices', 'write:payments']));
+
+        $found = $this->repository->findById($id);
+
+        self::assertNotNull($found);
+        self::assertSame($id, $found->id);
+        self::assertSame('jti-a', $found->jti);
+        self::assertSame('service:clear', $found->subject);
+        self::assertSame('NeNe Clear', $found->label);
+        self::assertSame(['read:invoices', 'write:payments'], $found->scopes);
+        self::assertSame(7, $found->createdBy);
+        self::assertNull($found->revokedAt);
+        self::assertFalse($found->isRevoked());
+    }
+
+    public function test_list_is_org_scoped_and_newest_first(): void
+    {
+        $this->repository->save($this->newToken('jti-1'));
+        $this->repository->save($this->newToken('jti-2'));
+        $this->insertForeignOrgToken('jti-foreign');
+
+        $items = $this->repository->findAll(50, 0);
+
+        self::assertCount(2, $items);
+        self::assertSame('jti-2', $items[0]->jti);
+        self::assertSame('jti-1', $items[1]->jti);
+        self::assertSame(2, $this->repository->count());
+    }
+
+    public function test_revoke_sets_timestamp_and_is_idempotent(): void
+    {
+        $id = $this->repository->save($this->newToken('jti-r'));
+
+        $this->repository->revoke($id, '2026-06-09 12:00:00');
+        $first = $this->repository->findById($id);
+        self::assertNotNull($first);
+        self::assertSame('2026-06-09 12:00:00', $first->revokedAt);
+        self::assertTrue($first->isRevoked());
+
+        // Re-revoking keeps the original timestamp and does not throw.
+        $this->repository->revoke($id, '2026-06-10 09:00:00');
+        $again = $this->repository->findById($id);
+        self::assertNotNull($again);
+        self::assertSame('2026-06-09 12:00:00', $again->revokedAt);
+    }
+
+    public function test_revoke_unknown_id_throws(): void
+    {
+        $this->expectException(ServiceTokenNotFoundException::class);
+        $this->repository->revoke(999, '2026-06-09 12:00:00');
+    }
+
+    public function test_revoke_foreign_org_token_throws(): void
+    {
+        $foreignId = $this->insertForeignOrgToken('jti-foreign');
+
+        $this->expectException(ServiceTokenNotFoundException::class);
+        $this->repository->revoke($foreignId, '2026-06-09 12:00:00');
+    }
+
+    private function insertForeignOrgToken(string $jti): int
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO service_tokens (organization_id, jti, subject, label, scopes, created_by, created_at, expires_at, revoked_at)
+             VALUES (2, ?, ?, ?, ?, ?, ?, ?, ?)',
+        );
+        $stmt->execute([$jti, 'service:clear', 'Other org', 'read:invoices', null, '2026-06-09 00:00:00', '2026-07-09 00:00:00', null]);
+
+        return (int) $this->pdo->lastInsertId();
+    }
+}

--- a/tests/ServiceToken/RevokeServiceTokenUseCaseTest.php
+++ b/tests/ServiceToken/RevokeServiceTokenUseCaseTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\ServiceToken;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ServiceToken\PdoServiceTokenRepository;
+use NeneInvoice\ServiceToken\RevokeServiceTokenUseCase;
+use NeneInvoice\ServiceToken\ServiceToken;
+use NeneInvoice\ServiceToken\ServiceTokenNotFoundException;
+use NeneInvoice\ServiceToken\ServiceTokenRepositoryInterface;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class RevokeServiceTokenUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+    private RecordingAuditRecorder $audit;
+    private PdoServiceTokenRepository $repository;
+    private RevokeServiceTokenUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/service_tokens.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $executor = new PdoDatabaseQueryExecutor($factory, $pdo);
+        $this->orgId = new RequestScopedHolder();
+        $this->orgId->set(5);
+        $this->repository = new PdoServiceTokenRepository($executor, $this->orgId);
+        $this->audit = new RecordingAuditRecorder();
+
+        $orgHolder = $this->orgId;
+        $audit = $this->audit;
+
+        $this->useCase = new RevokeServiceTokenUseCase(
+            new ImmediateTransactionManager($executor),
+            static fn (DatabaseQueryExecutorInterface $exec): ServiceTokenRepositoryInterface => new PdoServiceTokenRepository($exec, $orgHolder),
+            static fn (DatabaseQueryExecutorInterface $exec) => $audit,
+            new FixedClock('2026-06-09T12:00:00Z'),
+            $orgHolder,
+        );
+    }
+
+    private function seedToken(): int
+    {
+        return $this->repository->save(new ServiceToken(
+            id: null,
+            organizationId: 5,
+            jti: 'jti-x',
+            subject: 'service:clear',
+            label: 'NeNe Clear',
+            scopes: ['read:invoices'],
+            createdBy: 7,
+            createdAt: '2026-06-09 00:00:00',
+            expiresAt: '2026-07-09 00:00:00',
+            revokedAt: null,
+        ));
+    }
+
+    public function test_revoke_marks_token_and_audits(): void
+    {
+        $id = $this->seedToken();
+
+        $this->useCase->execute(7, $id);
+
+        $stored = $this->repository->findById($id);
+        self::assertNotNull($stored);
+        self::assertSame('2026-06-09 12:00:00', $stored->revokedAt);
+
+        self::assertCount(1, $this->audit->records);
+        self::assertSame('service_token.revoked', $this->audit->records[0]['action']);
+        self::assertSame('service_token', $this->audit->records[0]['entity_type']);
+        self::assertSame($id, $this->audit->records[0]['entity_id']);
+    }
+
+    public function test_revoke_unknown_token_throws(): void
+    {
+        $this->expectException(ServiceTokenNotFoundException::class);
+        $this->useCase->execute(7, 404);
+    }
+}

--- a/tests/Support/RecordingTokenIssuer.php
+++ b/tests/Support/RecordingTokenIssuer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nene2\Auth\TokenIssuerInterface;
+
+/**
+ * Test double for {@see TokenIssuerInterface} that captures the claims it was
+ * asked to sign and returns a deterministic, inspectable token string.
+ */
+final class RecordingTokenIssuer implements TokenIssuerInterface
+{
+    /** @var array<string, mixed> claims passed to the most recent issue() call */
+    public array $claims = [];
+
+    public function issue(array $claims): string
+    {
+        $this->claims = $claims;
+
+        return 'signed.' . (is_string($claims['jti'] ?? null) ? $claims['jti'] : '');
+    }
+}

--- a/tools/issue-service-token.php
+++ b/tools/issue-service-token.php
@@ -7,15 +7,20 @@ declare(strict_types=1);
  *
  * Usage:
  *   php tools/issue-service-token.php --org=1 --scopes=read:invoices,write:payments \
- *       [--sub=service:clear] [--ttl=2592000]
+ *       [--label="NeNe Clear"] [--sub=service:clear] [--ttl=2592000]
  *
  * Prints the bearer token to stdout. Clear stores it as NENE_INVOICE_BEARER_TOKEN.
  * The token is signed with the same HMAC secret as login tokens; treat it as a
- * secret. (Issuance/revocation via an operator UI is a follow-up.)
+ * secret. It is also recorded in the `service_tokens` registry (metadata + jti,
+ * never the value) so it appears in the operator UI and can be revoked there.
  */
 
-use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Validation\ValidationException;
+use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\ServiceToken\IssueServiceTokenUseCaseInterface;
+use NeneInvoice\ServiceToken\ServiceTokenField;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -44,24 +49,40 @@ $scopes = array_values(array_filter(
     explode(',', $args['scopes'] ?? 'read:invoices'),
     static fn (string $s): bool => $s !== '',
 ));
-$sub = $args['sub'] ?? 'service:clear';
-$ttl = isset($args['ttl']) && ctype_digit($args['ttl']) ? (int) $args['ttl'] : 2592000; // 30 days
+$ttl = isset($args['ttl']) && ctype_digit($args['ttl']) ? (int) $args['ttl'] : ServiceTokenField::DEFAULT_TTL_SECONDS;
 
-$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
-$issuer = $container->get(TokenIssuerInterface::class);
-
-if (!$issuer instanceof TokenIssuerInterface) {
-    fwrite(STDERR, "Error: token issuer service is unavailable.\n");
+// Validate exactly like the operator API does (scopes, label/subject length, TTL).
+try {
+    $input = ServiceTokenField::parse([
+        'label'       => $args['label'] ?? 'CLI-issued',
+        'scopes'      => $scopes,
+        'subject'     => $args['sub'] ?? ServiceTokenField::DEFAULT_SUBJECT,
+        'ttl_seconds' => $ttl,
+    ]);
+} catch (ValidationException $e) {
+    foreach ($e->errors() as $error) {
+        fwrite(STDERR, sprintf("Error: %s — %s\n", $error->field, $error->message));
+    }
     exit(1);
 }
 
-$now = time();
-$token = $issuer->issue([
-    'sub' => $sub,
-    'org' => $org,
-    'scopes' => $scopes,
-    'iat' => $now,
-    'exp' => $now + $ttl,
-]);
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
 
-echo $token . "\n";
+// The issue use case reads the org from the request-scoped holder (ADR 0006);
+// set it explicitly here since there is no HTTP request to resolve it.
+$orgHolder = $container->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+if (!$orgHolder instanceof RequestScopedHolder) {
+    fwrite(STDERR, "Error: org holder service is unavailable.\n");
+    exit(1);
+}
+$orgHolder->set($org);
+
+$useCase = $container->get(IssueServiceTokenUseCaseInterface::class);
+if (!$useCase instanceof IssueServiceTokenUseCaseInterface) {
+    fwrite(STDERR, "Error: service-token issuer is unavailable.\n");
+    exit(1);
+}
+
+$result = $useCase->execute(null, $input);
+
+echo $result->plaintextToken . "\n";


### PR DESCRIPTION
Closes #416

## 背景

NeNe Clear（downstream consumer / ADR 0009）が `/api/*` に接続するための **service token** は CLI でしか発行できず、発行 UI も失効手段も無かった（ステートレス JWT で DB 非保存のため一覧・個別失効が不可）。本 PR で **DB レジストリ化＋発行/一覧/失効 API** を実装し、運用可能にする（UI は #417）。

## 変更

- **`service_tokens` テーブル**（phinx + sqlite/mysql schema）。**トークン値は保存せず**、メタデータ＋`jti`（失効キー）のみ。
- **発行トークンに `jti` クレーム付与**（admin API・CLI 共通）。
- **オペレーター API `/admin/service-tokens`**（admin オーバーサイト = `manage_users`、org スコープ）:
  - `POST` 発行 → 平文トークンを**作成レスポンスで一度だけ**返す。
  - `GET` 一覧 → メタデータのみ（値は返さない）。
  - `DELETE /{id}` 失効（冪等）。
- **失効チェック**を `ServiceScopeMiddleware` に追加: `jti` を持つトークンはレジストリ照合し、失効・未登録なら `401 service-token-revoked`。`jti` 無しの旧 CLI トークンは後方互換で署名＋`exp` のみで通す。
- **CLI** `tools/issue-service-token.php` もレジストリ登録するよう更新（`--label` 追加・スコープ検証）。
- **ドキュメント**: 用語レジストリ（エンティティ／フィールド／Problem Details slug 2件／operationId 3件／status 値）、OpenAPI（`/admin/service-tokens` + スキーマ）、`sibling-products.md`、`current.md`。

## セキュリティ方針

- 認証層の変更だが fail-closed・人/サービス principal の層分けを退行させない（`security-posture-notes` 準拠）。member/viewer は API 拒否（403）。
- 会計・税務ロジックには非干渉。

## 検証

- `composer check` green（PHPUnit 423 / PHPStan / CS / OpenAPI / MCP）。新規ユニットテスト（リポジトリ org スコープ・冪等失効・authorizer・発行ユースケース・失効ユースケース・middleware 失効）。
- ローカル E2E: 発行(201, 平文1回) → 一覧(値なし) → `/api/invoices` 200 → 失効(204) → `/api/invoices` 401 `service-token-revoked`。member は 403。CLI 発行＋不正スコープのクリーンエラーを確認。

## セルフレビュー

backend-api / docs-policy / naming / compliance（非該当）チェックリスト確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)