### PR TITLE
docs(adr): カード決済の第1弾ゲートウェイを PAY.JP に確定 (#429)

### DIFF
--- a/docs/adr/0012-card-payment-on-invoices.md
+++ b/docs/adr/0012-card-payment-on-invoices.md
@@ -79,9 +79,12 @@ capability. The following are binding constraints, not implementation detail:
   and the invoice status updated automatically.
 - Fee handling, **net-of-fee deposit** vs gross amount, refunds, and chargebacks
   MUST be modelled against `docs/explanation/accounting-compliance.md`. This area
-  requires **tax-advisor (税理士) sign-off** before implementation, per CLAUDE.md
-  non-negotiable compliance rule. This ADR fixes the constraint, not the ledger
-  design.
+  requires **tax-advisor (税理士) sign-off**, per CLAUDE.md non-negotiable
+  compliance rule. The sign-off is a **release gate, not an implementation gate**:
+  the accounting model may be implemented beforehand, but card payment MUST NOT
+  be **released** until 税理士 sign-off is recorded (#430). Implementing ahead of
+  sign-off is done **at the risk of rework** if the model is rejected. This ADR
+  fixes the constraint, not the ledger design.
 
 ### Scope of this ADR
 

--- a/docs/adr/0012-card-payment-on-invoices.md
+++ b/docs/adr/0012-card-payment-on-invoices.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted
 
 ## Context
 
@@ -119,7 +119,8 @@ capability. The following are binding constraints, not implementation detail:
 ## Related
 
 - Issue: `#427`
-- PR: `#000`
+- PR: `#428` (proposed), `#429` selection ratified by ADR 0013
+- Launch gateway: `docs/adr/0013-launch-payment-gateway-payjp.md`
 - Product separation: `docs/adr/0002-separate-from-sibling-products.md`
 - Deployment tiers: `docs/adr/0003-dual-deployment-tiers.md`
 - Tax rounding: `docs/adr/0004-tax-rounding-per-rate.md`

--- a/docs/adr/0013-launch-payment-gateway-payjp.md
+++ b/docs/adr/0013-launch-payment-gateway-payjp.md
@@ -1,0 +1,70 @@
+# ADR 0013: PAY.JP as Launch Card Payment Gateway
+
+## Status
+
+accepted
+
+## Context
+
+ADR 0012 established that card payment on issued invoices is added as an
+optional, pluggable, **hosted-only (SAQ-A)** capability behind a
+`PaymentGatewayInterface`, and explicitly deferred the choice of the first
+concrete gateway. Issue #429 evaluated candidates; the comparison is recorded in
+`docs/integrations/payment-gateway-comparison.md` (checked 2026-06-13).
+
+Both finalists — **Stripe Checkout** and **PAY.JP** — are hosted, SAQ-A
+eligible, and support JPY. Distinguishing factors for our target operator
+(Japanese SMB self-host):
+
+- **PAY.JP**: processing fee from ~2.59%, JPY-native settlement (no FX), payout
+  fee ~¥250, Japan-domestic, JP-language support.
+- **Stripe Checkout**: processing fee ~3.6%, possible USD/FX settlement layer,
+  but more mature signed-webhook / idempotency / test-mode developer experience.
+
+## Decision
+
+- The **launch (first-class) gateway is PAY.JP**, implemented as the first
+  concrete adapter under `Payment/Gateway/` behind `PaymentGatewayInterface`.
+- **Stripe Checkout is the designated second adapter.** `PaymentGatewayInterface`
+  MUST be designed so Stripe drops in without reshaping the interface — in
+  particular it must absorb differing webhook-signature schemes and settlement/FX
+  handling.
+- All constraints of ADR 0012 remain binding and unchanged. Notably the
+  **SAQ-A discipline**: the payment-link page MUST NOT carry operator-controlled
+  scripts (analytics/GTM), which would expand scope to SAQ-A-EP. This becomes an
+  operator-guide constraint.
+- This decision does **not** lift the implementation gate from ADR 0012: card
+  payment implementation still requires the accounting model + tax-advisor
+  (税理士) sign-off tracked in #430.
+
+## Consequences
+
+**Benefits**
+
+- Lower processing cost and JPY-native settlement match the JP SMB audience.
+- Designing the interface with Stripe as a planned second adapter keeps the
+  abstraction honest and avoids PAY.JP-shaped lock-in.
+
+**Costs**
+
+- PAY.JP's ecosystem and tooling are smaller than Stripe's; webhook signature
+  verification and idempotency (#431) must be implemented carefully without
+  leaning on Stripe-grade libraries.
+
+**Follow-up**
+
+- #431 webhook ingress targets PAY.JP signature/idempotency first.
+- #432 Admin gateway config UI ships PAY.JP credentials first.
+- Add the "no operator scripts on payment page" rule to the operator guide.
+- Register any new identifiers in `docs/explanation/terminology.md` in the
+  implementing PR.
+
+## Related
+
+- Issue: `#429`
+- PR: `#000`
+- Parent decision: `docs/adr/0012-card-payment-on-invoices.md`
+- Comparison input: `docs/integrations/payment-gateway-comparison.md`
+- Accounting gate (blocks implementation): `#430`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0013-launch-payment-gateway-payjp.md
+++ b/docs/adr/0013-launch-payment-gateway-payjp.md
@@ -33,9 +33,10 @@ eligible, and support JPY. Distinguishing factors for our target operator
   **SAQ-A discipline**: the payment-link page MUST NOT carry operator-controlled
   scripts (analytics/GTM), which would expand scope to SAQ-A-EP. This becomes an
   operator-guide constraint.
-- This decision does **not** lift the implementation gate from ADR 0012: card
-  payment implementation still requires the accounting model + tax-advisor
-  (税理士) sign-off tracked in #430.
+- This decision does **not** lift the **release gate** from ADR 0012: the
+  accounting model may be implemented first, but card payment MUST NOT be
+  released until the accounting model + tax-advisor (税理士) sign-off (#430) is
+  recorded. Implementing ahead of sign-off is accepted **at the risk of rework**.
 
 ## Consequences
 


### PR DESCRIPTION
## 概要

Issue #429 の比較（PR #433 / `docs/integrations/payment-gateway-comparison.md`）を受け、第1弾カード決済ゲートウェイを **PAY.JP** に確定する。

- **ADR 0012** を `proposed → accepted` に昇格（ホスト型限定 / SAQ-A / pluggable の方針合意）
- **ADR 0013** を新規追加: 第1弾 = PAY.JP、第2アダプタ = Stripe Checkout

Closes #429

## ポイント

- `PaymentGatewayInterface` は **Stripe が無改造で載る**よう設計（webhook 署名方式・FX/決済通貨の差分を吸収）
- **SAQ-A 維持**: 決済リンクページに運用者スクリプト（解析/GTM）を載せない制約 → 運用ガイドに明記
- **税理士サインオフはリリースゲート**（実装マージ前ではなくリリース直前）。サインオフ自体は必須のまま維持。会計モデルは #430 で先行実装可だが、NG 時の手戻りリスクを許容する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)