### PR TITLE
feat(payment): 請求書ごとの決済リンク生成・失効を実装 (#436)

### DIFF
--- a/database/migrations/20260613100000_create_payment_links_table.php
+++ b/database/migrations/20260613100000_create_payment_links_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreatePaymentLinksTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('payment_links')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('invoice_id', 'integer', ['null' => false])
+            ->addColumn('token_hash', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('gateway', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('gateway_session_id', 'string', ['limit' => 255, 'null' => true])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false])
+            ->addColumn('expires_at', 'datetime', ['null' => false])
+            ->addColumn('paid_at', 'datetime', ['null' => true])
+            ->addColumn('revoked_at', 'datetime', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['token_hash'], ['unique' => true, 'name' => 'uniq_payment_links_token_hash'])
+            ->addIndex(['invoice_id'], ['name' => 'idx_payment_links_invoice_id'])
+            ->addIndex(['gateway_session_id'], ['name' => 'idx_payment_links_gateway_session_id'])
+            ->addIndex(['organization_id'], ['name' => 'idx_payment_links_organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -209,3 +209,28 @@ CREATE TABLE IF NOT EXISTS `service_tokens` (
     UNIQUE KEY `uniq_service_tokens_jti` (`jti`),
     KEY `idx_service_tokens_organization_id` (`organization_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- payment_links — hashed, time-limited, revocable links that let a payer settle
+-- one invoice on a hosted gateway (PAY.JP — ADR 0012/0013). Only the SHA-256
+-- hash of the raw URL token is stored; card data is never stored (SAQ-A).
+-- status: active | paid | revoked (expiry is derived from expires_at).
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `payment_links` (
+    `id`                 INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id`    INT          NOT NULL,
+    `invoice_id`         INT          NOT NULL,
+    `token_hash`         VARCHAR(64)  NOT NULL,
+    `gateway`            VARCHAR(32)  NOT NULL,
+    `gateway_session_id` VARCHAR(255) DEFAULT NULL,
+    `status`             VARCHAR(16)  NOT NULL,
+    `expires_at`         DATETIME     NOT NULL,
+    `paid_at`            DATETIME     DEFAULT NULL,
+    `revoked_at`         DATETIME     DEFAULT NULL,
+    `created_at`         DATETIME     NOT NULL,
+    `updated_at`         DATETIME     NOT NULL,
+    UNIQUE KEY `uniq_payment_links_token_hash` (`token_hash`),
+    KEY `idx_payment_links_invoice_id` (`invoice_id`),
+    KEY `idx_payment_links_gateway_session_id` (`gateway_session_id`),
+    KEY `idx_payment_links_organization_id` (`organization_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/schema/payment_links.sql
+++ b/database/schema/payment_links.sql
@@ -1,0 +1,24 @@
+-- Schema snapshot for the payment_links table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- A payment link is a hashed, time-limited, revocable URL that lets a payer settle
+-- one invoice on a hosted gateway (PAY.JP — ADR 0012/0013). The DB stores only the
+-- SHA-256 hash of the raw URL token; card data is never stored (SAQ-A).
+-- status: active | paid | revoked (expiry is derived from expires_at, not a stored status).
+CREATE TABLE IF NOT EXISTS payment_links (
+    id                  INTEGER      NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id     INTEGER      NOT NULL,
+    invoice_id          INTEGER      NOT NULL,
+    token_hash          VARCHAR(64)  NOT NULL,
+    gateway             VARCHAR(32)  NOT NULL,
+    gateway_session_id  VARCHAR(255),
+    status              VARCHAR(16)  NOT NULL,
+    expires_at          DATETIME     NOT NULL,
+    paid_at             DATETIME,
+    revoked_at          DATETIME,
+    created_at          DATETIME     NOT NULL,
+    updated_at          DATETIME     NOT NULL,
+    CONSTRAINT uniq_payment_links_token_hash UNIQUE (token_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_payment_links_invoice_id ON payment_links (invoice_id);
+CREATE INDEX IF NOT EXISTS idx_payment_links_gateway_session_id ON payment_links (gateway_session_id);
+CREATE INDEX IF NOT EXISTS idx_payment_links_organization_id ON payment_links (organization_id);

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -42,6 +42,7 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 | Document row | `LineItem` | `line_items` | `line_item_id` |
 | Template | `Template` | `templates` | `template_id` |
 | Receipt | `Payment` | `payments` | `payment_id` |
+| Payment link | `PaymentLink` | `payment_links` | `payment_link_id` |
 | Number generator | `DocumentSequence` | `document_sequences` | — |
 | Integration credential | `ServiceToken` | `service_tokens` | `service_token_id` |
 
@@ -64,6 +65,8 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
 | `user.status` | `active`, `invited` |
 | service_token status (computed) | `active`, `revoked` |
+| `payment_link.status` | `active`, `paid`, `revoked` (expiry derived from `expires_at`, not stored) |
+| `payment_link.gateway` | `payjp` (launch gateway — ADR 0013) |
 | Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
 | Org resolution mode | `single` (default), `path`, `subdomain`, `custom_domain` |
 
@@ -101,6 +104,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Client fields | `name_kana`, `contact_name`, `billing_address` | `kana`, `furigana`, `name_reading`, `contact`, `address` |
 | Item master defaults | `default_unit_price_cents`, `default_tax_rate_bps` | `default_price_cents`, `item_price_cents`, `default_rate`, `unit_price` |
 | Service-token fields | `jti`, `subject`, `label`, `scopes`, `created_by`, `expires_at`, `revoked_at`, `ttl_seconds` | `jwt_id`, `name`, `scope`, `created_user_id`, `expiry`, `revoked`, `ttl` |
+| Payment-link fields | `token_hash`, `gateway`, `gateway_session_id`, `status`, `expires_at`, `paid_at`, `revoked_at` | `token`, `session`, `provider`, `expiry`, `paid`, `revoked` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
@@ -147,6 +151,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `insufficient-scope` | Service token lacks the required scope (403; service API) |
 | `service-token-revoked` | Presented service token has been revoked (401; service API) |
 | `service-token-not-found` | Service-token id not found in the caller's org (404; operator API) |
+| `payment-link-not-found` | Payment-link id not found in the caller's org (404; operator API) |
 
 Add new slugs here before using them. Validation `errors[].field` uses
 snake_case paths (e.g. `body.registration_number`); `errors[].code` is

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1575,6 +1575,59 @@ paths:
               schema: { type: string, format: binary }
         '404':
           $ref: '#/components/responses/NotFound'
+  /admin/invoices/{id}/payment-links:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Payments]
+      summary: Generate a card payment link
+      description: >
+        Issues a time-limited (7 days), revocable payment link that lets the
+        payer settle the invoice on the hosted gateway (PAY.JP — ADR 0012/0013).
+        Re-issuing auto-revokes any prior active link for the invoice. Card data
+        never touches this API (SAQ-A). Requires ManageBilling capability.
+      operationId: generatePaymentLink
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Payment link generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentLinkResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /admin/payment-links/{id}/revoke:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Payments]
+      summary: Revoke a payment link
+      description: >
+        Revokes an active payment link so it can no longer be paid. Idempotent:
+        revoking an already-terminal link returns 200. Requires ManageBilling
+        capability.
+      operationId: revokePaymentLink
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Payment link revoked (or already inactive)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentLinkRevokeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /admin/invoices/{id}/issue:
     parameters:
       - $ref: '#/components/parameters/IdPathParam'
@@ -1938,6 +1991,33 @@ components:
           type: string
           description: Token expiry timestamp (Y-m-d H:i:s).
       required: [url, expires_at]
+    PaymentLinkResponse:
+      type: object
+      properties:
+        payment_link_id:
+          type: integer
+          description: Identifier of the generated payment link.
+        url:
+          type: string
+          description: Public payment URL (relative path, no auth required).
+        expires_at:
+          type: string
+          description: Link expiry timestamp (Y-m-d H:i:s).
+      required: [payment_link_id, url, expires_at]
+    PaymentLinkRevokeResponse:
+      type: object
+      properties:
+        payment_link_id:
+          type: integer
+          description: Identifier of the targeted payment link.
+        status:
+          type: string
+          enum: [revoked]
+          description: Resulting status (revoked).
+        revoked:
+          type: boolean
+          description: True if this call transitioned an active link; false if it was already inactive.
+      required: [payment_link_id, status, revoked]
     LineItemSuggestion:
       type: object
       properties:

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -32,6 +32,7 @@ use NeneInvoice\Payment\PaymentExceedsOutstandingExceptionHandler;
 use NeneInvoice\Payment\PaymentNotFoundExceptionHandler;
 use NeneInvoice\Payment\PaymentRouteRegistrar;
 use NeneInvoice\Payment\PaymentValidationExceptionHandler;
+use NeneInvoice\PaymentLink\PaymentLinkRouteRegistrar;
 use NeneInvoice\Quote\InvalidStateTransitionExceptionHandler;
 use NeneInvoice\Quote\QuoteNotFoundExceptionHandler;
 use NeneInvoice\Quote\QuoteRouteRegistrar;
@@ -96,6 +97,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $itemRoutes = $container->get(ItemRouteRegistrar::class);
                     $templateRoutes = $container->get(TemplateRouteRegistrar::class);
                     $serviceTokenRoutes = $container->get(ServiceTokenRouteRegistrar::class);
+                    $paymentLinkRoutes = $container->get(PaymentLinkRouteRegistrar::class);
 
                     if (!$dashboardRoutes instanceof DashboardRouteRegistrar) {
                         throw new LogicException('Dashboard route registrar service is invalid.');
@@ -161,7 +163,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Service token route registrar service is invalid.');
                     }
 
-                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes, $serviceTokenRoutes];
+                    if (!$paymentLinkRoutes instanceof PaymentLinkRouteRegistrar) {
+                        throw new LogicException('Payment link route registrar service is invalid.');
+                    }
+
+                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $invoiceRoutes, $paymentRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes, $serviceTokenRoutes, $paymentLinkRoutes];
                 },
             )
             ->set(

--- a/src/Auth/CapabilityResolver.php
+++ b/src/Auth/CapabilityResolver.php
@@ -45,7 +45,7 @@ final class CapabilityResolver
             return Capability::ViewBilling;
         }
 
-        foreach (['/admin/clients', '/admin/items', '/admin/templates', '/admin/quotes', '/admin/invoices', '/admin/payments', '/admin/line-items'] as $prefix) {
+        foreach (['/admin/clients', '/admin/items', '/admin/templates', '/admin/quotes', '/admin/invoices', '/admin/payments', '/admin/payment-links', '/admin/line-items'] as $prefix) {
             if (str_starts_with($path, $prefix)) {
                 return self::isReadMethod($method) ? Capability::ViewBilling : Capability::ManageBilling;
             }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -46,6 +46,7 @@ use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
 use NeneInvoice\Organization\Resolution\PathPrefixResolutionStrategy;
 use NeneInvoice\Organization\Resolution\SubdomainResolutionStrategy;
 use NeneInvoice\Payment\PaymentServiceProvider;
+use NeneInvoice\PaymentLink\PaymentLinkServiceProvider;
 use NeneInvoice\Quote\QuoteServiceProvider;
 use NeneInvoice\ServiceApi\ServiceApiServiceProvider;
 use NeneInvoice\ServiceApi\ServiceScopeMiddleware;
@@ -88,6 +89,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new PaymentServiceProvider());
         $builder->addProvider(new ServiceApiServiceProvider());
         $builder->addProvider(new ServiceTokenServiceProvider());
+        $builder->addProvider(new PaymentLinkServiceProvider());
 
         $builder
             ->set(Psr17Factory::class, static fn (ContainerInterface $container): Psr17Factory => new Psr17Factory())

--- a/src/PaymentLink/GeneratePaymentLinkHandler.php
+++ b/src/PaymentLink/GeneratePaymentLinkHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/invoices/{id}/payment-links`
+ * Issues a time-limited payment link for the invoice (auto-revoking any prior
+ * active link). Capability: ManageBilling (POST on /admin/invoices/*, via
+ * CapabilityResolver). The organization is resolved upstream into the holder.
+ */
+final readonly class GeneratePaymentLinkHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private GeneratePaymentLinkUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params    = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $invoiceId = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $result = $this->useCase->execute(AuthContext::userId($request), $invoiceId);
+
+        return $this->json->create([
+            'payment_link_id' => $result['paymentLinkId'],
+            'url'             => '/pay/' . $result['rawToken'],
+            'expires_at'      => $result['expiresAt'],
+        ], 201);
+    }
+}

--- a/src/PaymentLink/GeneratePaymentLinkUseCase.php
+++ b/src/PaymentLink/GeneratePaymentLinkUseCase.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+
+/**
+ * Generates a time-limited, hashed payment link for one invoice and persists it.
+ * Returns the raw (un-hashed) token so the caller can embed it in the URL — the
+ * raw token is never stored, only its SHA-256 hash (see {@see SecureTokenHelper}).
+ *
+ * Re-issuing auto-revokes any prior active link for the same invoice, so at most
+ * one link per invoice is payable (ADR 0012 §3). The launch gateway is PAY.JP
+ * (ADR 0013); `gateway_session_id` is created lazily and stays null here.
+ */
+final readonly class GeneratePaymentLinkUseCase implements GeneratePaymentLinkUseCaseInterface
+{
+    private const TTL_DAYS = 7;
+
+    /** Launch gateway — ADR 0013. Registered in `docs/explanation/terminology.md`. */
+    public const DEFAULT_GATEWAY = 'payjp';
+
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): PaymentLinkRepositoryInterface $linksFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private InvoiceRepositoryInterface $invoices,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $linksFactory,
+        private Closure $auditFactory,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /**
+     * @param int|null $actorUserId authenticated user who generated the link (null for system)
+     *
+     * @return array{rawToken: string, expiresAt: string, paymentLinkId: int}
+     * @throws InvoiceNotFoundException
+     */
+    public function execute(?int $actorUserId, int $invoiceId): array
+    {
+        // The invoice repository is org-scoped (holder), so a foreign invoice is
+        // already invisible here.
+        $invoice = $this->invoices->findById($invoiceId);
+
+        if ($invoice === null) {
+            throw new InvoiceNotFoundException($invoiceId);
+        }
+
+        $organizationId = $this->orgId->get();
+
+        // 256-bit token; only its SHA-256 hash is persisted.
+        [$rawToken, $tokenHash] = SecureTokenHelper::generateWithHash();
+        $now       = $this->clock->now();
+        $timestamp = $now->format('Y-m-d H:i:s');
+        $expiresAt = $now->modify('+' . self::TTL_DAYS . ' days')->format('Y-m-d H:i:s');
+
+        // Link insert, prior-link revoke, and audit commit atomically.
+        $linkId = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $invoiceId, $tokenHash, $expiresAt, $timestamp): int {
+            $links = ($this->linksFactory)($exec);
+
+            // At most one payable link per invoice: auto-revoke the prior active one.
+            $prior = $links->findActiveByInvoiceId($invoiceId);
+            if ($prior !== null && $prior->id !== null) {
+                $links->markRevoked($prior->id, $timestamp);
+            }
+
+            $linkId = $links->save(new PaymentLink(
+                organizationId: $organizationId,
+                invoiceId: $invoiceId,
+                tokenHash: $tokenHash,
+                gateway: self::DEFAULT_GATEWAY,
+                status: PaymentLinkStatus::Active,
+                expiresAt: $expiresAt,
+                createdAt: $timestamp,
+                updatedAt: $timestamp,
+            ));
+
+            // Audit (ADR 0008): issuing a public payment link is auditable. `after`
+            // carries only non-secret metadata — the raw token and its hash are
+            // never written to the audit trail.
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'payment_link.issued',
+                'payment_link',
+                $linkId,
+                null,
+                ['invoice_id' => $invoiceId, 'gateway' => self::DEFAULT_GATEWAY, 'expires_at' => $expiresAt],
+            );
+
+            return $linkId;
+        });
+
+        return ['rawToken' => $rawToken, 'expiresAt' => $expiresAt, 'paymentLinkId' => $linkId];
+    }
+}

