### PR TITLE
feat(payment): PAY.JP ゲートウェイ連携と公開決済ページを実装 (#439)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ BASE_DOMAIN=localhost
 #   php -r "echo bin2hex(random_bytes(32));"
 NENE2_LOCAL_JWT_SECRET=
 
+# --- Card payment gateway: PAY.JP (ADR 0013) ---
+# テストキーはダッシュボードで審査なしに取得可。本番キー(sk_live_)は審査後。
+# 値は秘匿（.env に置き、コミットしない）。
+PAYJP_SECRET_KEY=
+PAYJP_PUBLIC_KEY=
+# webhook エンドポイント登録時に発行される whook_ トークン（#431 で使用）。
+PAYJP_WEBHOOK_TOKEN=
+
 # --- Database (host / PHPUnit default: SQLite) ---
 # DB_ADAPTER: sqlite | mysql | pgsql （3アダプタ対応 — repository SQL は方言非依存）
 DB_ADAPTER=sqlite

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -59,7 +59,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `quote.status` | `draft`, `sent`, `accepted`, `rejected`, `expired` |
 | `invoice.status` | `draft`, `issued`, `partially_paid`, `paid` |
 | invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
-| `payment.method` | `bank_transfer`, `cash`, `other` |
+| `payment.method` | `bank_transfer`, `cash`, `card`, `other` |
 | `line_item.parent_type` | `quote`, `invoice`, `template` |
 | `line_item_suggestion.source` | `master`, `history` |
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1628,6 +1628,72 @@ paths:
           $ref: '#/components/responses/InsufficientCapability'
         '404':
           $ref: '#/components/responses/NotFound'
+  /pay/{token}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [Payments]
+      summary: Public card payment page
+      description: >
+        Public, no authentication. Renders a minimal HTML page that loads PAY.JP
+        Checkout (hosted card iframe — SAQ-A; no operator scripts). Returns a 404
+        HTML page for unknown/expired/revoked/paid links.
+      operationId: getPaymentPage
+      responses:
+        '200':
+          description: Payment page (HTML)
+          content:
+            text/html:
+              schema: { type: string }
+        '404':
+          description: Link not payable (HTML)
+          content:
+            text/html:
+              schema: { type: string }
+  /pay/{token}/charge:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Payments]
+      summary: Charge a payment link
+      description: >
+        Public, no authentication. Receives the single-use card token posted by
+        PAY.JP Checkout (`payjp-token`) and charges the invoice's outstanding
+        balance. Renders an HTML result page. No card data is read or stored.
+      operationId: chargePaymentLink
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                payjp-token:
+                  type: string
+                  description: Single-use card token from PAY.JP Checkout.
+              required: [payjp-token]
+      responses:
+        '200':
+          description: Payment accepted (HTML)
+          content:
+            text/html:
+              schema: { type: string }
+        '402':
+          description: Charge declined or failed (HTML)
+          content:
+            text/html:
+              schema: { type: string }
+        '404':
+          description: Link not payable (HTML)
+          content:
+            text/html:
+              schema: { type: string }
   /admin/invoices/{id}/issue:
     parameters:
       - $ref: '#/components/parameters/IdPathParam'

--- a/src/Payment/Gateway/GatewayCharge.php
+++ b/src/Payment/Gateway/GatewayCharge.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+/**
+ * The result of a successful gateway charge. `id` is the gateway charge
+ * identifier (e.g. PAY.JP `ch_…`), used as both the payment `external_reference`
+ * and the cross-path idempotency key (the synchronous charge and the later
+ * webhook must use the *same* charge id so they de-duplicate).
+ */
+final readonly class GatewayCharge
+{
+    public function __construct(
+        public string $id,
+        public bool $paid,
+        public int $amountCents,
+        public string $currency,
+    ) {
+    }
+}

