### PR TITLE
feat(frontend): window.__APP_BASE__ を React Router basename + API prefix に反映 (#477)

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
+import { routerBasename } from '@/shared/config/app-base'
 import { AppShell } from '@/pages/layout'
 import { AuditLogsPage } from '@/pages/audit-logs'
 import { ClientCreatePage } from '@/pages/client-create'
@@ -26,41 +27,44 @@ import { UserCreatePage } from '@/pages/user-create'
 import { UserEditPage } from '@/pages/user-edit'
 import { ServiceTokensPage } from '@/pages/service-tokens'
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <AppShell />,
-    children: [
-      { index: true, element: <Navigate to="/dashboard" replace /> },
-      { path: 'dashboard', element: <DashboardPage /> },
-      { path: 'invoices', element: <InvoicesPage /> },
-      { path: 'invoices/new', element: <InvoiceCreatePage /> },
-      { path: 'invoices/:id', element: <InvoiceDetailPage /> },
-      { path: 'clients', element: <ClientsPage /> },
-      { path: 'clients/new', element: <ClientCreatePage /> },
-      { path: 'clients/import', element: <ClientImportPage /> },
-      { path: 'clients/:id/edit', element: <ClientEditPage /> },
-      { path: 'items', element: <ItemsPage /> },
-      { path: 'items/new', element: <ItemCreatePage /> },
-      { path: 'items/import', element: <ItemImportPage /> },
-      { path: 'items/:id/edit', element: <ItemEditPage /> },
-      { path: 'quotes', element: <QuotesPage /> },
-      { path: 'quotes/new', element: <QuoteCreatePage /> },
-      { path: 'quotes/:id', element: <QuoteDetailPage /> },
-      { path: 'templates', element: <TemplatesPage /> },
-      { path: 'templates/new', element: <TemplateCreatePage /> },
-      { path: 'templates/:id/edit', element: <TemplateEditPage /> },
-      { path: 'settings', element: <CompanySettingsPage /> },
-      { path: 'users', element: <UsersPage /> },
-      { path: 'users/new', element: <UserCreatePage /> },
-      { path: 'users/:id/edit', element: <UserEditPage /> },
-      { path: 'audit-logs', element: <AuditLogsPage /> },
-      { path: 'service-tokens', element: <ServiceTokensPage /> },
-      { path: 'help', element: <HelpPage /> },
-    ],
-  },
-  { path: '*', element: <Navigate to="/invoices" replace /> },
-])
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <AppShell />,
+      children: [
+        { index: true, element: <Navigate to="/dashboard" replace /> },
+        { path: 'dashboard', element: <DashboardPage /> },
+        { path: 'invoices', element: <InvoicesPage /> },
+        { path: 'invoices/new', element: <InvoiceCreatePage /> },
+        { path: 'invoices/:id', element: <InvoiceDetailPage /> },
+        { path: 'clients', element: <ClientsPage /> },
+        { path: 'clients/new', element: <ClientCreatePage /> },
+        { path: 'clients/import', element: <ClientImportPage /> },
+        { path: 'clients/:id/edit', element: <ClientEditPage /> },
+        { path: 'items', element: <ItemsPage /> },
+        { path: 'items/new', element: <ItemCreatePage /> },
+        { path: 'items/import', element: <ItemImportPage /> },
+        { path: 'items/:id/edit', element: <ItemEditPage /> },
+        { path: 'quotes', element: <QuotesPage /> },
+        { path: 'quotes/new', element: <QuoteCreatePage /> },
+        { path: 'quotes/:id', element: <QuoteDetailPage /> },
+        { path: 'templates', element: <TemplatesPage /> },
+        { path: 'templates/new', element: <TemplateCreatePage /> },
+        { path: 'templates/:id/edit', element: <TemplateEditPage /> },
+        { path: 'settings', element: <CompanySettingsPage /> },
+        { path: 'users', element: <UsersPage /> },
+        { path: 'users/new', element: <UserCreatePage /> },
+        { path: 'users/:id/edit', element: <UserEditPage /> },
+        { path: 'audit-logs', element: <AuditLogsPage /> },
+        { path: 'service-tokens', element: <ServiceTokensPage /> },
+        { path: 'help', element: <HelpPage /> },
+      ],
+    },
+    { path: '*', element: <Navigate to="/invoices" replace /> },
+  ],
+  { basename: routerBasename },
+)
 
 export function AppRouter() {
   return <RouterProvider router={router} />

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,4 +1,10 @@
+import { apiBasePath } from '@/shared/config/app-base'
 import { AppError } from './errors'
+
+/** Prefixes an absolute API path with the install base (ADR 0015); no-op at root. */
+function apiUrl(path: string): string {
+  return apiBasePath + path
+}
 
 /**
  * The only module that calls `fetch`. Transport only — no domain logic.
@@ -83,7 +89,7 @@ function refreshAccessToken(): Promise<boolean> {
     if (csrf !== null) headers[CSRF_HEADER] = csrf
 
     try {
-      const response = await fetch('/auth/refresh', { method: 'POST', headers })
+      const response = await fetch(apiUrl('/auth/refresh'), { method: 'POST', headers })
       if (!response.ok) return false
       const token = (safeJsonParse(await response.text()) as { token?: unknown } | null)?.token
       if (typeof token !== 'string') return false
@@ -120,7 +126,7 @@ export async function revokeSession(): Promise<void> {
   if (csrf !== null) headers[CSRF_HEADER] = csrf
 
   try {
-    await fetch('/auth/logout', { method: 'POST', headers })
+    await fetch(apiUrl('/auth/logout'), { method: 'POST', headers })
   } catch {
     // best-effort; the caller clears the in-memory token regardless
   }
@@ -150,7 +156,7 @@ async function request<T>(method: string, path: string, body?: Json, isRetry = f
 
   let response: Response
   try {
-    response = await fetch(path, {
+    response = await fetch(apiUrl(path), {
       method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
@@ -193,7 +199,7 @@ async function requestBlob(path: string, isRetry = false): Promise<Blob> {
 
   let response: Response
   try {
-    response = await fetch(path, { method: 'GET', headers })
+    response = await fetch(apiUrl(path), { method: 'GET', headers })
   } catch {
     throw AppError.transport('Network request failed')
   }
@@ -221,7 +227,7 @@ async function postCsv<T>(path: string, csv: string, isRetry = false): Promise<T
 
   let response: Response
   try {
-    response = await fetch(path, { method: 'POST', headers, body: csv })
+    response = await fetch(apiUrl(path), { method: 'POST', headers, body: csv })
   } catch {
     throw AppError.transport('Network request failed')
   }

--- a/frontend/src/shared/config/app-base.test.ts
+++ b/frontend/src/shared/config/app-base.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { deriveApiBasePath, deriveRouterBasename } from './app-base'
+
+describe('install base derivation (ADR 0015)', () => {
+  it('document root → empty API prefix and "/" basename', () => {
+    expect(deriveApiBasePath('/')).toBe('')
+    expect(deriveRouterBasename('')).toBe('/')
+  })
+
+  it('subdirectory → "/invoice" prefix and basename', () => {
+    expect(deriveApiBasePath('/invoice/')).toBe('/invoice')
+    expect(deriveRouterBasename('/invoice')).toBe('/invoice')
+  })
+
+  it('nested suite path', () => {
+    expect(deriveApiBasePath('/NeNeSuite/invoice/')).toBe('/NeNeSuite/invoice')
+  })
+
+  it('missing or malformed meta falls back to root', () => {
+    expect(deriveApiBasePath(null)).toBe('')
+    expect(deriveApiBasePath('')).toBe('')
+    // Not an absolute path → ignored (defensive).
+    expect(deriveApiBasePath('invoice/')).toBe('')
+  })
+})

--- a/frontend/src/shared/config/app-base.ts
+++ b/frontend/src/shared/config/app-base.ts
@@ -1,0 +1,42 @@
+/**
+ * Install-location awareness for the SPA (ADR 0015).
+ *
+ * The backend serves the app shell through the front controller and injects the
+ * detected install base as `<meta name="app-base" content="<base>/">` (`/` at the
+ * document root, `/invoice/` under a subdirectory). The frontend reads it once to
+ * (a) prefix every absolute API path and (b) set the React Router `basename`, so
+ * one build runs at any path without a rebuild.
+ *
+ * In dev (Vite serves index.html with no injected meta) the base resolves to the
+ * document root, and the Vite proxy forwards `/auth` · `/admin` to the API.
+ */
+
+/** Normalizes the meta content to the API prefix: '' at root, '/invoice' under a subdir. */
+export function deriveApiBasePath(metaContent: string | null): string {
+  if (typeof metaContent !== 'string' || !metaContent.startsWith('/')) {
+    return ''
+  }
+
+  const trimmed = metaContent.replace(/\/+$/, '')
+
+  return trimmed
+}
+
+/** React Router basename: '/' at root, '/invoice' under a subdir. */
+export function deriveRouterBasename(apiBasePath: string): string {
+  return apiBasePath === '' ? '/' : apiBasePath
+}
+
+function readMetaBase(): string | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  return document.querySelector('meta[name="app-base"]')?.getAttribute('content') ?? null
+}
+
+/** URL prefix prepended to absolute API paths ('' at the document root). */
+export const apiBasePath: string = deriveApiBasePath(readMetaBase())
+
+/** Mount point for the SPA router ('/' at the document root). */
+export const routerBasename: string = deriveRouterBasename(apiBasePath)

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -13,6 +13,20 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+// php built-in server only: serve real static files (admin/assets/*, favicons)
+// as-is by returning false from the router script. Production Apache handles this
+// via the `.htaccess` `!-f` condition and never invokes index.php for existing
+// files, so this branch is dead there (and guarded to the cli-server SAPI, which
+// only the php built-in server uses, to be safe).
+if (PHP_SAPI === 'cli-server') {
+    $requestedPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+    $candidate = is_string($requestedPath) ? realpath(__DIR__ . $requestedPath) : false;
+
+    if ($candidate !== false && is_file($candidate) && str_starts_with($candidate, __DIR__ . DIRECTORY_SEPARATOR)) {
+        return false;
+    }
+}
+
 // Do not advertise the PHP version (defense in depth; `expose_php` may be On).
 header_remove('X-Powered-By');
 


