### PR TITLE
feat(backend): base-path 自動検出 + ルーティング除去 + SPA shell 配信 + cookie path 連動 (#476)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ APP_DEBUG=false
 APP_NAME="NeNe Invoice"
 PROBLEM_DETAILS_BASE_URL=https://nene-invoice.dev/problems/
 
+# --- Install location (ADR 0015) ---
+# 通常は空でよい。設置パス（root / サブディレクトリ）は SCRIPT_NAME から自動検出される。
+# リバースプロキシ等で自動検出が効かない場合のみ、例: APP_BASE_PATH=/invoice を指定する。
+APP_BASE_PATH=
+
 # --- Tenancy (ADR 0006) — default single-organization install ---
 TENANT_RESOLUTION=single
 ORG_SLUG=

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -7,10 +7,13 @@ RewriteRule ^ index.php [QSA,L]
 # Hardening (Apache + mod_headers). The Server version and TLS-level HSTS are
 # ultimately the web server / TLS-terminating proxy's responsibility.
 #
-# These run at the Apache layer with `always`, so they also cover the statically
-# served SPA shell + assets (admin/index.html, admin/assets/*) — which bypass
-# index.php (the `!-f` rewrite condition) and thus the PHP SecurityHeadersMiddleware
-# (FE-1). Without them the admin HTML had no anti-clickjacking / CSP headers.
+# These run at the Apache layer with `always`, so they cover every response:
+# the statically served SPA assets (admin/assets/* — real files, the `!-f`
+# rewrite condition), the JSON API (index.php), AND the SPA HTML shell, which is
+# now served *through* index.php so the install base can be injected (ADR 0015).
+# `always` applies to PHP-generated responses too, so the shell keeps its
+# anti-clickjacking / CSP headers (FE-1). The injected tags (<base>, <meta>) are
+# CSP-safe — no inline script, which `script-src 'self'` would block.
 <IfModule mod_headers.c>
     Header always unset X-Powered-By
     Header unset X-Powered-By

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use Nene2\Config\AppConfig;
 use Nene2\Http\ResponseEmitter;
+use NeneInvoice\Http\BasePath;
 use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Http\SpaShell;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -13,7 +16,8 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 // Do not advertise the PHP version (defense in depth; `expose_php` may be On).
 header_remove('X-Powered-By');
 
-$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+$projectRoot = dirname(__DIR__);
+$container = (new RuntimeContainerFactory($projectRoot))->create();
 
 $psr17Factory = $container->get(Psr17Factory::class);
 assert($psr17Factory instanceof Psr17Factory);
@@ -27,9 +31,34 @@ $serverRequestCreator = new ServerRequestCreator(
 
 $request = $serverRequestCreator->fromGlobals();
 
-$application = $container->get(RequestHandlerInterface::class);
-assert($application instanceof RequestHandlerInterface);
-$response = $application->handle($request);
+// --- Location-independent install (ADR 0015) ---------------------------------
+// Detect the URL base the app is installed under (document root / subdomain /
+// subdirectory) so one artifact runs anywhere. Resolving AppConfig first loads
+// `.env`, making the optional APP_BASE_PATH override available.
+$container->get(AppConfig::class);
+$override = $_SERVER['APP_BASE_PATH'] ?? $_ENV['APP_BASE_PATH'] ?? null;
+$base = BasePath::detect($request->getServerParams(), is_string($override) ? $override : null);
+
+$strippedPath = BasePath::strip($request->getUri()->getPath(), $base);
+$request = $request
+    ->withUri($request->getUri()->withPath($strippedPath))
+    ->withAttribute(BasePath::REQUEST_ATTRIBUTE, $base);
+
+// Non-API GET/HEAD requests get the SPA shell (with the base injected), which
+// also serves deep-links / F5. Everything else goes to the JSON API router.
+$method = $request->getMethod();
+$response = null;
+
+if (($method === 'GET' || $method === 'HEAD') && !BasePath::isApiPath($strippedPath)) {
+    $shell = new SpaShell($projectRoot . '/public_html/admin/index.html', $psr17Factory, $psr17Factory);
+    $response = $shell->serve($base);
+}
+
+if ($response === null) {
+    $application = $container->get(RequestHandlerInterface::class);
+    assert($application instanceof RequestHandlerInterface);
+    $response = $application->handle($request);
+}
 
 $emitter = $container->get(ResponseEmitter::class);
 assert($emitter instanceof ResponseEmitter);

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -9,6 +9,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeneInvoice\Http\BasePath;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -54,19 +55,22 @@ final readonly class LoginHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'invalid-credentials', 'Invalid Credentials', 401, $e->getMessage());
         }
 