--- a/src/Payment/Gateway/GatewayChargeRequest.php
+++ b/src/Payment/Gateway/GatewayChargeRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+/**
+ * A request to create a card charge on a payment gateway. `cardToken` is a
+ * gateway-issued, single-use token produced by the gateway's hosted card form
+ * (e.g. PAY.JP Checkout) — the raw PAN never reaches this application (SAQ-A).
+ *
+ * `metadata` carries our own references (e.g. payment_link_id, invoice_id) so a
+ * later webhook can resolve the charge back to the originating link.
+ */
+final readonly class GatewayChargeRequest
+{
+    /**
+     * @param array<string, string> $metadata
+     */
+    public function __construct(
+        public int $amountCents,
+        public string $currency,
+        public string $cardToken,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/src/Payment/Gateway/PayjpGateway.php
+++ b/src/Payment/Gateway/PayjpGateway.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+/**
+ * PAY.JP adapter (ADR 0013). Creates charges via the PAY.JP REST API using the
+ * secret key (basic auth, key as username, empty password). The card token comes
+ * from PAY.JP Checkout on the payer's browser, so no PAN passes through here
+ * (SAQ-A). The secret key is never logged.
+ */
+final readonly class PayjpGateway implements PaymentGatewayInterface
+{
+    public function __construct(
+        private string $secretKey,
+        private string $apiBaseUrl = 'https://api.pay.jp',
+        private int $timeoutSeconds = 30,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'payjp';
+    }
+
+    public function createCharge(GatewayChargeRequest $request): GatewayCharge
+    {
+        if ($this->secretKey === '') {
+            throw new PaymentGatewayException('PAY.JP secret key is not configured.');
+        }
+
+        $fields = [
+            'amount'   => (string) $request->amountCents,
+            'currency' => $request->currency,
+            'card'     => $request->cardToken,
+        ];
+        foreach ($request->metadata as $key => $value) {
+            $fields['metadata[' . $key . ']'] = $value;
+        }
+
+        [$status, $body] = $this->post('/v1/charges', $fields);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = is_array($parsed = json_decode($body, true)) ? $parsed : [];
+
+        if ($status < 200 || $status >= 300) {
+            // PAY.JP error payload: { "error": { "message": "...", "code": "..." } }.
+            $error   = is_array($decoded['error'] ?? null) ? $decoded['error'] : [];
+            $message = is_string($error['message'] ?? null) ? $error['message'] : 'PAY.JP charge failed.';
+
+            throw new PaymentGatewayException($message);
+        }
+
+        $id = is_string($decoded['id'] ?? null) ? $decoded['id'] : '';
+        if ($id === '') {
+            throw new PaymentGatewayException('PAY.JP returned a charge without an id.');
+        }
+
+        return new GatewayCharge(
+            id: $id,
+            paid: (bool) ($decoded['paid'] ?? false),
+            amountCents: (int) ($decoded['amount'] ?? $request->amountCents),
+            currency: is_string($decoded['currency'] ?? null) ? $decoded['currency'] : $request->currency,
+        );
+    }
+
+    /**
+     * @param array<string, string> $fields
+     * @return array{0: int, 1: string}
+     */
+    private function post(string $path, array $fields): array
+    {
+        $handle = curl_init($this->apiBaseUrl . $path);
+        if ($handle === false) {
+            throw new PaymentGatewayException('Unable to initialise the PAY.JP request.');
+        }
+
+        curl_setopt_array($handle, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => http_build_query($fields),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_USERPWD        => $this->secretKey . ':',
+            CURLOPT_TIMEOUT        => $this->timeoutSeconds,
+            CURLOPT_HTTPHEADER     => ['Content-Type: application/x-www-form-urlencoded'],
+        ]);
+
+        $body   = curl_exec($handle);
+        $status = (int) curl_getinfo($handle, CURLINFO_HTTP_CODE);
+        $errno  = curl_errno($handle);
+        $error  = curl_error($handle);
+        curl_close($handle);
+
+        if ($errno !== 0 || !is_string($body)) {
+            // Never include the secret key; curl errors do not contain it.
+            throw new PaymentGatewayException('PAY.JP request failed: ' . $error);
+        }
+
+        return [$status, $body];
+    }
+}

--- a/src/Payment/Gateway/PaymentGatewayException.php
+++ b/src/Payment/Gateway/PaymentGatewayException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+use RuntimeException;
+
+/**
+ * Raised when a gateway charge cannot be completed (declined card, gateway
+ * error, transport failure). The message is safe for logging but MUST NOT carry
+ * card data (SAQ-A).
+ */
+final class PaymentGatewayException extends RuntimeException
+{
+}

--- a/src/Payment/Gateway/PaymentGatewayInterface.php
+++ b/src/Payment/Gateway/PaymentGatewayInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+/**
+ * Abstraction over a hosted card-payment gateway (ADR 0012/0013). The launch
+ * implementation is PAY.JP; Stripe Checkout is the designated second adapter, so
+ * this contract must not bake in any one gateway's specifics (e.g. webhook
+ * signature scheme — PAY.JP uses a token header, not HMAC).
+ *
+ * Only hosted/tokenized flows are permitted: the raw PAN never reaches this
+ * application (SAQ-A).
+ */
+interface PaymentGatewayInterface
+{
+    /** Registry value identifying the gateway (e.g. `payjp`). */
+    public function name(): string;
+
+    /**
+     * Creates a card charge from a gateway-issued card token.
+     *
+     * @throws PaymentGatewayException on decline, gateway error, or transport failure
+     */
+    public function createCharge(GatewayChargeRequest $request): GatewayCharge;
+}

--- a/src/PaymentLink/ChargePaymentLinkHandler.php
+++ b/src/PaymentLink/ChargePaymentLinkHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Routing\Router;
+use NeneInvoice\Payment\Gateway\PaymentGatewayException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /pay/{token}/charge` — public, no authentication. Receives the single-use
+ * card token posted by PAY.JP Checkout (`payjp-token`) and charges the invoice's
+ * outstanding balance. Renders a minimal HTML result page (browser form submit).
+ *
+ * Not-payable links render 404; a declined/failed charge renders 402. No card
+ * data is read or stored (SAQ-A).
+ */
+final readonly class ChargePaymentLinkHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private ChargePaymentLinkUseCaseInterface $useCase,
+        private Psr17Factory $psr17,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params   = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $rawToken = is_array($params) && isset($params['token']) ? (string) $params['token'] : '';
+
+        $body      = $request->getParsedBody();
+        $cardToken = is_array($body) && isset($body['payjp-token']) ? (string) $body['payjp-token'] : '';
+
+        if ($cardToken === '') {
+            return $this->html(400, $this->messagePage('お支払いに失敗しました', 'カード情報が送信されませんでした。'));
+        }
+
+        try {
+            $result = $this->useCase->execute($rawToken, $cardToken);
+        } catch (PaymentLinkNotPayableException) {
+            return $this->html(404, $this->messagePage('お支払いリンクが無効です', 'このリンクは支払えません。'));
+        } catch (PaymentGatewayException) {
+            return $this->html(402, $this->messagePage('お支払いに失敗しました', 'カードが拒否されたか、決済に失敗しました。'));
+        }
+
+        $yen = htmlspecialchars(number_format($result->amountCents), ENT_QUOTES, 'UTF-8');
+
+        return $this->html(200, $this->messagePage('お支払いが完了しました', "¥{$yen} のお支払いを受け付けました。"));
+    }
+
+    private function messagePage(string $title, string $detail): string
+    {
+        $t = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+        $d = htmlspecialchars($detail, ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+            <!doctype html>
+            <html lang="ja">
+            <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{$t}</title></head>
+            <body><main><h1>{$t}</h1><p>{$d}</p></main></body>
+            </html>
+            HTML;
+    }
+
+    private function html(int $status, string $body): ResponseInterface
+    {
+        return $this->psr17->createResponse($status)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withBody($this->psr17->createStream($body));
+    }
+}

--- a/src/PaymentLink/ChargePaymentLinkResult.php
+++ b/src/PaymentLink/ChargePaymentLinkResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+/** Outcome of a successful payment-link charge. */
+final readonly class ChargePaymentLinkResult
+{
+    public function __construct(
+        public int $paymentLinkId,
+        public int $invoiceId,
+        public string $chargeId,
+        public int $amountCents,
+        /** Resulting invoice status: `paid` or `partially_paid`. */
+        public string $invoiceStatus,
+    ) {
+    }
+}

--- a/src/PaymentLink/ChargePaymentLinkUseCase.php
+++ b/src/PaymentLink/ChargePaymentLinkUseCase.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\Gateway\GatewayChargeRequest;
+use NeneInvoice\Payment\Gateway\PaymentGatewayInterface;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
+
+/**
+ * Public, token-authenticated card payment against a payment link (ADR 0012/0013).
+ *
+ * Runs without an authenticated session: the unguessable link token is the trust
+ * anchor, so the org is scoped *from the resolved link* (mirroring the public
+ * download-token route). The invoice's outstanding balance is charged via the
+ * gateway, then recorded as a `payment` (reusing {@see RecordPaymentUseCaseInterface},
+ * keyed by the gateway charge id so a later webhook de-duplicates), and the link
+ * is marked paid. No PAN passes through here (SAQ-A).
+ */
+final readonly class ChargePaymentLinkUseCase implements ChargePaymentLinkUseCaseInterface
+{
+    private const CURRENCY = 'jpy';
+
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private PaymentLinkRepositoryInterface $links,
+        private InvoiceRepositoryInterface $invoices,
+        private PaymentRepositoryInterface $payments,
+        private PaymentGatewayInterface $gateway,
+        private RecordPaymentUseCaseInterface $recordPayment,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(string $rawToken, string $cardToken): ChargePaymentLinkResult
+    {
+        $now  = $this->clock->now()->format('Y-m-d H:i:s');
+        $link = $this->links->findByHash(SecureTokenHelper::hash($rawToken));
+
+        if ($link === null || $link->id === null || !$link->isPayable($now)) {
+            throw new PaymentLinkNotPayableException('Payment link is not payable.');
+        }
+
+        // Public route (no OrgResolver): scope the org from the resolved link.
+        $this->orgId->set($link->organizationId);
+
+        $invoice = $this->invoices->findById($link->invoiceId);
+        if ($invoice === null || $invoice->id === null
+            || !in_array($invoice->status, [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid], true)) {
+            throw new PaymentLinkNotPayableException('Invoice is not in a payable state.');
+        }
+
+        $outstanding = $invoice->totalCents - $this->payments->totalPaidForInvoice($invoice->id);
+        if ($outstanding <= 0) {
+            throw new PaymentLinkNotPayableException('Invoice has no outstanding balance.');
+        }
+
+        // Charge first (may throw PaymentGatewayException on decline), then record.
+        $charge = $this->gateway->createCharge(new GatewayChargeRequest(
+            amountCents: $outstanding,
+            currency: self::CURRENCY,
+            cardToken: $cardToken,
+            metadata: [
+                'payment_link_id' => (string) $link->id,
+                'invoice_id'      => (string) $invoice->id,
+            ],
+        ));
+
+        // Idempotency key = gateway charge id, shared with the #431 webhook so the
+        // two settlement producers never double-book.
+        $result = $this->recordPayment->execute(null, $invoice->id, new RecordPaymentInput(
+            amountCents: $charge->amountCents,
+            paidAt: $now,
+            method: 'card',
+            externalReference: $charge->id,
+            idempotencyKey: $charge->id,
+        ));
+
+        $this->links->markPaid($link->id, $charge->id, $now);
+
+        return new ChargePaymentLinkResult(
+            paymentLinkId: $link->id,
+            invoiceId: $invoice->id,
+            chargeId: $charge->id,
+            amountCents: $charge->amountCents,
+            invoiceStatus: $result->invoice->status->value,
+        );
+    }
+}

--- a/src/PaymentLink/ChargePaymentLinkUseCaseInterface.php
+++ b/src/PaymentLink/ChargePaymentLinkUseCaseInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use NeneInvoice\Payment\Gateway\PaymentGatewayException;
+
+interface ChargePaymentLinkUseCaseInterface
+{
+    /**
+     * Charges the invoice behind a payment link using a gateway card token.
+     *
+     * @throws PaymentLinkNotPayableException link missing/expired/revoked/paid or nothing outstanding
+     * @throws PaymentGatewayException charge declined or gateway error
+     */
+    public function execute(string $rawToken, string $cardToken): ChargePaymentLinkResult;
+}

--- a/src/PaymentLink/PayPageHandler.php
+++ b/src/PaymentLink/PayPageHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
+use Nene2\Routing\Router;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /pay/{token}` — public, no authentication. Renders a minimal page that
+ * loads PAY.JP Checkout (hosted card iframe). The card is entered on PAY.JP's
+ * iframe, never on a form we control, and this page injects **no operator
+ * scripts** (analytics/GTM) — keeping the operator at PCI DSS SAQ-A (ADR 0012).
+ *
+ * Not-payable links (unknown/expired/revoked/paid/settled) render a 404 page to
+ * avoid leaking which links exist.
+ */
+final readonly class PayPageHandler implements RequestHandlerInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private PaymentLinkRepositoryInterface $links,
+        private InvoiceRepositoryInterface $invoices,
+        private PaymentRepositoryInterface $payments,
+        private \Nene2\Http\ClockInterface $clock,
+        private Psr17Factory $psr17,
+        private RequestScopedHolder $orgId,
+        private string $publicKey,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params   = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $rawToken = is_array($params) && isset($params['token']) ? (string) $params['token'] : '';
+
+        $amount = $this->resolveOutstanding($rawToken);
+        if ($amount === null) {
+            return $this->html(404, $this->notFoundPage());
+        }
+
+        return $this->html(200, $this->payPage($rawToken, $amount));
+    }
+
+    /** Returns the outstanding cents to charge, or null when the link is not payable. */
+    private function resolveOutstanding(string $rawToken): ?int
+    {
+        $now  = $this->clock->now()->format('Y-m-d H:i:s');
+        $link = $this->links->findByHash(SecureTokenHelper::hash($rawToken));
+
+        if ($link === null || !$link->isPayable($now)) {
+            return null;
+        }
+
+        $this->orgId->set($link->organizationId);
+
+        $invoice = $this->invoices->findById($link->invoiceId);
+        if ($invoice === null || $invoice->id === null
+            || !in_array($invoice->status, [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid], true)) {
+            return null;
+        }
+
+        $outstanding = $invoice->totalCents - $this->payments->totalPaidForInvoice($invoice->id);
+
+        return $outstanding > 0 ? $outstanding : null;
+    }
+
+    private function payPage(string $rawToken, int $amountCents): string
+    {
+        $action = '/pay/' . rawurlencode($rawToken) . '/charge';
+        $key    = htmlspecialchars($this->publicKey, ENT_QUOTES, 'UTF-8');
+        $amount = (string) $amountCents;
+        $yen    = htmlspecialchars(number_format($amountCents), ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+            <!doctype html>
+            <html lang="ja">
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+              <title>お支払い</title>
+            </head>
+            <body>
+              <main>
+                <h1>カードでお支払い</h1>
+                <p>お支払い金額: <strong>¥{$yen}</strong></p>
+                <form action="{$action}" method="post">
+                  <script
+                    src="https://checkout.pay.jp/"
+                    class="payjp-button"
+                    data-key="{$key}"
+                    data-amount="{$amount}"
+                    data-currency="jpy"></script>
+                </form>
+              </main>
+            </body>
+            </html>
+            HTML;
+    }
+
+    private function notFoundPage(): string
+    {
+        return <<<HTML
+            <!doctype html>
+            <html lang="ja">
+            <head><meta charset="utf-8"><title>リンクが無効です</title></head>
+            <body><main><h1>お支払いリンクが無効です</h1>
+            <p>このお支払いリンクは存在しないか、期限切れ・失効・支払い済みです。</p></main></body>
+            </html>
+            HTML;
+    }
+
+    private function html(int $status, string $body): ResponseInterface
+    {
+        return $this->psr17->createResponse($status)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withBody($this->psr17->createStream($body));
+    }
+}

