### PR TITLE
feat(frontend): 起動時サイレントリフレッシュ + logout のサーバ側 revocation 連動 (#463)

### DIFF
--- a/frontend/src/app/auth-gate.test.tsx
+++ b/frontend/src/app/auth-gate.test.tsx
@@ -1,0 +1,41 @@
+import { screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setAuthToken } from '@/shared/api/client'
+import { server } from '@tests/msw/server'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+import { AuthGate } from './auth-gate'
+
+describe('AuthGate (ADR 0014 silent refresh)', () => {
+  beforeEach(() => {
+    setAuthToken('seed')
+    setAuthToken(null)
+  })
+
+  it('restores the session on mount and reveals the app (no login flash)', async () => {
+    // Default handler: /auth/refresh succeeds → token seated.
+    renderWithProviders(
+      <AuthGate>
+        <div>PROTECTED CONTENT</div>
+      </AuthGate>,
+    )
+
+    expect(await screen.findByText('PROTECTED CONTENT')).toBeInTheDocument()
+  })
+
+  it('falls through to the login screen when the refresh fails', async () => {
+    server.use(http.post('/auth/refresh', () => new HttpResponse(null, { status: 401 })))
+
+    renderWithProviders(
+      <AuthGate>
+        <div>PROTECTED CONTENT</div>
+      </AuthGate>,
+    )
+
+    // The probe resolves to a signed-out state → login, never the protected app.
+    await waitFor(() => {
+      expect(screen.queryByText('PROTECTED CONTENT')).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/auth-gate.tsx
+++ b/frontend/src/app/auth-gate.tsx
@@ -1,14 +1,43 @@
-import { useSyncExternalStore, type ReactNode } from 'react'
-import { hasAuthToken, subscribeAuthChange } from '@/shared/api/client'
+import { useEffect, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { hasAuthToken, refreshSession, subscribeAuthChange } from '@/shared/api/client'
+import { useTranslation } from '@/shared/i18n'
+import { Spinner } from '@/shared/ui'
 import { LoginPage } from '@/pages/login'
 
 /**
  * Fail-closed auth shell. Reactively gates on the in-memory token: no token →
  * login screen; a successful login flips the store and reveals the app. A 401
  * elsewhere clears the token (sign-out), which lands the user back here.
+ *
+ * On first mount with no token (e.g. after a full page reload) it attempts one
+ * silent refresh via the httpOnly refresh cookie (ADR 0014) before deciding. A
+ * neutral splash covers that probe so an authenticated operator never flashes
+ * the login screen on reload; a failed probe falls through to login as before.
  */
 export function AuthGate({ children }: { children: ReactNode }) {
+  const { t } = useTranslation()
   const authed = useSyncExternalStore(subscribeAuthChange, hasAuthToken)
+  // Skip the probe (and splash) when a token is already in memory.
+  const [probed, setProbed] = useState(() => hasAuthToken())
+
+  useEffect(() => {
+    if (hasAuthToken()) return
+    let active = true
+    void refreshSession().finally(() => {
+      if (active) setProbed(true)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  if (!authed && !probed) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner label={t('admin.auth.restoringSession')} />
+      </div>
+    )
+  }
 
   if (!authed) {
     return <LoginPage />

--- a/frontend/src/entities/auth/mutations.test.ts
+++ b/frontend/src/entities/auth/mutations.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { hasAuthToken, setAuthToken } from '@/shared/api/client'
 import { server } from '@tests/msw/server'
 import { renderHookWithProviders } from '@tests/render/render-with-providers'
-import { useLogin } from './mutations'
+import { signOut, useLogin } from './mutations'
 
 describe('useLogin', () => {
   it('stores the bearer token on success', async () => {
@@ -44,5 +44,27 @@ describe('useLogin', () => {
     })
     expect(result.current.error?.slug).toBe('invalid-credentials')
     expect(hasAuthToken()).toBe(false)
+  })
+})
+
+describe('signOut', () => {
+  it('clears the in-memory token and revokes the session server-side', async () => {
+    let loggedOut = false
+    server.use(
+      http.post('/auth/logout', () => {
+        loggedOut = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    setAuthToken('active-token')
+
+    signOut()
+
+    // Local token is cleared immediately (fail-closed, no wait on the network) …
+    expect(hasAuthToken()).toBe(false)
+    // … and the server-side revocation is fired best-effort.
+    await waitFor(() => {
+      expect(loggedOut).toBe(true)
+    })
   })
 })

--- a/frontend/src/entities/auth/mutations.ts
+++ b/frontend/src/entities/auth/mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, type UseMutationResult } from '@tanstack/react-query'
-import { apiClient, setAuthToken } from '@/shared/api/client'
+import { apiClient, revokeSession, setAuthToken } from '@/shared/api/client'
 import type { AppError } from '@/shared/api/errors'
 import type { LoginResponseDto } from './api-types'
 import type { Credentials } from './model'
@@ -21,7 +21,13 @@ export function useLogin(): UseMutationResult<string, AppError, Credentials> {
   })
 }
 
-/** Clears the in-memory session; the auth shell observes this and shows login. */
+/**
+ * Signs out (ADR 0014): fires a best-effort server-side revocation of the
+ * refresh-token family (and cookie clear), then clears the in-memory token
+ * immediately so the fail-closed auth shell shows login without waiting on the
+ * network.
+ */
 export function signOut(): void {
+  void revokeSession()
   setAuthToken(null)
 }

--- a/frontend/src/shared/api/client.test.ts
+++ b/frontend/src/shared/api/client.test.ts
@@ -1,7 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { server } from '@tests/msw/server'
-import { apiClient, hasAuthToken, setAuthToken, wasSessionExpired } from './client'
+import {
+  apiClient,
+  hasAuthToken,
+  refreshSession,
+  revokeSession,
+  setAuthToken,
+  wasSessionExpired,
+} from './client'
 
 describe('apiClient — 401 session handling', () => {
   beforeEach(() => {
@@ -48,5 +55,92 @@ describe('apiClient — 401 session handling', () => {
 
     expect(hasAuthToken()).toBe(false)
     expect(wasSessionExpired()).toBe(true)
+  })
+})
+
+describe('silent re-authentication (ADR 0014)', () => {
+  beforeEach(() => {
+    setAuthToken('seed')
+    setAuthToken(null)
+  })
+
+  it('transparently refreshes and replays a mid-session 401', async () => {
+    setAuthToken('expired-token')
+    let calls = 0
+    server.use(
+      http.get('/admin/users', () => {
+        calls += 1
+        // Expired access token on the first hit; succeeds after the silent refresh.
+        return calls === 1
+          ? new HttpResponse(null, { status: 401 })
+          : HttpResponse.json({ items: [], total: 0, limit: 100, offset: 0 })
+      }),
+    )
+
+    const data = await apiClient.get('/admin/users')
+
+    expect(data).toEqual({ items: [], total: 0, limit: 100, offset: 0 })
+    expect(calls).toBe(2)
+    // The session survived transparently: token rotated, no expiry notice.
+    expect(hasAuthToken()).toBe(true)
+    expect(wasSessionExpired()).toBe(false)
+  })
+
+  it('fails closed when the refresh cookie is also dead', async () => {
+    setAuthToken('valid-token')
+    server.use(
+      http.get('/admin/users', () => new HttpResponse(null, { status: 401 })),
+      http.post('/auth/refresh', () => new HttpResponse(null, { status: 401 })),
+    )
+
+    await expect(apiClient.get('/admin/users')).rejects.toBeDefined()
+
+    expect(hasAuthToken()).toBe(false)
+    expect(wasSessionExpired()).toBe(true)
+  })
+
+  it('restores a session from the refresh cookie on app start', async () => {
+    const restored = await refreshSession()
+
+    expect(restored).toBe(true)
+    expect(hasAuthToken()).toBe(true)
+  })
+
+  it('stays signed out when the app-start refresh fails', async () => {
+    server.use(http.post('/auth/refresh', () => new HttpResponse(null, { status: 401 })))
+
+    const restored = await refreshSession()
+
+    expect(restored).toBe(false)
+    expect(hasAuthToken()).toBe(false)
+  })
+
+  it('de-duplicates concurrent refreshes into one request (single-flight)', async () => {
+    let refreshCalls = 0
+    server.use(
+      http.post('/auth/refresh', () => {
+        refreshCalls += 1
+        return HttpResponse.json({ token: 'refreshed-token' })
+      }),
+    )
+
+    await Promise.all([refreshSession(), refreshSession(), refreshSession()])
+
+    expect(refreshCalls).toBe(1)
+    expect(hasAuthToken()).toBe(true)
+  })
+
+  it('revokeSession posts to the logout endpoint', async () => {
+    let loggedOut = false
+    server.use(
+      http.post('/auth/logout', () => {
+        loggedOut = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+
+    await revokeSession()
+
+    expect(loggedOut).toBe(true)
   })
 })

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -52,9 +52,98 @@ function handleUnauthorized(status: number): void {
   }
 }
 
+const CSRF_COOKIE = 'ni_csrf'
+const CSRF_HEADER = 'X-CSRF-Token'
+
+/** Reads a non-httpOnly cookie value by name (the double-submit CSRF token). */
+function readCookie(name: string): string | null {
+  const prefix = `${name}=`
+  for (const part of document.cookie.split('; ')) {
+    if (part.startsWith(prefix)) return decodeURIComponent(part.slice(prefix.length))
+  }
+  return null
+}
+
+/**
+ * Silent re-authentication (ADR 0014). Exchanges the httpOnly refresh cookie for
+ * a fresh in-memory access token, echoing the readable CSRF cookie in the
+ * required header. De-duplicated: concurrent callers (the app-start probe and
+ * any number of 401 retries) share one in-flight request. Resolves true when a
+ * token was seated, false on any failure — the caller decides whether to fail
+ * closed.
+ */
+let refreshInFlight: Promise<boolean> | null = null
+
+function refreshAccessToken(): Promise<boolean> {
+  if (refreshInFlight !== null) return refreshInFlight
+
+  refreshInFlight = (async (): Promise<boolean> => {
+    const csrf = readCookie(CSRF_COOKIE)
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (csrf !== null) headers[CSRF_HEADER] = csrf
+
+    try {
+      const response = await fetch('/auth/refresh', { method: 'POST', headers })
+      if (!response.ok) return false
+      const token = (safeJsonParse(await response.text()) as { token?: unknown } | null)?.token
+      if (typeof token !== 'string') return false
+      setAuthToken(token)
+      return true
+    } catch {
+      return false
+    } finally {
+      refreshInFlight = null
+    }
+  })()
+
+  return refreshInFlight
+}
+
+/**
+ * Attempt to restore a session on app start: after a full reload the in-memory
+ * token is gone, but the refresh cookie may still be valid. Resolves true when
+ * the session was restored (the auth shell then reveals the app instead of the
+ * login screen).
+ */
+export function refreshSession(): Promise<boolean> {
+  return refreshAccessToken()
+}
+
+/**
+ * Server-side logout (ADR 0014): revokes the refresh-token family and clears the
+ * cookies. Best-effort — a network failure still lets the caller clear the local
+ * in-memory token.
+ */
+export async function revokeSession(): Promise<void> {
+  const csrf = readCookie(CSRF_COOKIE)
+  const headers: Record<string, string> = {}
+  if (csrf !== null) headers[CSRF_HEADER] = csrf
+
+  try {
+    await fetch('/auth/logout', { method: 'POST', headers })
+  } catch {
+    // best-effort; the caller clears the in-memory token regardless
+  }
+}
+
+/**
+ * On a 401 for a signed-in caller, try one silent refresh and report whether the
+ * original request should be retried. Skips the auth endpoints (no recursion)
+ * and the not-signed-in case (a failed login stays a credentials error).
+ */
+async function shouldRetryAfterRefresh(
+  status: number,
+  path: string,
+  isRetry: boolean,
+): Promise<boolean> {
+  if (status !== 401 || isRetry || authToken === null) return false
+  if (path === '/auth/refresh' || path === '/auth/logout') return false
+  return refreshAccessToken()
+}
+
 type Json = Record<string, unknown>
 
-async function request<T>(method: string, path: string, body?: Json): Promise<T> {
+async function request<T>(method: string, path: string, body?: Json, isRetry = false): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (body !== undefined) headers['Content-Type'] = 'application/json'
   if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
@@ -78,6 +167,10 @@ async function request<T>(method: string, path: string, body?: Json): Promise<T>
   const parsed: unknown = text === '' ? null : safeJsonParse(text)
 
   if (!response.ok) {
+    // Access token may have expired mid-session — try one silent refresh + replay.
+    if (await shouldRetryAfterRefresh(response.status, path, isRetry)) {
+      return request<T>(method, path, body, true)
+    }
     handleUnauthorized(response.status)
     throw AppError.fromProblem(response.status, parsed)
   }
@@ -94,7 +187,7 @@ function safeJsonParse(text: string): unknown {
 }
 
 /** Fetches a binary resource and returns it as a Blob. Sends the Bearer token. */
-async function requestBlob(path: string): Promise<Blob> {
+async function requestBlob(path: string, isRetry = false): Promise<Blob> {
   const headers: Record<string, string> = {}
   if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
 
@@ -106,6 +199,9 @@ async function requestBlob(path: string): Promise<Blob> {
   }
 
   if (!response.ok) {
+    if (await shouldRetryAfterRefresh(response.status, path, isRetry)) {
+      return requestBlob(path, true)
+    }
     handleUnauthorized(response.status)
     const text = await response.text()
     throw AppError.fromProblem(response.status, text === '' ? null : safeJsonParse(text))
@@ -119,7 +215,7 @@ async function requestBlob(path: string): Promise<Blob> {
  * and 422 (rejected — the report carries the format/row errors) resolve with the
  * body; only auth / transport / 5xx throw. Used by template-only CSV import.
  */
-async function postCsv<T>(path: string, csv: string): Promise<T> {
+async function postCsv<T>(path: string, csv: string, isRetry = false): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json', 'Content-Type': 'text/csv' }
   if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
 
@@ -137,6 +233,9 @@ async function postCsv<T>(path: string, csv: string): Promise<T> {
     return parsed as T
   }
 
+  if (await shouldRetryAfterRefresh(response.status, path, isRetry)) {
+    return postCsv<T>(path, csv, true)
+  }
   handleUnauthorized(response.status)
   throw AppError.fromProblem(response.status, parsed)
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -79,6 +79,7 @@ export const enMessages: MessageCatalog = {
   'admin.auth.trustQualified': 'Qualified-invoice ready',
   'admin.auth.failed': 'Incorrect email or password.',
   'admin.auth.sessionExpired': 'Your session has expired. Please sign in again.',
+  'admin.auth.restoringSession': 'Restoring your session…',
   'admin.auth.emailInvalid': 'Enter a valid email address.',
   'admin.auth.passwordRequired': 'Enter your password.',
   'admin.account.signedInAs': 'Signed in as {{email}}',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -84,6 +84,7 @@ export const jaMessages = {
   'admin.auth.trustQualified': '適格請求書対応',
   'admin.auth.failed': 'メールアドレスまたはパスワードが正しくありません。',
   'admin.auth.sessionExpired': 'セッションの有効期限が切れました。再度ログインしてください。',
+  'admin.auth.restoringSession': 'セッションを確認しています…',
   'admin.auth.emailInvalid': '有効なメールアドレスを入力してください。',
   'admin.auth.passwordRequired': 'パスワードを入力してください。',
   'admin.account.signedInAs': '{{email}} でログイン中',

--- a/frontend/tests/msw/handlers.ts
+++ b/frontend/tests/msw/handlers.ts
@@ -6,6 +6,10 @@ import { buildInvoiceDto, buildInvoiceWithLinesDto } from '@tests/factories/invo
 export const handlers = [
   http.post('/auth/login', () => HttpResponse.json({ token: 'test-token' })),
 
+  http.post('/auth/refresh', () => HttpResponse.json({ token: 'refreshed-token' })),
+
+  http.post('/auth/logout', () => new HttpResponse(null, { status: 204 })),
+
   http.get('/admin/me', () =>
     HttpResponse.json({ id: 1, email: 'admin@example.com', role: 'admin', organization_id: 1 }),
   ),


### PR DESCRIPTION
Closes #463

ADR 0014 のフロント配線（バックエンド #462/#466 に依存）。access token はメモリ保持のまま、httpOnly refresh cookie によるサイレント再認証を有効化し、**F5 リロードでログイン画面に飛ばされる現状を解消**する。

## 実装

| 箇所 | 内容 |
| --- | --- |
| `shared/api/client.ts` | 唯一の fetch 層に refresh を実装（cookie/CSRF はここに閉じ込め） |
| └ `refreshSession()` | 起動時に `/auth/refresh` を試行。読み取り可能な `ni_csrf` を `X-CSRF-Token` で double-submit。成功で access token を seed |
| └ 401 リトライ | サインイン中の 401 で **1 度だけ**サイレントリフレッシュ→元リクエストを再送（access token の 1h 失効を透過化）。失敗時のみ従来どおり fail-closed。`/auth/*`・未サインイン（ログイン失敗）は対象外 |
| └ single-flight | 並行呼び出し（複数タブ／同時 401）を 1 リクエストに集約（#463 の競合要件） |
| └ `revokeSession()` | `/auth/logout` を best-effort 送信 |
| `app/auth-gate.tsx` | 初回マウントで token 無しなら refresh を試行。判定までニュートラルなスプラッシュを表示し、認証済みユーザーのログイン画面チラ見えを防止。失敗は従来どおりログインへ |
| `entities/auth` | `signOut()` を revoke 連動に（即時ローカルクリア＋サーバ側 family 失効） |
| i18n | `admin.auth.restoringSession` を ja/en に追加 |

## 設計判断（レビュー観点）

- access token は引き続き**メモリ保持のみ**（XSS posture 維持）。cookie/CSRF 処理は `shared/api` に閉じ込め、FSD レイヤリング（features/pages は `shared/api` を直接 import しない）を維持。
- 401 リトライは `isRetry` ガードで**最大1回**・`/auth/*` 非対象でループ防止。未サインインの 401 は従来どおり「ログイン失敗のフォームエラー」のまま。
- fail-closed 維持: refresh 失敗（cookie 無し/失効）→ token クリア＋`セッション期限切れ`通知→ログイン。
- スプラッシュは token がメモリにある場合スキップ（初期 state = `hasAuthToken()`）。

## テスト

- `client.test.ts`: 透過リフレッシュ＋再送 / refresh も失効で fail-closed / 起動時復元 / 起動時失敗で signed-out / **single-flight 1リクエスト** / logout 送信。
- `auth-gate.test.tsx`: 復元成功でアプリ表示（ログインチラ見えなし）/ 失敗でログイン。
- `mutations.test.ts`: `signOut` が即時クリア＋logout 送信。
- MSW に `/auth/refresh`・`/auth/logout` 既定ハンドラを追加。
- 既存の signed-in 401 テストは「refresh も失効→fail-closed」の経路を引き続き検証。

## 確認

- frontend CI 相当: `lint` / `format` / `knip` / `vitest`（254 passed）/ `build` すべて green。
- ローカル実機: **Vite proxy（:5185）経由**で login→Set-Cookie 透過→refresh 200 を確認（dev の cookie/プロキシ往復が機能）。

## フォローアップ

- remember-me（「ログイン状態を保持」チェックボックス配線・refresh 寿命可変）＋ アイドル/絶対タイムアウトは **#464**。
- リリース前セキュリティレビュー **#465**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)