--- a/src/PaymentLink/GeneratePaymentLinkUseCaseInterface.php
+++ b/src/PaymentLink/GeneratePaymentLinkUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+interface GeneratePaymentLinkUseCaseInterface
+{
+    /** @return array{rawToken: string, expiresAt: string, paymentLinkId: int} */
+    public function execute(?int $actorUserId, int $invoiceId): array;
+}

--- a/src/PaymentLink/PaymentLink.php
+++ b/src/PaymentLink/PaymentLink.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+/**
+ * A hashed, time-limited, revocable link that lets a payer settle one invoice on
+ * a hosted payment gateway (PAY.JP — ADR 0012/0013). The raw token is only ever
+ * held in memory and in the URL; the database stores only its SHA-256 hash.
+ *
+ * `gatewaySessionId` is null until the hosted gateway session is created (lazily,
+ * on first visit to the public link). No card data is ever stored (SAQ-A).
+ */
+final readonly class PaymentLink
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public string $tokenHash,
+        public string $gateway,
+        public PaymentLinkStatus $status,
+        public string $expiresAt,
+        public ?string $gatewaySessionId = null,
+        public ?string $paidAt = null,
+        public ?string $revokedAt = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+
+    public function isExpired(string $now): bool
+    {
+        return $this->expiresAt <= $now;
+    }
+
+    /** A link is payable only while active and not yet expired. */
+    public function isPayable(string $now): bool
+    {
+        return $this->status === PaymentLinkStatus::Active && !$this->isExpired($now);
+    }
+}