--- a/src/PaymentLink/PaymentLinkNotPayableException.php
+++ b/src/PaymentLink/PaymentLinkNotPayableException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use RuntimeException;
+
+/**
+ * Raised when a payment link cannot be paid: unknown token, expired, revoked,
+ * already paid, or its invoice has no outstanding balance. Surfaced as 404 to
+ * avoid leaking which links exist (oracle), mirroring the download-token route.
+ */
+final class PaymentLinkNotPayableException extends RuntimeException
+{
+}

--- a/src/PaymentLink/PaymentLinkRepositoryInterface.php
+++ b/src/PaymentLink/PaymentLinkRepositoryInterface.php
@@ -24,8 +24,21 @@ interface PaymentLinkRepositoryInterface
     public function findByHash(string $tokenHash): ?PaymentLink;
 
     /**
+     * Lookup by gateway charge/session id, **not** organization-scoped: the
+     * settlement webhook (#431) resolves the owning organization *from* the link.
+     */
+    public function findByGatewaySessionId(string $gatewaySessionId): ?PaymentLink;
+
+    /**
      * Marks an active link revoked. Org-scoped and idempotent: returns true only
      * when an active link in the caller's org transitioned to revoked.
      */
     public function markRevoked(int $id, string $revokedAt): bool;
+
+    /**
+     * Marks an active link paid and records the gateway charge id. Org-scoped and
+     * idempotent: returns true only when an active link in the caller's org
+     * transitioned to paid.
+     */
+    public function markPaid(int $id, string $gatewaySessionId, string $paidAt): bool;
 }

