### PR TITLE
docs: ステータス系ドキュメントの鮮度更新・不整合解消 (#470)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Ops / MCP         ──→         │
 
 ## 現在の開発状況
 
-> **最終更新: 2026-06-04**（`docs/todo/current.md` が正本）
+> **最終更新: 2026-06-17**（`docs/todo/current.md` が正本）
 
 | フェーズ | 状態 |
 | --- | --- |
@@ -28,7 +28,7 @@ Ops / MCP         ──→         │
 | Phase 2 管理 UI（React）＋ 適格請求書 PDF ＋ ダッシュボード ＋ 監査ログ ＋ ja/en | ✅ 完了 |
 | Phase 3 Tier A 共有ホスティング（インストーラ・リリース ZIP・運用ガイド） | ✅ 完了 |
 | セキュリティ診断 Round 1–2 | ✅ 完了（指摘修正済み） |
-| Phase 4 エコシステム連携（Records / Concierge・決済GW） | 🔄 進行中（CSV エクスポート・一覧の検索/フィルタ/ソート・言語切替UI は実装済み） |
+| Phase 4 エコシステム連携（Records / Concierge・決済GW） | 🔄 進行中（CSV エクスポート・一覧の検索/フィルタ/ソート・言語切替UI・service token 運用・カード決済（PAY.JP；決済リンク/webhook/設定UI・ADR 0013）・認証セッション永続化（サイレント再認証・ADR 0014）は実装済み。残り: Records カタログ連携・Concierge webhook・remember-me/タイムアウト #464・リリース前セキュリティレビュー #465） |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ NeNe Invoice is an open-source billing platform built on [NENE2](https://github.
 
 ## Quick Start
 
-**Status:** Phases 0–3 shipped — multi-tenant billing API, React admin UI, qualified-invoice PDF, payments, audit logging, bilingual (ja/en) UI with a language switcher, and list search / filter / sort are all in place, plus the Tier A shared-hosting install path and two security-assessment rounds. Phase 4 (sibling-product integration) is in progress; CSV export already landed.
+**Status:** Phases 0–3 shipped — multi-tenant billing API, React admin UI, qualified-invoice PDF, payments, audit logging, bilingual (ja/en) UI with a language switcher, and list search / filter / sort are all in place, plus the Tier A shared-hosting install path and two security-assessment rounds. Phase 4 (sibling-product integration) is in progress: CSV export, service-token management, optional hosted card payments (PAY.JP — pay links, webhook, gateway settings; [ADR 0013](./docs/adr/0013-launch-payment-gateway-payjp.md)), and silent re-authentication via an httpOnly refresh cookie ([ADR 0014](./docs/adr/0014-auth-session-persistence-refresh-cookie.md)) have landed.
 
 ### Option A — Docker (recommended, fastest)
 

--- a/docs/adr/0011-csv-import-template-only.md
+++ b/docs/adr/0011-csv-import-template-only.md
@@ -108,6 +108,6 @@ Adopt a **template-only** import model with explicit, stated rejection reasons.
 ## Related
 
 - Issue: `#384`
-- PR: `#000`
+- PR: `#385` (ADR + design memo; status still `proposed` — implementation pending)
 - Supersedes: none
 - Superseded by: none

--- a/docs/adr/0013-launch-payment-gateway-payjp.md
+++ b/docs/adr/0013-launch-payment-gateway-payjp.md
@@ -63,7 +63,7 @@ eligible, and support JPY. Distinguishing factors for our target operator
 ## Related
 
 - Issue: `#429`
-- PR: `#000`
+- PR: `#434` (ADR); implementation `#438` (pay links), `#441` (gateway + pay page), `#442` (webhook), `#443`/`#444` (gateway settings API/UI)
 - Parent decision: `docs/adr/0012-card-payment-on-invoices.md`
 - Comparison input: `docs/integrations/payment-gateway-comparison.md`
 - Accounting gate (blocks implementation): `#430`

--- a/docs/adr/0014-auth-session-persistence-refresh-cookie.md
+++ b/docs/adr/0014-auth-session-persistence-refresh-cookie.md
@@ -156,8 +156,8 @@ scope here).
 
 ## Related
 
-- Issue: `#458`
-- PR: `#000`
+- Issue: `#458` (ADR); implementation `#462` (backend), `#463` (frontend), `#464` (remember-me), `#465` (security review)
+- PR: `#459` (proposed), `#461` (accepted); implementation `#466` (backend), `#467` (frontend)
 - Related: ADR 0006 (multi-tenancy and roles — refresh must stay tenant-scoped)
 - Supersedes: none
 - Superseded by: none

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,10 +74,12 @@ Goal: connect to sibling products.
 
 - CSV export (clients, quotes, invoices, payments, audit; list-filter aware; formula-injection safe) ✅
 - CSV import (template-only, clients + items) — design first, see ADR 0011 / `explanation/csv-import-design.md`
