### PR TITLE
feat(auth): POST /auth/refresh + /auth/logout — refresh token ローテーション/reuse検知/CSRF (#462)

### DIFF
--- a/database/migrations/20260617000000_create_refresh_tokens_table.php
+++ b/database/migrations/20260617000000_create_refresh_tokens_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Persists rotating refresh tokens for silent re-authentication (ADR 0014).
+ *
+ * Only the SHA-256 hash of the opaque token is stored — never the plaintext —
+ * mirroring the no-plaintext posture of `service_tokens`. `family_id` ties a
+ * rotation lineage together so that presenting an already-used or revoked token
+ * (`used_at` / `revoked_at` set) can invalidate the whole family (reuse defense).
+ */
+final class CreateRefreshTokensTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('refresh_tokens')
+            ->addColumn('organization_id', 'integer', ['null' => true])
+            ->addColumn('user_id', 'integer', ['null' => false])
+            ->addColumn('family_id', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('token_hash', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('issued_at', 'datetime', ['null' => false])
+            ->addColumn('expires_at', 'datetime', ['null' => false])
+            ->addColumn('used_at', 'datetime', ['null' => true])
+            ->addColumn('revoked_at', 'datetime', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addIndex(['token_hash'], ['unique' => true, 'name' => 'uniq_refresh_tokens_token_hash'])
+            ->addIndex(['family_id'], ['name' => 'idx_refresh_tokens_family_id'])
+            ->addIndex(['user_id'], ['name' => 'idx_refresh_tokens_user_id'])
+            ->create();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -145,6 +145,8 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `cannot-delete-self` | A user cannot delete their own account (409) |
 | `invalid-credentials` | Login failed — wrong email or password |
 | `too-many-requests` | Too many failed login attempts from the source IP (429; login throttling) |
+| `invalid-refresh-token` | Refresh cookie missing/expired/invalid or principal ineligible — silent re-auth fails closed (401; ADR 0014) |
+| `csrf-token-invalid` | Double-submit CSRF check failed on a cookie-authenticated endpoint (403; ADR 0014) |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request (404; OrgResolverMiddleware) |
@@ -175,7 +177,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | operationId | Resource |
 | --- | --- |
 | `getHealth` | System |
-| `login`, `getCurrentUser` | Auth |
+| `login`, `refreshSession`, `logout`, `getCurrentUser` | Auth |
 | `listAuditLogs`, `exportAuditLogs` | Audit (admin oversight) |
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -90,6 +90,51 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '429':
           $ref: '#/components/responses/TooManyRequests'
+  /auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Silent re-authentication
+      description: >
+        Exchanges the httpOnly refresh cookie for a fresh in-memory access token
+        and rotates the refresh token (ADR 0014). Requires the double-submit CSRF
+        header. On any failure the session fails closed (401) and the cookies are
+        cleared, so the SPA falls back to the login screen.
+      operationId: refreshSession
+      security:
+        - refreshCookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CsrfTokenHeader'
+      responses:
+        '200':
+          description: Access token re-issued; refresh + CSRF cookies rotated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+              example:
+                token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/CsrfForbidden'
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: Logout (server-side revocation)
+      description: >
+        Revokes the refresh-token family server-side and clears the cookies
+        (ADR 0014). Idempotent: returns 204 and clears the cookies even when no
+        valid cookie is presented. Requires the double-submit CSRF header.
+      operationId: logout
+      security:
+        - refreshCookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CsrfTokenHeader'
+      responses:
+        '204':
+          description: Session revoked; cookies cleared.
+        '403':
+          $ref: '#/components/responses/CsrfForbidden'
   /admin/me:
     get:
       tags: [Auth]
@@ -1941,6 +1986,13 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    refreshCookieAuth:
+      type: apiKey
+      in: cookie
+      name: ni_refresh
+      description: >
+        httpOnly refresh-token cookie issued at login (ADR 0014). Sent
+        automatically by the browser to the /auth path; never readable by JS.
   parameters:
     LimitParam:
       name: limit
@@ -1969,6 +2021,15 @@ components:
       schema:
         type: integer
         minimum: 1
+    CsrfTokenHeader:
+      name: X-CSRF-Token
+      in: header
+      required: true
+      description: >
+        Double-submit CSRF token — must echo the readable `ni_csrf` cookie
+        (ADR 0014). Required on cookie-authenticated, state-changing endpoints.
+      schema:
+        type: string
   responses:
     Unauthorized:
       description: Missing or invalid bearer token, or bad credentials.
@@ -1978,6 +2039,12 @@ components:
             $ref: '#/components/schemas/ProblemDetails'
     InsufficientCapability:
       description: Authenticated but lacking the required capability.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    CsrfForbidden:
+      description: Double-submit CSRF token missing or invalid (ADR 0014).
       content:
         application/problem+json:
           schema:

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -15,12 +15,17 @@ final readonly class AuthRouteRegistrar
     public function __construct(
         private LoginHandler $loginHandler,
         private GetCurrentUserHandler $getCurrentUserHandler,
+        private RefreshHandler $refreshHandler,
+        private LogoutHandler $logoutHandler,
     ) {
     }
 
     public function __invoke(Router $router): void
     {
         $router->post('/auth/login', fn ($request) => $this->loginHandler->handle($request));
+        // Public (cookie-authenticated): silent re-auth and server-side logout — ADR 0014.
+        $router->post('/auth/refresh', fn ($request) => $this->refreshHandler->handle($request));
+        $router->post('/auth/logout', fn ($request) => $this->logoutHandler->handle($request));
         $router->get('/admin/me', fn ($request) => $this->getCurrentUserHandler->handle($request));
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -154,11 +154,36 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                RefreshTokenRepositoryInterface::class,
+                static function (ContainerInterface $container): RefreshTokenRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoRefreshTokenRepository($query);
+                },
+            )
+            ->set(
+                RefreshTokenIssuer::class,
+                static function (ContainerInterface $container): RefreshTokenIssuer {
+                    $repository = $container->get(RefreshTokenRepositoryInterface::class);
+
+                    if (!$repository instanceof RefreshTokenRepositoryInterface) {
+                        throw new LogicException('Refresh token repository service is invalid.');
+                    }
+
+                    return new RefreshTokenIssuer($repository);
+                },
+            )
+            ->set(
                 LoginUseCaseInterface::class,
                 static function (ContainerInterface $container): LoginUseCaseInterface {
                     $users = $container->get(UserRepositoryInterface::class);
                     $tokenIssuer = $container->get(TokenIssuerInterface::class);
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $refreshTokenIssuer = $container->get(RefreshTokenIssuer::class);
 
                     if (!$users instanceof UserRepositoryInterface) {
                         throw new LogicException('User repository service is invalid.');
@@ -172,7 +197,50 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new LoginUseCase($users, $tokenIssuer, new PdoLoginThrottle($query));
+                    if (!$refreshTokenIssuer instanceof RefreshTokenIssuer) {
+                        throw new LogicException('Refresh token issuer service is invalid.');
+                    }
+
+                    return new LoginUseCase($users, $tokenIssuer, new PdoLoginThrottle($query), $refreshTokenIssuer);
+                },
+            )
+            ->set(
+                RefreshSessionUseCaseInterface::class,
+                static function (ContainerInterface $container): RefreshSessionUseCaseInterface {
+                    $repository = $container->get(RefreshTokenRepositoryInterface::class);
+                    $users = $container->get(UserRepositoryInterface::class);
+                    $issuer = $container->get(RefreshTokenIssuer::class);
+                    $tokenIssuer = $container->get(TokenIssuerInterface::class);
+
+                    if (!$repository instanceof RefreshTokenRepositoryInterface) {
+                        throw new LogicException('Refresh token repository service is invalid.');
+                    }
+
+                    if (!$users instanceof UserRepositoryInterface) {
+                        throw new LogicException('User repository service is invalid.');
+                    }
+
+                    if (!$issuer instanceof RefreshTokenIssuer) {
+                        throw new LogicException('Refresh token issuer service is invalid.');
+                    }
+
+                    if (!$tokenIssuer instanceof TokenIssuerInterface) {
+                        throw new LogicException('Token issuer service is invalid.');
+                    }
+
+                    return new RefreshSessionUseCase($repository, $users, $issuer, $tokenIssuer);
+                },
+            )
+            ->set(
+                LogoutUseCaseInterface::class,
+                static function (ContainerInterface $container): LogoutUseCaseInterface {
+                    $repository = $container->get(RefreshTokenRepositoryInterface::class);
+
+                    if (!$repository instanceof RefreshTokenRepositoryInterface) {
+                        throw new LogicException('Refresh token repository service is invalid.');
+                    }
+
+                    return new LogoutUseCase($repository);
                 },
             )
             ->set(
@@ -232,10 +300,56 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                RefreshHandler::class,
+                static function (ContainerInterface $container): RefreshHandler {
+                    $useCase = $container->get(RefreshSessionUseCaseInterface::class);
+                    $json = $container->get(JsonResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$useCase instanceof RefreshSessionUseCaseInterface) {
+                        throw new LogicException('Refresh session use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new RefreshHandler($useCase, $json, $problemDetails);
+                },
+            )
+            ->set(
+                LogoutHandler::class,
+                static function (ContainerInterface $container): LogoutHandler {
+                    $useCase = $container->get(LogoutUseCaseInterface::class);
+                    $json = $container->get(JsonResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$useCase instanceof LogoutUseCaseInterface) {
+                        throw new LogicException('Logout use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new LogoutHandler($useCase, $json, $problemDetails);
+                },
+            )
+            ->set(
                 AuthRouteRegistrar::class,
                 static function (ContainerInterface $container): AuthRouteRegistrar {
                     $loginHandler = $container->get(LoginHandler::class);
                     $getCurrentUserHandler = $container->get(GetCurrentUserHandler::class);
+                    $refreshHandler = $container->get(RefreshHandler::class);
+                    $logoutHandler = $container->get(LogoutHandler::class);
 
                     if (!$loginHandler instanceof LoginHandler) {
                         throw new LogicException('Login handler service is invalid.');
@@ -245,7 +359,15 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Get current user handler service is invalid.');
                     }
 
-                    return new AuthRouteRegistrar($loginHandler, $getCurrentUserHandler);
+                    if (!$refreshHandler instanceof RefreshHandler) {
+                        throw new LogicException('Refresh handler service is invalid.');
+                    }
+
+                    if (!$logoutHandler instanceof LogoutHandler) {
+                        throw new LogicException('Logout handler service is invalid.');
+                    }
+
+                    return new AuthRouteRegistrar($loginHandler, $getCurrentUserHandler, $refreshHandler, $logoutHandler);
                 },
             );
     }

--- a/src/Auth/CsrfGuard.php
+++ b/src/Auth/CsrfGuard.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Stateless double-submit CSRF check for the cookie-authenticated endpoints
+ * (`/auth/refresh`, `/auth/logout`) — ADR 0014.
+ *
+ * The refresh cookie rides automatically on cross-site requests (mitigated, but
+ * not eliminated, by `SameSite=Strict`), so these endpoints additionally require
+ * the caller to echo the readable `ni_csrf` cookie in an `X-CSRF-Token` header.
+ * A forged cross-site request cannot read that cookie to set the header. The
+ * `/admin/*` and `/api/*` routes need no such check: they authenticate with a
+ * non-ambient `Authorization` bearer that cross-site requests cannot forge.
+ */
+final class CsrfGuard
+{
+    public const HEADER = 'X-CSRF-Token';
+
+    /**
+     * @throws CsrfValidationException when the header is absent or mismatched
+     */
+    public static function assert(ServerRequestInterface $request): void
+    {
+        $cookie = SessionCookies::csrfCookieValue($request);
+        $header = $request->getHeaderLine(self::HEADER);
+
+        if ($cookie === null || $header === '' || !hash_equals($cookie, $header)) {
+            throw new CsrfValidationException();
+        }
+    }
+}

--- a/src/Auth/CsrfValidationException.php
+++ b/src/Auth/CsrfValidationException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use RuntimeException;
+
+/**
+ * The double-submit CSRF check failed on a cookie-authenticated endpoint: the
+ * `X-CSRF-Token` header was missing or did not match the `ni_csrf` cookie.
+ */
+final class CsrfValidationException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('CSRF token missing or invalid.');
+    }
+}

--- a/src/Auth/InvalidRefreshTokenException.php
+++ b/src/Auth/InvalidRefreshTokenException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use RuntimeException;
+
+/**
+ * The presented refresh token is missing, unknown, expired, or its principal is
+ * no longer eligible (deactivated / moved tenant). The session fails closed:
+ * the caller clears the cookie and returns 401.
+ */
+final class InvalidRefreshTokenException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The refresh token is missing, expired, or invalid.');
+    }
+}

--- a/src/Auth/IssuedRefreshToken.php
+++ b/src/Auth/IssuedRefreshToken.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * The plaintext refresh token to hand back to the client (via `Set-Cookie`)
+ * together with its absolute expiry. The plaintext exists only in transit; the
+ * persisted record keeps just the hash.
+ */
+final readonly class IssuedRefreshToken
+{
+    public function __construct(
+        public string $rawToken,
+        public string $expiresAt,
+        public int $expiresAtTimestamp,
+    ) {
+    }
+}

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -54,6 +54,19 @@ final readonly class LoginHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'invalid-credentials', 'Invalid Credentials', 401, $e->getMessage());
         }
 
-        return $this->json->create(['token' => $output->token]);
+        return $this->withSessionCookies($this->json->create(['token' => $output->token]), $output->refreshToken);
+    }
+
+    /**
+     * Seats the rotated refresh token in its httpOnly cookie and issues a fresh
+     * double-submit CSRF cookie (readable by JS) alongside it (ADR 0014).
+     */
+    private function withSessionCookies(ResponseInterface $response, IssuedRefreshToken $refreshToken): ResponseInterface
+    {
+        $csrfToken = RefreshTokenSecret::generateCsrfToken();
+
+        return $response
+            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($refreshToken->rawToken, $refreshToken->expiresAtTimestamp))
+            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $refreshToken->expiresAtTimestamp));
     }
 }

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -8,6 +8,7 @@ final readonly class LoginOutput
 {
     public function __construct(
         public string $token,
+        public IssuedRefreshToken $refreshToken,
     ) {
     }
 }

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -26,6 +26,7 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokenIssuer,
         private LoginThrottleInterface $throttle,