--- a/src/PaymentLink/PaymentLinkRouteRegistrar.php
+++ b/src/PaymentLink/PaymentLinkRouteRegistrar.php
@@ -12,6 +12,8 @@ final readonly class PaymentLinkRouteRegistrar
     public function __construct(
         private GeneratePaymentLinkHandler $generateHandler,
         private RevokePaymentLinkHandler $revokeHandler,
+        private PayPageHandler $payPageHandler,
+        private ChargePaymentLinkHandler $chargeHandler,
     ) {
     }
 
@@ -19,8 +21,15 @@ final readonly class PaymentLinkRouteRegistrar
     {
         $generate = $this->generateHandler;
         $revoke   = $this->revokeHandler;
+        $payPage  = $this->payPageHandler;
+        $charge   = $this->chargeHandler;
 
+        // Admin (ManageBilling via CapabilityResolver).
         $router->post('/admin/invoices/{id}/payment-links', static fn (ServerRequestInterface $r) => $generate->handle($r));
         $router->post('/admin/payment-links/{id}/revoke', static fn (ServerRequestInterface $r) => $revoke->handle($r));
+
+        // Public (token-authenticated, no session) — hosted card payment (SAQ-A).
+        $router->get('/pay/{token}', static fn (ServerRequestInterface $r) => $payPage->handle($r));
+        $router->post('/pay/{token}/charge', static fn (ServerRequestInterface $r) => $charge->handle($r));
     }
 }

