### PR TITLE
feat(payment): PAY.JP 決済 webhook ingress を実装 (#431)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -152,6 +152,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `service-token-revoked` | Presented service token has been revoked (401; service API) |
 | `service-token-not-found` | Service-token id not found in the caller's org (404; operator API) |
 | `payment-link-not-found` | Payment-link id not found in the caller's org (404; operator API) |
+| `invalid-webhook-token` | PAY.JP webhook `X-Payjp-Webhook-Token` missing or incorrect (401; public webhook) |
 
 Add new slugs here before using them. Validation `errors[].field` uses
 snake_case paths (e.g. `body.registration_number`); `errors[].code` is

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1694,6 +1694,37 @@ paths:
           content:
             text/html:
               schema: { type: string }
+  /webhooks/payjp:
+    post:
+      tags: [Payments]
+      summary: PAY.JP settlement webhook
+      description: >
+        Public ingress for PAY.JP webhook events, authenticated by the
+        `X-Payjp-Webhook-Token` header (PAY.JP does not HMAC-sign webhooks).
+        Records a confirmed `charge.succeeded` settlement against its payment link
+        (idempotent on the charge id). Returns 200 for handled, ignored, and
+        unresolvable events so PAY.JP stops retrying; 401 for a bad token.
+      operationId: payjpWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: PAY.JP event object (id, type, data charge, …).
+      responses:
+        '200':
+          description: Event acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+        '400':
+          description: Malformed body
+        '401':
+          description: Missing or incorrect webhook token
   /admin/invoices/{id}/issue:
     parameters:
       - $ref: '#/components/parameters/IdPathParam'

--- a/src/Payment/Gateway/PayjpWebhookHandler.php
+++ b/src/Payment/Gateway/PayjpWebhookHandler.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Payment\Gateway;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\PaymentLink\RecordSettlementUseCaseInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /webhooks/payjp` — public, no session. Authenticates the request by the
+ * shared-secret header `X-Payjp-Webhook-Token` (PAY.JP does **not** HMAC-sign
+ * webhooks — verified against docs.pay.jp/v1/webhook), then records a confirmed
+ * `charge.succeeded` settlement against its payment link.
+ *
+ * Returns 401 for a missing/incorrect token (fail-closed when unconfigured),
+ * 400 for a malformed body, and **200** for everything else — including ignored
+ * event types and unresolvable charges — so PAY.JP (which retries up to 3× on
+ * non-2xx) stops retrying a permanently-handled event. No card data is read.
+ */
+final readonly class PayjpWebhookHandler implements RequestHandlerInterface
+{
+    private const SETTLEMENT_EVENT = 'charge.succeeded';
+
+    public function __construct(
+        private RecordSettlementUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+        private string $expectedToken,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // Fail closed: an unconfigured token rejects all webhooks.
+        $presented = $request->getHeaderLine('X-Payjp-Webhook-Token');
+        if ($this->expectedToken === '' || !hash_equals($this->expectedToken, $presented)) {
+            return $this->problemDetails->create($request, 'invalid-webhook-token', 'Unauthorized', 401, 'Webhook token is missing or incorrect.');
+        }
+
+        $decoded = json_decode((string) $request->getBody(), true);
+        if (!is_array($decoded)) {
+            return $this->problemDetails->create($request, 'invalid-json', 'Bad Request', 400, 'Webhook body is not a JSON object.');
+        }
+
+        $type = is_string($decoded['type'] ?? null) ? $decoded['type'] : '';
+        if ($type !== self::SETTLEMENT_EVENT) {
+            // Acknowledge unhandled event types without retrying.
+            return $this->json->create(['status' => 'ignored'], 200);
+        }
+
+        $charge = is_array($decoded['data'] ?? null) ? $decoded['data'] : [];
+        $chargeId = is_string($charge['id'] ?? null) ? $charge['id'] : '';
+        if ($chargeId === '') {
+            return $this->json->create(['status' => 'ignored'], 200);
+        }
+
+        $amountCents   = (int) ($charge['amount'] ?? 0);
+        $metadata      = is_array($charge['metadata'] ?? null) ? $charge['metadata'] : [];
+        $rawLinkId     = $metadata['payment_link_id'] ?? null;
+        $paymentLinkId = is_numeric($rawLinkId) ? (int) $rawLinkId : null;
+
+        $outcome = $this->useCase->execute($paymentLinkId, $chargeId, $amountCents);
+
+        return $this->json->create(['status' => strtolower($outcome->name)], 200);
+    }
+}

--- a/src/PaymentLink/PaymentLinkRepositoryInterface.php
+++ b/src/PaymentLink/PaymentLinkRepositoryInterface.php
@@ -30,6 +30,15 @@ interface PaymentLinkRepositoryInterface
     public function findByGatewaySessionId(string $gatewaySessionId): ?PaymentLink;
 
     /**
+     * Lookup by primary key, **not** organization-scoped — webhook-only. The
+     * settlement webhook (#431) recovers the org from a gateway-authenticated
+     * event's `metadata.payment_link_id`, which works even when the synchronous
+     * charge crashed before persisting `gateway_session_id`. Do not use on
+     * tenant-facing paths; use {@see findById()} there.
+     */
+    public function findByIdUnscoped(int $id): ?PaymentLink;
+
+    /**
      * Marks an active link revoked. Org-scoped and idempotent: returns true only
      * when an active link in the caller's org transitioned to revoked.
      */

--- a/src/PaymentLink/PaymentLinkRouteRegistrar.php
+++ b/src/PaymentLink/PaymentLinkRouteRegistrar.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\PaymentLink;
 
 use Nene2\Routing\Router;
+use NeneInvoice\Payment\Gateway\PayjpWebhookHandler;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class PaymentLinkRouteRegistrar
@@ -14,6 +15,7 @@ final readonly class PaymentLinkRouteRegistrar
         private RevokePaymentLinkHandler $revokeHandler,
         private PayPageHandler $payPageHandler,
         private ChargePaymentLinkHandler $chargeHandler,
+        private PayjpWebhookHandler $webhookHandler,
     ) {
     }
 
@@ -23,6 +25,7 @@ final readonly class PaymentLinkRouteRegistrar
         $revoke   = $this->revokeHandler;
         $payPage  = $this->payPageHandler;
         $charge   = $this->chargeHandler;
+        $webhook  = $this->webhookHandler;
 
         // Admin (ManageBilling via CapabilityResolver).
         $router->post('/admin/invoices/{id}/payment-links', static fn (ServerRequestInterface $r) => $generate->handle($r));
@@ -31,5 +34,8 @@ final readonly class PaymentLinkRouteRegistrar
         // Public (token-authenticated, no session) — hosted card payment (SAQ-A).
         $router->get('/pay/{token}', static fn (ServerRequestInterface $r) => $payPage->handle($r));
         $router->post('/pay/{token}/charge', static fn (ServerRequestInterface $r) => $charge->handle($r));
+
+        // Public webhook (X-Payjp-Webhook-Token authenticated) — settlement backstop.
+        $router->post('/webhooks/payjp', static fn (ServerRequestInterface $r) => $webhook->handle($r));
     }
 }

--- a/src/PaymentLink/PaymentLinkServiceProvider.php
+++ b/src/PaymentLink/PaymentLinkServiceProvider.php
@@ -17,6 +17,7 @@ use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditServiceProvider;
 use NeneInvoice\Invoice\InvoiceRepositoryInterface;
 use NeneInvoice\Payment\Gateway\PayjpGateway;
+use NeneInvoice\Payment\Gateway\PayjpWebhookHandler;
 use NeneInvoice\Payment\Gateway\PaymentGatewayInterface;
 use NeneInvoice\Payment\PaymentRepositoryInterface;
 use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
@@ -114,12 +115,31 @@ final readonly class PaymentLinkServiceProvider implements ServiceProviderInterf
                 ),
             )
             ->set(
+                RecordSettlementUseCaseInterface::class,
+                static fn (ContainerInterface $c): RecordSettlementUseCase => new RecordSettlementUseCase(
+                    self::resolve($c, PaymentLinkRepositoryInterface::class),
+                    self::resolve($c, RecordPaymentUseCaseInterface::class),
+                    self::resolve($c, ClockInterface::class),
+                    self::orgHolder($c),
+                ),
+            )
+            ->set(
+                PayjpWebhookHandler::class,
+                static fn (ContainerInterface $c): PayjpWebhookHandler => new PayjpWebhookHandler(
+                    self::resolve($c, RecordSettlementUseCaseInterface::class),
+                    self::resolve($c, JsonResponseFactory::class),
+                    self::resolve($c, ProblemDetailsResponseFactory::class),
+                    (string) (getenv('PAYJP_WEBHOOK_TOKEN') ?: ''),
+                ),
+            )
+            ->set(
                 PaymentLinkRouteRegistrar::class,
                 static fn (ContainerInterface $c): PaymentLinkRouteRegistrar => new PaymentLinkRouteRegistrar(
                     self::resolve($c, GeneratePaymentLinkHandler::class),
                     self::resolve($c, RevokePaymentLinkHandler::class),
                     self::resolve($c, PayPageHandler::class),
                     self::resolve($c, ChargePaymentLinkHandler::class),
+                    self::resolve($c, PayjpWebhookHandler::class),
                 ),
             );
     }

--- a/src/PaymentLink/PdoPaymentLinkRepository.php
+++ b/src/PaymentLink/PdoPaymentLinkRepository.php
@@ -81,6 +81,16 @@ final readonly class PdoPaymentLinkRepository implements PaymentLinkRepositoryIn
         return $row !== null ? $this->mapRow($row) : null;
     }
 
+    public function findByIdUnscoped(int $id): ?PaymentLink
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM payment_links WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
     public function markRevoked(int $id, string $revokedAt): bool
     {
         $affected = $this->query->execute(

--- a/src/PaymentLink/RecordSettlementUseCase.php
+++ b/src/PaymentLink/RecordSettlementUseCase.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Invoice\InvoiceNotFoundException;
+use NeneInvoice\Payment\PaymentExceedsOutstandingException;
+use NeneInvoice\Payment\PaymentValidationException;
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
+
+/**
+ * Records a confirmed gateway settlement (e.g. PAY.JP `charge.succeeded`) against
+ * its payment link. This is the **backstop** producer to the synchronous charge
+ * (#439): both key the payment by the gateway **charge id**, so a webhook replay
+ * (PAY.JP retries up to 3×) or a duplicate of the synchronous payment is
+ * de-duplicated by {@see RecordPaymentUseCaseInterface}'s idempotency.
+ *
+ * Runs without an authenticated session: the org is recovered *from the resolved
+ * link* (the event was gateway-authenticated upstream), mirroring the public
+ * payment route. No card data is present (SAQ-A).
+ */
+final readonly class RecordSettlementUseCase implements RecordSettlementUseCaseInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private PaymentLinkRepositoryInterface $links,
+        private RecordPaymentUseCaseInterface $recordPayment,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(?int $paymentLinkId, string $chargeId, int $amountCents): SettlementOutcome
+    {
+        $link = $paymentLinkId !== null
+            ? $this->links->findByIdUnscoped($paymentLinkId)
+            : $this->links->findByGatewaySessionId($chargeId);
+
+        if ($link === null || $link->id === null) {
+            return SettlementOutcome::LinkNotFound;
+        }
+
+        // Recover the tenant from the resolved link (no OrgResolver on webhooks).
+        $this->orgId->set($link->organizationId);
+
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        try {
+            $this->recordPayment->execute(null, $link->invoiceId, new RecordPaymentInput(
+                amountCents: $amountCents,
+                paidAt: $now,
+                method: 'card',
+                externalReference: $chargeId,
+                idempotencyKey: $chargeId,
+            ));
+        } catch (InvoiceNotFoundException | PaymentValidationException | PaymentExceedsOutstandingException) {
+            // Invoice gone, not issued, or already covered by another payment —
+            // nothing safe to record. Acknowledge so the gateway stops retrying.
+            return SettlementOutcome::Ignored;
+        }
+
+        // Idempotent: only an active link transitions; a replay is a no-op.
+        $this->links->markPaid($link->id, $chargeId, $now);
+
+        return SettlementOutcome::Recorded;
+    }
+}

--- a/src/PaymentLink/RecordSettlementUseCaseInterface.php
+++ b/src/PaymentLink/RecordSettlementUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+interface RecordSettlementUseCaseInterface
+{
+    /**
+     * Records a confirmed gateway settlement against the payment link it belongs
+     * to (idempotent on the gateway charge id). Resolves the link by
+     * `$paymentLinkId` (from the event metadata) when given, else by `$chargeId`.
+     */
+    public function execute(?int $paymentLinkId, string $chargeId, int $amountCents): SettlementOutcome;
+}

--- a/src/PaymentLink/SettlementOutcome.php
+++ b/src/PaymentLink/SettlementOutcome.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\PaymentLink;
+
+/** Result of processing a settlement event, so the webhook can choose a status. */
+enum SettlementOutcome
+{
+    /** Payment recorded (or idempotently already recorded) and link marked paid. */
+    case Recorded;
+    /** The event could not be mapped to a known link — acknowledged, not retried. */
+    case LinkNotFound;
+    /** The link resolved but the invoice was not in a recordable state — ignored. */
+    case Ignored;
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -81,6 +81,7 @@ final class OpenApiContractTest extends TestCase
         'revokePaymentLink',
         'getPaymentPage',
         'chargePaymentLink',
+        'payjpWebhook',
         'sendInvoiceEmail',
         'exportInvoicesCsv',
         'exportPaymentsCsv',

--- a/tests/Payment/Gateway/PayjpWebhookHandlerTest.php
+++ b/tests/Payment/Gateway/PayjpWebhookHandlerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Payment\Gateway;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Payment\Gateway\PayjpWebhookHandler;
+use NeneInvoice\PaymentLink\RecordSettlementUseCaseInterface;
+use NeneInvoice\PaymentLink\SettlementOutcome;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PayjpWebhookHandlerTest extends TestCase
+{
+    private const TOKEN = 'whook_test_secret';
+
+    private Psr17Factory $psr17;
+
+    /** @var array{paymentLinkId: ?int, chargeId: string, amountCents: int}|null */
+    private ?array $captured = null;
+
+    private RecordSettlementUseCaseInterface $useCase;
+
+    protected function setUp(): void
+    {
+        $this->psr17    = new Psr17Factory();
+        $this->captured = null;
+
+        $test = $this;
+        $this->useCase = new class ($test) implements RecordSettlementUseCaseInterface {
+            public function __construct(private readonly PayjpWebhookHandlerTest $test)
+            {
+            }
+
+            public function execute(?int $paymentLinkId, string $chargeId, int $amountCents): SettlementOutcome
+            {
+                $this->test->capture($paymentLinkId, $chargeId, $amountCents);
+
+                return SettlementOutcome::Recorded;
+            }
+        };
+    }
+
+    public function capture(?int $paymentLinkId, string $chargeId, int $amountCents): void
+    {
+        $this->captured = ['paymentLinkId' => $paymentLinkId, 'chargeId' => $chargeId, 'amountCents' => $amountCents];
+    }
+
+    private function handler(string $expectedToken = self::TOKEN): PayjpWebhookHandler
+    {
+        return new PayjpWebhookHandler(
+            $this->useCase,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17),
+            $expectedToken,
+        );
+    }
+
+    private function request(string $body, ?string $token = self::TOKEN): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest('POST', '/webhooks/payjp');
+        if ($token !== null) {
+            $request = $request->withHeader('X-Payjp-Webhook-Token', $token);
+        }
+
+        return $request->withBody($this->psr17->createStream($body));
+    }
+
+    private function chargeEvent(string $chargeId = 'ch_evt', int $amount = 1000, ?string $linkId = '7'): string
+    {
+        $metadata = $linkId !== null ? ['payment_link_id' => $linkId] : [];
+
+        return (string) json_encode([
+            'id'   => 'evnt_1',
+            'type' => 'charge.succeeded',
+            'data' => ['id' => $chargeId, 'amount' => $amount, 'metadata' => $metadata],
+        ]);
+    }
+
+    public function test_rejects_missing_token(): void
+    {
+        $response = $this->handler()->handle($this->request($this->chargeEvent(), token: null));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertNull($this->captured);
+    }
+
+    public function test_rejects_incorrect_token(): void
+    {
+        $response = $this->handler()->handle($this->request($this->chargeEvent(), token: 'whook_wrong'));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertNull($this->captured);
+    }
+
+    public function test_fails_closed_when_token_unconfigured(): void
+    {
+        $response = $this->handler(expectedToken: '')->handle($this->request($this->chargeEvent()));
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertNull($this->captured);
+    }
+
+    public function test_malformed_body_returns_400(): void
+    {
+        $response = $this->handler()->handle($this->request('not-json'));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertNull($this->captured);
+    }
+
+    public function test_non_settlement_event_is_acknowledged_without_dispatch(): void
+    {
+        $body     = (string) json_encode(['id' => 'evnt_2', 'type' => 'charge.failed', 'data' => ['id' => 'ch_x']]);
+        $response = $this->handler()->handle($this->request($body));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNull($this->captured);
+    }
+
+    public function test_charge_succeeded_dispatches_parsed_values(): void
+    {
+        $response = $this->handler()->handle($this->request($this->chargeEvent('ch_evt', 1500, '7')));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($this->captured);
+        self::assertSame(7, $this->captured['paymentLinkId']);
+        self::assertSame('ch_evt', $this->captured['chargeId']);
+        self::assertSame(1500, $this->captured['amountCents']);
+    }
+
+    public function test_charge_without_metadata_link_id_dispatches_null(): void
+    {
+        $response = $this->handler()->handle($this->request($this->chargeEvent('ch_evt', 1000, null)));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($this->captured);
+        self::assertNull($this->captured['paymentLinkId']);
+        self::assertSame('ch_evt', $this->captured['chargeId']);
+    }
+}

--- a/tests/PaymentLink/RecordSettlementUseCaseTest.php
+++ b/tests/PaymentLink/RecordSettlementUseCaseTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use NeneInvoice\PaymentLink\RecordSettlementUseCase;
+use NeneInvoice\PaymentLink\SettlementOutcome;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentLinkRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class RecordSettlementUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+
+    private InMemoryInvoiceRepository $invoices;
+
+    private InMemoryPaymentRepository $payments;
+
+    private InMemoryPaymentLinkRepository $links;
+
+    private RecordSettlementUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
+        $this->payments = new InMemoryPaymentRepository($this->holder);
+        $this->links    = new InMemoryPaymentLinkRepository(1);
+        $recordPayment  = new RecordPaymentUseCase(
+            $this->payments,
+            $this->invoices,
+            new ImmediateTransactionManager(),
+            fn () => $this->payments,
+            fn () => $this->invoices,
+            fn () => new RecordingAuditRecorder(),
+            new FixedClock(),
+            $this->holder,
+        );
+        $this->useCase = new RecordSettlementUseCase($this->links, $recordPayment, new FixedClock(), $this->holder);
+    }
+
+    private function seedInvoice(InvoiceStatus $status = InvoiceStatus::Issued, int $total = 1000): int
+    {
+        return $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: $status, subtotalCents: $total, taxCents: 0, totalCents: $total));
+    }
+
+    private function seedLink(int $invoiceId, ?string $gatewaySessionId = null): int
+    {
+        return $this->links->save(new PaymentLink(
+            organizationId: 1,
+            invoiceId: $invoiceId,
+            tokenHash: 'hash-' . $invoiceId,
+            gateway: 'payjp',
+            status: PaymentLinkStatus::Active,
+            expiresAt: '2026-06-13 03:00:00',
+            gatewaySessionId: $gatewaySessionId,
+            createdAt: '2026-06-06 03:00:00',
+            updatedAt: '2026-06-06 03:00:00',
+        ));
+    }
+
+    public function test_resolves_by_payment_link_id_records_and_marks_paid(): void
+    {
+        $invoiceId = $this->seedInvoice();
+        $linkId    = $this->seedLink($invoiceId);
+
+        $outcome = $this->useCase->execute($linkId, 'ch_1', 1000);
+
+        self::assertSame(SettlementOutcome::Recorded, $outcome);
+        self::assertSame(1000, $this->payments->totalPaidForInvoice($invoiceId));
+        $link = $this->links->findByIdUnscoped($linkId);
+        self::assertNotNull($link);
+        self::assertSame(PaymentLinkStatus::Paid, $link->status);
+        self::assertSame('ch_1', $link->gatewaySessionId);
+    }
+
+    public function test_resolves_by_charge_id_when_no_metadata_link_id(): void
+    {
+        $invoiceId = $this->seedInvoice();
+        $this->seedLink($invoiceId, gatewaySessionId: 'ch_2');
+
+        $outcome = $this->useCase->execute(null, 'ch_2', 1000);
+
+        self::assertSame(SettlementOutcome::Recorded, $outcome);
+        self::assertSame(1000, $this->payments->totalPaidForInvoice($invoiceId));
+    }
+
+    public function test_replayed_event_is_idempotent(): void
+    {
+        $invoiceId = $this->seedInvoice();
+        $linkId    = $this->seedLink($invoiceId);
+
+        $this->useCase->execute($linkId, 'ch_3', 1000);
+        $second = $this->useCase->execute($linkId, 'ch_3', 1000);
+
+        self::assertSame(SettlementOutcome::Recorded, $second);
+        // Same charge id → one payment, not two (idempotency on charge id).
+        self::assertSame(1000, $this->payments->totalPaidForInvoice($invoiceId));
+    }
+
+    public function test_unknown_link_returns_link_not_found(): void
+    {
+        self::assertSame(SettlementOutcome::LinkNotFound, $this->useCase->execute(999, 'ch_x', 1000));
+        self::assertSame(SettlementOutcome::LinkNotFound, $this->useCase->execute(null, 'ch_unknown', 1000));
+    }
+
+    public function test_non_recordable_invoice_is_ignored(): void
+    {
+        $invoiceId = $this->seedInvoice(InvoiceStatus::Draft);
+        $linkId    = $this->seedLink($invoiceId);
+
+        $outcome = $this->useCase->execute($linkId, 'ch_4', 1000);
+
+        self::assertSame(SettlementOutcome::Ignored, $outcome);
+        self::assertSame(0, $this->payments->totalPaidForInvoice($invoiceId));
+    }
+}

--- a/tests/Support/InMemoryPaymentLinkRepository.php
+++ b/tests/Support/InMemoryPaymentLinkRepository.php
@@ -86,6 +86,11 @@ final class InMemoryPaymentLinkRepository implements PaymentLinkRepositoryInterf
         return null;
     }
 
+    public function findByIdUnscoped(int $id): ?PaymentLink
+    {
+        return $this->byId[$id] ?? null;
+    }
+
     public function markRevoked(int $id, string $revokedAt): bool
     {
         $link = $this->byId[$id] ?? null;


### PR DESCRIPTION
## 概要

#439（producer）の上に決済確定の **backstop** webhook を実装。設計メモ（実仕様で修正済）どおり、PAY.JP の `charge.succeeded` を受けて入金を確定する。

Closes #431

## 実装

- **公開 `POST /webhooks/payjp`**（`PayjpWebhookHandler`）: `X-Payjp-Webhook-Token` を**定数時間照合**（PAY.JP は HMAC 署名しない — 実仕様確認済）。未設定トークンは **fail-closed（401）**。不正 JSON は 400。対象外イベント・解決不能イベントは **200**（PAY.JP の最大3回リトライを止めるため）。
- **`RecordSettlementUseCase`**: `metadata.payment_link_id`（同期決済がクラッシュした場合の backstop に有効）を優先解決、なければ charge id で逆引き。org はリンクから復元（公開コンテキスト）。**idempotency_key = charge id** で同期決済（#439）と二重起票しない → リンク `paid` 化（冪等）。
- リポジトリに **`findByIdUnscoped`**（webhook 専用・非 org スコープ、明示ドキュメント）
- terminology に `invalid-webhook-token`、OpenAPI に `POST /webhooks/payjp`

## テスト / 品質

- `RecordSettlementUseCaseTest`: link_id 解決 / charge_id 逆引き / 冪等リプレイ / 未検出 / 非対象（draft）→ ignored
- `PayjpWebhookHandlerTest`: トークン欠如・不一致・未設定 fail-closed / 不正JSON 400 / 対象外イベント無ディスパッチ / charge.succeeded のパース＆ディスパッチ
- `composer check` green（phpunit **455** / phpstan / cs / openapi / mcp）

## 残作業（実運用）

実 webhook 受信検証は **PAY.JP ダッシュボードで endpoint 登録 → `PAYJP_WEBHOOK_TOKEN` を `.env` に設定**後に可能（コードは契約ファースト＋フェイクで検証済）。会計起票の本設計は #430（リリースゲート, 税理士）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)