-        return $this->withSessionCookies($this->json->create(['token' => $output->token]), $output->refreshToken);
+        $base = BasePath::fromRequest($request);
+
+        return $this->withSessionCookies($this->json->create(['token' => $output->token]), $output->refreshToken, $base);
     }
 
     /**
      * Seats the rotated refresh token in its httpOnly cookie and issues a fresh
-     * double-submit CSRF cookie (readable by JS) alongside it (ADR 0014).
+     * double-submit CSRF cookie (readable by JS) alongside it (ADR 0014). Cookie
+     * paths are scoped to the install base (ADR 0015).
      */
-    private function withSessionCookies(ResponseInterface $response, IssuedRefreshToken $refreshToken): ResponseInterface
+    private function withSessionCookies(ResponseInterface $response, IssuedRefreshToken $refreshToken, string $base): ResponseInterface
     {
         $csrfToken = RefreshTokenSecret::generateCsrfToken();
 
         return $response
-            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($refreshToken->rawToken, $refreshToken->expiresAtTimestamp))
-            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $refreshToken->expiresAtTimestamp));
+            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($refreshToken->rawToken, $refreshToken->expiresAtTimestamp, $base))
+            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $refreshToken->expiresAtTimestamp, $base));
     }
 }

--- a/src/Auth/LogoutHandler.php
+++ b/src/Auth/LogoutHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Auth;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Http\BasePath;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -34,9 +35,10 @@ final readonly class LogoutHandler implements RequestHandlerInterface
         }
 
         $this->useCase->execute(SessionCookies::refreshToken($request));
+        $base = BasePath::fromRequest($request);
 
         return $this->json->createEmpty(204)
-            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh())
-            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf());
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh($base))
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf($base));
     }
 }

--- a/src/Auth/RefreshHandler.php
+++ b/src/Auth/RefreshHandler.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Auth;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Http\BasePath;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -46,18 +47,21 @@ final readonly class RefreshHandler implements RequestHandlerInterface
             return $this->failClosed($request);
         }
 
+        $base = BasePath::fromRequest($request);
         $csrfToken = RefreshTokenSecret::generateCsrfToken();
 
         return $this->json->create(['token' => $session->accessToken])
-            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($session->refreshToken->rawToken, $session->refreshToken->expiresAtTimestamp))
-            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $session->refreshToken->expiresAtTimestamp));
+            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($session->refreshToken->rawToken, $session->refreshToken->expiresAtTimestamp, $base))
+            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $session->refreshToken->expiresAtTimestamp, $base));
     }
 
     private function failClosed(ServerRequestInterface $request): ResponseInterface
     {
+        $base = BasePath::fromRequest($request);
+
         return $this->problemDetails
             ->create($request, 'invalid-refresh-token', 'Unauthorized', 401, 'The session could not be refreshed.')
-            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh())
-            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf());
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh($base))
+            ->withAddedHeader('Set-Cookie', SessionCookies::clearCsrf($base));
     }
 }

--- a/src/Auth/SessionCookies.php
+++ b/src/Auth/SessionCookies.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Auth;
 
+use NeneInvoice\Http\BasePath;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Builds and reads the session cookies for silent re-authentication (ADR 0014).
  *
  * - **Refresh cookie** (`ni_refresh`): `HttpOnly` so JS can never read it,
- *   `Secure`, `SameSite=Strict`, and `Path=/auth` so it is only sent to the auth
- *   endpoints. This is the long-lived credential.
+ *   `Secure`, `SameSite=Strict`, and `Path=<base>/auth` so it is only sent to the
+ *   auth endpoints. This is the long-lived credential.
  * - **CSRF cookie** (`ni_csrf`): deliberately readable by JS (no `HttpOnly`) for