--- a/src/PaymentLink/PaymentLinkServiceProvider.php
+++ b/src/PaymentLink/PaymentLinkServiceProvider.php
@@ -16,6 +16,11 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Payment\Gateway\PayjpGateway;
+use NeneInvoice\Payment\Gateway\PaymentGatewayInterface;
+use NeneInvoice\Payment\PaymentRepositoryInterface;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 
 final readonly class PaymentLinkServiceProvider implements ServiceProviderInterface
@@ -72,10 +77,49 @@ final readonly class PaymentLinkServiceProvider implements ServiceProviderInterf
                 ),
             )
             ->set(
+                PaymentGatewayInterface::class,
+                static fn (ContainerInterface $c): PaymentGatewayInterface => new PayjpGateway(
+                    (string) (getenv('PAYJP_SECRET_KEY') ?: ''),
+                ),
+            )
+            ->set(
+                ChargePaymentLinkUseCaseInterface::class,
+                static fn (ContainerInterface $c): ChargePaymentLinkUseCase => new ChargePaymentLinkUseCase(
+                    self::resolve($c, PaymentLinkRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, PaymentGatewayInterface::class),
+                    self::resolve($c, RecordPaymentUseCaseInterface::class),
+                    self::resolve($c, ClockInterface::class),
+                    self::orgHolder($c),
+                ),
+            )
+            ->set(
+                PayPageHandler::class,
+                static fn (ContainerInterface $c): PayPageHandler => new PayPageHandler(
+                    self::resolve($c, PaymentLinkRepositoryInterface::class),
+                    self::resolve($c, InvoiceRepositoryInterface::class),
+                    self::resolve($c, PaymentRepositoryInterface::class),
+                    self::resolve($c, ClockInterface::class),
+                    self::resolve($c, Psr17Factory::class),
+                    self::orgHolder($c),
+                    (string) (getenv('PAYJP_PUBLIC_KEY') ?: ''),
+                ),
+            )
+            ->set(
+                ChargePaymentLinkHandler::class,
+                static fn (ContainerInterface $c): ChargePaymentLinkHandler => new ChargePaymentLinkHandler(
+                    self::resolve($c, ChargePaymentLinkUseCaseInterface::class),
+                    self::resolve($c, Psr17Factory::class),
+                ),
+            )
+            ->set(
                 PaymentLinkRouteRegistrar::class,
                 static fn (ContainerInterface $c): PaymentLinkRouteRegistrar => new PaymentLinkRouteRegistrar(
                     self::resolve($c, GeneratePaymentLinkHandler::class),
                     self::resolve($c, RevokePaymentLinkHandler::class),
+                    self::resolve($c, PayPageHandler::class),
+                    self::resolve($c, ChargePaymentLinkHandler::class),
                 ),
             );
     }

--- a/src/PaymentLink/PdoPaymentLinkRepository.php
+++ b/src/PaymentLink/PdoPaymentLinkRepository.php
@@ -71,11 +71,31 @@ final readonly class PdoPaymentLinkRepository implements PaymentLinkRepositoryIn
         return $row !== null ? $this->mapRow($row) : null;
     }
 