+- MCP tool catalog ✅
+- Service-token registry + management UI (issue / list / revoke; `/admin/service-tokens`) ✅
+- Optional hosted card payment — PAY.JP gateway, per-invoice pay links, webhook ingress, gateway settings UI (ADR 0012 / 0013) ✅
+- Silent re-authentication via httpOnly refresh cookie (ADR 0014) ✅ — remember-me + idle/absolute timeout (#464) and pre-release security review (#465) outstanding
 - NeNe Records product catalog import
 - NeNe Concierge lead → draft client / quote webhook
-- MCP tool catalog
-- Optional payment gateway
 
 **Status: 🔄 in progress.**
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-06-08 (NeNe Clear 連携の税務サインオフ状況・Clear 側完了を反映; merged through #413)
+Last updated: 2026-06-17 (カード決済（PAY.JP）・service token 運用・認証セッション永続化（ADR 0014）の完了を反映; merged through #469)
 
 ## Recently merged
 
@@ -402,15 +402,17 @@ Phase 1–3 後の運用・UX 強化と Phase 4 着手分（すべて merged）:
 - **PDF 日本語文字化け修正（#245/#246）** — mPDF のフォント上書き解消＋合計欄のリテラル表示バグ修正。
 - **一覧の検索・フィルタ・ソート（#247〜#252）** — 請求書/見積書（番号・取引先名検索、状態・期限・金額レンジ、全カラムソート）、取引先（名称・担当者・メール・登録番号検索＋ソート）。一覧の取引先 ID 数字表示も名前表示に修正。
 - **vitest v4 更新（#226/#227）** — critical CVE（GHSA-5xrq-8626-4rwp）解消。
+- **service token レジストリ運用（#416 PR #418 backend / #417 PR #419 frontend）** — 発行済みトークンを `service_tokens` レジストリに記録（メタデータ＋`jti` のみ・値は保存しない）し、`/admin/service-tokens`（admin）で発行・一覧・失効。失効は `ServiceScopeMiddleware` が `jti` 照合で即時拒否（`401 service-token-revoked`）。
+- **カード決済（PAY.JP・ADR 0012/0013）** — 請求書受領側のカード決済を hosted-only（SAQ-A）で追加。`PaymentGatewayInterface` 抽象 + PAY.JP 実装・公開決済ページ（#439 PR #441）、請求書ごとの決済リンク生成/失効（#436 PR #438）、webhook ingress（#431 PR #442）、ゲートウェイ設定の状態確認・疎通テスト API/UI（#432 PR #443/#444）。第1弾 GW を PAY.JP に確定（ADR 0013）。
+- **認証セッション永続化 — サイレント再認証（ADR 0014）** — access token はメモリ保持のまま、httpOnly refresh cookie でリロード後もサイレント再認証。ADR 起票/採択（#458 PR #459/#461）、backend `POST /auth/refresh`・`/auth/logout`（ローテーション/reuse 検知/CSRF・#462 PR #466）、frontend 起動時サイレントリフレッシュ＋logout 連動（#463 PR #467）。`npm audit` の vite high を chore 解消（#468 PR #469）。
 
-## Next steps（Phase 4 残り）
+## Next steps
 
-Phase 1–3・セキュリティ診断・上記 UX 強化は完了。Phase 4 の残り：
+Phase 1–3・セキュリティ診断・上記 UX 強化・カード決済（PAY.JP）・service token 運用・認証セッション永続化（ADR 0014 の backend/frontend）は完了。残り：
 
-- **NeNe Clear service token 運用（#416 backend / #417 frontend）** — 🔄 進行中。発行済みトークンを `service_tokens` レジストリに記録（メタデータ＋`jti` のみ・値は保存しない）し、`/admin/service-tokens`（admin）で発行・一覧・失効。失効は `ServiceScopeMiddleware` が `jti` 照合で即時拒否（`401 service-token-revoked`）。#416 が backend、#417 がオペレーター UI。
+- **認証セッション永続化の残（ADR 0014）** — remember-me（「ログイン状態を保持」チェックボックス配線・refresh 寿命可変）＋アイドル/絶対タイムアウト（#464）、リリース前セキュリティレビュー（CSRF・ローテーション/reuse・revocation の横断確認、#465）。
 - **NeNe Records 商品カタログ連携** — 明細行への商品インポート
 - **NeNe Concierge webhook** — リード → 取引先/見積下書き自動生成
-- **決済ゲートウェイ連携** — Stripe 等（任意）
 - **ユーザー一覧の検索/ソート**（任意・通常少人数のため未対応）
 
 ### 技術的負債（既知・低優先）


### PR DESCRIPTION
Closes #470

ステータス系ドキュメントが実装状況より古く、矛盾が出ていたため最新化（コード変更なし・ドキュメントのみ）。

## 解消した不整合（いずれも実装は merged だがドキュメント未追随）

| 箇所 | Before | After |
| --- | --- | --- |
| `docs/todo/current.md` | Last updated 2026-06-08 / merged through #413 | 2026-06-17 / through #469 |
| 同・Next steps | service token（#416/#417）が🔄進行中、「決済GW=**Stripe** 等」 | 完了分を「直近の追加実装（merged）」へ移動。**ADR 0013 で PAY.JP 確定**を反映 |
| 同 | ADR 0014 認証セッション永続化が**未記載** | backend/frontend 完了を追記、残り #464/#465 を明記 |
| `CLAUDE.md` | 最終更新 2026-06-04 / Phase 4 状況が古い | 2026-06-17 / service token・カード決済・サイレント再認証を反映 |
| `docs/roadmap.md` | Phase 4 完了項目に ✅ なし | MCP・service token・カード決済（PAY.JP）・サイレント再認証に ✅ |
| ADR 0011/0013/0014 | Related の `PR: #000` プレースホルダ | 実 PR 番号に（0011 は proposed のため introducing PR + 注記） |
| `README.md` | Phase 4「CSV export already landed」のみ | カード決済（PAY.JP）・サイレント再認証（ADR 0014）を追記 |

## 確認・方針

- 事実確認: `src/ServiceToken/*`・`src/Payment/Gateway/PayjpGateway.php`・`PaymentLink`・`GatewaySettings`・`/admin/*` の OpenAPI 定義の存在、および merged PR（#418/#419/#438/#441/#442/#443/#444/#466/#467）で裏取り。
- `docs/security/2026-06-08-*` の日付は**診断実施日の履歴**なので変更せず。
- `0000-template.md` の `#000` は**テンプレートの意図的プレースホルダ**なので変更せず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)