### PR TITLE
fix(installer): スキーマ適用の分割破綻を修正 + schema.sql の乖離解消 + パリティ guard (#482)

### DIFF
--- a/compose.installer.yaml
+++ b/compose.installer.yaml
@@ -1,0 +1,58 @@
+# NeNe Invoice — インストーラ疑似体験スタック（ADR 0015 / Tier A 共有ホスティング相当）
+#
+# 開発スタック（compose.yaml）と違い、マイグレーションも seed も**自動実行しない**。
+# 空の MySQL と「新規展開されたアプリ」を用意し、ブラウザで install.php を体験する。
+#
+# 使い方:
+#   1) npm run build --prefix frontend          # 管理 UI をビルド（未ビルドなら）
+#   2) sh docker/installer-demo/setup.sh         # 新規展開を /tmp に作成（repo を汚さない）
+#   3) docker compose -p nene-installer -f compose.installer.yaml up -d --build
+#   4) ブラウザで http://localhost:8595/install.php
+#        DB: host=mysql / port=3306 / name=nene_invoice / user=nene_invoice / pass=nene_invoice
+#        管理者: 任意のメール・8文字以上のパスワード・会社名
+#   5) 完了後 http://localhost:8595/ でログイン
+#   後始末:
+#     docker compose -p nene-installer -f compose.installer.yaml down -v
+#     rm -rf /tmp/nene-installer-demo
+#
+# ポートは CLAUDE.md の 85**/35** 規約に従う（dev: 8510/3585・security: 8590/3385 と非衝突）。
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/installer-demo/Dockerfile
+    depends_on:
+      mysql:
+        condition: service_healthy
+    ports:
+      - "8595:80"
+    volumes:
+      # リポジトリ外の「新規展開」をドキュメントルートにする。install.php が書く
+      # .env / var/.installed はここに残り、開発用の repo には影響しない。
+      - /tmp/nene-installer-demo:/var/www/html
+
+  mysql:
+    image: mysql:8.4
+    # 空の DB を 1 つだけ用意（共有ホスティングで「DB を 1 個もらった」状態）。
+    # マイグレーションも seed も行わない — スキーマ投入は install.php の役目。
+    environment:
+      MYSQL_DATABASE: nene_invoice
+      MYSQL_USER: nene_invoice
+      MYSQL_PASSWORD: nene_invoice
+      MYSQL_ROOT_PASSWORD: nene_invoice_root
+    ports:
+      - "3595:3306"
+    volumes:
+      - installer-mysql-data:/var/lib/mysql
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} --silent",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  installer-mysql-data:

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS `clients` (
     `id`                  INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     `organization_id`     INT          NOT NULL,
     `name`                VARCHAR(255) NOT NULL,
+    `name_kana`           VARCHAR(255) DEFAULT NULL,
     `contact_name`        VARCHAR(255) DEFAULT NULL,
     `email`               VARCHAR(255) DEFAULT NULL,
     `billing_address`     TEXT         DEFAULT NULL,
@@ -245,4 +246,57 @@ CREATE TABLE IF NOT EXISTS `payment_links` (
     KEY `idx_payment_links_invoice_id` (`invoice_id`),
     KEY `idx_payment_links_gateway_session_id` (`gateway_session_id`),
     KEY `idx_payment_links_organization_id` (`organization_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- refresh_tokens — rotating refresh tokens for silent re-authentication
+-- (ADR 0014). Only the SHA-256 hash of the opaque token is stored. `family_id`
+-- ties a rotation lineage so presenting a used/revoked token revokes the family.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `refresh_tokens` (
+    `id`              INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id` INT          DEFAULT NULL,
+    `user_id`         INT          NOT NULL,
+    `family_id`       VARCHAR(64)  NOT NULL,
+    `token_hash`      VARCHAR(64)  NOT NULL,
+    `issued_at`       DATETIME     NOT NULL,
+    `expires_at`      DATETIME     NOT NULL,
+    `used_at`         DATETIME     DEFAULT NULL,
+    `revoked_at`      DATETIME     DEFAULT NULL,
+    `created_at`      DATETIME     NOT NULL,
+    UNIQUE KEY `uniq_refresh_tokens_token_hash` (`token_hash`),
+    KEY `idx_refresh_tokens_family_id` (`family_id`),
+    KEY `idx_refresh_tokens_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- items — reusable line-item master (品目マスタ), soft-deletable.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `items` (
+    `id`                       INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id`          INT          NOT NULL,
+    `description`              VARCHAR(255) NOT NULL,
+    `default_unit_price_cents` INT          NOT NULL DEFAULT 0,
+    `default_tax_rate_bps`     INT          NOT NULL DEFAULT 1000,
+    `is_deleted`               TINYINT(1)   NOT NULL DEFAULT 0,
+    `deleted_at`               DATETIME     DEFAULT NULL,
+    `created_at`               DATETIME     NOT NULL,
+    `updated_at`               DATETIME     NOT NULL,
+    KEY `idx_items_organization_id` (`organization_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- templates — reusable document templates (header + shared line_items),
+-- soft-deletable.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `templates` (
+    `id`              INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id` INT          NOT NULL,
+    `name`            VARCHAR(255) NOT NULL,
+    `notes`           TEXT         DEFAULT NULL,
+    `is_deleted`      TINYINT(1)   NOT NULL DEFAULT 0,
+    `deleted_at`      DATETIME     DEFAULT NULL,
+    `created_at`      DATETIME     NOT NULL,
+    `updated_at`      DATETIME     NOT NULL,
+    KEY `idx_templates_organization_id` (`organization_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docker/installer-demo/Dockerfile
+++ b/docker/installer-demo/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# NeNe Invoice — インストーラ疑似体験用イメージ（Tier A 共有ホスティング相当）
+#
+# PHP 8.4 + Apache のみ。アプリのコードと「ビルド済み SPA」は compose のバインド
+# マウント（新規展開された dist）から供給するので、ここでは焼き込まない。
+# `.htaccess`（AllowOverride All）・mod_rewrite・pdo_mysql など、共有ホスティングが
+# 通常備える前提を再現する。
+FROM php:8.4-apache
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libicu-dev libsqlite3-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install pdo_mysql pdo_sqlite intl gd \
+    && rm -rf /var/lib/apt/lists/* \
+    && a2enmod rewrite headers \
+    && printf '<Directory /var/www/html/public_html>\n    AllowOverride All\n    Require all granted\n</Directory>\n' > /etc/apache2/conf-available/nene-invoice.conf \
+    && a2enconf nene-invoice \
+    && sed -ri -e 's!/var/www/html!/var/www/html/public_html!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!/var/www/html/public_html!g' /etc/apache2/apache2.conf \
+    && printf 'expose_php = Off\ndisplay_errors = Off\nlog_errors = On\n' > /usr/local/etc/php/conf.d/nene-invoice.ini
+
+WORKDIR /var/www/html

--- a/docker/installer-demo/setup.sh
+++ b/docker/installer-demo/setup.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# NeNe Invoice — インストーラ疑似体験の「新規展開」を作る。
+#
+# リリース ZIP を展開した直後（.env も .installed も無い）状態を再現するため、
+# 配布物に含まれるファイル群だけをリポジトリ外の隔離ディレクトリにコピーする。
+# こうすることで install.php が書き込む .env / var/.installed が**開発用の repo を
+# 汚さない**。
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="${INSTALLER_DEMO_DIR:-/tmp/nene-installer-demo}"
+
+echo "→ 新規展開を作成: $DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST/var"
+
+# リリース ZIP（tools/build-release.sh）と同じ構成。
+for d in src vendor database public_html; do
+  cp -r "$ROOT/$d" "$DEST/$d"
+done
+cp "$ROOT/composer.json" "$ROOT/phinx.php" "$ROOT/.env.example" "$DEST/"
+
+# 念のため新規状態を保証（万一コピー元に紛れていても除去）。
+rm -f "$DEST/.env" "$DEST/var/.installed"
+
+# 共有ホスティング相当: Apache(www-data) が .env と var/.installed を書けるよう、
+# ルートと var/ を書き込み可能にする（install.php の要件チェックが見るのはここ）。
+chmod 777 "$DEST" "$DEST/var"
+
+if [ ! -f "$DEST/public_html/admin/index.html" ]; then
+  echo "⚠ public_html/admin/index.html が無い。先に 'npm run build --prefix frontend' を実行してください。" >&2
+fi
+
+echo "✓ 完了: $DEST"
+echo "  次: docker compose -p nene-installer -f compose.installer.yaml up -d --build"

--- a/public_html/install.php
+++ b/public_html/install.php
@@ -117,10 +117,14 @@ function applySchema(PDO $pdo, string $schemaFile): void
         throw new RuntimeException('スキーマファイルを読み込めませんでした: ' . $schemaFile);
     }
 
-    // 空行・コメント行を除いてセミコロン区切りで分割
+    // 分割前に `--` 行コメントを除去する。コメント自体に `;` を含むことがあり
+    // （例: "-- Metadata only; the token value is never stored."）、先に `;` で
+    // 分割するとコメント後半が SQL 文として実行され構文エラーになるため。
+    $withoutComments = preg_replace('/^\s*--.*$/m', '', $sql);
+
     $statements = array_filter(
-        array_map('trim', explode(';', $sql)),
-        static fn (string $s): bool => $s !== '' && !str_starts_with(ltrim($s), '--'),
+        array_map('trim', explode(';', (string) $withoutComments)),
+        static fn (string $s): bool => $s !== '',
     );
 
     foreach ($statements as $stmt) {

--- a/tests/Installer/SchemaParityTest.php
+++ b/tests/Installer/SchemaParityTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Tier A web installer against schema drift (issue #482).
+ *
+ * The CLI-less installer (`public_html/install.php`) provisions the database
+ * from a hand-maintained DDL file rather than Phinx, so the two can diverge — as
+ * happened when `refresh_tokens` (ADR 0014) was added by a migration but not to
+ * the installer schema, leaving fresh installs unable to silent-refresh. This
+ * test fails if any table created by a migration is absent from the installer
+ * schema, so a real install would have provisioned it.
+ */
+final class SchemaParityTest extends TestCase
+{
+    public function test_every_migration_created_table_exists_in_the_installer_schema(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $schema = (string) file_get_contents($root . '/database/schema/mysql/schema.sql');
+
+        $missing = [];
+
+        foreach (glob($root . '/database/migrations/*.php') ?: [] as $file) {
+            $src = (string) file_get_contents($file);
+
+            // Only migrations that CREATE a table need a matching DDL block;
+            // column-adding / altering migrations call update()/save() instead.
+            if (!str_contains($src, '->create()')) {
+                continue;
+            }
+
+            if (preg_match("/->table\('([^']+)'/", $src, $m) !== 1) {
+                continue;
+            }
+
+            $table = $m[1];
+
+            if (preg_match('/CREATE TABLE[^;]*`' . preg_quote($table, '/') . '`/i', $schema) !== 1) {
+                $missing[] = $table;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $missing,
+            'Installer schema.sql is missing tables created by migrations: ' . implode(', ', $missing),
+        );
+    }
+
+    public function test_every_migration_column_exists_in_the_installer_schema(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $schema = (string) file_get_contents($root . '/database/schema/mysql/schema.sql');
+
+        $missing = [];
+
+        foreach (glob($root . '/database/migrations/*.php') ?: [] as $file) {
+            $src = (string) file_get_contents($file);
+
+            if (preg_match_all("/->addColumn\('([^']+)'/", $src, $matches) === false) {
+                continue;
+            }
+
+            foreach ($matches[1] as $column) {
+                // Name-level guard (not type): every column a migration adds —
+                // whether creating a table or altering one — must appear in the
+                // installer DDL, or a fresh install would be missing it.
+                if (preg_match('/`' . preg_quote($column, '/') . '`/', $schema) !== 1) {
+                    $missing[$column] = basename($file);
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            array_keys($missing),
+            'Installer schema.sql is missing columns added by migrations: '
+            . implode(', ', array_map(static fn (string $c, string $f): string => "$c ($f)", array_keys($missing), array_values($missing))),
+        );
+    }
+}


### PR DESCRIPTION
Closes #482

インストーラ疑似体験スタックで判明した、**新規インストールを完了できない**リリースブロッカーを修正。共有ホスティングの新規顧客が実際に踏む。

## 修正

| 対象 | 内容 |
| --- | --- |
| `public_html/install.php` | `applySchema()` が `explode(';')` の前にコメントを除去しておらず、`--` コメント内の `;`（例 `-- Metadata only; ...`）で文分割が破綻 → コメント後半を SQL 実行して `SQLSTATE[42000]`。**全新規インストールがステップ1で失敗**。→ 分割前に `--` 行コメントを除去 |
| `database/schema/mysql/schema.sql` | migration と乖離していた **refresh_tokens（ADR 0014）・items（品目）・templates・clients.name_kana** を追加。修正前は新規インストールでこれらの機能が壊れていた |
| `tests/Installer/SchemaParityTest.php`（新） | 再発防止。**migration が作る全テーブル＋全カラム名**が installer schema.sql に存在することを検証（このテストは refresh_tokens / items / templates / name_kana を即検出した） |

## インストーラ QA 用スタック（バグ発見の harness・同梱）

`compose.installer.yaml` + `docker/installer-demo/{Dockerfile,setup.sh}`。dev スタックと違い**マイグレーション/シードを自動実行せず**、空 MySQL ＋「新規展開」を用意してブラウザで `install.php` を体験/検証できる。

```
npm run build --prefix frontend
sh docker/installer-demo/setup.sh
docker compose -p nene-installer -f compose.installer.yaml up -d --build
# http://localhost:8595/install.php  (DB: host=mysql / nene_invoice ×3)
```

## 検証（クリーン DB で end-to-end）

- ステップ1（schema 適用）→ 302、ステップ2 → 「インストール完了」。
- ログイン → `/admin/{items,clients,templates,me}` 全 200、`/auth/refresh` 200（refresh_tokens が効いている）。
- `composer check` green（560 tests・うち parity 2 件 / phpstan / cs / openapi / mcp）。

## フォローアップ（任意）

- schema.sql の**カラム型**レベル一致（現状 parity はテーブル/カラム名の存在まで）。SQLite/PG 用 schema の有無も要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)