+    public function findByGatewaySessionId(string $gatewaySessionId): ?PaymentLink
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payment_links WHERE gateway_session_id = ?',
+            [$gatewaySessionId],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
     public function markRevoked(int $id, string $revokedAt): bool
     {
         $affected = $this->query->execute(
             'UPDATE payment_links SET status = ?, revoked_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND status = ?',
             [PaymentLinkStatus::Revoked->value, $revokedAt, $revokedAt, $id, $this->orgId->get(), PaymentLinkStatus::Active->value],
+        );
+
+        return $affected > 0;
+    }
+
+    public function markPaid(int $id, string $gatewaySessionId, string $paidAt): bool
+    {
+        $affected = $this->query->execute(
+            'UPDATE payment_links SET status = ?, gateway_session_id = ?, paid_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND status = ?',
+            [PaymentLinkStatus::Paid->value, $gatewaySessionId, $paidAt, $paidAt, $id, $this->orgId->get(), PaymentLinkStatus::Active->value],
         );
 
         return $affected > 0;

--- a/tests/Integration/PayjpGatewayChargeTest.php
+++ b/tests/Integration/PayjpGatewayChargeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Integration;
+
+use NeneInvoice\Payment\Gateway\GatewayChargeRequest;
+use NeneInvoice\Payment\Gateway\PayjpGateway;
+use NeneInvoice\Payment\Gateway\PaymentGatewayException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the real PAY.JP API with the configured **test** secret key. Skipped
+ * unless `PAYJP_SECRET_KEY` (sk_test_…) is present, so CI without the key and
+ * contributors without an account skip it. Test mode moves no real money.
+ *
+ * Scope: authentication + error parsing against the live API. The *successful*
+ * charge path cannot be exercised here because PAY.JP deliberately rejects raw
+ * card numbers sent server-side (`unsafe_credit_card_param`) — card tokens must
+ * be minted in the browser via PAY.JP Checkout / payjp.js. That is exactly our
+ * SAQ-A design (no PAN server-side); the happy path is covered by
+ * {@see \NeneInvoice\Tests\PaymentLink\ChargePaymentLinkUseCaseTest} with a fake
+ * gateway, and end-to-end via a real Checkout token (manual / browser E2E).
+ */
+final class PayjpGatewayChargeTest extends TestCase
+{
+    private string $secretKey = '';
+
+    protected function setUp(): void
+    {
+        $key = getenv('PAYJP_SECRET_KEY') ?: ($_ENV['PAYJP_SECRET_KEY'] ?? '');
+        if (!is_string($key) || !str_starts_with($key, 'sk_test_')) {
+            self::markTestSkipped('PAYJP_SECRET_KEY (sk_test_…) not set; skipping live PAY.JP test.');
+        }
+        $this->secretKey = $key;
+    }
+
+    public function test_authenticates_and_parses_a_declined_charge(): void
+    {
+        // A bad token reaches PAY.JP (auth OK) and comes back as a structured
+        // error, which the adapter surfaces as a PaymentGatewayException.
+        $gateway = new PayjpGateway($this->secretKey);
+
+        $this->expectException(PaymentGatewayException::class);
+        $gateway->createCharge(new GatewayChargeRequest(
+            amountCents: 500,
+            currency: 'jpy',
+            cardToken: 'tok_obviously_invalid',
+        ));
+    }
+
+    public function test_missing_key_fails_closed_without_network(): void
+    {
+        $gateway = new PayjpGateway('');
+
+        $this->expectException(PaymentGatewayException::class);
+        $gateway->createCharge(new GatewayChargeRequest(
+            amountCents: 500,
+            currency: 'jpy',
+            cardToken: 'tok_whatever',
+        ));
+    }
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -79,6 +79,8 @@ final class OpenApiContractTest extends TestCase
         'recordPayment',
         'generatePaymentLink',
         'revokePaymentLink',
+        'getPaymentPage',
+        'chargePaymentLink',
         'sendInvoiceEmail',
         'exportInvoicesCsv',
         'exportPaymentsCsv',

--- a/tests/PaymentLink/ChargePaymentLinkUseCaseTest.php
+++ b/tests/PaymentLink/ChargePaymentLinkUseCaseTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\SecureTokenHelper;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\Gateway\PaymentGatewayException;
+use NeneInvoice\Payment\Payment;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\PaymentLink\ChargePaymentLinkUseCase;
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkNotPayableException;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use NeneInvoice\Tests\Support\FakeGateway;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentLinkRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class ChargePaymentLinkUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+
+    private InMemoryInvoiceRepository $invoices;
+
+    private InMemoryPaymentRepository $payments;
+
+    private InMemoryPaymentLinkRepository $links;
+
+    private RecordPaymentUseCase $recordPayment;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
+        $this->payments = new InMemoryPaymentRepository($this->holder);
+        $this->links    = new InMemoryPaymentLinkRepository(1);
+        $audit          = new RecordingAuditRecorder();
+        $this->recordPayment = new RecordPaymentUseCase(
+            $this->payments,
+            $this->invoices,
+            new ImmediateTransactionManager(),
+            fn () => $this->payments,
+            fn () => $this->invoices,
+            fn () => $audit,
+            new FixedClock(),
+            $this->holder,
+        );
+    }
+
+    private function useCase(FakeGateway $gateway): ChargePaymentLinkUseCase
+    {
+        return new ChargePaymentLinkUseCase(
+            $this->links,
+            $this->invoices,
+            $this->payments,
+            $gateway,
+            $this->recordPayment,
+            new FixedClock(),
+            $this->holder,
+        );
+    }
+
+    private function seedInvoice(int $totalCents = 1000, InvoiceStatus $status = InvoiceStatus::Issued): int
+    {
+        return $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: $status, subtotalCents: $totalCents, taxCents: 0, totalCents: $totalCents));
+    }
+
+    private function seedLink(int $invoiceId, string $rawToken, PaymentLinkStatus $status = PaymentLinkStatus::Active): int
+    {
+        return $this->links->save(new PaymentLink(
+            organizationId: 1,
+            invoiceId: $invoiceId,
+            tokenHash: SecureTokenHelper::hash($rawToken),
+            gateway: 'payjp',
+            status: $status,
+            expiresAt: '2026-06-13 03:00:00',
+            createdAt: '2026-06-06 03:00:00',
+            updatedAt: '2026-06-06 03:00:00',
+        ));
+    }
+
+    public function test_charges_outstanding_records_payment_and_marks_link_paid(): void
+    {
+        $invoiceId = $this->seedInvoice(1000);
+        $this->seedLink($invoiceId, 'raw-1');
+        $gateway = new FakeGateway('ch_test_1');
+
+        $result = $this->useCase($gateway)->execute('raw-1', 'tok_card');
+
+        self::assertSame('ch_test_1', $result->chargeId);
+        self::assertSame(1000, $result->amountCents);
+        self::assertSame('paid', $result->invoiceStatus);
+
+        // Gateway received the outstanding amount, jpy, and our metadata.
+        self::assertNotNull($gateway->lastRequest);
+        self::assertSame(1000, $gateway->lastRequest->amountCents);
+        self::assertSame('jpy', $gateway->lastRequest->currency);
+        self::assertSame('tok_card', $gateway->lastRequest->cardToken);
+        self::assertSame((string) $invoiceId, $gateway->lastRequest->metadata['invoice_id']);
+        self::assertArrayHasKey('payment_link_id', $gateway->lastRequest->metadata);
+
+        // Payment recorded as a card payment keyed by the charge id.
+        self::assertSame(1000, $this->payments->totalPaidForInvoice($invoiceId));
+        $payment = $this->payments->findByIdempotencyKey('ch_test_1');
+        self::assertNotNull($payment);
+        self::assertSame('card', $payment->method);
+        self::assertSame('ch_test_1', $payment->externalReference);
+
+        // Link marked paid with the charge id.
+        $link = $this->links->findByHash(SecureTokenHelper::hash('raw-1'));
+        self::assertNotNull($link);
+        self::assertSame(PaymentLinkStatus::Paid, $link->status);
+        self::assertSame('ch_test_1', $link->gatewaySessionId);
+    }
+
+    public function test_charges_only_the_outstanding_balance(): void
+    {
+        $invoiceId = $this->seedInvoice(1000, InvoiceStatus::PartiallyPaid);
+        // 400 already paid → outstanding 600.
+        $this->payments->save(new Payment(organizationId: 1, invoiceId: $invoiceId, amountCents: 400, paidAt: '2026-06-06 03:00:00'));
+        $this->seedLink($invoiceId, 'raw-2');
+        $gateway = new FakeGateway('ch_test_2');
+
+        $result = $this->useCase($gateway)->execute('raw-2', 'tok_card');
+
+        self::assertNotNull($gateway->lastRequest);
+        self::assertSame(600, $gateway->lastRequest->amountCents, 'must charge only the outstanding balance');
+        self::assertSame(600, $result->amountCents);
+        self::assertSame('paid', $result->invoiceStatus);
+    }
+
+    public function test_revoked_link_is_not_payable(): void
+    {
+        $invoiceId = $this->seedInvoice(1000);
+        $this->seedLink($invoiceId, 'raw-3', PaymentLinkStatus::Revoked);
+
+        $this->expectException(PaymentLinkNotPayableException::class);
+        $this->useCase(new FakeGateway())->execute('raw-3', 'tok_card');
+    }
+
+    public function test_unknown_token_is_not_payable(): void
+    {
+        $this->expectException(PaymentLinkNotPayableException::class);
+        $this->useCase(new FakeGateway())->execute('no-such-token', 'tok_card');
+    }
+
+    public function test_declined_charge_records_no_payment_and_leaves_link_active(): void
+    {
+        $invoiceId = $this->seedInvoice(1000);
+        $this->seedLink($invoiceId, 'raw-4');
+        $gateway = new FakeGateway('ch_x', 'Your card was declined.');
+
+        try {
+            $this->useCase($gateway)->execute('raw-4', 'tok_card');
+            self::fail('expected PaymentGatewayException');
+        } catch (PaymentGatewayException) {
+            // expected
+        }
+
+        self::assertSame(0, $this->payments->totalPaidForInvoice($invoiceId), 'no payment on decline');
+        $link = $this->links->findByHash(SecureTokenHelper::hash('raw-4'));
+        self::assertNotNull($link);
+        self::assertSame(PaymentLinkStatus::Active, $link->status, 'link stays active on decline');
+    }
+}