--- a/src/PaymentLink/PaymentLinkRepositoryInterface.php
+++ b/src/PaymentLink/PaymentLinkRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+interface PaymentLinkRepositoryInterface
+{
+    public function save(PaymentLink $link): int;
+
+    /**
+     * The currently active link for an invoice in the caller's organization, if
+     * any. Used to auto-revoke a prior active link when re-issuing.
+     */
+    public function findActiveByInvoiceId(int $invoiceId): ?PaymentLink;
+
+    /** Org-scoped lookup by primary key (for admin revoke). */
+    public function findById(int $id): ?PaymentLink;
+
+    /**
+     * Lookup by token hash, **not** organization-scoped: the public link page and
+     * the settlement webhook resolve the owning organization *from* the link.
+     */
+    public function findByHash(string $tokenHash): ?PaymentLink;
+
+    /**
+     * Marks an active link revoked. Org-scoped and idempotent: returns true only
+     * when an active link in the caller's org transitioned to revoked.
+     */
+    public function markRevoked(int $id, string $revokedAt): bool;
+}

--- a/src/PaymentLink/PaymentLinkRouteRegistrar.php
+++ b/src/PaymentLink/PaymentLinkRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class PaymentLinkRouteRegistrar
+{
+    public function __construct(
+        private GeneratePaymentLinkHandler $generateHandler,
+        private RevokePaymentLinkHandler $revokeHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $generate = $this->generateHandler;
+        $revoke   = $this->revokeHandler;
+
+        $router->post('/admin/invoices/{id}/payment-links', static fn (ServerRequestInterface $r) => $generate->handle($r));
+        $router->post('/admin/payment-links/{id}/revoke', static fn (ServerRequestInterface $r) => $revoke->handle($r));
+    }
+}

