### PR TITLE
fix(frontend): 閉じた DatePicker ポップオーバーの横スクロールバーを解消 (#452)

### DIFF
--- a/frontend/src/shared/ui/components/DatePicker.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.tsx
@@ -60,7 +60,10 @@ export function DatePicker({
 
   const [open, setOpen] = useState(false)
   const [view, setView] = useState(() => selected ?? new Date())
-  const [flip, setFlip] = useState({ up: false, right: false })
+  // Vertical flip depends on scroll position at open time; horizontal flip
+  // depends only on the field's stable left edge (see the two effects below).
+  const [flipUp, setFlipUp] = useState(false)
+  const [flipRight, setFlipRight] = useState(false)
   // Editable text mirrors `value`; kept local while typing, normalized on commit.
   const [text, setText] = useState(() => display(value))
   // Re-sync the field when the committed value changes (calendar pick, form
@@ -107,15 +110,35 @@ export function DatePicker({
     }
   }, [open])
 
+  // Horizontal anchor depends only on the field's left edge, which is stable
+  // whether the popover is open or closed. Compute it on mount + resize so the
+  // CLOSED-but-still-mounted popover of a right-edge field is right-anchored and
+  // never extends past the viewport — a left-anchored 270px popover on the
+  // right-most filter field grows the document width, showing a phantom
+  // horizontal (and knock-on vertical) scrollbar even when everything fits (#452).
+  useLayoutEffect(() => {
+    const measure = (): void => {
+      if (wrapRef.current === null) return
+      const r = wrapRef.current.getBoundingClientRect()
+      setFlipRight(r.left + 280 > window.innerWidth)
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => {
+      window.removeEventListener('resize', measure)
+    }
+  }, [])
+
+  // Vertical flip depends on scroll position, so it is recomputed each open.
   useLayoutEffect(() => {
     if (!open || popRef.current === null) return
     const r = popRef.current.getBoundingClientRect()
-    setFlip({ up: r.bottom > window.innerHeight - 8, right: r.right > window.innerWidth - 8 })
+    setFlipUp(r.bottom > window.innerHeight - 8)
   }, [open])
 
   const openPicker = (): void => {
     setView(selected ?? new Date())
-    setFlip({ up: false, right: false })
+    setFlipUp(false)
     setOpen(true)
   }
 
@@ -197,7 +220,7 @@ export function DatePicker({
 
       <div
         ref={popRef}
-        className={cn('dp-pop', flip.up && 'up', flip.right && 'right')}
+        className={cn('dp-pop', flipUp && 'up', flipRight && 'right')}
         role="dialog"
         // Closed popover stays in the DOM for the fade transition, but must be
         // removed from the tab order / a11y tree — otherwise tabbing into a


### PR DESCRIPTION
Closes #452

## 事象
請求書一覧（/invoices）など日付フィルタを持つ一覧画面で、コンテンツが画面に収まっていても横（および連動して縦）スクロールバーが常時表示されていた。

## 原因
`DatePicker` の閉じたカレンダーポップオーバー `.dp-pop` はフェードアウト用に DOM へ残す設計（`inert`）。`position:absolute; left:0; width:270px` のため、フィルタ右端列の日付フィールドでは画面右端を約23pxはみ出し、`scrollWidth` を膨らませていた。右寄せフリップ `.dp-pop.right` は `open` 時の `useLayoutEffect` でしか算出されず、閉じている間は無補正だった。

## 修正
横方向フリップはフィールドの水平位置のみで決まり開閉に依存しないため、`open` 依存をやめ**マウント時＋リサイズ時**に算出。閉じたポップオーバーにも右寄せが効くようにした。縦フリップ（スクロール位置依存）は従来どおり `open` 時に算出。フェード・`inert`(a11y) は維持。

親レイアウトの grid→inline 変更では解消しない（絶対配置のはみ出しのため）ことも実測で確認済み。

## 検証（Playwright, 実データ11件）
| 対応 | 横オーバーフロー |
| --- | --- |
| 修正前 | 23px |
| grid→inline(flex) | 23px（変化なし） |
| **本修正** | **0px** |

- 1024〜1536px の各幅で hOverflow=0 / vOverflow=0 を確認
- 右端 "Issued from" のカレンダーを開いても右寄せで画面内に完全表示
- `DatePicker.test.tsx` 7件 green / eslint・prettier clean

## セルフレビュー
フロントエンド差分セルフレビュー（型・lint・format・テスト・実機オーバーフロー計測）

🤖 Generated with [Claude Code](https://claude.com/claude-code)