- *   the double-submit check; `Secure`, `SameSite=Strict`, `Path=/` so the SPA can
- *   echo it in a header. It is not a credential on its own.
+ *   the double-submit check; `Secure`, `SameSite=Strict`, `Path=<base>/` so the
+ *   SPA can echo it in a header. It is not a credential on its own.
+ *
+ * The cookie `Path` is **base-relative** (ADR 0015): under a subdirectory install
+ * the refresh cookie must scope to `/invoice/auth` (so the browser sends it to
+ * `/invoice/auth/refresh`), and the CSRF cookie to `/invoice/` (not the whole
+ * domain, which would leak it to a sibling site at `/`). At the document root the
+ * base is `''`, giving the original `/auth` and `/`. Callers pass the detected
+ * base via {@see BasePath::fromRequest()}.
  *
  * `Secure` is always set. Browsers treat `http://localhost` as a secure context,
  * so this holds for local dev as well as production HTTPS.
@@ -23,9 +31,6 @@ final class SessionCookies
 {
     public const REFRESH_COOKIE = 'ni_refresh';
     public const CSRF_COOKIE = 'ni_csrf';
-
-    private const REFRESH_PATH = '/auth';
-    private const CSRF_PATH = '/';
 
     public static function refreshToken(ServerRequestInterface $request): ?string
     {
@@ -41,24 +46,34 @@ final class SessionCookies
         return is_string($value) && $value !== '' ? $value : null;
     }
 
-    public static function setRefresh(string $rawToken, int $expiresAtTimestamp): string
+    public static function setRefresh(string $rawToken, int $expiresAtTimestamp, string $basePath = ''): string
     {
-        return self::build(self::REFRESH_COOKIE, $rawToken, self::REFRESH_PATH, $expiresAtTimestamp, httpOnly: true);
+        return self::build(self::REFRESH_COOKIE, $rawToken, self::refreshPath($basePath), $expiresAtTimestamp, httpOnly: true);
     }
 
-    public static function setCsrf(string $csrfToken, int $expiresAtTimestamp): string
+    public static function setCsrf(string $csrfToken, int $expiresAtTimestamp, string $basePath = ''): string
     {
-        return self::build(self::CSRF_COOKIE, $csrfToken, self::CSRF_PATH, $expiresAtTimestamp, httpOnly: false);
+        return self::build(self::CSRF_COOKIE, $csrfToken, self::csrfPath($basePath), $expiresAtTimestamp, httpOnly: false);
     }
 
-    public static function clearRefresh(): string
+    public static function clearRefresh(string $basePath = ''): string
     {
-        return self::build(self::REFRESH_COOKIE, '', self::REFRESH_PATH, 0, httpOnly: true);
+        return self::build(self::REFRESH_COOKIE, '', self::refreshPath($basePath), 0, httpOnly: true);
     }
 
-    public static function clearCsrf(): string
+    public static function clearCsrf(string $basePath = ''): string
     {
-        return self::build(self::CSRF_COOKIE, '', self::CSRF_PATH, 0, httpOnly: false);
+        return self::build(self::CSRF_COOKIE, '', self::csrfPath($basePath), 0, httpOnly: false);
+    }
+
+    private static function refreshPath(string $basePath): string
+    {
+        return $basePath . '/auth';
+    }
+
+    private static function csrfPath(string $basePath): string
+    {
+        return $basePath . '/';
     }
 
     private static function build(string $name, string $value, string $path, int $expiresAtTimestamp, bool $httpOnly): string

--- a/src/Http/BasePath.php
+++ b/src/Http/BasePath.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Detects the URL base path the application is installed under, so one artifact
+ * runs at the document root, a subdomain root, or a subdirectory without a
+ * rebuild (ADR 0015).
+ *
+ * The base is discovered at request time from `SCRIPT_NAME` (the URL to the
+ * front controller — Apache/CGI always sets it), with an explicit
+ * `APP_BASE_PATH` override for reverse-proxy / atypical-rewrite edge cases.
+ *
+ * Normalized form: the document root is the empty string `''` (so paths
+ * concatenate cleanly), any subdirectory is `/segment` with a leading slash and
+ * no trailing slash (e.g. `/invoice`, `/NeNeSuite/invoice`).
+ */
+final class BasePath
+{
+    /** Request attribute under which the front controller stores the detected base. */
+    public const REQUEST_ATTRIBUTE = 'app.base_path';
+
+    /** API path prefixes that must reach the router, never the SPA shell. */
+    private const API_PREFIXES = ['/auth', '/admin', '/api', '/health', '/machine', '/examples'];
+
+    /**
+     * @param array<string, mixed> $serverParams PSR-7 server params (or `$_SERVER`)
+     */
+    public static function detect(array $serverParams, ?string $override = null): string
+    {
+        if ($override !== null && $override !== '') {
+            return self::normalize($override);
+        }
+
+        $script = $serverParams['SCRIPT_NAME'] ?? '';
+
+        if (!is_string($script)) {
+            return '';
+        }
+
+        $script = str_replace('\\', '/', $script);
+
+        // Trust SCRIPT_NAME only when it points at the front controller, as
+        // Apache/nginx set it after rewriting to index.php (e.g.
+        // `/invoice/index.php`). The php built-in server in router-script mode
+        // sets SCRIPT_NAME to the *request path* instead, which would mis-detect
+        // (e.g. `/admin/me` → `/admin`); fall back to root there — dev runs at
+        // root, and APP_BASE_PATH overrides if needed.
+        if (!str_ends_with($script, '/index.php')) {
+            return '';
+        }
+
+        return self::normalize(dirname($script));
+    }
+
+    /** Reads the base the front controller stored on the request (`''` if absent). */
+    public static function fromRequest(ServerRequestInterface $request): string
+    {
+        $base = $request->getAttribute(self::REQUEST_ATTRIBUTE);
+
+        return is_string($base) ? $base : '';
+    }
+
+    /** `''` for the document root; otherwise `/segment` (leading slash, no trailing). */
+    public static function normalize(string $path): string
+    {
+        $trimmed = '/' . trim($path, '/');
+
+        return $trimmed === '/' ? '' : $trimmed;
+    }
+
+    /**
+     * Removes the base prefix from a request path, returning the base-relative
+     * path (always leading-slash) that the router and middleware expect.
+     */
+    public static function strip(string $path, string $base): string
+    {
+        if ($base === '') {
+            return $path === '' ? '/' : $path;
+        }
+
+        if ($path === $base) {
+            return '/';
+        }
+
+        if (str_starts_with($path, $base . '/')) {
+            return substr($path, strlen($base));
+        }
+
+        // Not under the detected base (unexpected) — leave untouched.
+        return $path;
+    }
+
+    /**
+     * True when the base-relative path targets the JSON API (router-handled),
+     * as opposed to a human SPA route that should receive the app shell.
+     */
+    public static function isApiPath(string $strippedPath): bool
+    {
+        foreach (self::API_PREFIXES as $prefix) {
+            if ($strippedPath === $prefix || str_starts_with($strippedPath, $prefix . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Http/SpaShell.php
+++ b/src/Http/SpaShell.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Serves the built admin SPA shell for non-API routes, injecting the detected
+ * install base so one artifact works at any path (ADR 0015).
+ *
+ * Two tags are injected into `<head>` — both CSP-safe (no inline script, which
+ * `script-src 'self'` would block):
+ *
+ * - `<base href="<base>/admin/">` so the shell's relative asset references
+ *   (`./assets/…`, built by Vite with `base: './'`) resolve to the real files
+ *   under `admin/`, even though the shell itself is served from the install root.
+ * - `<meta name="app-base" content="<base>/">` which the frontend reads to set
+ *   the router basename and prefix every API call.
+ *
+ * Serving the shell through the front controller (rather than a static file)
+ * also fixes SPA deep-links / F5: any non-API GET returns the shell.
+ */
+final readonly class SpaShell
+{
+    public function __construct(
+        private string $shellPath,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    /**
+     * Returns the base-injected shell, or null when the built shell is absent
+     * (e.g. a backend-only checkout) so the caller can fall back to the API.
+     */
+    public function serve(string $base): ?ResponseInterface
+    {
+        if (!is_file($this->shellPath)) {
+            return null;
+        }
+
+        $html = file_get_contents($this->shellPath);
+
+        if ($html === false) {
+            return null;
+        }
+
+        $response = $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/html; charset=UTF-8')
+            ->withBody($this->streamFactory->createStream($this->inject($html, $base)));
+
+        return $response;
+    }
+
+    private function inject(string $html, string $base): string
+    {
+        $assetBase = htmlspecialchars($base . '/admin/', ENT_QUOTES);
+        $appBase = htmlspecialchars($base . '/', ENT_QUOTES);
+
+        $tags = "<head>\n    <base href=\"{$assetBase}\" />\n    <meta name=\"app-base\" content=\"{$appBase}\" />";
+
+        // Inject right after the opening <head> so <base> precedes any relative
+        // URL. If the marker is absent (unexpected), serve the shell unchanged.
+        return str_replace('<head>', $tags, $html);
+    }
+}

--- a/tests/Auth/SessionCookiesTest.php
+++ b/tests/Auth/SessionCookiesTest.php
@@ -21,6 +21,24 @@ final class SessionCookiesTest extends TestCase
         self::assertStringContainsString('SameSite=Strict', $cookie);
     }
 
+    public function test_cookie_paths_are_scoped_to_the_install_base(): void
+    {
+        // Subdirectory install (ADR 0015): cookies must scope under /invoice.
+        $refresh = SessionCookies::setRefresh('raw', 0, '/invoice');
+        $csrf = SessionCookies::setCsrf('csrf', 0, '/invoice');
+
+        self::assertStringContainsString('Path=/invoice/auth', $refresh);
+        self::assertStringContainsString('Path=/invoice/', $csrf);
+        // Not over-scoped to the whole domain.
+        self::assertStringNotContainsString('Path=/;', $csrf);
+    }
+
+    public function test_clearing_cookies_uses_the_same_base_scoped_path(): void
+    {
+        self::assertStringContainsString('Path=/invoice/auth', SessionCookies::clearRefresh('/invoice'));
+        self::assertStringContainsString('Path=/invoice/', SessionCookies::clearCsrf('/invoice'));
+    }
+
     public function test_csrf_cookie_is_readable_but_secure_and_strict(): void
     {
         $cookie = SessionCookies::setCsrf('csrf-token', strtotime('2026-07-01 00:00:00 UTC'));

--- a/tests/Http/BasePathTest.php
+++ b/tests/Http/BasePathTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use NeneInvoice\Http\BasePath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BasePathTest extends TestCase
+{
+    /** @return iterable<string, array{0: string, 1: string}> */
+    public static function scriptNames(): iterable
+    {
+        yield 'document root' => ['/index.php', ''];
+        yield 'subdirectory' => ['/invoice/index.php', '/invoice'];
+        yield 'nested suite' => ['/NeNeSuite/invoice/index.php', '/NeNeSuite/invoice'];
+    }
+
+    #[DataProvider('scriptNames')]
+    public function test_detects_base_from_script_name(string $scriptName, string $expected): void
+    {
+        self::assertSame($expected, BasePath::detect(['SCRIPT_NAME' => $scriptName]));
+    }
+
+    public function test_override_wins_and_is_normalized(): void
+    {
+        self::assertSame('/invoice', BasePath::detect(['SCRIPT_NAME' => '/index.php'], '/invoice/'));
+        self::assertSame('', BasePath::detect(['SCRIPT_NAME' => '/sub/index.php'], '/'));
+    }
+
+    public function test_missing_script_name_is_root(): void
+    {
+        self::assertSame('', BasePath::detect([]));
+    }
+
+    public function test_untrusted_script_name_falls_back_to_root(): void
+    {
+        // php built-in server (router mode) sets SCRIPT_NAME to the request path,
+        // not the front controller — must not be mistaken for the base.
+        self::assertSame('', BasePath::detect(['SCRIPT_NAME' => '/admin/me']));
+        self::assertSame('', BasePath::detect(['SCRIPT_NAME' => '/dashboard']));
+    }
+
+    /** @return iterable<string, array{0: string, 1: string, 2: string}> */
+    public static function stripCases(): iterable
+    {
+        yield 'root passthrough' => ['/health', '', '/health'];
+        yield 'subdir api' => ['/invoice/auth/login', '/invoice', '/auth/login'];
+        yield 'subdir bare base' => ['/invoice', '/invoice', '/'];
+        yield 'nested' => ['/NeNeSuite/invoice/admin/me', '/NeNeSuite/invoice', '/admin/me'];
+        yield 'not under base' => ['/other/x', '/invoice', '/other/x'];
+    }
+
+    #[DataProvider('stripCases')]
+    public function test_strips_base_prefix(string $path, string $base, string $expected): void
+    {
+        self::assertSame($expected, BasePath::strip($path, $base));
+    }
+
+    /** @return iterable<string, array{0: string, 1: bool}> */
+    public static function apiPaths(): iterable
+    {
+        yield 'auth' => ['/auth/login', true];
+        yield 'admin' => ['/admin/me', true];
+        yield 'api' => ['/api/invoices', true];
+        yield 'health' => ['/health', true];
+        yield 'root is spa' => ['/', false];
+        yield 'dashboard is spa' => ['/dashboard', false];
+        yield 'admin-ish but not boundary' => ['/administration', false];
+    }
+
+    #[DataProvider('apiPaths')]
+    public function test_classifies_api_vs_spa(string $path, bool $isApi): void
+    {
+        self::assertSame($isApi, BasePath::isApiPath($path));
+    }
+}


### PR DESCRIPTION
Closes #476

ADR 0015「設置場所非依存」のバックエンド基盤。設置場所（document root / サブドメイン / サブディレクトリ）を**ランタイム自動検出**し、1 つの成果物がどこでも動くようにする。FE 側（basename＋API prefix）は #477。

## 実装

| 追加/変更 | 内容 |
| --- | --- |
| `src/Http/BasePath.php`（新） | `SCRIPT_NAME` から設置ベース検出。**front controller を指す `*/index.php` のときのみ信頼**（php built-in server の router モードは SCRIPT_NAME に request path を入れるため root にフォールバック）。`APP_BASE_PATH` override。base 除去・API/SPA 判定 |
| `src/Http/SpaShell.php`（新） | 非 API に `admin/index.html` を配信し `<base href="<base>/admin/">`（相対 assets 解決）と `<meta name="app-base">`（FE が読む）を注入。**inline script 不使用＝CSP 安全**。ディープリンク/F5 も解決 |
| `public_html/index.php` | base 検出 → request path から除去 → GET/HEAD 非 API は SPA shell、それ以外は API ルーター。base を request attribute に格納 |
| `src/Auth/SessionCookies.php` | cookie Path を base 連動（`<base>/auth`・`<base>/`）。**ADR 0014 の `/auth`・`/` 固定を解消**し CSRF cookie の過剰スコープも是正。Login/Refresh/Logout が base を渡す |
| `.env.example` | `APP_BASE_PATH`（既定空・自動検出。override は escape hatch） |
| `.htaccess` | コメントを実態（shell は PHP 経由・assets は静的・`always set` で全レスポンスにヘッダ）に更新 |

## 設計判断（レビュー観点）

- root 設置は **base=`''` の特殊ケース**に収束（分岐を増やさない）。
- assets は実ファイルのまま静的配信（Vite `base: './'`）。HTML shell のみ PHP 経由。
- 注入は CSP（`script-src 'self'`）に抵触しない `<base>`/`<meta>` のみ。`base-uri 'self'` も同一オリジン相対で適合。
- php built-in server の SCRIPT_NAME quirk を検出ロジックで吸収（dev は root 想定・override 可）。

## 検証（実機 + 自動）

- **root**: `/`=SPA shell（`<base href="/admin/">`）・`/health`=200・`/admin/me`=401・`/api/*`=401・login cookie `Path=/auth`・refresh 200・logout 204。
- **サブディレクトリ（`APP_BASE_PATH=/invoice`）**: `/invoice/health`=200（base 除去）・`/invoice/admin/me`=401・`/invoice/`=shell（`<base href="/invoice/admin/">`）・deep link 200・login cookie **`Path=/invoice/auth`・`/invoice/`**。
- `composer check` green: 558 tests / phpstan / cs / openapi / mcp。`BasePath` 18・`SessionCookies` base ケース追加。

## フォローアップ

- FE: `window.__APP_BASE__`（=`<meta app-base>`）を React Router basename＋API prefix に（#477）。
- インストーラ表示（#478）、ドキュメント（#479）、セキュリティレビュー（#465：SPA-via-PHP 配信・cookie scoping）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)