--- a/src/PaymentLink/PaymentLinkServiceProvider.php
+++ b/src/PaymentLink/PaymentLinkServiceProvider.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\ApplicationServiceProvider;
+use NeneInvoice\Audit\AuditServiceProvider;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class PaymentLinkServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                PaymentLinkRepositoryInterface::class,
+                static function (ContainerInterface $c): PaymentLinkRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoPaymentLinkRepository($query, self::orgHolder($c));
+                },
+            )
+            ->set(
+                GeneratePaymentLinkUseCaseInterface::class,
+                static fn (ContainerInterface $c): GeneratePaymentLinkUseCase => new GeneratePaymentLinkUseCase(
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): PaymentLinkRepositoryInterface => new PdoPaymentLinkRepository($exec, self::orgHolder($c)),
+                    AuditServiceProvider::recorderFactory($c),
+                    self::resolve($c, ClockInterface::class),
+                    self::orgHolder($c),
+                ),
+            )
+            ->set(
+                RevokePaymentLinkUseCaseInterface::class,
+                static fn (ContainerInterface $c): RevokePaymentLinkUseCase => new RevokePaymentLinkUseCase(
+                    self::resolve($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $exec): PaymentLinkRepositoryInterface => new PdoPaymentLinkRepository($exec, self::orgHolder($c)),
+                    AuditServiceProvider::recorderFactory($c),
+                    self::resolve($c, ClockInterface::class),
+                    self::orgHolder($c),
+                ),
+            )
+            ->set(
+                GeneratePaymentLinkHandler::class,
+                static fn (ContainerInterface $c): GeneratePaymentLinkHandler => new GeneratePaymentLinkHandler(
+                    self::resolve($c, GeneratePaymentLinkUseCaseInterface::class),
+                    self::resolve($c, JsonResponseFactory::class),
+                ),
+            )
+            ->set(
+                RevokePaymentLinkHandler::class,
+                static fn (ContainerInterface $c): RevokePaymentLinkHandler => new RevokePaymentLinkHandler(
+                    self::resolve($c, RevokePaymentLinkUseCaseInterface::class),
+                    self::resolve($c, JsonResponseFactory::class),
+                    self::resolve($c, ProblemDetailsResponseFactory::class),
+                ),
+            )
+            ->set(
+                PaymentLinkRouteRegistrar::class,
+                static fn (ContainerInterface $c): PaymentLinkRouteRegistrar => new PaymentLinkRouteRegistrar(
+                    self::resolve($c, GeneratePaymentLinkHandler::class),
+                    self::resolve($c, RevokePaymentLinkHandler::class),
+                ),
+            );
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
+    private static function resolve(ContainerInterface $c, string $id): object
+    {
+        $service = $c->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service %s is invalid.', $id));
+        }
+
+        return $service;
+    }
+
+    /** @return RequestScopedHolder<int> */
+    private static function orgHolder(ContainerInterface $c): RequestScopedHolder
+    {
+        $holder = $c->get(ApplicationServiceProvider::ORG_ID_HOLDER);
+
+        if (!$holder instanceof RequestScopedHolder) {
+            throw new LogicException('Org id holder service is invalid.');
+        }
+
+        return $holder;
+    }
+}