### PR DESCRIPTION
Closes #477

ADR 0015 のフロント側（BE 基盤 #476/#480 に依存）。BE が SPA shell に注入する `<meta name="app-base" content="<base>/">` を読み、**設置場所非依存をブラウザで完成**させる。これでサブディレクトリ設置が end-to-end で動く。

## 実装

| 変更 | 内容 |
| --- | --- |
| `shared/config/app-base.ts`（新） | `<meta app-base>` を 1 度読み、**API prefix**（root=`''`、subdir=`/invoice`）と **React Router basename**（`/` or `/invoice`）を導出。純粋関数 `deriveApiBasePath`/`deriveRouterBasename` を切り出してテスト可能に |
| `shared/api/client.ts` | 全 fetch（`request`/`requestBlob`/`postCsv`/`refreshSession`/`revokeSession`）に `apiUrl()` で prefix 前置。**401 リトライ判定は prefix 前のパスで行うため不変** |
| `app/router.tsx` | `createBrowserRouter(..., { basename: routerBasename })` |

## 補足: `public_html/index.php`（dev のみ・no-op under Apache）

ビルド済み SPA を php built-in server で配信して検証する際、`/admin/assets/*` が router(index.php) に吸われて 401 になる php -S の仕様（router script は全リクエストを経由）に対し、**`cli-server` SAPI 限定**で実ファイルを `return false` 静的配信するガードを追加。Apache は `.htaccess` の `!-f` で元から index.php を経由しないため**本番は無影響**。

## 設計判断

- dev（Vite が index.html を配信・meta 注入なし）→ base は root に解決 → 従来どおり Vite proxy 経由。FE テストも root（meta なし）で不変。
- access token はメモリ保持のまま（ADR 0014 不変）。cookie/CSRF/サイレントリフレッシュも base 配下で動作。

## 検証

- 実機（php -S・`APP_BASE_PATH=/invoice`）: shell の `app-base` meta、`/admin/assets/*` 200（静的）、`/admin/me` 401・`/health` 200（API/SPA 判定）、login cookie の base 連動。
- FE: `lint` / `format` / `vitest`(258) / `knip` / `build` green。`app-base` 導出ユニットテスト追加。
- BE: `test`(558) / `phpstan` / `cs` green（index.php 変更分）。

## フォローアップ

- インストーラ設置先表示（#478）、ドキュメント（#479）、セキュリティレビュー（#465）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)