--- a/tests/PaymentLink/PdoPaymentLinkRepositoryTest.php
+++ b/tests/PaymentLink/PdoPaymentLinkRepositoryTest.php
@@ -100,4 +100,32 @@ final class PdoPaymentLinkRepositoryTest extends TestCase
         self::assertNull($this->repo->findById($id));
         self::assertFalse($this->repo->markRevoked($id, '2026-06-07 00:00:00'));
     }
+
+    public function test_mark_paid_records_charge_id_and_is_findable_by_session(): void
+    {
+        $id = $this->repo->save($this->activeLink(1, 5, 'raw-paid'));
+
+        self::assertTrue($this->repo->markPaid($id, 'ch_test_abc', '2026-06-07 00:00:00'));
+
+        $byId = $this->repo->findById($id);
+        self::assertNotNull($byId);
+        self::assertSame(PaymentLinkStatus::Paid, $byId->status);
+        self::assertSame('ch_test_abc', $byId->gatewaySessionId);
+        self::assertSame('2026-06-07 00:00:00', $byId->paidAt);
+
+        // Reverse lookup by gateway charge id (webhook path) is not org-scoped.
+        $bySession = $this->repo->findByGatewaySessionId('ch_test_abc');
+        self::assertNotNull($bySession);
+        self::assertSame($id, $bySession->id);
+
+        // markPaid is idempotent: a second call (now non-active) is a no-op.
+        self::assertFalse($this->repo->markPaid($id, 'ch_test_abc', '2026-06-08 00:00:00'));
+    }
+
+    public function test_mark_paid_is_org_scoped(): void
+    {
+        $id = $this->repo->save($this->activeLink(2, 9, 'raw-foreign-paid'));
+
+        self::assertFalse($this->repo->markPaid($id, 'ch_x', '2026-06-07 00:00:00'));
+    }
 }