--- a/src/PaymentLink/PaymentLinkStatus.php
+++ b/src/PaymentLink/PaymentLinkStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+/**
+ * Persisted lifecycle state of a {@see PaymentLink}.
+ *
+ * Expiry is **not** a stored status — it is derived from `expires_at` at read
+ * time ({@see PaymentLink::isExpired()}), so an `active` link past its expiry is
+ * treated as expired without a background sweep. String values are registered in
+ * `docs/explanation/terminology.md` (binding).
+ */
+enum PaymentLinkStatus: string
+{
+    case Active = 'active';
+    case Paid = 'paid';
+    case Revoked = 'revoked';
+}

--- a/src/PaymentLink/PdoPaymentLinkRepository.php
+++ b/src/PaymentLink/PdoPaymentLinkRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoPaymentLinkRepository implements PaymentLinkRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, invoice_id, token_hash, gateway, gateway_session_id, status, expires_at, paid_at, revoked_at, created_at, updated_at';
+
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function save(PaymentLink $link): int
+    {
+        return $this->query->insert(
+            'INSERT INTO payment_links (organization_id, invoice_id, token_hash, gateway, gateway_session_id, status, expires_at, paid_at, revoked_at, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $link->organizationId,
+                $link->invoiceId,
+                $link->tokenHash,
+                $link->gateway,
+                $link->gatewaySessionId,
+                $link->status->value,
+                $link->expiresAt,
+                $link->paidAt,
+                $link->revokedAt,
+                $link->createdAt,
+                $link->updatedAt,
+            ],
+        );
+    }
+
+    public function findActiveByInvoiceId(int $invoiceId): ?PaymentLink
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payment_links WHERE invoice_id = ? AND organization_id = ? AND status = ? LIMIT 1',
+            [$invoiceId, $this->orgId->get(), PaymentLinkStatus::Active->value],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findById(int $id): ?PaymentLink
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payment_links WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findByHash(string $tokenHash): ?PaymentLink
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payment_links WHERE token_hash = ?',
+            [$tokenHash],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function markRevoked(int $id, string $revokedAt): bool
+    {
+        $affected = $this->query->execute(
+            'UPDATE payment_links SET status = ?, revoked_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND status = ?',
+            [PaymentLinkStatus::Revoked->value, $revokedAt, $revokedAt, $id, $this->orgId->get(), PaymentLinkStatus::Active->value],
+        );
+
+        return $affected > 0;
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): PaymentLink
+    {
+        return new PaymentLink(
+            organizationId: (int) $row['organization_id'],
+            invoiceId: (int) $row['invoice_id'],
+            tokenHash: (string) $row['token_hash'],
+            gateway: (string) $row['gateway'],
+            status: PaymentLinkStatus::from((string) $row['status']),
+            expiresAt: (string) $row['expires_at'],
+            gatewaySessionId: $row['gateway_session_id'] !== null ? (string) $row['gateway_session_id'] : null,
+            paidAt: $row['paid_at'] !== null ? (string) $row['paid_at'] : null,
+            revokedAt: $row['revoked_at'] !== null ? (string) $row['revoked_at'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/PaymentLink/RevokeOutcome.php
+++ b/src/PaymentLink/RevokeOutcome.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+/** Result of a revoke attempt, so the handler can pick the right HTTP status. */
+enum RevokeOutcome
+{
+    /** An active link transitioned to revoked. */
+    case Revoked;
+    /** The link exists but was already terminal (revoked/paid); revoke is a no-op. */
+    case AlreadyInactive;
+    /** No link with that id in the caller's organization. */
+    case NotFound;
+}

--- a/src/PaymentLink/RevokePaymentLinkHandler.php
+++ b/src/PaymentLink/RevokePaymentLinkHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneInvoice\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /admin/payment-links/{id}/revoke`
+ * Revokes an active payment link. Capability: ManageBilling (POST on
+ * /admin/payment-links/*, via CapabilityResolver). Idempotent: revoking an
+ * already-terminal link returns 200; an unknown id (or another org's link)
+ * returns 404 `payment-link-not-found`.
+ */
+final readonly class RevokePaymentLinkHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private RevokePaymentLinkUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $outcome = $this->useCase->execute(AuthContext::userId($request), $id);
+
+        if ($outcome === RevokeOutcome::NotFound) {
+            return $this->problemDetails->create($request, 'payment-link-not-found', 'Not Found', 404, 'Payment link not found.');
+        }
+
+        return $this->json->create([
+            'payment_link_id' => $id,
+            'status'          => PaymentLinkStatus::Revoked->value,
+            'revoked'         => $outcome === RevokeOutcome::Revoked,
+        ], 200);
+    }
+}

--- a/src/PaymentLink/RevokePaymentLinkUseCase.php
+++ b/src/PaymentLink/RevokePaymentLinkUseCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+/**
+ * Revokes an active payment link so it can no longer be paid (ADR 0012 §3).
+ * Org-scoped and idempotent: a link belonging to another organization is
+ * invisible (NotFound), and revoking an already-terminal link is a no-op.
+ */
+final readonly class RevokePaymentLinkUseCase implements RevokePaymentLinkUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): PaymentLinkRepositoryInterface $linksFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $linksFactory,
+        private Closure $auditFactory,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(?int $actorUserId, int $paymentLinkId): RevokeOutcome
+    {
+        $organizationId = $this->orgId->get();
+        $now            = $this->clock->now()->format('Y-m-d H:i:s');
+
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $paymentLinkId, $now): RevokeOutcome {
+            $links = ($this->linksFactory)($exec);
+
+            $link = $links->findById($paymentLinkId);
+            if ($link === null) {
+                return RevokeOutcome::NotFound;
+            }
+
+            if (!$links->markRevoked($paymentLinkId, $now)) {
+                // Exists but was not active (already revoked/paid) — idempotent no-op.
+                return RevokeOutcome::AlreadyInactive;
+            }
+
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $organizationId,
+                'payment_link.revoked',
+                'payment_link',
+                $paymentLinkId,
+                ['status' => PaymentLinkStatus::Active->value],
+                ['status' => PaymentLinkStatus::Revoked->value],
+            );
+
+            return RevokeOutcome::Revoked;
+        });
+    }
+}

--- a/src/PaymentLink/RevokePaymentLinkUseCaseInterface.php
+++ b/src/PaymentLink/RevokePaymentLinkUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+interface RevokePaymentLinkUseCaseInterface
+{
+    public function execute(?int $actorUserId, int $paymentLinkId): RevokeOutcome;
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -77,6 +77,8 @@ final class OpenApiContractTest extends TestCase
         'issueInvoice',
         'listPayments',
         'recordPayment',
+        'generatePaymentLink',
+        'revokePaymentLink',
         'sendInvoiceEmail',
         'exportInvoicesCsv',
         'exportPaymentsCsv',

--- a/tests/PaymentLink/GeneratePaymentLinkUseCaseTest.php
+++ b/tests/PaymentLink/GeneratePaymentLinkUseCaseTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\PaymentLink\GeneratePaymentLinkUseCase;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentLinkRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratePaymentLinkUseCaseTest extends TestCase
+{
+    private InMemoryInvoiceRepository $invoices;
+
+    private InMemoryPaymentLinkRepository $links;
+
+    private GeneratePaymentLinkUseCase $useCase;
+
+    private RecordingAuditRecorder $audit;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
+        $this->links    = new InMemoryPaymentLinkRepository(1);
+        $this->audit    = new RecordingAuditRecorder();
+        $this->useCase  = new GeneratePaymentLinkUseCase($this->invoices, new ImmediateTransactionManager(), fn () => $this->links, fn () => $this->audit, new FixedClock(), $this->holder);
+    }
+
+    private function newInvoice(int $organizationId = 1): int
+    {
+        return $this->invoices->save(new Invoice(organizationId: $organizationId, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 100, totalCents: 1100));
+    }
+
+    public function test_generates_active_payjp_link_for_invoice_in_org(): void
+    {
+        $id = $this->newInvoice();
+
+        $result = $this->useCase->execute(7, $id);
+
+        self::assertNotEmpty($result['rawToken']);
+        self::assertSame('2026-06-13 03:00:00', $result['expiresAt']);
+        self::assertGreaterThan(0, $result['paymentLinkId']);
+
+        // Stored hashed, active, with the launch gateway.
+        $stored = $this->links->findByHash(hash('sha256', $result['rawToken']));
+        self::assertNotNull($stored);
+        self::assertSame($id, $stored->invoiceId);
+        self::assertSame(PaymentLinkStatus::Active, $stored->status);
+        self::assertSame('payjp', $stored->gateway);
+        self::assertNull($stored->gatewaySessionId);
+    }
+
+    public function test_records_audit_log_without_leaking_token(): void
+    {
+        $id = $this->newInvoice();
+
+        $result = $this->useCase->execute(7, $id);
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame(7, $record['actor_user_id']);
+        self::assertSame(1, $record['organization_id']);
+        self::assertSame('payment_link.issued', $record['action']);
+        self::assertSame('payment_link', $record['entity_type']);
+        self::assertSame($result['paymentLinkId'], $record['entity_id']);
+        self::assertNull($record['before']);
+        self::assertSame(['invoice_id' => $id, 'gateway' => 'payjp', 'expires_at' => $result['expiresAt']], $record['after']);
+
+        $encoded = json_encode($record, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString($result['rawToken'], $encoded);
+        self::assertStringNotContainsString(hash('sha256', $result['rawToken']), $encoded);
+    }
+
+    public function test_reissue_auto_revokes_prior_active_link(): void
+    {
+        $id = $this->newInvoice();
+
+        $first  = $this->useCase->execute(7, $id);
+        $second = $this->useCase->execute(7, $id);
+
+        $priorLink = $this->links->findByHash(hash('sha256', $first['rawToken']));
+        self::assertNotNull($priorLink);
+        self::assertSame(PaymentLinkStatus::Revoked, $priorLink->status, 'prior link must be auto-revoked on re-issue');
+
+        $newLink = $this->links->findByHash(hash('sha256', $second['rawToken']));
+        self::assertNotNull($newLink);
+        self::assertSame(PaymentLinkStatus::Active, $newLink->status);
+
+        // Exactly one active link remains for the invoice.
+        $active = $this->links->findActiveByInvoiceId($id);
+        self::assertNotNull($active);
+        self::assertSame($newLink->id, $active->id);
+    }
+
+    public function test_throws_for_wrong_org(): void
+    {
+        // Invoice belongs to org 2; the holder resolves org 1, so it is invisible.
+        $id = $this->newInvoice(2);
+
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->execute(7, $id);
+    }
+
+    public function test_raw_token_is_url_safe_base64(): void
+    {
+        $id     = $this->newInvoice();
+        $result = $this->useCase->execute(7, $id);
+
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9\-_]+$/', $result['rawToken']);
+    }
+}

--- a/tests/PaymentLink/PdoPaymentLinkRepositoryTest.php
+++ b/tests/PaymentLink/PdoPaymentLinkRepositoryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use NeneInvoice\PaymentLink\PdoPaymentLinkRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoPaymentLinkRepositoryTest extends TestCase
+{
+    private PdoPaymentLinkRepository $repo;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/payment_links.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repo = new PdoPaymentLinkRepository(new PdoDatabaseQueryExecutor($factory, $pdo), $this->holder);
+    }
+
+    private function activeLink(int $organizationId, int $invoiceId, string $rawToken): PaymentLink
+    {
+        return new PaymentLink(
+            organizationId: $organizationId,
+            invoiceId: $invoiceId,
+            tokenHash: hash('sha256', $rawToken),
+            gateway: 'payjp',
+            status: PaymentLinkStatus::Active,
+            expiresAt: '2026-06-13 03:00:00',
+            createdAt: '2026-06-06 03:00:00',
+            updatedAt: '2026-06-06 03:00:00',
+        );
+    }
+
+    public function test_saves_and_finds_by_hash(): void
+    {
+        $id = $this->repo->save($this->activeLink(1, 5, 'raw-abc'));
+        self::assertGreaterThan(0, $id);
+
+        $found = $this->repo->findByHash(hash('sha256', 'raw-abc'));
+        self::assertNotNull($found);
+        self::assertSame(5, $found->invoiceId);
+        self::assertSame(PaymentLinkStatus::Active, $found->status);
+        self::assertSame('payjp', $found->gateway);
+        self::assertNull($found->gatewaySessionId);
+    }
+
+    public function test_find_active_by_invoice_is_org_scoped(): void
+    {
+        $this->repo->save($this->activeLink(1, 5, 'raw-org1'));
+        $this->repo->save($this->activeLink(2, 5, 'raw-org2'));
+
+        $found = $this->repo->findActiveByInvoiceId(5);
+        self::assertNotNull($found);
+        self::assertSame(1, $found->organizationId, 'must only see the caller-org link');
+    }
+
+    public function test_mark_revoked_is_org_scoped_and_idempotent(): void
+    {
+        $id = $this->repo->save($this->activeLink(1, 5, 'raw-revoke'));
+
+        self::assertTrue($this->repo->markRevoked($id, '2026-06-07 00:00:00'));
+        self::assertSame(PaymentLinkStatus::Revoked, $this->repo->findById($id)?->status);
+
+        // Second revoke is a no-op (already revoked).
+        self::assertFalse($this->repo->markRevoked($id, '2026-06-08 00:00:00'));
+    }
+
+    public function test_find_by_id_hides_other_org(): void
+    {
+        $id = $this->repo->save($this->activeLink(2, 9, 'raw-foreign'));
+
+        self::assertNull($this->repo->findById($id));
+        self::assertFalse($this->repo->markRevoked($id, '2026-06-07 00:00:00'));
+    }
+}

--- a/tests/PaymentLink/RevokePaymentLinkUseCaseTest.php
+++ b/tests/PaymentLink/RevokePaymentLinkUseCaseTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use NeneInvoice\PaymentLink\RevokeOutcome;
+use NeneInvoice\PaymentLink\RevokePaymentLinkUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryPaymentLinkRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class RevokePaymentLinkUseCaseTest extends TestCase
+{
+    private InMemoryPaymentLinkRepository $links;
+
+    private RevokePaymentLinkUseCase $useCase;
+
+    private RecordingAuditRecorder $audit;
+
+    protected function setUp(): void
+    {
+        $holder = new RequestScopedHolder();
+        $holder->set(1);
+        $this->links   = new InMemoryPaymentLinkRepository(1);
+        $this->audit   = new RecordingAuditRecorder();
+        $this->useCase = new RevokePaymentLinkUseCase(new ImmediateTransactionManager(), fn () => $this->links, fn () => $this->audit, new FixedClock(), $holder);
+    }
+
+    private function saveLink(int $organizationId, PaymentLinkStatus $status): int
+    {
+        return $this->links->save(new PaymentLink(
+            organizationId: $organizationId,
+            invoiceId: 5,
+            tokenHash: hash('sha256', 'raw-' . $status->value . '-' . $organizationId),
+            gateway: 'payjp',
+            status: $status,
+            expiresAt: '2026-06-13 03:00:00',
+            createdAt: '2026-06-06 03:00:00',
+            updatedAt: '2026-06-06 03:00:00',
+        ));
+    }
+
+    public function test_revokes_active_link_and_audits(): void
+    {
+        $id = $this->saveLink(1, PaymentLinkStatus::Active);
+
+        $outcome = $this->useCase->execute(7, $id);
+
+        self::assertSame(RevokeOutcome::Revoked, $outcome);
+        self::assertSame(PaymentLinkStatus::Revoked, $this->links->findById($id)?->status);
+
+        self::assertCount(1, $this->audit->records);
+        $record = $this->audit->records[0];
+        self::assertSame('payment_link.revoked', $record['action']);
+        self::assertSame('payment_link', $record['entity_type']);
+        self::assertSame($id, $record['entity_id']);
+        self::assertSame(['status' => 'active'], $record['before']);
+        self::assertSame(['status' => 'revoked'], $record['after']);
+    }
+
+    public function test_revoking_already_revoked_is_idempotent_no_op(): void
+    {
+        $id = $this->saveLink(1, PaymentLinkStatus::Revoked);
+
+        $outcome = $this->useCase->execute(7, $id);
+
+        self::assertSame(RevokeOutcome::AlreadyInactive, $outcome);
+        self::assertCount(0, $this->audit->records);
+    }
+
+    public function test_unknown_id_returns_not_found(): void
+    {
+        $outcome = $this->useCase->execute(7, 999);
+
+        self::assertSame(RevokeOutcome::NotFound, $outcome);
+        self::assertCount(0, $this->audit->records);
+    }
+
+    public function test_other_org_link_is_invisible(): void
+    {
+        // Link belongs to org 2; the use case resolves org 1.
+        $id = $this->saveLink(2, PaymentLinkStatus::Active);
+
+        $outcome = $this->useCase->execute(7, $id);
+
+        self::assertSame(RevokeOutcome::NotFound, $outcome);
+    }
+}

--- a/tests/Support/InMemoryPaymentLinkRepository.php
+++ b/tests/Support/InMemoryPaymentLinkRepository.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkRepositoryInterface;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+
+/**
+ * In-memory {@see PaymentLinkRepositoryInterface} for use-case tests. Org scope
+ * is supplied at construction so the double mirrors the org-scoped PDO repo.
+ */
+final class InMemoryPaymentLinkRepository implements PaymentLinkRepositoryInterface
+{
+    /** @var array<int, PaymentLink> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function __construct(private readonly int $organizationId = 1)
+    {
+    }
+
+    public function save(PaymentLink $link): int
+    {
+        $id              = $this->nextId++;
+        $this->byId[$id] = new PaymentLink(
+            organizationId: $link->organizationId,
+            invoiceId: $link->invoiceId,
+            tokenHash: $link->tokenHash,
+            gateway: $link->gateway,
+            status: $link->status,
+            expiresAt: $link->expiresAt,
+            gatewaySessionId: $link->gatewaySessionId,
+            paidAt: $link->paidAt,
+            revokedAt: $link->revokedAt,
+            id: $id,
+            createdAt: $link->createdAt,
+            updatedAt: $link->updatedAt,
+        );
+
+        return $id;
+    }
+
+    public function findActiveByInvoiceId(int $invoiceId): ?PaymentLink
+    {
+        foreach ($this->byId as $link) {
+            if ($link->invoiceId === $invoiceId
+                && $link->organizationId === $this->organizationId
+                && $link->status === PaymentLinkStatus::Active) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
+    public function findById(int $id): ?PaymentLink
+    {
+        $link = $this->byId[$id] ?? null;
+
+        return $link !== null && $link->organizationId === $this->organizationId ? $link : null;
+    }
+
+    public function findByHash(string $tokenHash): ?PaymentLink
+    {
+        foreach ($this->byId as $link) {
+            if ($link->tokenHash === $tokenHash) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
+    public function markRevoked(int $id, string $revokedAt): bool
+    {
+        $link = $this->byId[$id] ?? null;
+
+        if ($link === null
+            || $link->organizationId !== $this->organizationId
+            || $link->status !== PaymentLinkStatus::Active) {
+            return false;
+        }
+
+        $this->byId[$id] = new PaymentLink(
+            organizationId: $link->organizationId,
+            invoiceId: $link->invoiceId,
+            tokenHash: $link->tokenHash,
+            gateway: $link->gateway,
+            status: PaymentLinkStatus::Revoked,
+            expiresAt: $link->expiresAt,
+            gatewaySessionId: $link->gatewaySessionId,
+            paidAt: $link->paidAt,
+            revokedAt: $revokedAt,
+            id: $link->id,
+            createdAt: $link->createdAt,
+            updatedAt: $revokedAt,
+        );
+
+        return true;
+    }
+}


### PR DESCRIPTION
## 概要

ADR 0012 §3 / ADR 0013 と設計メモ（`docs/integrations/payment-link-design.md`）に基づき、請求書ごとの**決済リンク生成・失効**を実装する。**#431（webhook）の前提**。

Closes #436

## 実装範囲

`InvoiceDownloadToken`（ハッシュ化トークン + 有効期限 + org スコープ + 監査つきトランザクション）を踏襲した `PaymentLink` ドメイン一式：

- **`payment_links` テーブル**（Phinx migration + sqlite/mysql スキーマスナップショット）
- **モデル/状態** `active | paid | revoked`（期限切れは `expires_at` から導出、無蓄積）
- **リポジトリ**（save / findActiveByInvoiceId / findById / findByHash / markRevoked）
- **生成 UseCase**：再発行時に旧 active リンクを自動失効（1請求書1アクティブ）、SHA-256 ハッシュのみ保存（生トークン非保持）、監査 `payment_link.issued`
- **失効 UseCase**：冪等・org スコープ。他組織リンクは不可視 → `404 payment-link-not-found`
- **公開 Admin ルート**：`POST /admin/invoices/{id}/payment-links`、`POST /admin/payment-links/{id}/revoke`
- **認可**：`CapabilityResolver` に `/admin/payment-links` を追加（ManageBilling）
- **OpenAPI** 2 エンドポイント + **terminology.md** 識別子登録

## スコープ外（後続）

- `paid` 遷移（決済 webhook が入金記録時にセット）→ #431
- 公開 `/pay/{token}` ページと PAY.JP セッション生成 → ゲートウェイアダプタ実装時（lazy、`gateway_session_id` は現状 null）
- カードデータは一切保存・中継しない（SAQ-A）

## セキュリティ / マルチテナント

- 全クエリ `organization_id` スコープ（ADR 0006）。`findByHash` のみ非スコープ（公開ページ/webhook がリンクから組織を解決するため）
- 生トークンは URL/メモリのみ、DB は SHA-256 ハッシュのみ。監査に生トークン/ハッシュを書かないテストを追加

## テスト / 品質

- 新規テスト 13（生成・失効 UseCase + PDO リポジトリ、org 分離・冪等・自動失効・監査非漏洩）
- `composer check`（phpunit 436 / phpstan / php-cs-fixer / openapi / mcp）green。integration はローカルでは skip（MySQL 必須、CI で実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)