### PR TITLE
build(frontend): npm audit fix で vite を 7.3.5 に更新（high 解消）(#468)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9890,9 +9890,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes #468

新規公表アドバイザリにより、フロント CI `check` 内の `npm audit --audit-level=high` が **high 深刻度**で失敗し、全フロント PR（#467 含む・main も同様）がブロックされていた。コード変更とは無関係のリポジトリ全体の CI 破損。

## 変更

- `npm audit fix`（非 force）で **vite 7.3.3 → 7.3.5**（semver パッチ・非破壊）。
- `frontend/package-lock.json` のみ変更（3 行・vite の解決バージョン）。`package.json` は range 内のため変更なし。

## 解消した high

- `vite` `server.fs.deny` バイパス（Windows alternate paths）/ `launch-editor` NTLMv2 hash disclosure。

## 確認

- `npm audit --audit-level=high` → pass（high/critical なし）。
- `npm run build` → green（vite 7.3.5 で動作）。

## スコープ外

- 残る js-yaml / @redocly/openapi-core は **moderate**（`--audit-level=high` 非該当）。別途対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)