--- a/tests/Support/FakeGateway.php
+++ b/tests/Support/FakeGateway.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Payment\Gateway\GatewayCharge;
+use NeneInvoice\Payment\Gateway\GatewayChargeRequest;
+use NeneInvoice\Payment\Gateway\PaymentGatewayException;
+use NeneInvoice\Payment\Gateway\PaymentGatewayInterface;
+
+/**
+ * Configurable {@see PaymentGatewayInterface} double. Returns a charge whose id
+ * is `$chargeId` and amount echoes the request, or throws when `$declineMessage`
+ * is set. Records the last request for assertions (e.g. metadata).
+ */
+final class FakeGateway implements PaymentGatewayInterface
+{
+    public ?GatewayChargeRequest $lastRequest = null;
+
+    public function __construct(
+        private readonly string $chargeId = 'ch_fake_1',
+        private readonly ?string $declineMessage = null,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'fake';
+    }
+
+    public function createCharge(GatewayChargeRequest $request): GatewayCharge
+    {
+        $this->lastRequest = $request;
+
+        if ($this->declineMessage !== null) {
+            throw new PaymentGatewayException($this->declineMessage);
+        }
+
+        return new GatewayCharge(
+            id: $this->chargeId,
+            paid: true,
+            amountCents: $request->amountCents,
+            currency: $request->currency,
+        );
+    }
+}

--- a/tests/Support/InMemoryPaymentLinkRepository.php
+++ b/tests/Support/InMemoryPaymentLinkRepository.php
@@ -75,6 +75,17 @@ final class InMemoryPaymentLinkRepository implements PaymentLinkRepositoryInterf
         return null;
     }
 
+    public function findByGatewaySessionId(string $gatewaySessionId): ?PaymentLink
+    {
+        foreach ($this->byId as $link) {
+            if ($link->gatewaySessionId === $gatewaySessionId) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
     public function markRevoked(int $id, string $revokedAt): bool
     {
         $link = $this->byId[$id] ?? null;
@@ -98,6 +109,34 @@ final class InMemoryPaymentLinkRepository implements PaymentLinkRepositoryInterf
             id: $link->id,
             createdAt: $link->createdAt,
             updatedAt: $revokedAt,
+        );
+
+        return true;
+    }
+
+    public function markPaid(int $id, string $gatewaySessionId, string $paidAt): bool
+    {
+        $link = $this->byId[$id] ?? null;
+
+        if ($link === null
+            || $link->organizationId !== $this->organizationId
+            || $link->status !== PaymentLinkStatus::Active) {
+            return false;
+        }
+
+        $this->byId[$id] = new PaymentLink(
+            organizationId: $link->organizationId,
+            invoiceId: $link->invoiceId,
+            tokenHash: $link->tokenHash,
+            gateway: $link->gateway,
+            status: PaymentLinkStatus::Paid,
+            expiresAt: $link->expiresAt,
+            gatewaySessionId: $gatewaySessionId,
+            paidAt: $paidAt,
+            revokedAt: $link->revokedAt,
+            id: $link->id,
+            createdAt: $link->createdAt,
+            updatedAt: $paidAt,
         );
 
         return true;


### PR DESCRIPTION
## 概要

#436 の決済リンクに対する **producer** を実装。ADR 0012/0013・設計メモに基づき、`PaymentGatewayInterface` + PAY.JP アダプタ + 公開決済ページ（PAY.JP Checkout）を追加。これで #431（webhook）が逆引きする `gateway_session_id` の生成側が揃う。

Closes #439

## 実装

- **`src/Payment/Gateway/`**: `PaymentGatewayInterface`（HMAC を前提化しない — PAY.JP はトークンヘッダ）、`PayjpGateway`（`/v1/charges`・basic auth・カード番号非通過＝SAQ-A・secret 非ログ）、`GatewayChargeRequest`/`GatewayCharge`/`PaymentGatewayException`
- **`ChargePaymentLinkUseCase`**: 公開トークンで org をスコープ（公開 DL トークン前例を踏襲）→ outstanding を charge → 既存 `RecordPaymentUseCase` で入金記録 → リンクを `paid` 化。**idempotency_key = charge id**（#431 webhook と二重起票しない）
- **公開ルート**: `GET /pay/{token}`（最小 HTML + PAY.JP Checkout iframe、**運用者スクリプト非注入で SAQ-A 維持**）、`POST /pay/{token}/charge`（PAY.JP の `payjp-token` を受領）
- **リポジトリ拡張**: `markPaid` / `findByGatewaySessionId`（webhook 逆引き用）
- 設定: PAY.JP キーは `.env`（コミット禁止）、`.env.example` に placeholder
- `payment.method` に `card` 登録、OpenAPI 2 公開ルート、terminology 更新

## テスト / 品質

- 新規テスト: `ChargePaymentLinkUseCaseTest`（fake gateway: outstanding 充当・decline 時無記録・revoked 不可）、`PdoPaymentLinkRepositoryTest`（markPaid/逆引き/org 分離）、`PayjpGatewayChargeTest`（**実 PAY.JP 疎通**, env ガード・test mode）
- `composer check` green（phpunit 443 / phpstan / cs / openapi / mcp）。integration はローカルで実キー時のみ実行、CI は skip

## 重要な裏取り（SAQ-A の確証）

実装中に PAY.JP テスト API で確認: **サーバから生カード番号を送ると拒否される**（`unsafe_credit_card_param` → "use Checkout/payjp.js"）。これは我々の SAQ-A 設計が PAY.JP 側でも強制されている裏付けで、カードトークンは**ブラウザ Checkout 由来に限定**される。したがって成功 charge の自動 E2E は不可（ブラウザトークンが要る）で、ユニットテスト（fake）+ 実 API 疎通テスト（auth/エラー解析）+ 手動ブラウザ E2E で担保。

## スコープ外（後続）

- #431 webhook ingress（決済確定の backstop。charge id 共有で冪等）
- #432 Admin ゲートウェイ設定 UI（現状キーは env 直読み）
- 会計起票の本設計は #430（リリースゲート, 税理士）

🤖 Generated with [Claude Code](https://claude.com/claude-code)