+        private RefreshTokenIssuer $refreshTokenIssuer,
     ) {
     }
 
@@ -69,6 +70,10 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
             'exp' => $now + self::TOKEN_TTL_SECONDS,
         ]);
 
-        return new LoginOutput($token);
+        // Start a fresh refresh-token family for this login (ADR 0014). The
+        // plaintext is returned to the handler to seat in the httpOnly cookie.
+        $refreshToken = $this->refreshTokenIssuer->issue((int) $user->id, $user->organizationId);
+
+        return new LoginOutput($token, $refreshToken);
     }
 }

--- a/src/Auth/LogoutHandler.php
+++ b/src/Auth/LogoutHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /auth/logout` — public (cookie-authenticated). Revokes the refresh-token
+ * family server-side and clears the cookies (ADR 0014). Idempotent: it returns
+ * 204 and clears the cookies even when no/invalid cookie is presented, so the
+ * client can always reach a signed-out state.
+ */
+final readonly class LogoutHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private LogoutUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            CsrfGuard::assert($request);
+        } catch (CsrfValidationException $e) {
+            return $this->problemDetails->create($request, 'csrf-token-invalid', 'Forbidden', 403, $e->getMessage());
+        }
+
+        $this->useCase->execute(SessionCookies::refreshToken($request));
+
+        return $this->json->createEmpty(204)
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh())
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf());
+    }
+}

--- a/src/Auth/LogoutUseCase.php
+++ b/src/Auth/LogoutUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Server-side session revocation (ADR 0014).
+ *
+ * Logout MUST invalidate the refresh token server-side — clearing the in-memory
+ * access token alone is not sufficient. Revoking the whole family also kills any
+ * sibling token a thief may hold. Logout is idempotent and never fails: an
+ * unknown/absent cookie is a no-op so the handler can always clear the cookie
+ * and return success.
+ */
+final readonly class LogoutUseCase implements LogoutUseCaseInterface
+{
+    public function __construct(
+        private RefreshTokenRepositoryInterface $refreshTokens,
+    ) {
+    }
+
+    public function execute(?string $rawToken): void
+    {
+        if ($rawToken === null || $rawToken === '') {
+            return;
+        }
+
+        $record = $this->refreshTokens->findByHash(RefreshTokenSecret::hash($rawToken));
+
+        if ($record === null) {
+            return;
+        }
+
+        $this->refreshTokens->revokeFamily($record->familyId, date('Y-m-d H:i:s'));
+    }
+}

--- a/src/Auth/LogoutUseCaseInterface.php
+++ b/src/Auth/LogoutUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+interface LogoutUseCaseInterface
+{
+    /** Idempotently revokes the family of the presented refresh token, if any. */
+    public function execute(?string $rawToken): void;
+}

--- a/src/Auth/PdoRefreshTokenRepository.php
+++ b/src/Auth/PdoRefreshTokenRepository.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoRefreshTokenRepository implements RefreshTokenRepositoryInterface
+{
+    private const COLUMNS = 'id, user_id, organization_id, family_id, token_hash, issued_at, expires_at, used_at, revoked_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findByHash(string $tokenHash): ?RefreshToken
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM refresh_tokens WHERE token_hash = ?',
+            [$tokenHash],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function create(RefreshToken $token): int
+    {
+        $this->query->execute(
+            'INSERT INTO refresh_tokens
+                (user_id, organization_id, family_id, token_hash, issued_at, expires_at, used_at, revoked_at, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $token->userId,
+                $token->organizationId,
+                $token->familyId,
+                $token->tokenHash,
+                $token->issuedAt,
+                $token->expiresAt,
+                $token->usedAt,
+                $token->revokedAt,
+                date('Y-m-d H:i:s'),
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function markUsed(int $id, string $usedAt): void
+    {
+        $this->query->execute(
+            'UPDATE refresh_tokens SET used_at = ? WHERE id = ? AND used_at IS NULL',
+            [$usedAt, $id],
+        );
+    }
+
+    public function revokeFamily(string $familyId, string $revokedAt): void
+    {
+        $this->query->execute(
+            'UPDATE refresh_tokens SET revoked_at = ? WHERE family_id = ? AND revoked_at IS NULL',
+            [$revokedAt, $familyId],
+        );
+    }
+
+    public function deleteExpired(string $now): int
+    {
+        return $this->query->execute(
+            'DELETE FROM refresh_tokens WHERE expires_at < ?',
+            [$now],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): RefreshToken
+    {
+        return new RefreshToken(
+            userId: (int) $row['user_id'],
+            organizationId: isset($row['organization_id']) ? (int) $row['organization_id'] : null,
+            familyId: (string) $row['family_id'],
+            tokenHash: (string) $row['token_hash'],
+            issuedAt: (string) $row['issued_at'],
+            expiresAt: (string) $row['expires_at'],
+            usedAt: isset($row['used_at']) ? (string) $row['used_at'] : null,
+            revokedAt: isset($row['revoked_at']) ? (string) $row['revoked_at'] : null,
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Auth/RefreshHandler.php
+++ b/src/Auth/RefreshHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `POST /auth/refresh` — public (cookie-authenticated). Exchanges the httpOnly
+ * refresh cookie for a fresh in-memory access token and rotates the refresh
+ * token (ADR 0014). Failure fails closed: 401 and the cookies are cleared, so
+ * the SPA falls back to the login screen exactly as before.
+ */
+final readonly class RefreshHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private RefreshSessionUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $rawToken = SessionCookies::refreshToken($request);
+
+        // No cookie → simply not signed in. Fail closed without disclosing more.
+        if ($rawToken === null) {
+            return $this->failClosed($request);
+        }
+
+        try {
+            CsrfGuard::assert($request);
+        } catch (CsrfValidationException $e) {
+            return $this->problemDetails->create($request, 'csrf-token-invalid', 'Forbidden', 403, $e->getMessage());
+        }
+
+        try {
+            $session = $this->useCase->execute($rawToken);
+        } catch (InvalidRefreshTokenException | RefreshTokenReuseException $e) {
+            return $this->failClosed($request);
+        }
+
+        $csrfToken = RefreshTokenSecret::generateCsrfToken();
+
+        return $this->json->create(['token' => $session->accessToken])
+            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($session->refreshToken->rawToken, $session->refreshToken->expiresAtTimestamp))
+            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $session->refreshToken->expiresAtTimestamp));
+    }
+
+    private function failClosed(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails
+            ->create($request, 'invalid-refresh-token', 'Unauthorized', 401, 'The session could not be refreshed.')
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh())
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf());
+    }
+}

--- a/src/Auth/RefreshSessionUseCase.php
+++ b/src/Auth/RefreshSessionUseCase.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Nene2\Auth\TokenIssuerInterface;
+use NeneInvoice\User\UserRepositoryInterface;
+
+/**
+ * Silent re-authentication via the refresh-token cookie (ADR 0014).
+ *
+ * Validates the presented token, rotates it within its family, and re-mints a
+ * short-lived access token scoped to the SAME user and organization (no
+ * cross-tenant escalation — ADR 0006). Presenting an already-spent or revoked
+ * token revokes the entire family (reuse defense).
+ */
+final readonly class RefreshSessionUseCase implements RefreshSessionUseCaseInterface
+{
+    /** Mirrors {@see LoginUseCase}: access tokens stay short-lived and in-memory. */
+    private const ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+    public function __construct(
+        private RefreshTokenRepositoryInterface $refreshTokens,
+        private UserRepositoryInterface $users,
+        private RefreshTokenIssuer $issuer,
+        private TokenIssuerInterface $tokenIssuer,
+    ) {
+    }
+
+    public function execute(string $rawToken): RefreshedSession
+    {
+        $now = date('Y-m-d H:i:s');
+        $record = $this->refreshTokens->findByHash(RefreshTokenSecret::hash($rawToken));
+
+        if ($record === null) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        // Replay: a token that was already rotated away (or revoked) is presented
+        // again → assume theft and burn the whole lineage.
+        if ($record->isConsumed()) {
+            $this->refreshTokens->revokeFamily($record->familyId, $now);
+
+            throw new RefreshTokenReuseException();
+        }
+
+        if ($record->isExpired($now)) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        // Re-read the principal: the session must end if the user was deactivated
+        // or moved tenant since the token was issued.
+        $user = $this->users->findById($record->userId);
+
+        if (
+            $user === null
+            || $user->id === null
+            || $user->status !== 'active'
+            || $user->organizationId !== $record->organizationId
+        ) {
+            $this->refreshTokens->revokeFamily($record->familyId, $now);
+
+            throw new InvalidRefreshTokenException();
+        }
+
+        // Rotate: spend the presented token, then mint its successor in the family.
+        $this->refreshTokens->markUsed($record->id ?? 0, $now);
+        $rotated = $this->issuer->issue($user->id, $user->organizationId, $record->familyId);
+
+        $issuedAt = time();
+        $accessToken = $this->tokenIssuer->issue([
+            'sub' => $user->id,
+            'role' => $user->role->value,
+            'org' => $user->organizationId,
+            'iat' => $issuedAt,
+            'exp' => $issuedAt + self::ACCESS_TOKEN_TTL_SECONDS,
+        ]);
+
+        return new RefreshedSession($accessToken, $rotated);
+    }
+}

--- a/src/Auth/RefreshSessionUseCaseInterface.php
+++ b/src/Auth/RefreshSessionUseCaseInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+interface RefreshSessionUseCaseInterface
+{
+    /**
+     * @throws InvalidRefreshTokenException when the token is unknown/expired/ineligible
+     * @throws RefreshTokenReuseException when an already-spent token is replayed
+     */
+    public function execute(string $rawToken): RefreshedSession;
+}

--- a/src/Auth/RefreshToken.php
+++ b/src/Auth/RefreshToken.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * A persisted refresh-token record (ADR 0014). The plaintext token is never
+ * stored; {@see $tokenHash} holds its SHA-256 digest. A token is spendable only
+ * while `usedAt` and `revokedAt` are both null and it has not expired.
+ */
+final readonly class RefreshToken
+{
+    public function __construct(
+        public int $userId,
+        public ?int $organizationId,
+        public string $familyId,
+        public string $tokenHash,
+        public string $issuedAt,
+        public string $expiresAt,
+        public ?string $usedAt = null,
+        public ?string $revokedAt = null,
+        public ?int $id = null,
+    ) {
+    }
+
+    /** True once the token has been rotated away (spent) or explicitly revoked. */
+    public function isConsumed(): bool
+    {
+        return $this->usedAt !== null || $this->revokedAt !== null;
+    }
+
+    public function isExpired(string $now): bool
+    {
+        return $this->expiresAt < $now;
+    }
+}

--- a/src/Auth/RefreshTokenIssuer.php
+++ b/src/Auth/RefreshTokenIssuer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Mints and persists a new refresh token for a principal (ADR 0014).
+ *
+ * Used both at login (a fresh family) and on rotation (a new token within the
+ * existing family). Remember-me / variable lifetime is a follow-up (issue #464);
+ * for now the lifetime is a single fixed default.
+ */
+final readonly class RefreshTokenIssuer
+{
+    /**
+     * Absolute lifetime of a refresh token. Until remember-me lands (#464) this
+     * is the single default applied to every session.
+     */
+    public const TOKEN_TTL_SECONDS = 14 * 24 * 60 * 60;
+
+    public function __construct(
+        private RefreshTokenRepositoryInterface $repository,
+    ) {
+    }
+
+    /**
+     * Issues a refresh token, starting a new family when $familyId is null
+     * (login) or extending an existing family on rotation.
+     */
+    public function issue(int $userId, ?int $organizationId, ?string $familyId = null): IssuedRefreshToken
+    {
+        $now = time();
+        $expiresAtTs = $now + self::TOKEN_TTL_SECONDS;
+
+        $raw = RefreshTokenSecret::generateRaw();
+
+        $this->repository->create(new RefreshToken(
+            userId: $userId,
+            organizationId: $organizationId,
+            familyId: $familyId ?? RefreshTokenSecret::generateFamilyId(),
+            tokenHash: RefreshTokenSecret::hash($raw),
+            issuedAt: date('Y-m-d H:i:s', $now),
+            expiresAt: date('Y-m-d H:i:s', $expiresAtTs),
+        ));
+
+        return new IssuedRefreshToken($raw, date('Y-m-d H:i:s', $expiresAtTs), $expiresAtTs);
+    }
+}

--- a/src/Auth/RefreshTokenRepositoryInterface.php
+++ b/src/Auth/RefreshTokenRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Persistence for rotating refresh tokens (ADR 0014).
+ *
+ * Lookups are keyed by the SHA-256 hash of the opaque token, which is itself the
+ * bearer capability — so these operations are intentionally NOT organization
+ * scoped (the refresh endpoint runs before any auth context exists). The calling
+ * use case is responsible for re-deriving and verifying the tenant.
+ */
+interface RefreshTokenRepositoryInterface
+{
+    public function findByHash(string $tokenHash): ?RefreshToken;
+
+    /** Persists a freshly minted token and returns its row id. */
+    public function create(RefreshToken $token): int;
+
+    /** Marks a token as spent (rotated away) so any later presentation is reuse. */
+    public function markUsed(int $id, string $usedAt): void;
+
+    /** Revokes every still-live token sharing the family (reuse / logout defense). */
+    public function revokeFamily(string $familyId, string $revokedAt): void;
+
+    /** Housekeeping: removes tokens already past their absolute expiry. */
+    public function deleteExpired(string $now): int;
+}

--- a/src/Auth/RefreshTokenReuseException.php
+++ b/src/Auth/RefreshTokenReuseException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use RuntimeException;
+
+/**
+ * An already-rotated (or revoked) refresh token was presented — the hallmark of
+ * a stolen-token replay. The whole token family has been revoked as a result;
+ * the caller fails closed exactly like {@see InvalidRefreshTokenException}, but
+ * the distinct type lets logging/audit flag the replay.
+ */
+final class RefreshTokenReuseException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The refresh token has already been used; the session family was revoked.');
+    }
+}

--- a/src/Auth/RefreshTokenSecret.php
+++ b/src/Auth/RefreshTokenSecret.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Generation and hashing of opaque session secrets (ADR 0014).
+ *
+ * The refresh token and CSRF token are high-entropy random strings. The refresh
+ * token is only ever transported in an `httpOnly` cookie and is persisted as a
+ * SHA-256 hash, so a database leak cannot yield a usable credential. The CSRF
+ * token is a stateless double-submit value: it rides a JS-readable cookie and is
+ * echoed back in a header; the server only checks the two match, so it is never
+ * stored.
+ */
+final class RefreshTokenSecret
+{
+    /** Raw entropy in bytes for the opaque refresh/CSRF tokens. */
+    private const TOKEN_BYTES = 32;
+
+    /** A new opaque refresh-token plaintext (URL-safe, no padding). */
+    public static function generateRaw(): string
+    {
+        return self::base64Url(random_bytes(self::TOKEN_BYTES));
+    }
+
+    /** A rotation-lineage identifier shared by every token in a family. */
+    public static function generateFamilyId(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+
+    /** A double-submit CSRF value (returned to the client via a readable cookie). */
+    public static function generateCsrfToken(): string
+    {
+        return self::base64Url(random_bytes(self::TOKEN_BYTES));
+    }
+
+    /** SHA-256 digest used as the stored/looked-up handle for a refresh token. */
+    public static function hash(string $rawToken): string
+    {
+        return hash('sha256', $rawToken);
+    }
+
+    private static function base64Url(string $bytes): string
+    {
+        return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+    }
+}

--- a/src/Auth/RefreshedSession.php
+++ b/src/Auth/RefreshedSession.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+/**
+ * Outcome of a successful silent refresh: a fresh in-memory access token plus
+ * the rotated refresh token to re-seat in the cookie.
+ */
+final readonly class RefreshedSession
+{
+    public function __construct(
+        public string $accessToken,
+        public IssuedRefreshToken $refreshToken,
+    ) {
+    }
+}

--- a/src/Auth/SessionCookies.php
+++ b/src/Auth/SessionCookies.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Builds and reads the session cookies for silent re-authentication (ADR 0014).
+ *
+ * - **Refresh cookie** (`ni_refresh`): `HttpOnly` so JS can never read it,
+ *   `Secure`, `SameSite=Strict`, and `Path=/auth` so it is only sent to the auth
+ *   endpoints. This is the long-lived credential.
+ * - **CSRF cookie** (`ni_csrf`): deliberately readable by JS (no `HttpOnly`) for
+ *   the double-submit check; `Secure`, `SameSite=Strict`, `Path=/` so the SPA can
+ *   echo it in a header. It is not a credential on its own.
+ *
+ * `Secure` is always set. Browsers treat `http://localhost` as a secure context,
+ * so this holds for local dev as well as production HTTPS.
+ */
+final class SessionCookies
+{
+    public const REFRESH_COOKIE = 'ni_refresh';
+    public const CSRF_COOKIE = 'ni_csrf';
+
+    private const REFRESH_PATH = '/auth';
+    private const CSRF_PATH = '/';
+
+    public static function refreshToken(ServerRequestInterface $request): ?string
+    {
+        $value = $request->getCookieParams()[self::REFRESH_COOKIE] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    public static function csrfCookieValue(ServerRequestInterface $request): ?string
+    {
+        $value = $request->getCookieParams()[self::CSRF_COOKIE] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    public static function setRefresh(string $rawToken, int $expiresAtTimestamp): string
+    {
+        return self::build(self::REFRESH_COOKIE, $rawToken, self::REFRESH_PATH, $expiresAtTimestamp, httpOnly: true);
+    }
+
+    public static function setCsrf(string $csrfToken, int $expiresAtTimestamp): string
+    {
+        return self::build(self::CSRF_COOKIE, $csrfToken, self::CSRF_PATH, $expiresAtTimestamp, httpOnly: false);
+    }
+
+    public static function clearRefresh(): string
+    {
+        return self::build(self::REFRESH_COOKIE, '', self::REFRESH_PATH, 0, httpOnly: true);
+    }
+
+    public static function clearCsrf(): string
+    {
+        return self::build(self::CSRF_COOKIE, '', self::CSRF_PATH, 0, httpOnly: false);
+    }
+
+    private static function build(string $name, string $value, string $path, int $expiresAtTimestamp, bool $httpOnly): string
+    {
+        // Expired (timestamp 0) → clear with an epoch expiry and Max-Age=0.
+        $expiry = $value === ''
+            ? 'Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0'
+            : 'Expires=' . gmdate('D, d M Y H:i:s', $expiresAtTimestamp) . ' GMT';
+
+        $attributes = [
+            $name . '=' . $value,
+            'Path=' . $path,
+            $expiry,
+            'Secure',
+            'SameSite=Strict',
+        ];
+
+        if ($httpOnly) {
+            $attributes[] = 'HttpOnly';
+        }
+
+        return implode('; ', $attributes);
+    }
+}

--- a/tests/Auth/CsrfGuardTest.php
+++ b/tests/Auth/CsrfGuardTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\CsrfGuard;
+use NeneInvoice\Auth\CsrfValidationException;
+use NeneInvoice\Auth\SessionCookies;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class CsrfGuardTest extends TestCase
+{
+    public function test_passes_when_header_matches_cookie(): void
+    {
+        $request = $this->request(cookie: 'tok-123', header: 'tok-123');
+
+        CsrfGuard::assert($request);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_rejects_missing_header(): void
+    {
+        $this->expectException(CsrfValidationException::class);
+        CsrfGuard::assert($this->request(cookie: 'tok-123', header: null));
+    }
+
+    public function test_rejects_missing_cookie(): void
+    {
+        $this->expectException(CsrfValidationException::class);
+        CsrfGuard::assert($this->request(cookie: null, header: 'tok-123'));
+    }
+
+    public function test_rejects_mismatch(): void
+    {
+        $this->expectException(CsrfValidationException::class);
+        CsrfGuard::assert($this->request(cookie: 'tok-123', header: 'tok-XXX'));
+    }
+
+    private function request(?string $cookie, ?string $header): ServerRequestInterface
+    {
+        $request = (new Psr17Factory())->createServerRequest('POST', '/auth/refresh');
+
+        if ($cookie !== null) {
+            $request = $request->withCookieParams([SessionCookies::CSRF_COOKIE => $cookie]);
+        }
+
+        if ($header !== null) {
+            $request = $request->withHeader(CsrfGuard::HEADER, $header);
+        }
+
+        return $request;
+    }
+}

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -8,9 +8,11 @@ use Nene2\Auth\LocalBearerTokenVerifier;
 use NeneInvoice\Auth\InvalidCredentialsException;
 use NeneInvoice\Auth\LoginInput;
 use NeneInvoice\Auth\LoginUseCase;
+use NeneInvoice\Auth\RefreshTokenIssuer;
 use NeneInvoice\Auth\Role;
 use NeneInvoice\Auth\TooManyLoginAttemptsException;
 use NeneInvoice\Tests\Support\InMemoryLoginThrottle;
+use NeneInvoice\Tests\Support\InMemoryRefreshTokenRepository;
 use NeneInvoice\User\User;
 use NeneInvoice\User\UserRepositoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +24,7 @@ final class LoginUseCaseTest extends TestCase
     public function test_issues_token_with_identity_claims_on_valid_credentials(): void
     {
         $verifier = new LocalBearerTokenVerifier(self::SECRET);
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier, new InMemoryLoginThrottle());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier, new InMemoryLoginThrottle(), $this->refreshIssuer());
 
         $output = $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
 
@@ -34,7 +36,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_wrong_password(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('admin@example.com', 'wrong'));
@@ -42,7 +44,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_unknown_email(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('nobody@example.com', 'correct-horse'));
@@ -54,6 +56,7 @@ final class LoginUseCaseTest extends TestCase
             $this->repositoryWithUser('correct-horse', 'disabled'),
             new LocalBearerTokenVerifier(self::SECRET),
             new InMemoryLoginThrottle(),
+            $this->refreshIssuer(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
@@ -66,6 +69,7 @@ final class LoginUseCaseTest extends TestCase
             $this->repositoryWithUser('correct-horse', 'invited'),
             new LocalBearerTokenVerifier(self::SECRET),
             new InMemoryLoginThrottle(),
+            $this->refreshIssuer(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
@@ -83,6 +87,7 @@ final class LoginUseCaseTest extends TestCase
             $this->repositoryWithUser('correct-horse'),
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
+            $this->refreshIssuer(),
         );
 
         // Even with the correct password, the IP is over the failure ceiling.
@@ -97,6 +102,7 @@ final class LoginUseCaseTest extends TestCase
             $this->repositoryWithUser('correct-horse'),
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
+            $this->refreshIssuer(),
         );
 
         try {
@@ -117,11 +123,17 @@ final class LoginUseCaseTest extends TestCase
             $this->repositoryWithUser('correct-horse'),
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
+            $this->refreshIssuer(),
         );
 
         $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.9'));
 
         self::assertSame(0, $throttle->countFailuresSince('203.0.113.9', '1970-01-01 00:00:00'));
+    }
+
+    private function refreshIssuer(): RefreshTokenIssuer
+    {
+        return new RefreshTokenIssuer(new InMemoryRefreshTokenRepository());
     }
 
     private function repositoryWithUser(string $plainPassword, string $status = 'active'): UserRepositoryInterface

--- a/tests/Auth/LogoutUseCaseTest.php
+++ b/tests/Auth/LogoutUseCaseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\LogoutUseCase;
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Auth\RefreshTokenSecret;
+use NeneInvoice\Tests\Support\InMemoryRefreshTokenRepository;
+use PHPUnit\Framework\TestCase;
+
+final class LogoutUseCaseTest extends TestCase
+{
+    public function test_revokes_the_token_family(): void
+    {
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $issued = (new RefreshTokenIssuer($refreshTokens))->issue(42, 1);
+
+        (new LogoutUseCase($refreshTokens))->execute($issued->rawToken);
+
+        $record = $refreshTokens->findByHash(RefreshTokenSecret::hash($issued->rawToken));
+        self::assertNotNull($record);
+        self::assertNotNull($record->revokedAt);
+    }
+
+    public function test_is_a_noop_for_a_missing_or_unknown_token(): void
+    {
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $useCase = new LogoutUseCase($refreshTokens);
+
+        // No exception for null/empty/unknown — logout is idempotent.
+        $useCase->execute(null);
+        $useCase->execute('');
+        $useCase->execute('unknown');
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Auth/RefreshSessionUseCaseTest.php
+++ b/tests/Auth/RefreshSessionUseCaseTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+use NeneInvoice\Auth\InvalidRefreshTokenException;
+use NeneInvoice\Auth\RefreshSessionUseCase;
+use NeneInvoice\Auth\RefreshToken;
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Auth\RefreshTokenReuseException;
+use NeneInvoice\Auth\RefreshTokenSecret;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\Tests\Support\InMemoryRefreshTokenRepository;
+use NeneInvoice\Tests\Support\InMemoryUserRepository;
+use NeneInvoice\User\User;
+use PHPUnit\Framework\TestCase;
+
+final class RefreshSessionUseCaseTest extends TestCase
+{
+    private const SECRET = 'test-secret';
+
+    public function test_rotates_token_and_mints_access_token_scoped_to_same_tenant(): void
+    {
+        $users = new InMemoryUserRepository();
+        $userId = $users->save($this->user(organizationId: 5));
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $verifier = new LocalBearerTokenVerifier(self::SECRET);
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, $verifier);
+
+        $issued = $issuer->issue($userId, 5);
+
+        $session = $useCase->execute($issued->rawToken);
+
+        // Access token carries the same principal + tenant (no cross-tenant escalation).
+        $claims = $verifier->verify($session->accessToken);
+        self::assertSame($userId, $claims['sub'] ?? null);
+        self::assertSame(5, $claims['org'] ?? null);
+
+        // The presented token was rotated away for a brand-new one.
+        self::assertNotSame($issued->rawToken, $session->refreshToken->rawToken);
+        self::assertNotNull($refreshTokens->findByHash(RefreshTokenSecret::hash($session->refreshToken->rawToken)));
+    }
+
+    public function test_unknown_token_fails_closed(): void
+    {
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $useCase = new RefreshSessionUseCase(
+            $refreshTokens,
+            new InMemoryUserRepository(),
+            new RefreshTokenIssuer($refreshTokens),
+            new LocalBearerTokenVerifier(self::SECRET),
+        );
+
+        $this->expectException(InvalidRefreshTokenException::class);
+        $useCase->execute('not-a-real-token');
+    }
+
+    public function test_replaying_a_rotated_token_revokes_the_whole_family(): void
+    {
+        $users = new InMemoryUserRepository();
+        $userId = $users->save($this->user(organizationId: 1));
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+
+        $issued = $issuer->issue($userId, 1);
+        $rotated = $useCase->execute($issued->rawToken); // spend the first token
+
+        // Replaying the spent token is treated as theft: reuse exception …
+        try {
+            $useCase->execute($issued->rawToken);
+            self::fail('Expected reuse to be rejected.');
+        } catch (RefreshTokenReuseException) {
+            // expected
+        }
+
+        // … and the rotated sibling is now dead too (family revoked): presenting
+        // a revoked token also fails closed (reported as reuse).
+        $this->expectException(RefreshTokenReuseException::class);
+        $useCase->execute($rotated->refreshToken->rawToken);
+    }
+
+    public function test_expired_token_fails_closed(): void
+    {
+        $users = new InMemoryUserRepository();
+        $userId = $users->save($this->user(organizationId: 1));
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $raw = RefreshTokenSecret::generateRaw();
+        $refreshTokens->create(new RefreshToken(
+            userId: $userId,
+            organizationId: 1,
+            familyId: RefreshTokenSecret::generateFamilyId(),
+            tokenHash: RefreshTokenSecret::hash($raw),
+            issuedAt: '2020-01-01 00:00:00',
+            expiresAt: '2020-01-08 00:00:00',
+        ));
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, new RefreshTokenIssuer($refreshTokens), new LocalBearerTokenVerifier(self::SECRET));
+
+        $this->expectException(InvalidRefreshTokenException::class);
+        $useCase->execute($raw);
+    }
+
+    public function test_deactivated_user_cannot_refresh(): void
+    {
+        $users = new InMemoryUserRepository();
+        $userId = $users->save($this->user(organizationId: 1, status: 'disabled'));
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $issued = $issuer->issue($userId, 1);
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+
+        $this->expectException(InvalidRefreshTokenException::class);
+        $useCase->execute($issued->rawToken);
+    }
+
+    public function test_tenant_mismatch_since_issuance_fails_closed(): void
+    {
+        $users = new InMemoryUserRepository();
+        // User now lives in org 9, but the token was minted for org 1.
+        $userId = $users->save($this->user(organizationId: 9));
+        $refreshTokens = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $issued = $issuer->issue($userId, 1);
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+
+        $this->expectException(InvalidRefreshTokenException::class);
+        $useCase->execute($issued->rawToken);
+    }
+
+    private function user(int $organizationId, string $status = 'active'): User
+    {
+        return new User(
+            email: 'op@example.com',
+            passwordHash: password_hash('x', PASSWORD_DEFAULT),
+            role: Role::Admin,
+            organizationId: $organizationId,
+            status: $status,
+        );
+    }
+}

--- a/tests/Auth/SessionCookiesTest.php
+++ b/tests/Auth/SessionCookiesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\SessionCookies;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class SessionCookiesTest extends TestCase
+{
+    public function test_refresh_cookie_is_httponly_secure_strict_and_path_scoped(): void
+    {
+        $cookie = SessionCookies::setRefresh('raw-token', strtotime('2026-07-01 00:00:00 UTC'));
+
+        self::assertStringStartsWith('ni_refresh=raw-token;', $cookie);
+        self::assertStringContainsString('Path=/auth', $cookie);
+        self::assertStringContainsString('HttpOnly', $cookie);
+        self::assertStringContainsString('Secure', $cookie);
+        self::assertStringContainsString('SameSite=Strict', $cookie);
+    }
+
+    public function test_csrf_cookie_is_readable_but_secure_and_strict(): void
+    {
+        $cookie = SessionCookies::setCsrf('csrf-token', strtotime('2026-07-01 00:00:00 UTC'));
+
+        self::assertStringStartsWith('ni_csrf=csrf-token;', $cookie);
+        self::assertStringContainsString('Path=/', $cookie);
+        // Double-submit token must be JS-readable: it is deliberately NOT HttpOnly.
+        self::assertStringNotContainsString('HttpOnly', $cookie);
+        self::assertStringContainsString('Secure', $cookie);
+        self::assertStringContainsString('SameSite=Strict', $cookie);
+    }
+
+    public function test_clear_cookies_expire_in_the_past(): void
+    {
+        self::assertStringContainsString('Max-Age=0', SessionCookies::clearRefresh());
+        self::assertStringContainsString('Expires=Thu, 01 Jan 1970', SessionCookies::clearRefresh());
+        self::assertStringContainsString('Max-Age=0', SessionCookies::clearCsrf());
+    }
+
+    public function test_reads_tokens_from_cookie_params(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('POST', '/auth/refresh')
+            ->withCookieParams([
+                SessionCookies::REFRESH_COOKIE => 'r-value',
+                SessionCookies::CSRF_COOKIE => 'c-value',
+            ]);
+
+        self::assertSame('r-value', SessionCookies::refreshToken($request));
+        self::assertSame('c-value', SessionCookies::csrfCookieValue($request));
+    }
+
+    public function test_absent_cookies_read_as_null(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('POST', '/auth/refresh');
+
+        self::assertNull(SessionCookies::refreshToken($request));
+        self::assertNull(SessionCookies::csrfCookieValue($request));
+    }
+}

--- a/tests/Integration/RefreshTokenRepositoryDialectTest.php
+++ b/tests/Integration/RefreshTokenRepositoryDialectTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Integration;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Auth\PdoRefreshTokenRepository;
+use NeneInvoice\Auth\RefreshToken;
+use NeneInvoice\Auth\RefreshTokenSecret;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises {@see PdoRefreshTokenRepository} against the real production engines
+ * (MySQL + PostgreSQL — issue #396): hash lookup, rotation (`markUsed`), family
+ * revocation, and the `IS NULL` predicates. PostgreSQL is the strict case for the
+ * nullable `organization_id` / `used_at` / `revoked_at` columns.
+ *
+ * Skips when the adapter is not configured, so the default SQLite `composer test`
+ * is unaffected. CI applies the schema via `phinx migrate` first.
+ */
+#[Group('integration')]
+final class RefreshTokenRepositoryDialectTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: callable(): ?PdoDatabaseQueryExecutor}>
+     */
+    public static function adapters(): iterable
+    {
+        yield 'postgresql' => [static fn (): ?PdoDatabaseQueryExecutor => IntegrationDatabase::pgsql()];
+        yield 'mysql' => [static fn (): ?PdoDatabaseQueryExecutor => IntegrationDatabase::mysql()];
+    }
+
+    /**
+     * @param callable(): ?PdoDatabaseQueryExecutor $connect
+     */
+    #[DataProvider('adapters')]
+    public function test_rotation_and_family_revocation_round_trip(callable $connect): void
+    {
+        $db = $connect();
+
+        if ($db === null) {
+            self::markTestSkipped('Integration DB not configured for this adapter.');
+        }
+
+        $userId = random_int(1_000_000, 9_999_999);
+        $familyId = RefreshTokenSecret::generateFamilyId();
+        $repo = new PdoRefreshTokenRepository($db);
+
+        try {
+            $rawA = RefreshTokenSecret::generateRaw();
+            $idA = $repo->create($this->token($userId, $familyId, $rawA));
+
+            // Hash lookup returns the row; org/used/revoked nullables come back null.
+            $found = $repo->findByHash(RefreshTokenSecret::hash($rawA));
+            self::assertNotNull($found);
+            self::assertSame($userId, $found->userId);
+            self::assertNull($found->organizationId);
+            self::assertFalse($found->isConsumed());
+
+            // Rotate: spend A, then add B in the same family.
+            $repo->markUsed($idA, '2026-06-17 00:00:00');
+            $spentA = $repo->findByHash(RefreshTokenSecret::hash($rawA));
+            self::assertNotNull($spentA);
+            self::assertTrue($spentA->isConsumed());
+
+            $rawB = RefreshTokenSecret::generateRaw();
+            $repo->create($this->token($userId, $familyId, $rawB));
+
+            // Revoking the family kills every still-live token (B), and is keyed by family.
+            $repo->revokeFamily($familyId, '2026-06-17 00:01:00');
+            $revokedB = $repo->findByHash(RefreshTokenSecret::hash($rawB));
+            self::assertNotNull($revokedB);
+            self::assertNotNull($revokedB->revokedAt);
+        } finally {
+            $db->execute('DELETE FROM refresh_tokens WHERE user_id = ?', [$userId]);
+        }
+    }
+
+    private function token(int $userId, string $familyId, string $rawToken): RefreshToken
+    {
+        return new RefreshToken(
+            userId: $userId,
+            organizationId: null,
+            familyId: $familyId,
+            tokenHash: RefreshTokenSecret::hash($rawToken),
+            issuedAt: '2026-06-17 00:00:00',
+            expiresAt: '2026-07-01 00:00:00',
+        );
+    }
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -26,6 +26,8 @@ final class OpenApiContractTest extends TestCase
         'getDashboard',
         'listLineItemSuggestions',
         'login',
+        'refreshSession',
+        'logout',
         'getCurrentUser',
         'listAuditLogs',
         'exportAuditLogs',

--- a/tests/Support/InMemoryRefreshTokenRepository.php
+++ b/tests/Support/InMemoryRefreshTokenRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\Auth\RefreshToken;
+use NeneInvoice\Auth\RefreshTokenRepositoryInterface;
+
+/**
+ * In-memory refresh-token store for use-case tests. Mirrors the PDO repository's
+ * semantics: hash lookup, sequential ids, used/revoked marking, and family-wide
+ * revocation.
+ */
+final class InMemoryRefreshTokenRepository implements RefreshTokenRepositoryInterface
+{
+    /** @var array<int, RefreshToken> */
+    private array $rows = [];
+
+    private int $nextId = 1;
+
+    public function findByHash(string $tokenHash): ?RefreshToken
+    {
+        foreach ($this->rows as $row) {
+            if ($row->tokenHash === $tokenHash) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+
+    public function create(RefreshToken $token): int
+    {
+        $id = $this->nextId++;
+
+        $this->rows[$id] = new RefreshToken(
+            userId: $token->userId,
+            organizationId: $token->organizationId,
+            familyId: $token->familyId,
+            tokenHash: $token->tokenHash,
+            issuedAt: $token->issuedAt,
+            expiresAt: $token->expiresAt,
+            usedAt: $token->usedAt,
+            revokedAt: $token->revokedAt,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function markUsed(int $id, string $usedAt): void
+    {
+        $row = $this->rows[$id] ?? null;
+
+        if ($row === null || $row->usedAt !== null) {
+            return;
+        }
+
+        $this->rows[$id] = $this->with($row, usedAt: $usedAt);
+    }
+
+    public function revokeFamily(string $familyId, string $revokedAt): void
+    {
+        foreach ($this->rows as $id => $row) {
+            if ($row->familyId === $familyId && $row->revokedAt === null) {
+                $this->rows[$id] = $this->with($row, revokedAt: $revokedAt);
+            }
+        }
+    }
+
+    public function deleteExpired(string $now): int
+    {
+        $deleted = 0;
+        foreach ($this->rows as $id => $row) {
+            if ($row->expiresAt < $now) {
+                unset($this->rows[$id]);
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    private function with(RefreshToken $row, ?string $usedAt = null, ?string $revokedAt = null): RefreshToken
+    {
+        return new RefreshToken(
+            userId: $row->userId,
+            organizationId: $row->organizationId,
+            familyId: $row->familyId,
+            tokenHash: $row->tokenHash,
+            issuedAt: $row->issuedAt,
+            expiresAt: $row->expiresAt,
+            usedAt: $usedAt ?? $row->usedAt,
+            revokedAt: $revokedAt ?? $row->revokedAt,
+            id: $row->id,
+        );
+    }
+}


### PR DESCRIPTION
Closes #462

ADR 0014「Silent Re-authentication via httpOnly Refresh Cookie」のバックエンド実装。リロードでログインに飛ばされる現状を解消するためのサーバ側基盤。フロント配線（サイレントリフレッシュ）は #463、remember-me/寿命可変は #464、リリース前セキュリティレビューは #465。

## 実装

| 項目 | 内容 |
| --- | --- |
| **テーブル** | `refresh_tokens`（token は **SHA-256 ハッシュで保存**、平文は保持しない＝`service_tokens` と同方針。`family_id` でローテーション系列、`used_at`/`revoked_at` で reuse 検知） |
| **login** | refresh token family を新規発行。`ni_refresh`（HttpOnly/Secure/SameSite=Strict/Path=/auth）＋ `ni_csrf`（読み取り可/Secure/SameSite=Strict/Path=/）を付与 |
| **POST /auth/refresh** | cookie を検証 → **同一 user / 同一 organization** の access token を再発行（クロステナント昇格不可・ADR 0006）。トークンをローテーションし、使用済み/失効トークン再提示で **family 全体を失効** |
| **POST /auth/logout** | family をサーバ側失効＋cookie クリア。冪等（cookie 無しでも 204＋クリア） |
| **CSRF** | cookie 認証エンドポイントに double-submit（`X-CSRF-Token` == `ni_csrf`）。`/admin/*` `/api/*` は非アンビエントな Bearer のため対象外 |
| **access token** | 従来どおり短命（3600s）・**メモリ保持のみ**（XSS posture 維持・永続化しない） |

## 設計判断（レビュー観点）

- **refresh token は opaque 乱数**（32B base64url）。DB にはハッシュのみ。漏洩しても再利用不可。
- **`Secure` は常時付与**。ブラウザは `http://localhost` を secure context 扱いするためローカル dev でも送信される。
- **fail-closed**: refresh 失敗（無し/期限切れ/無効/ユーザ非アクティブ/org 不一致）は 401＋cookie クリア。
- refresh 時は `findById` でユーザを再読込し、`status=active` と org 一致を検証（発行後の無効化・テナント移動を反映）。
- refresh token 寿命は現状固定（14日）。remember-me による可変化は #464。
- **family 絶対寿命の上限**（スライディング更新の cap）は未実装 → セキュリティレビュー（#465）で要検討。

## テスト

- ユニット: rotation／reuse→family 失効／expired／非アクティブ user／**org 不一致**／CSRF（一致・欠如・不一致）／cookie 属性／logout 冪等。
- 統合（MySQL/PostgreSQL dialect・#396）: `PdoRefreshTokenRepository` の hash lookup・markUsed・revokeFamily・nullable 列（PG strict）。
- ローカル e2e 実機確認: login→refresh(200,rotated)→reuse(401,family revoked)→logout(204)→refresh(401)／CSRF 欠如(403)。
- `composer check`（test 538／phpstan／cs／openapi／mcp）green。

## ドキュメント

- OpenAPI: `refreshSession`/`logout` オペレーション、`refreshCookieAuth` securityScheme、`CsrfTokenHeader` parameter、`CsrfForbidden` response。
- terminology: operationId `refreshSession`/`logout`、Problem Details slug `invalid-refresh-token`/`csrf-token-invalid` を登録。

## マイグレーション注意

dev SQLite の phinxlog は既存の理由で古い状態のため、ローカルでは `refresh_tokens` を直接作成して検証した（既知の dev-DB 乖離）。マイグレーション自体は CI のクリーン DB（MySQL/PG）で適用・検証される。

## セルフレビューチェックリスト

- [x] snake_case JSON / integer cents 非該当（トークンは文字列）
- [x] マルチテナント: refresh は org スコープ維持（ADR 0006）
- [x] 命名・識別子を terminology.md に登録（同一 PR）
- [x] OpenAPI 契約テスト更新
- [x] `composer check` green
- [ ] **リリース前セキュリティレビュー（#465）** — CSRF・ローテーション/reuse・revocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)