### PR TITLE
feat(installer): install.php を新デザイン（split・ホストプリセット・ローディング）に刷新 (#484)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
  *
  * セキュリティ: インストール完了後に .installed ファイルが生成されます。
  * 既存の .installed が存在する場合はこのスクリプトを拒否します。
+ *
+ * 画面デザインは ClaudeDesign 提供のセットアップウィザード（deep-green SaaS
+ * テーマ）に準拠。React プロトタイプを自己完結 PHP + バニラ JS に移植している。
  */
 
 define('ROOT', dirname(__DIR__));
@@ -80,33 +83,59 @@ function h(string $s): string
     return htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
 }
 
-function checkRequirements(): array
+/**
+ * 各サーバー要件を構造化して返す（画面表示・合否判定の単一の真実）。
+ *
+ * @return list<array{label: string, detail: string, ok: bool, fix: string}>
+ */
+function requirementChecks(): array
 {
-    $errors = [];
+    $phpOk = PHP_VERSION_ID >= 80400;
 
-    if (PHP_VERSION_ID < 80400) {
-        $errors[] = 'PHP 8.4 以上が必要です（現在: ' . PHP_VERSION . '）';
-    }
-
+    $extOk = true;
     foreach (['pdo', 'pdo_mysql', 'mbstring', 'openssl', 'json'] as $ext) {
         if (!extension_loaded($ext)) {
-            $errors[] = "PHP 拡張モジュール {$ext} が見つかりません";
+            $extOk = false;
         }
     }
 
-    if (!is_writable(ROOT . '/var') && !mkdir(ROOT . '/var', 0755, true) && !is_dir(ROOT . '/var')) {
-        $errors[] = 'var/ ディレクトリへの書き込み権限がありません';
-    }
+    $varOk = is_writable(ROOT . '/var') || @mkdir(ROOT . '/var', 0755, true) || is_dir(ROOT . '/var');
+    $varOk = $varOk && is_writable(ROOT . '/var');
+    $rootOk = is_writable(ROOT);
+    $vendorOk = file_exists(ROOT . '/vendor/autoload.php');
 
-    if (!is_writable(ROOT)) {
-        $errors[] = 'ルートディレクトリへの書き込み権限がありません（.env ファイルを作成できません）';
-    }
-
-    if (!file_exists(ROOT . '/vendor/autoload.php')) {
-        $errors[] = 'vendor/ ディレクトリが見つかりません。ZIP ファイルが完全に展開されているか確認してください';
-    }
-
-    return $errors;
+    return [
+        [
+            'label' => 'PHP 8.4 以上',
+            'detail' => '現在: ' . PHP_VERSION,
+            'ok' => $phpOk,
+            'fix' => 'サーバーのコントロールパネルで使用する PHP のバージョンを 8.4 以上に切り替えてください。',
+        ],
+        [
+            'label' => 'PHP 拡張モジュール',
+            'detail' => 'pdo / pdo_mysql / mbstring / openssl / json',
+            'ok' => $extOk,
+            'fix' => '不足している拡張モジュールを有効化してください（ホスティングのサポートにご確認ください）。',
+        ],
+        [
+            'label' => 'var/ ディレクトリへの書き込み権限',
+            'detail' => $varOk ? '書き込み可' : '書き込み不可',
+            'ok' => $varOk,
+            'fix' => 'ファイルマネージャまたは FTP で <code>var/</code> フォルダのパーミッションを「書き込み可（755 または 775）」に変更してください。',
+        ],
+        [
+            'label' => 'ルートディレクトリへの書き込み権限',
+            'detail' => '.env ファイルを作成します',
+            'ok' => $rootOk,
+            'fix' => '展開先フォルダを一時的に書き込み可にしてください。インストール完了後は元の権限に戻して構いません。',
+        ],
+        [
+            'label' => 'vendor/ ディレクトリ（依存一式）',
+            'detail' => '依存ライブラリ',
+            'ok' => $vendorOk,
+            'fix' => 'ZIP ファイルが完全に展開されているか確認してください。',
+        ],
+    ];
 }
 
 function applySchema(PDO $pdo, string $schemaFile): void
@@ -163,17 +192,41 @@ ENV;
     file_put_contents(ENV_FILE, $content);
 }
 
-// -------------------------------------------------------------------
-// POST 処理
-// -------------------------------------------------------------------
-$step        = (int) ($_GET['step'] ?? 1);
-$errors      = [];
-$success     = false;
-$reqErrors   = checkRequirements();
+/** SVG アイコン（静的・信頼済みマークアップ）。 */
+function ico(string $name): string
+{
+    return match ($name) {
+        'mono' => '<svg viewBox="0 0 42 42"><text x="-2" y="31" font-family="sans-serif" font-weight="800" font-size="32" fill="currentColor" opacity="0.4">N</text><text x="11" y="31" font-family="sans-serif" font-weight="800" font-size="32" fill="currentColor">N</text></svg>',
+        'check' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5l4 4 8-9"/></svg>',
+        'x' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M5 5l10 10M15 5L5 15"/></svg>',
+        'arrow' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10h11M11 5l5 5-5 5"/></svg>',
+        'back' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M16 10H5M9 5L4 10l5 5"/></svg>',
+        'shield' => '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M8 2l5 2v3.5c0 3-2 5.3-5 6.5-3-1.2-5-3.5-5-6.5V4z"/></svg>',
+        'server' => '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2.5" y="3" width="11" height="4.5" rx="1"/><rect x="2.5" y="8.5" width="11" height="4.5" rx="1"/><circle cx="5" cy="5.25" r=".6" fill="currentColor"/><circle cx="5" cy="10.75" r=".6" fill="currentColor"/></svg>',
+        'oss' => '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M8 1.5l2 4.5 4.8.4-3.6 3.2 1.1 4.7L8 11.8 3.7 14.3l1.1-4.7L1.2 6.4 6 6z"/></svg>',
+        'help' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7.5"/><path d="M7.8 7.7a2.2 2.2 0 0 1 4.3.6c0 1.5-2.1 1.9-2.1 3"/><path d="M10 14.2v.01"/></svg>',
+        'eye' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10s3-5.5 8-5.5S18 10 18 10s-3 5.5-8 5.5S2 10 2 10z"/><circle cx="10" cy="10" r="2.4"/></svg>',
+        'eyeoff' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l14 14"/><path d="M8.2 8.3A2.4 2.4 0 0 0 10 12.4M5.5 5.7C3.4 7 2 10 2 10s3 5.5 8 5.5c1.4 0 2.6-.4 3.7-1M16 12.7c1.3-1.3 2-2.7 2-2.7s-3-5.5-8-5.5c-.5 0-1 .05-1.4.13"/></svg>',
+        'warn' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3l8 14H2z"/><path d="M10 8v4M10 14.5v.01"/></svg>',
+        'trash' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 5.5h13M8 5.5V4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5M5.5 5.5l.7 10a1.5 1.5 0 0 0 1.5 1.4h4.6a1.5 1.5 0 0 0 1.5-1.4l.7-10"/></svg>',
+        'login' => '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"/><path d="M12 6l4 4-4 4M16 10H8"/></svg>',
+        default => '',
+    };
+}
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+// -------------------------------------------------------------------
+// POST 処理 + 画面状態
+// -------------------------------------------------------------------
+$step        = (int) ($_GET['step'] ?? 0);   // 0=要件チェック(landing) / 1=DB / 2=管理者
+$errors      = [];                            // バナー用
+$fieldErrors = [];                            // フィールド単位（管理者ステップ）
+$success     = false;
+$checks      = requirementChecks();
+$reqErrors   = array_values(array_filter($checks, static fn (array $c): bool => !$c['ok']));
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $reqErrors === []) {
     if ($step === 1) {
-        // DB 接続テスト
+        // DB 接続テスト + スキーマ適用
         $dbHost = trim($_POST['db_host'] ?? 'localhost');
         $dbPort = (int) ($_POST['db_port'] ?? 3306);
         $dbName = trim($_POST['db_name'] ?? '');
@@ -181,7 +234,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $dbPass = $_POST['db_pass'] ?? '';
 
         if ($dbName === '' || $dbUser === '') {
-            $errors[] = 'DB 名とユーザー名は必須です';
+            $errors[] = 'データベース名とユーザー名は必須です。';
         } else {
             try {
                 $dsn = "mysql:host={$dbHost};port={$dbPort};dbname={$dbName};charset=utf8mb4";
@@ -203,62 +256,104 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $adminPassword = $_POST['admin_password'] ?? '';
         $companyName   = trim($_POST['company_name'] ?? '');
 
-        if ($adminEmail === '' || $adminPassword === '' || $companyName === '') {
-            $errors[] = 'すべての項目を入力してください';
-        } elseif (!filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
-            $errors[] = '有効なメールアドレスを入力してください';
-        } elseif (strlen($adminPassword) < 8) {
-            $errors[] = 'パスワードは 8 文字以上で設定してください';
-        } elseif (!file_exists(ENV_FILE)) {
-            $errors[] = '.env ファイルが見つかりません。ステップ 1 からやり直してください';
+        if ($companyName === '' || $adminEmail === '' || $adminPassword === '') {
+            $errors[] = 'すべての項目を入力してください。';
+            if ($companyName === '') {
+                $fieldErrors['company'] = '会社名を入力してください。';
+            }
+            if ($adminEmail === '') {
+                $fieldErrors['email'] = 'メールアドレスを入力してください。';
+            }
+            if ($adminPassword === '') {
+                $fieldErrors['pw'] = 'パスワードを入力してください。';
+            }
         } else {
-            try {
-                // .env から接続情報を再読込
-                $env = parse_ini_file(ENV_FILE);
+            if (!filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+                $fieldErrors['email'] = '有効なメールアドレスを入力してください。';
+            }
+            if (strlen($adminPassword) < 8) {
+                $fieldErrors['pw'] = 'パスワードは 8 文字以上にしてください。';
+            }
+            if ($fieldErrors !== []) {
+                $errors[] = '入力内容に誤りがあります。';
+            }
+        }
 
-                if ($env === false) {
-                    throw new RuntimeException('.env ファイルを読み込めませんでした');
+        if ($errors === [] && $fieldErrors === []) {
+            if (!file_exists(ENV_FILE)) {
+                $errors[] = '.env ファイルが見つかりません。ステップ 1 からやり直してください。';
+            } else {
+                try {
+                    $env = parse_ini_file(ENV_FILE);
+
+                    if ($env === false) {
+                        throw new RuntimeException('.env ファイルを読み込めませんでした。');
+                    }
+
+                    $dsn = sprintf(
+                        'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+                        $env['DB_HOST'] ?? 'localhost',
+                        $env['DB_PORT'] ?? '3306',
+                        $env['DB_NAME'] ?? '',
+                    );
+                    $pdo = new PDO($dsn, $env['DB_USER'] ?? '', $env['DB_PASSWORD'] ?? '', [
+                        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    ]);
+
+                    $now = date('Y-m-d H:i:s');
+
+                    $orgSlug = preg_replace('/[^a-z0-9\-]/', '-', strtolower($companyName)) ?: 'default';
+                    $pdo->prepare('INSERT INTO organizations (name, slug, plan, is_active, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)')
+                        ->execute([$companyName, $orgSlug, 'free', $now, $now]);
+                    $orgId = (int) $pdo->lastInsertId();
+
+                    $pdo->prepare('INSERT INTO company_settings (organization_id, legal_name, created_at, updated_at) VALUES (?, ?, ?, ?)')
+                        ->execute([$orgId, $companyName, $now, $now]);
+
+                    $hash = password_hash($adminPassword, PASSWORD_BCRYPT);
+                    $pdo->prepare('INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+                        ->execute([$adminEmail, $hash, 'admin', $orgId, 'active', $now, $now]);
+
+                    file_put_contents(INSTALLED_MARKER, date('c'));
+
+                    $success = true;
+                } catch (PDOException $e) {
+                    $errors[] = 'データベースエラー: ' . $e->getMessage();
+                } catch (RuntimeException $e) {
+                    $errors[] = $e->getMessage();
                 }
-
-                $dsn = sprintf(
-                    'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
-                    $env['DB_HOST'] ?? 'localhost',
-                    $env['DB_PORT'] ?? '3306',
-                    $env['DB_NAME'] ?? '',
-                );
-                $pdo = new PDO($dsn, $env['DB_USER'] ?? '', $env['DB_PASSWORD'] ?? '', [
-                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                ]);
-
-                $now = date('Y-m-d H:i:s');
-
-                // 組織を作成
-                $orgSlug = preg_replace('/[^a-z0-9\-]/', '-', strtolower($companyName)) ?: 'default';
-                $pdo->prepare('INSERT INTO organizations (name, slug, plan, is_active, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)')
-                    ->execute([$companyName, $orgSlug, 'free', $now, $now]);
-                $orgId = (int) $pdo->lastInsertId();
-
-                // 会社設定を作成
-                $pdo->prepare('INSERT INTO company_settings (organization_id, legal_name, created_at, updated_at) VALUES (?, ?, ?, ?)')
-                    ->execute([$orgId, $companyName, $now, $now]);
-
-                // 管理者ユーザーを作成
-                $hash = password_hash($adminPassword, PASSWORD_BCRYPT);
-                $pdo->prepare('INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-                    ->execute([$adminEmail, $hash, 'admin', $orgId, 'active', $now, $now]);
-
-                // .installed マーカーを作成
-                file_put_contents(INSTALLED_MARKER, date('c'));
-
-                $success = true;
-            } catch (PDOException $e) {
-                $errors[] = 'データベースエラー: ' . $e->getMessage();
-            } catch (RuntimeException $e) {
-                $errors[] = $e->getMessage();
             }
         }
     }
 }
+
+// 表示する画面を決定。要件不合格なら常に要件画面でブロック。
+if ($reqErrors !== []) {
+    $view = 'requirements';
+} elseif ($success) {
+    $view = 'complete';
+} elseif ($step === 2) {
+    $view = 'admin';
+} elseif ($step === 1) {
+    $view = 'database';
+} else {
+    $view = 'requirements';
+}
+
+// ステッパー位置（0=DB / 1=管理者 / 2=完了）。要件・DB は 0。
+$stepIdx = match ($view) {
+    'admin' => 1,
+    'complete' => 2,
+    default => 0,
+};
+$vsteps = [
+    ['t' => 'データベース', 'd' => '接続情報の入力'],
+    ['t' => '管理者設定', 'd' => 'アカウント作成'],
+    ['t' => '完了', 'd' => 'セットアップ終了'],
+];
+
+// POST 値の復元用ヘルパー
+$old = static fn (string $k, string $default = ''): string => h($_POST[$k] ?? $default);
 
 ?>
 <!DOCTYPE html>
@@ -266,114 +361,540 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>NeNe Invoice インストーラー</title>
+<title>NeNe Invoice — セットアップウィザード</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 42'%3E%3Crect width='42' height='42' fill='%23275245'/%3E%3Ctext x='-2' y='32' font-family='sans-serif' font-weight='800' font-size='32' fill='%23ffffff' opacity='0.4'%3EN%3C/text%3E%3Ctext x='11' y='32' font-family='sans-serif' font-weight='800' font-size='32' fill='%23ffffff'%3EN%3C/text%3E%3C/svg%3E">
 <style>
-* { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: -apple-system, 'Hiragino Kaku Gothic Pro', sans-serif; background: #f5f5f5; color: #333; padding: 2rem 1rem; }
-.container { max-width: 520px; margin: 0 auto; background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.1); padding: 2rem; }
-h1 { font-size: 1.4rem; margin-bottom: .25rem; }
-.subtitle { color: #666; font-size: .9rem; margin-bottom: 1.5rem; }
-.steps { display: flex; gap: .5rem; margin-bottom: 1.5rem; }
-.step { flex: 1; padding: .4rem; text-align: center; border-radius: 4px; font-size: .8rem; background: #e8e8e8; color: #888; }
-.step.active { background: #0066cc; color: #fff; }
-.step.done { background: #28a745; color: #fff; }
-label { display: block; font-size: .85rem; color: #555; margin-bottom: .25rem; margin-top: 1rem; }
-input[type=text], input[type=email], input[type=password], input[type=number] {
-    width: 100%; padding: .5rem .75rem; border: 1px solid #ccc; border-radius: 4px; font-size: .95rem;
+/* NeNe Invoice — セットアップウィザード（ClaudeDesign 準拠 / deep-green SaaS） */
+:root{
+  --bg:oklch(98% 0.0025 175);--surface:oklch(100% 0 0);--surface-2:oklch(97.4% 0.0035 175);
+  --surface-sunk:oklch(96.2% 0.004 175);--border:oklch(90.5% 0.006 172);--border-strong:oklch(83.5% 0.008 172);
+  --fg:oklch(27% 0.011 172);--fg-muted:oklch(50% 0.01 172);--fg-subtle:oklch(62% 0.008 172);--fg-faint:oklch(73% 0.007 172);
+  --brand:oklch(41% 0.046 167);--brand-strong:oklch(34% 0.045 168);--brand-deep:oklch(28% 0.036 170);
+  --brand-soft:oklch(93.5% 0.018 167);--brand-softer:oklch(97% 0.01 167);--on-brand:oklch(98.5% 0.006 165);--link:oklch(46% 0.055 215);
+  --ok:oklch(47% 0.07 155);--ok-soft:oklch(94.5% 0.028 155);--danger:oklch(49% 0.115 28);--danger-soft:oklch(95% 0.03 28);
+  --warn:oklch(55% 0.075 75);--warn-soft:oklch(95% 0.035 80);--info:oklch(48% 0.055 235);--info-soft:oklch(95% 0.025 235);
+  --side-brand:oklch(93% 0.025 158);
+  --radius:8px;--radius-sm:6px;--radius-lg:12px;
+  --shadow-card:0 1px 2px oklch(30% 0.02 165 / 0.06);
+  --shadow-pop:0 8px 28px oklch(28% 0.03 165 / 0.16), 0 2px 6px oklch(28% 0.03 165 / 0.08);
+  --ring:0 0 0 3px oklch(43% 0.072 162 / 0.20);
+  --font-sans:"Noto Sans JP",system-ui,sans-serif;--font-serif:"Noto Serif JP",serif;--font-num:"Roboto Mono","Noto Sans JP",monospace;
 }
-button { margin-top: 1.5rem; width: 100%; padding: .65rem; background: #0066cc; color: #fff; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
-button:hover { background: #0052a3; }
-.error { background: #fff0f0; border: 1px solid #f5c6c6; border-radius: 4px; padding: .75rem 1rem; margin-bottom: 1rem; color: #c00; font-size: .9rem; }
-.error li { margin-left: 1.2rem; margin-top: .25rem; }
-.success { background: #f0fff0; border: 1px solid #b2dfb2; border-radius: 4px; padding: 1rem; color: #2a7a2a; }
-.success h2 { margin-bottom: .5rem; }
-.success a { color: #0066cc; }
-.req-error { color: #c00; font-size: .85rem; }
-.check-ok { color: #2a7a2a; font-size: .85rem; }
-hr { border: none; border-top: 1px solid #eee; margin: 1.25rem 0; }
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html,body{height:100%}
+body{font-family:var(--font-sans);background:var(--bg);color:var(--fg);line-height:1.6;-webkit-font-smoothing:antialiased;font-feature-settings:"palt" 1}
+code{font-family:var(--font-num)}
+::selection{background:color-mix(in oklch,var(--brand) 24%,transparent)}
+.iz{min-height:100vh;background:var(--bg)}
+.iz-stage{display:grid;grid-template-columns:minmax(380px,0.92fr) 1.08fr;min-height:100vh}
+.iz-aside{position:relative;overflow:hidden;color:oklch(95% 0.012 160);background:linear-gradient(157deg,var(--brand-strong) 0%,var(--brand-deep) 60%,oklch(24% 0.03 172) 100%);display:flex;flex-direction:column;justify-content:space-between;padding:48px 46px 38px}
+.iz-aside::before{content:"";position:absolute;inset:0;pointer-events:none;background-image:linear-gradient(oklch(100% 0 0 / 0.05) 1px,transparent 1px),linear-gradient(90deg,oklch(100% 0 0 / 0.05) 1px,transparent 1px);background-size:40px 40px;mask-image:linear-gradient(150deg,#000 8%,transparent 80%)}
+.iz-aside::after{content:"";position:absolute;right:-80px;bottom:-100px;width:440px;height:440px;background:radial-gradient(circle at 30% 30%,oklch(100% 0 0 / 0.06),transparent 60%);pointer-events:none}
+.iz-aside>*{position:relative;z-index:1}
+.iz-bs-top{display:flex;align-items:center;gap:13px}
+.mono-mark{width:38px;height:34px;flex:none;color:var(--side-brand);display:block}
+.mono-mark svg{width:100%;height:100%;display:block}
+.iz-bs-top .abt-name{font-size:18px;font-weight:700;color:#fff;letter-spacing:.01em}
+.iz-bs-top .abt-sub{font-size:10.5px;color:oklch(80% 0.02 160);letter-spacing:.16em;text-transform:uppercase;margin-top:3px}
+.iz-bs-mid{max-width:400px}
+.iz-bs-mid h2{font-family:var(--font-serif);font-size:25px;font-weight:700;line-height:1.5;letter-spacing:.01em;color:#fff;text-wrap:balance}
+.iz-bs-mid .lead{font-size:13px;color:oklch(84% 0.02 160);margin-top:14px;line-height:1.9}
+.vstep{list-style:none;margin:30px 0 0;padding:0}
+.vstep li{display:flex;gap:14px;padding-bottom:4px}
+.vstep .vs-rail{display:flex;flex-direction:column;align-items:center;flex:none}
+.vstep .vs-dot{width:30px;height:30px;border-radius:50%;flex:none;display:grid;place-items:center;font-family:var(--font-num);font-size:13px;font-weight:600;background:oklch(100% 0 0 / 0.10);color:oklch(86% 0.02 160);border:1px solid oklch(100% 0 0 / 0.20);transition:all .2s}
+.vstep .vs-dot svg{width:14px;height:14px}
+.vstep .vs-line{width:2px;flex:1;min-height:22px;background:oklch(100% 0 0 / 0.16);margin:4px 0}
+.vstep li:last-child .vs-line{display:none}
+.vstep .vs-body{padding-top:3px;padding-bottom:18px;flex:1;min-width:0}
+.vstep .vs-t{font-size:14px;font-weight:600;color:oklch(92% 0.015 160)}
+.vstep .vs-d{font-size:11.5px;color:oklch(74% 0.02 160);margin-top:2px;white-space:nowrap}
+.vstep li.active .vs-dot{background:var(--side-brand);color:var(--brand-deep);border-color:var(--side-brand);box-shadow:0 0 0 5px oklch(100% 0 0 / 0.08)}
+.vstep li.active .vs-t{color:#fff}
+.vstep li.done .vs-dot{background:oklch(100% 0 0 / 0.16);color:var(--side-brand);border-color:oklch(100% 0 0 / 0.28)}
+.vstep li.done .vs-line{background:var(--side-brand);opacity:.6}
+.iz-bs-foot .iz-trust{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px}
+.iz-trust .tb{display:inline-flex;align-items:center;gap:6px;font-size:10.5px;font-weight:600;color:oklch(88% 0.015 160);background:oklch(100% 0 0 / 0.08);border:1px solid oklch(100% 0 0 / 0.14);border-radius:999px;padding:4px 11px}
+.iz-trust .tb svg{width:12px;height:12px;color:var(--side-brand)}
+.iz-bs-foot .copy{font-size:10.5px;color:oklch(72% 0.02 160)}
+.iz-main{background:var(--surface);display:grid;place-items:start center;padding:46px 40px;overflow-y:auto}
+.iz-form{width:100%;max-width:460px}
+.hstep{display:none;gap:8px;margin-bottom:26px}
+.hstep .hs{flex:1;text-align:center;font-size:11.5px;font-weight:600;padding:8px 4px;border-radius:var(--radius-sm);color:var(--fg-faint);background:var(--surface-sunk);border:1px solid var(--border)}
+.hstep .hs.active{background:var(--brand);color:var(--on-brand);border-color:var(--brand)}
+.hstep .hs.done{background:var(--brand-soft);color:var(--brand-strong);border-color:color-mix(in oklch,var(--brand) 24%,transparent)}
+.hstep .hs.done::before{content:"✓ "}
+.iz-head{font-family:var(--font-serif);font-size:23px;font-weight:700;letter-spacing:.005em;color:var(--fg)}
+.iz-headsub{font-size:13px;color:var(--fg-muted);margin:7px 0 24px;line-height:1.8}
+.iz-headsub b{color:var(--fg);font-weight:600}
+.field{margin-bottom:16px}
+.field:last-of-type{margin-bottom:0}
+.label{display:flex;align-items:center;gap:4px;flex-wrap:wrap;font-size:12.5px;font-weight:600;color:var(--fg);margin-bottom:6px}
+.label .req{color:var(--danger);font-weight:700}
+.label .opt{color:var(--fg-muted);font-weight:400;font-size:11px}
+.input{display:block;width:100%;font-family:inherit;font-size:13.5px;color:var(--fg);background:var(--surface);border:1px solid var(--border-strong);border-radius:var(--radius-sm);padding:10px 12px;transition:border-color .12s,box-shadow .12s}
+.input.mono{font-family:var(--font-num)}
+.input::placeholder{color:var(--fg-faint)}
+.input:focus{outline:none;border-color:var(--brand);box-shadow:var(--ring)}
+.input.is-error{border-color:var(--danger);background:color-mix(in oklch,var(--danger) 5%,var(--surface))}
+.hint{font-size:11.5px;color:var(--fg-muted);margin-top:6px;line-height:1.65}
+.hint code,.hint b{color:var(--fg)}
+.hint code{font-size:.92em;background:var(--surface-sunk);border:1px solid var(--border);border-radius:4px;padding:.5px 5px}
+.err-text{font-size:11.5px;color:var(--danger);margin-top:6px;font-weight:600;display:flex;align-items:center;gap:5px}
+.err-text svg{width:13px;height:13px;flex:none}
+.form-row2{display:grid;grid-template-columns:1fr 116px;gap:12px}
+.pw-wrap{position:relative}
+.pw-wrap .input{padding-right:42px}
+.pw-eye{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:30px;height:30px;display:grid;place-items:center;background:transparent;border:0;color:var(--fg-faint);cursor:pointer;border-radius:var(--radius-sm)}
+.pw-eye:hover{color:var(--fg-muted);background:var(--surface-sunk)}
+.pw-eye svg{width:17px;height:17px}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;border-radius:var(--radius-sm);font-family:inherit;font-size:13.5px;font-weight:600;cursor:pointer;padding:11px 18px;border:1px solid transparent;line-height:1;transition:background .12s,box-shadow .12s,color .12s}
+.btn svg{width:16px;height:16px}
+.btn-block{width:100%}
+.btn-primary{background:var(--brand);color:var(--on-brand)}
+.btn-primary:hover{background:var(--brand-strong)}
+.btn-primary:disabled{opacity:.65;cursor:progress}
+.btn-ghost{background:var(--surface);color:var(--fg);border-color:var(--border-strong)}
+.btn-ghost:hover{background:var(--surface-2)}
+.btn-row{display:flex;gap:10px;margin-top:24px}
+.btn-row .btn{flex:1}
+.btn-row .btn-back{flex:0 0 auto;padding-left:14px;padding-right:14px}
+.btn-lg{padding:13px 20px;font-size:14px}
+.linkbtn{background:none;border:0;color:var(--link);cursor:pointer;font:inherit;font-weight:600;font-size:12px;padding:0;display:inline-flex;align-items:center;gap:5px;text-decoration:none}
+.linkbtn:hover{text-decoration:underline}
+.linkbtn svg{width:13px;height:13px}
+.tip{position:relative;display:inline-grid;place-items:center;width:16px;height:16px;border-radius:50%;background:var(--border-strong);color:var(--surface);font-size:11px;font-weight:700;cursor:help;flex:none}
+.tip:hover .tip-body,.tip:focus .tip-body{display:block}
+.tip-body{display:none;position:absolute;z-index:20;left:50%;bottom:150%;transform:translateX(-50%);width:250px;background:oklch(20% 0.02 168);color:oklch(94% 0.01 165);font-size:11.5px;font-weight:400;line-height:1.6;padding:9px 11px;border-radius:var(--radius-sm);text-align:left;box-shadow:var(--shadow-pop)}
+.tip-body code{color:oklch(86% 0.05 150);background:oklch(100% 0 0 / 0.08);padding:.5px 4px;border-radius:3px}
+.tip-body::after{content:"";position:absolute;top:100%;left:50%;transform:translateX(-50%);border:6px solid transparent;border-top-color:oklch(20% 0.02 168)}
+.alert{display:flex;gap:10px;align-items:flex-start;padding:12px 14px;border-radius:var(--radius-sm);font-size:12.5px;border:1px solid;margin-bottom:18px;line-height:1.65}
+.alert>svg{width:17px;height:17px;flex:none;margin-top:1px}
+.alert .a-body{flex:1;min-width:0}
+.alert .a-title{font-weight:700;font-size:13px}
+.alert .a-text{margin-top:3px;color:inherit;opacity:.92}
+.alert.error{background:var(--danger-soft);color:var(--danger);border-color:color-mix(in oklch,var(--danger) 30%,transparent)}
+.alert.ok{background:var(--ok-soft);color:var(--ok);border-color:color-mix(in oklch,var(--ok) 30%,transparent)}
+.alert .det{margin-top:8px;font-family:var(--font-num);font-size:11px;background:color-mix(in oklch,var(--danger) 8%,transparent);border:1px solid color-mix(in oklch,var(--danger) 22%,transparent);border-radius:5px;padding:7px 9px;word-break:break-all}
+.alert summary{cursor:pointer;font-weight:600;font-size:11.5px;margin-top:8px}
+.reqs{list-style:none;margin:0;padding:0;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.reqs li{display:flex;gap:12px;padding:13px 15px;border-bottom:1px solid var(--border);align-items:flex-start}
+.reqs li:last-child{border-bottom:none}
+.reqs li.fail{background:color-mix(in oklch,var(--danger) 5%,transparent)}
+.reqs .ic{width:22px;height:22px;flex:none;border-radius:50%;display:grid;place-items:center;margin-top:1px}
+.reqs .ic svg{width:13px;height:13px}
+.reqs .pass .ic{background:var(--ok-soft);color:var(--ok)}
+.reqs .fail .ic{background:var(--danger-soft);color:var(--danger)}
+.reqs .rq-t{font-size:13px;font-weight:600;color:var(--fg)}
+.reqs .fail .rq-t{color:var(--danger)}
+.reqs .rq-d{font-size:11.5px;color:var(--fg-muted);margin-top:2px;font-family:var(--font-num)}
+.reqs .rq-fix{font-size:11.5px;color:var(--fg-muted);margin-top:7px;line-height:1.7;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:8px 10px}
+.reqs .rq-fix b{color:var(--fg)}
+.reqs .rq-fix code{font-family:var(--font-num);background:var(--surface-sunk);border:1px solid var(--border);border-radius:4px;padding:.5px 5px;font-size:.92em}
+.reqs .rq-body{flex:1;min-width:0}
+.host-help{margin-bottom:18px;padding:14px 15px;background:var(--brand-softer);border:1px solid color-mix(in oklch,var(--brand) 14%,var(--border));border-radius:var(--radius)}
+.host-help .hh-q{font-size:12px;font-weight:600;color:var(--fg);display:flex;align-items:center;gap:7px}
+.host-help .hh-q svg{width:15px;height:15px;color:var(--brand-strong);flex:none}
+.host-help .hh-sub{font-size:11.5px;color:var(--fg-muted);margin:4px 0 11px}
+.host-chips{display:flex;flex-wrap:wrap;gap:7px}
+.host-chip{font-family:inherit;font-size:11.5px;font-weight:600;cursor:pointer;padding:6px 11px;border-radius:999px;background:var(--surface);border:1px solid var(--border-strong);color:var(--fg-muted);transition:all .12s}
+.host-chip:hover{border-color:var(--brand);color:var(--brand-strong)}
+.host-chip.on{background:var(--brand);color:var(--on-brand);border-color:var(--brand)}
+.cp-toggle{margin-top:9px}
+.cp-toggle svg{transition:transform .15s}
+.cp-toggle.open svg{transform:rotate(180deg)}
+.cp-diagram{margin-top:12px;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;background:var(--surface)}
+.cp-bar{display:flex;align-items:center;gap:6px;padding:8px 11px;background:var(--surface-2);border-bottom:1px solid var(--border);font-size:11px;color:var(--fg-subtle)}
+.cp-bar .dot{width:8px;height:8px;border-radius:50%;background:var(--border-strong)}
+.cp-bar .cp-url{font-family:var(--font-num);font-size:10.5px;margin-left:6px}
+.cp-grid{display:grid;grid-template-columns:116px 1fr;min-height:150px}
+.cp-menu{background:var(--surface-sunk);border-right:1px solid var(--border);padding:8px 0}
+.cp-menu .cp-mi{font-size:11px;color:var(--fg-muted);padding:7px 12px;display:flex;align-items:center;gap:7px}
+.cp-menu .cp-mi.hot{background:var(--brand-soft);color:var(--brand-strong);font-weight:700;box-shadow:inset 3px 0 0 var(--brand)}
+.cp-menu .cp-mi .cp-bullet{width:6px;height:6px;border-radius:2px;background:currentColor;opacity:.5;flex:none}
+.cp-body{padding:13px 15px}
+.cp-body .cp-h{font-size:11.5px;font-weight:700;color:var(--fg);margin-bottom:9px}
+.cp-kv{display:grid;grid-template-columns:auto 1fr;gap:5px 12px;font-size:11px}
+.cp-kv .k{color:var(--fg-muted);white-space:nowrap}
+.cp-kv .v{font-family:var(--font-num);color:var(--fg);font-weight:600}
+.cp-kv .v.hl{background:oklch(85% 0.16 95 / 0.5);border-radius:3px;padding:0 4px}
+.cp-note{font-size:10.5px;color:var(--fg-subtle);margin-top:11px;line-height:1.6;border-top:1px dashed var(--border);padding-top:9px}
+.iz-loading .ld-h{font-family:var(--font-serif);font-size:19px;font-weight:700;color:var(--fg)}
+.iz-loading .ld-sub{font-size:12.5px;color:var(--fg-muted);margin:6px 0 22px}
+.substeps{list-style:none;margin:0;padding:0}
+.substeps li{display:flex;align-items:center;gap:13px;padding:12px 0;border-bottom:1px solid var(--border)}
+.substeps li:last-child{border-bottom:none}
+.ss-ic{width:26px;height:26px;flex:none;border-radius:50%;display:grid;place-items:center}
+.ss-pending .ss-ic{background:var(--surface-sunk);border:1px solid var(--border);color:var(--fg-faint)}
+.ss-pending .ss-ic::after{content:"";width:7px;height:7px;border-radius:50%;background:var(--fg-faint);opacity:.5}
+.ss-active .ss-ic{background:var(--brand-soft)}
+.ss-done .ss-ic{background:var(--ok);color:#fff}
+.ss-done .ss-ic svg{width:14px;height:14px}
+.ss-t{font-size:13px;font-weight:600;color:var(--fg)}
+.ss-pending .ss-t{color:var(--fg-faint);font-weight:500}
+.ss-active .ss-t{color:var(--brand-strong)}
+.ss-d{font-size:11px;color:var(--fg-muted);margin-top:1px}
+.ss-pending .ss-d{color:var(--fg-faint)}
+.ss-meta{margin-left:auto;font-size:10.5px;color:var(--fg-faint);font-family:var(--font-num)}
+.ss-active .ss-meta{color:var(--brand-strong)}
+.spinner{width:15px;height:15px;border:2px solid color-mix(in oklch,var(--brand) 30%,transparent);border-top-color:var(--brand);border-radius:50%;animation:spin .7s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+.ld-warn{display:flex;gap:8px;align-items:center;margin-top:22px;font-size:11.5px;color:var(--fg-subtle);background:var(--surface-2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:9px 12px}
+.ld-warn svg{width:14px;height:14px;flex:none;color:var(--warn)}
+.ld-bar{height:5px;border-radius:999px;background:var(--surface-sunk);border:1px solid var(--border);overflow:hidden;margin-bottom:22px}
+.ld-bar>span{display:block;height:100%;background:var(--brand);transition:width .5s ease;width:0}
+.done-mark{width:60px;height:60px;border-radius:50%;margin:4px 0 18px;background:var(--ok-soft);color:var(--ok);display:grid;place-items:center;animation:pop .4s cubic-bezier(.2,.9,.3,1.4)}
+.done-mark svg{width:30px;height:30px}
+@keyframes pop{from{transform:scale(.4);opacity:0}to{transform:scale(1);opacity:1}}
+.done-title{font-family:var(--font-serif);font-size:25px;font-weight:700;color:var(--fg)}
+.done-sub{font-size:13px;color:var(--fg-muted);margin:7px 0 22px}
+.sec-warn{display:flex;gap:12px;align-items:flex-start;padding:15px 16px;border-radius:var(--radius);border:1px solid color-mix(in oklch,var(--danger) 34%,transparent);background:var(--danger-soft);margin-bottom:22px}
+.sec-warn>.sw-ico{width:34px;height:34px;flex:none;border-radius:50%;background:color-mix(in oklch,var(--danger) 16%,transparent);color:var(--danger);display:grid;place-items:center}
+.sec-warn .sw-ico svg{width:19px;height:19px}
+.sec-warn .sw-t{font-size:13.5px;font-weight:700;color:var(--danger)}
+.sec-warn .sw-d{font-size:12px;color:color-mix(in oklch,var(--danger) 78%,var(--fg));margin-top:4px;line-height:1.7}
+.sec-warn .sw-d code{font-family:var(--font-num);background:color-mix(in oklch,var(--danger) 12%,transparent);border-radius:4px;padding:.5px 5px}
+.next-h{font-size:12px;font-weight:700;color:var(--fg-muted);letter-spacing:.04em;text-transform:uppercase;margin-bottom:10px}
+.next-list{list-style:none;margin:0 0 24px;padding:0}
+.next-list li{display:flex;gap:12px;padding:10px 0;border-bottom:1px solid var(--border);font-size:13px;color:var(--fg);align-items:flex-start}
+.next-list li:last-child{border-bottom:none}
+.next-list .nl-n{width:22px;height:22px;flex:none;border-radius:50%;background:var(--brand-soft);color:var(--brand-strong);display:grid;place-items:center;font-size:11.5px;font-weight:700;font-family:var(--font-num);margin-top:1px}
+.next-list .nl-d{font-size:11.5px;color:var(--fg-muted);margin-top:2px}
+[hidden]{display:none !important}
+@media (max-width:900px){
+  .iz-stage{grid-template-columns:1fr}
+  .iz-aside{padding:30px 26px 26px;flex-direction:row;align-items:center;justify-content:space-between;gap:16px}
+  .iz-aside .iz-bs-mid,.iz-aside .iz-bs-foot,.vstep{display:none}
+  .iz-main{padding:32px 22px 48px}
+  .hstep{display:flex}
+}
+@media (max-width:520px){.form-row2{grid-template-columns:1fr}.iz-head,.done-title{font-size:21px}}
+@media (prefers-reduced-motion:reduce){.done-mark{animation:none}}
 </style>
 </head>
 <body>
-<div class="container">
-  <h1>NeNe Invoice</h1>
-  <p class="subtitle">セットアップウィザード</p>
+<div class="iz">
+  <div class="iz-stage">
 
-  <?php if ($reqErrors !== []) : ?>
-  <div class="error">
-    <strong>要件チェック失敗</strong>
-    <ul>
-      <?php foreach ($reqErrors as $e) : ?>
-      <li><?= h($e) ?></li>
-      <?php endforeach; ?>
-    </ul>
+    <aside class="iz-aside">
+      <div class="iz-bs-top">
+        <span class="mono-mark"><?= ico('mono') ?></span>
+        <div><div class="abt-name">NeNe Invoice</div><div class="abt-sub">Setup Wizard</div></div>
+      </div>
+      <div class="iz-bs-mid">
+        <h2>請求業務を、<br>自分の手元で始める。</h2>
+        <p class="lead">適格請求書（インボイス）対応の見積・請求・入金管理。専門知識がなくても、3 ステップでセットアップが完了します。</p>
+        <ul class="vstep">
+          <?php foreach ($vsteps as $i => $s): ?>
+            <li class="<?= $i === $stepIdx ? 'active' : ($i < $stepIdx ? 'done' : '') ?>">
+              <div class="vs-rail"><span class="vs-dot"><?= $i < $stepIdx ? ico('check') : ($i + 1) ?></span><span class="vs-line"></span></div>
+              <div class="vs-body"><div class="vs-t"><?= h($s['t']) ?></div><div class="vs-d"><?= h($s['d']) ?></div></div>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+      <div class="iz-bs-foot">
+        <div class="iz-trust">
+          <span class="tb"><?= ico('shield') ?>適格請求書対応</span>
+          <span class="tb"><?= ico('server') ?>セルフホスト</span>
+          <span class="tb"><?= ico('oss') ?>オープンソース（MIT）</span>
+        </div>
+        <div class="copy">© 2026 NeNe Invoice — install.php</div>
+      </div>
+    </aside>
+
+    <div class="iz-main">
+      <div class="iz-form" id="izView">
+        <div class="hstep">
+          <?php foreach ($vsteps as $i => $s): ?>
+            <div class="hs <?= $i === $stepIdx ? 'active' : ($i < $stepIdx ? 'done' : '') ?>"><?= ($i + 1) . '. ' . h($s['t']) ?></div>
+          <?php endforeach; ?>
+        </div>
+
+        <?php if ($view === 'requirements'): ?>
+        <div class="iz-head">サーバー要件の確認</div>
+        <div class="iz-headsub">インストールを始める前に、サーバーが NeNe Invoice の動作条件を満たしているか確認します。</div>
+
+        <?php if ($reqErrors === []): ?>
+          <div class="alert ok"><?= ico('check') ?><div class="a-body"><div class="a-title">すべての要件を満たしています</div><div class="a-text">このサーバーでインストールを続行できます。</div></div></div>
+        <?php else: ?>
+          <div class="alert error"><?= ico('warn') ?><div class="a-body"><div class="a-title">要件チェックに失敗しました</div><div class="a-text">以下を解消してから、ページを再読み込みしてください。解決後にセットアップを続行できます。</div></div></div>
+        <?php endif; ?>
+
+        <ul class="reqs">
+          <?php foreach ($checks as $c): ?>
+            <li class="<?= $c['ok'] ? 'pass' : 'fail' ?>">
+              <span class="ic"><?= $c['ok'] ? ico('check') : ico('x') ?></span>
+              <div class="rq-body">
+                <div class="rq-t"><?= h($c['label']) ?></div>
+                <div class="rq-d"><?= h($c['detail']) ?></div>
+                <?php if (!$c['ok']): ?><div class="rq-fix"><b>解決方法:</b> <?= $c['fix'] ?></div><?php endif; ?>
+              </div>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+
+        <div class="btn-row">
+          <?php if ($reqErrors === []): ?>
+            <a class="btn btn-primary btn-block" href="install.php?step=1">セットアップを開始<?= ico('arrow') ?></a>
+          <?php else: ?>
+            <a class="btn btn-primary btn-block" href="install.php">再読み込みして再チェック</a>
+          <?php endif; ?>
+        </div>
+
+        <?php elseif ($view === 'database'): ?>
+        <div class="iz-head">データベースに接続</div>
+        <div class="iz-headsub">MySQL の接続情報を入力してください。これらは契約中の<b>レンタルサーバー管理画面（コントロールパネル）の「データベース」欄</b>で確認できます。</div>
+
+        <?php if ($errors !== []): ?>
+          <div class="alert error"><?= ico('warn') ?><div class="a-body"><div class="a-title">データベースに接続できませんでした</div><div class="a-text">ホスト名・ポート・ユーザー名・パスワードをご確認ください。共有サーバーではホスト名が <code>localhost</code> ではなく専用ホスト名のことが多いです。</div><details><summary>技術的な詳細を表示</summary><div class="det"><?= h(implode("\n", $errors)) ?></div></details></div></div>
+        <?php endif; ?>
+
+        <div class="host-help">
+          <div class="hh-q"><?= ico('help') ?>お使いのレンタルサーバーは？</div>
+          <div class="hh-sub">選ぶと、ホスト名の<b>記入例</b>を自動入力します（実際の値はコントロールパネルでご確認ください）。</div>
+          <div class="host-chips" id="hostChips"></div>
+          <button type="button" class="linkbtn cp-toggle" id="cpToggle">コントロールパネルのどこを見る？</button>
+          <div class="cp-diagram" id="cpDiagram" hidden>
+            <div class="cp-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="cp-url">https://cp.your-host.example/database</span></div>
+            <div class="cp-grid">
+              <div class="cp-menu">
+                <div class="cp-mi"><span class="cp-bullet"></span>ドメイン</div>
+                <div class="cp-mi"><span class="cp-bullet"></span>メール</div>
+                <div class="cp-mi hot"><span class="cp-bullet"></span>データベース</div>
+                <div class="cp-mi"><span class="cp-bullet"></span>FTP</div>
+                <div class="cp-mi"><span class="cp-bullet"></span>SSL</div>
+              </div>
+              <div class="cp-body">
+                <div class="cp-h">データベース情報</div>
+                <div class="cp-kv">
+                  <span class="k">ホスト名</span><span class="v hl" id="cpHost">localhost</span>
+                  <span class="k">データベース名</span><span class="v" id="cpDb">yourname_invoice</span>
+                  <span class="k">ユーザー名</span><span class="v" id="cpUser">yourname</span>
+                  <span class="k">ポート</span><span class="v">3306</span>
+                </div>
+                <div class="cp-note" id="cpNote">契約中のレンタルサーバー管理画面（コントロールパネル）の「データベース」欄で確認できます。 黄色の<b>ホスト名</b>を下のフォームにそのまま貼り付けてください。</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <form method="post" action="install.php?step=1" id="dbForm">
+          <div class="form-row2">
+            <div class="field">
+              <label class="label" for="db_host">ホスト<span class="req">*</span>
+                <span class="tip" tabindex="0">?<span class="tip-body">データベースサーバーのアドレス。共有ホスティングでは <code>localhost</code> ではなく専用ホスト名（例 mysqlXXX.example.ne.jp）のことが多いです。</span></span>
+              </label>
+              <input id="db_host" name="db_host" class="input mono" value="<?= $old('db_host', 'localhost') ?>" placeholder="例: mysqlXXX.db.sakura.ne.jp">
+            </div>
+            <div class="field">
+              <label class="label" for="db_port">ポート<span class="req">*</span>
+                <span class="tip" tabindex="0">?<span class="tip-body">通常は MySQL 既定の <code>3306</code> のままで問題ありません。</span></span>
+              </label>
+              <input id="db_port" name="db_port" class="input mono" value="<?= $old('db_port', '3306') ?>">
+            </div>
+          </div>
+          <p class="hint" style="margin-top:-8px;margin-bottom:16px">初期値は <code>localhost</code> / <code>3306</code>。共有サーバーではホストを専用ホスト名に書き換えることが多いです。</p>
+
+          <div class="field">
+            <label class="label" for="db_name">データベース名<span class="req">*</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">コントロールパネルで作成済みのデータベース名。空のデータベースを指定してください（既存データには触れません）。</span></span>
+            </label>
+            <input id="db_name" name="db_name" class="input mono" value="<?= $old('db_name') ?>" placeholder="例: yourname_invoice" required>
+            <p class="hint">事前に作成した<b>空のデータベース</b>を指定します。テーブルはこのインストーラが作成します。</p>
+          </div>
+
+          <div class="field">
+            <label class="label" for="db_user">ユーザー名<span class="req">*</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">そのデータベースにアクセスできる MySQL ユーザー名。コントロールパネルの DB 情報に記載されています。</span></span>
+            </label>
+            <input id="db_user" name="db_user" class="input mono" value="<?= $old('db_user') ?>" placeholder="例: yourname_invoice" required>
+          </div>
+
+          <div class="field">
+            <label class="label" for="db_pass">パスワード<span class="opt">（任意）</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">上記 MySQL ユーザーのパスワード。コントロールパネルで設定／確認できます。<b>NeNe Invoice のログインパスワードとは別物</b>です。</span></span>
+            </label>
+            <div class="pw-wrap">
+              <input id="db_pass" name="db_pass" class="input mono" type="password" value="<?= $old('db_pass') ?>" placeholder="••••••••">
+              <button type="button" class="pw-eye" data-pw="db_pass" tabindex="-1" aria-label="パスワード表示切替"><?= ico('eye') ?></button>
+            </div>
+            <p class="hint">サーバーの DB ユーザーのパスワード。<b>NeNe Invoice のログインパスワードとは別物</b>です。</p>
+          </div>
+
+          <div class="btn-row">
+            <a class="btn btn-ghost btn-back" href="install.php" aria-label="戻る"><?= ico('back') ?></a>
+            <button type="submit" class="btn btn-primary">接続テスト＆スキーマ適用<?= ico('arrow') ?></button>
+          </div>
+        </form>
+
+        <?php elseif ($view === 'admin'): ?>
+        <div class="iz-head">管理者アカウントを作成</div>
+        <div class="iz-headsub">最初の管理者アカウントと、請求書に印字する会社情報を設定します。</div>
+
+        <?php if ($errors !== []): ?>
+          <div class="alert error"><?= ico('warn') ?><div class="a-body"><div class="a-title">入力内容を確認してください</div><div class="a-text"><?= h(implode(' ', $errors)) ?></div></div></div>
+        <?php endif; ?>
+
+        <form method="post" action="install.php?step=2" id="adminForm">
+          <div class="field">
+            <label class="label" for="company_name">会社名（法人名）<span class="req">*</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">適格請求書（インボイス）の<b>発行者名</b>として、見積書・請求書 PDF に印字されます。正式名称を入力してください。後から設定画面で変更できます。</span></span>
+            </label>
+            <input id="company_name" name="company_name" class="input<?= isset($fieldErrors['company']) ? ' is-error' : '' ?>" value="<?= $old('company_name') ?>" placeholder="例: 株式会社ねね商事" required>
+            <?php if (isset($fieldErrors['company'])): ?><p class="err-text"><?= ico('warn') ?><?= h($fieldErrors['company']) ?></p><?php else: ?><p class="hint">請求書 PDF に発行者として印字されます（後から変更可）。</p><?php endif; ?>
+          </div>
+
+          <div class="field">
+            <label class="label" for="admin_email">管理者メールアドレス<span class="req">*</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">最初の管理者（admin）アカウントのログイン ID になります。運用担当者のメールを推奨します。</span></span>
+            </label>
+            <input id="admin_email" name="admin_email" class="input<?= isset($fieldErrors['email']) ? ' is-error' : '' ?>" value="<?= $old('admin_email') ?>" placeholder="例: admin@yourcompany.co.jp" required>
+            <?php if (isset($fieldErrors['email'])): ?><p class="err-text"><?= ico('warn') ?><?= h($fieldErrors['email']) ?></p><?php else: ?><p class="hint">このメールが<b>最初の管理者ログイン ID</b> になります。</p><?php endif; ?>
+          </div>
+
+          <div class="field">
+            <label class="label" for="admin_password">管理者パスワード<span class="opt">（8 文字以上）</span><span class="req">*</span>
+              <span class="tip" tabindex="0">?<span class="tip-body">8 文字以上。パスワードは安全にハッシュ化して保存され、元の文字列は保持されません。<b>DB 接続パスワードとは別物</b>です。</span></span>
+            </label>
+            <div class="pw-wrap">
+              <input id="admin_password" name="admin_password" class="input<?= isset($fieldErrors['pw']) ? ' is-error' : '' ?>" type="password" placeholder="8 文字以上" required minlength="8">
+              <button type="button" class="pw-eye" data-pw="admin_password" tabindex="-1" aria-label="パスワード表示切替"><?= ico('eye') ?></button>
+            </div>
+            <?php if (isset($fieldErrors['pw'])): ?><p class="err-text"><?= ico('warn') ?><?= h($fieldErrors['pw']) ?></p><?php else: ?><p class="hint">8 文字以上。<b>ハッシュ化して安全に保管</b>されます（元の文字列は保存されません）。</p><?php endif; ?>
+          </div>
+
+          <div class="btn-row">
+            <a class="btn btn-ghost btn-back" href="install.php?step=1" aria-label="戻る"><?= ico('back') ?></a>
+            <button type="submit" class="btn btn-primary">インストールを実行<?= ico('arrow') ?></button>
+          </div>
+        </form>
+
+        <?php else: /* complete */ ?>
+        <div class="done-mark"><?= ico('check') ?></div>
+        <div class="done-title">インストール完了</div>
+        <div class="done-sub">NeNe Invoice のセットアップが完了しました。管理画面にログインして、最初の請求書を作成しましょう。</div>
+
+        <div class="sec-warn">
+          <span class="sw-ico"><?= ico('trash') ?></span>
+          <div>
+            <div class="sw-t">セキュリティ: 必ず install.php を削除してください</div>
+            <div class="sw-d">放置すると第三者に再セットアップされる恐れがあります。FTP またはファイルマネージャから <code>install.php</code> を<b>削除（またはリネーム）</b>してください。</div>
+          </div>
+        </div>
+
+        <div class="next-h">次のステップ</div>
+        <ol class="next-list">
+          <li><span class="nl-n">1</span><div><b><code>install.php</code> を削除する</b><div class="nl-d">最優先。サーバーからこのファイルを消します。</div></div></li>
+          <li><span class="nl-n">2</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>
+          <li><span class="nl-n">3</span><div><b>会社情報・登録番号・銀行口座を設定</b><div class="nl-d">最初の見積書・請求書を作成できます。</div></div></li>
+        </ol>
+
+        <a class="btn btn-primary btn-block btn-lg" href="./"><?= ico('login') ?>管理画面にログイン</a>
+        <?php endif; ?>
+      </div>
+
+      <!-- ローディング（フォーム送信中に JS で表示） -->
+      <div class="iz-form iz-loading" id="izLoading" hidden>
+        <div class="ld-h">インストールしています</div>
+        <div class="ld-sub">接続の確認からテーブル作成までを順に実行しています。完了までこのページを開いたままにしてください。</div>
+        <div class="ld-bar"><span id="ldBar"></span></div>
+        <ul class="substeps" id="substeps">
+          <li data-ss class="ss-pending"><span class="ss-ic"></span><div><div class="ss-t">接続を確認しています</div><div class="ss-d">データベースサーバーへ接続</div></div><span class="ss-meta">待機中</span></li>
+          <li data-ss class="ss-pending"><span class="ss-ic"></span><div><div class="ss-t">テーブルを作成しています</div><div class="ss-d">スキーマを適用中</div></div><span class="ss-meta">待機中</span></li>
+          <li data-ss class="ss-pending"><span class="ss-ic"></span><div><div class="ss-t">設定を保存しています</div><div class="ss-d">.env を書き出し中</div></div><span class="ss-meta">待機中</span></li>
+        </ul>
+        <div class="ld-warn"><?= ico('warn') ?>このページを閉じたり、ボタンを二度押ししないでください。</div>
+      </div>
+    </div>
   </div>
-  <?php return; endif; ?>
-
-  <div class="steps">
-    <div class="step <?= $step === 1 ? 'active' : ($step > 1 ? 'done' : '') ?>">1. データベース</div>
-    <div class="step <?= $step === 2 ? 'active' : ($step > 2 ? 'done' : '') ?>">2. 管理者設定</div>
-    <div class="step <?= $success ? 'done' : '' ?>">3. 完了</div>
-  </div>
-
-  <?php if ($errors !== []) : ?>
-  <div class="error">
-    <ul>
-      <?php foreach ($errors as $e) : ?>
-      <li><?= h($e) ?></li>
-      <?php endforeach; ?>
-    </ul>
-  </div>
-  <?php endif; ?>
-
-  <?php if ($success) : ?>
-  <div class="success">
-    <h2>✓ インストール完了</h2>
-    <p>管理画面にログインしてください。</p>
-    <p style="margin-top:.75rem"><a href="/admin/">管理画面を開く →</a></p>
-    <hr>
-    <p style="font-size:.85rem;color:#555">
-      <strong>セキュリティ:</strong> install.php を削除または .htaccess でアクセス禁止にしてください。
-    </p>
-  </div>
-
-  <?php elseif ($step === 1) : ?>
-  <form method="post" action="install.php?step=1">
-    <p style="font-size:.9rem;color:#555">MySQL の接続情報を入力してください。</p>
-
-    <label for="db_host">ホスト</label>
-    <input type="text" id="db_host" name="db_host" value="<?= h($_POST['db_host'] ?? 'localhost') ?>" required>
-
-    <label for="db_port">ポート</label>
-    <input type="number" id="db_port" name="db_port" value="<?= h((string) ($_POST['db_port'] ?? 3306)) ?>" required>
-
-    <label for="db_name">データベース名</label>
-    <input type="text" id="db_name" name="db_name" value="<?= h($_POST['db_name'] ?? '') ?>" required>
-
-    <label for="db_user">ユーザー名</label>
-    <input type="text" id="db_user" name="db_user" value="<?= h($_POST['db_user'] ?? '') ?>" required>
-
-    <label for="db_pass">パスワード</label>
-    <input type="password" id="db_pass" name="db_pass">
-
-    <button type="submit">接続テスト &amp; スキーマ適用 →</button>
-  </form>
-
-  <?php else : ?>
-  <form method="post" action="install.php?step=2">
-    <p style="font-size:.9rem;color:#555">管理者アカウントと会社情報を設定します。</p>
-
-    <label for="company_name">会社名（法人名）</label>
-    <input type="text" id="company_name" name="company_name" value="<?= h($_POST['company_name'] ?? '') ?>" required>
-
-    <label for="admin_email">管理者メールアドレス</label>
-    <input type="email" id="admin_email" name="admin_email" value="<?= h($_POST['admin_email'] ?? '') ?>" required>
-
-    <label for="admin_password">管理者パスワード（8 文字以上）</label>
-    <input type="password" id="admin_password" name="admin_password" required minlength="8">
-
-    <button type="submit">インストール実行 →</button>
-  </form>
-  <?php endif; ?>
 </div>
+
+<script>
+(function () {
+  // ---- アイコン（チェブロン・スピナー・チェック） ----
+  var CHEVRON = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M5 7.5l5 5 5-5"/></svg>';
+  var CHECK = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5l4 4 8-9"/></svg>';
+  var EYE = <?= json_encode(ico('eye')) ?>;
+  var EYEOFF = <?= json_encode(ico('eyeoff')) ?>;
+
+  // ---- パスワード表示切替 ----
+  document.querySelectorAll('.pw-eye').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var inp = document.getElementById(btn.dataset.pw);
+      if (!inp) return;
+      var show = inp.type === 'password';
+      inp.type = show ? 'text' : 'password';
+      btn.innerHTML = show ? EYEOFF : EYE;
+    });
+  });
+
+  // ---- ホストプリセット + コントロールパネル図（DB 画面のみ） ----
+  var HOSTS = [
+    { id: 'sakura', label: 'さくら', host: 'mysqlXXX.db.sakura.ne.jp', db: 'yourname_invoice', user: 'yourname', note: '「データベース」→ 該当 DB の「データベースサーバ」欄がホスト名です。' },
+    { id: 'heteml', label: 'ヘテムル', host: 'mysqlXXX.heteml.lib', db: '_invoice', user: '_user', note: '「データベース」→「データベース一覧」の「ホスト名（DB サーバー）」を使います。' },
+    { id: 'xserver', label: 'エックスサーバー', host: 'mysqlXXXX.xserver.jp', db: 'yourid_invoice', user: 'yourid_user', note: 'サーバーパネル「MySQL 設定」→「MySQL ホスト名」を確認してください。' },
+    { id: 'conoha', label: 'ConoHa WING', host: 'mysqlXXX.conoha.ne.jp', db: 'yourname_invoice', user: 'yourname', note: '「データベース」→ 対象 DB の「ホスト名」をコピーしてください。' },
+    { id: 'other', label: 'その他 / わからない', host: 'localhost', db: 'yourname_invoice', user: 'yourname', note: '契約中のレンタルサーバー管理画面（コントロールパネル）の「データベース」欄で確認できます。' }
+  ];
+  var chipWrap = document.getElementById('hostChips');
+  if (chipWrap) {
+    var hostInput = document.getElementById('db_host');
+    var cpHost = document.getElementById('cpHost'), cpDb = document.getElementById('cpDb'),
+        cpUser = document.getElementById('cpUser'), cpNote = document.getElementById('cpNote');
+    var apply = function (h, fill) {
+      document.querySelectorAll('.host-chip').forEach(function (c) { c.classList.toggle('on', c.dataset.id === h.id); });
+      if (cpHost) cpHost.textContent = h.host;
+      if (cpDb) cpDb.textContent = h.db || 'yourname_invoice';
+      if (cpUser) cpUser.textContent = h.user || 'yourname';
+      if (cpNote) cpNote.innerHTML = h.note + ' 黄色の<b>ホスト名</b>を下のフォームにそのまま貼り付けてください。';
+      if (fill && hostInput && h.id !== 'other') hostInput.value = h.host;
+    };
+    HOSTS.forEach(function (h) {
+      var b = document.createElement('button');
+      b.type = 'button'; b.className = 'host-chip'; b.dataset.id = h.id; b.textContent = h.label;
+      b.addEventListener('click', function () { apply(h, true); });
+      chipWrap.appendChild(b);
+    });
+
+    var cpToggle = document.getElementById('cpToggle'), cpDiagram = document.getElementById('cpDiagram');
+    cpToggle.innerHTML = 'コントロールパネルのどこを見る？' + CHEVRON;
+    cpToggle.addEventListener('click', function () {
+      var open = cpDiagram.hasAttribute('hidden');
+      if (open) { cpDiagram.removeAttribute('hidden'); cpToggle.classList.add('open'); }
+      else { cpDiagram.setAttribute('hidden', ''); cpToggle.classList.remove('open'); }
+    });
+  }
+
+  // ---- 送信時のローディング表示（接続確認 → テーブル作成 → 設定保存） ----
+  var view = document.getElementById('izView'), loading = document.getElementById('izLoading');
+  function startLoading() {
+    if (!view || !loading) return;
+    view.setAttribute('hidden', '');
+    loading.removeAttribute('hidden');
+    var lis = loading.querySelectorAll('[data-ss]'), bar = document.getElementById('ldBar');
+    var i = 0;
+    var advance = function () {
+      lis.forEach(function (li, n) {
+        li.className = n < i ? 'ss-done' : n === i ? 'ss-active' : 'ss-pending';
+        var ic = li.querySelector('.ss-ic'), meta = li.querySelector('.ss-meta');
+        ic.innerHTML = n < i ? CHECK : n === i ? '<span class="spinner"></span>' : '';
+        meta.textContent = n < i ? '完了' : n === i ? '実行中…' : '待機中';
+      });
+      if (bar) bar.style.width = Math.round((i / lis.length) * 100) + '%';
+    };
+    advance();
+    // サーバー応答までの体感進捗（実際の遷移はサーバー応答で起きる）。
+    [900, 1900, 2900].forEach(function (ms, n) { setTimeout(function () { i = n + 1; advance(); }, ms); });
+  }
+  ['dbForm', 'adminForm'].forEach(function (id) {
+    var f = document.getElementById(id);
+    if (f) f.addEventListener('submit', function () {
+      Array.prototype.forEach.call(f.querySelectorAll('button[type=submit]'), function (b) { b.disabled = true; });
+      startLoading();
+    });
+  });
+})();
+</script>
 </body>
 </html>

--- a/public_html/install.php
+++ b/public_html/install.php
@@ -352,6 +352,17 @@ $vsteps = [
     ['t' => '完了', 'd' => 'セットアップ終了'],
 ];
 
+// レンタルサーバーのホスト記入例プリセット（チップ）。
+$hosts = [
+    ['id' => 'sakura', 'label' => 'さくら', 'host' => 'mysqlXXX.db.sakura.ne.jp', 'db' => 'yourname_invoice', 'user' => 'yourname', 'note' => '「データベース」→ 該当 DB の「データベースサーバ」欄がホスト名です。'],
+    ['id' => 'heteml', 'label' => 'ヘテムル', 'host' => 'mysqlXXX.heteml.lib', 'db' => '_invoice', 'user' => '_user', 'note' => '「データベース」→「データベース一覧」の「ホスト名（DB サーバー）」を使います。'],
+    ['id' => 'xserver', 'label' => 'エックスサーバー', 'host' => 'mysqlXXXX.xserver.jp', 'db' => 'yourid_invoice', 'user' => 'yourid_user', 'note' => 'サーバーパネル「MySQL 設定」→「MySQL ホスト名」を確認してください。'],
+    ['id' => 'conoha', 'label' => 'ConoHa WING', 'host' => 'mysqlXXX.conoha.ne.jp', 'db' => 'yourname_invoice', 'user' => 'yourname', 'note' => '「データベース」→ 対象 DB の「ホスト名」をコピーしてください。'],
+    ['id' => 'other', 'label' => 'その他 / わからない', 'host' => 'localhost', 'db' => 'yourname_invoice', 'user' => 'yourname', 'note' => '契約中のレンタルサーバー管理画面（コントロールパネル）の「データベース」欄で確認できます。'],
+];
+
+$hasError = $errors !== [] || $fieldErrors !== [];
+
 // POST 値の復元用ヘルパー
 $old = static fn (string $k, string $default = ''): string => h($_POST[$k] ?? $default);
 
@@ -572,7 +583,7 @@ code{font-family:var(--font-num)}
 @media (prefers-reduced-motion:reduce){.done-mark{animation:none}}
 </style>
 </head>
-<body>
+<body data-view="<?= h($view) ?>" data-error="<?= $hasError ? '1' : '0' ?>">
 <div class="iz">
   <div class="iz-stage">
 
@@ -653,7 +664,11 @@ code{font-family:var(--font-num)}
         <div class="host-help">
           <div class="hh-q"><?= ico('help') ?>お使いのレンタルサーバーは？</div>
           <div class="hh-sub">選ぶと、ホスト名の<b>記入例</b>を自動入力します（実際の値はコントロールパネルでご確認ください）。</div>
-          <div class="host-chips" id="hostChips"></div>
+          <div class="host-chips" id="hostChips">
+            <?php foreach ($hosts as $hh): ?>
+              <button type="button" class="host-chip" data-id="<?= h($hh['id']) ?>" data-host="<?= h($hh['host']) ?>" data-db="<?= h($hh['db']) ?>" data-user="<?= h($hh['user']) ?>" data-note="<?= h($hh['note']) ?>"><?= h($hh['label']) ?></button>
+            <?php endforeach; ?>
+          </div>
           <button type="button" class="linkbtn cp-toggle" id="cpToggle">コントロールパネルのどこを見る？</button>
           <div class="cp-diagram" id="cpDiagram" hidden>
             <div class="cp-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="cp-url">https://cp.your-host.example/database</span></div>
@@ -749,7 +764,7 @@ code{font-family:var(--font-num)}
             <label class="label" for="admin_email">管理者メールアドレス<span class="req">*</span>
               <span class="tip" tabindex="0">?<span class="tip-body">最初の管理者（admin）アカウントのログイン ID になります。運用担当者のメールを推奨します。</span></span>
             </label>
-            <input id="admin_email" name="admin_email" class="input<?= isset($fieldErrors['email']) ? ' is-error' : '' ?>" value="<?= $old('admin_email') ?>" placeholder="例: admin@yourcompany.co.jp" required>
+            <input id="admin_email" name="admin_email" type="email" class="input<?= isset($fieldErrors['email']) ? ' is-error' : '' ?>" value="<?= $old('admin_email') ?>" placeholder="例: admin@yourcompany.co.jp" required>
             <?php if (isset($fieldErrors['email'])): ?><p class="err-text"><?= ico('warn') ?><?= h($fieldErrors['email']) ?></p><?php else: ?><p class="hint">このメールが<b>最初の管理者ログイン ID</b> になります。</p><?php endif; ?>
           </div>
 
@@ -810,91 +825,6 @@ code{font-family:var(--font-num)}
   </div>
 </div>
 
-<script>
-(function () {
-  // ---- アイコン（チェブロン・スピナー・チェック） ----
-  var CHEVRON = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M5 7.5l5 5 5-5"/></svg>';
-  var CHECK = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5l4 4 8-9"/></svg>';
-  var EYE = <?= json_encode(ico('eye')) ?>;
-  var EYEOFF = <?= json_encode(ico('eyeoff')) ?>;
-
-  // ---- パスワード表示切替 ----
-  document.querySelectorAll('.pw-eye').forEach(function (btn) {
-    btn.addEventListener('click', function () {
-      var inp = document.getElementById(btn.dataset.pw);
-      if (!inp) return;
-      var show = inp.type === 'password';
-      inp.type = show ? 'text' : 'password';
-      btn.innerHTML = show ? EYEOFF : EYE;
-    });
-  });
-
-  // ---- ホストプリセット + コントロールパネル図（DB 画面のみ） ----
-  var HOSTS = [
-    { id: 'sakura', label: 'さくら', host: 'mysqlXXX.db.sakura.ne.jp', db: 'yourname_invoice', user: 'yourname', note: '「データベース」→ 該当 DB の「データベースサーバ」欄がホスト名です。' },
-    { id: 'heteml', label: 'ヘテムル', host: 'mysqlXXX.heteml.lib', db: '_invoice', user: '_user', note: '「データベース」→「データベース一覧」の「ホスト名（DB サーバー）」を使います。' },
-    { id: 'xserver', label: 'エックスサーバー', host: 'mysqlXXXX.xserver.jp', db: 'yourid_invoice', user: 'yourid_user', note: 'サーバーパネル「MySQL 設定」→「MySQL ホスト名」を確認してください。' },
-    { id: 'conoha', label: 'ConoHa WING', host: 'mysqlXXX.conoha.ne.jp', db: 'yourname_invoice', user: 'yourname', note: '「データベース」→ 対象 DB の「ホスト名」をコピーしてください。' },
-    { id: 'other', label: 'その他 / わからない', host: 'localhost', db: 'yourname_invoice', user: 'yourname', note: '契約中のレンタルサーバー管理画面（コントロールパネル）の「データベース」欄で確認できます。' }
-  ];
-  var chipWrap = document.getElementById('hostChips');
-  if (chipWrap) {
-    var hostInput = document.getElementById('db_host');
-    var cpHost = document.getElementById('cpHost'), cpDb = document.getElementById('cpDb'),
-        cpUser = document.getElementById('cpUser'), cpNote = document.getElementById('cpNote');
-    var apply = function (h, fill) {
-      document.querySelectorAll('.host-chip').forEach(function (c) { c.classList.toggle('on', c.dataset.id === h.id); });
-      if (cpHost) cpHost.textContent = h.host;
-      if (cpDb) cpDb.textContent = h.db || 'yourname_invoice';
-      if (cpUser) cpUser.textContent = h.user || 'yourname';
-      if (cpNote) cpNote.innerHTML = h.note + ' 黄色の<b>ホスト名</b>を下のフォームにそのまま貼り付けてください。';
-      if (fill && hostInput && h.id !== 'other') hostInput.value = h.host;
-    };
-    HOSTS.forEach(function (h) {
-      var b = document.createElement('button');
-      b.type = 'button'; b.className = 'host-chip'; b.dataset.id = h.id; b.textContent = h.label;
-      b.addEventListener('click', function () { apply(h, true); });
-      chipWrap.appendChild(b);
-    });
-
-    var cpToggle = document.getElementById('cpToggle'), cpDiagram = document.getElementById('cpDiagram');
-    cpToggle.innerHTML = 'コントロールパネルのどこを見る？' + CHEVRON;
-    cpToggle.addEventListener('click', function () {
-      var open = cpDiagram.hasAttribute('hidden');
-      if (open) { cpDiagram.removeAttribute('hidden'); cpToggle.classList.add('open'); }
-      else { cpDiagram.setAttribute('hidden', ''); cpToggle.classList.remove('open'); }
-    });
-  }
-
-  // ---- 送信時のローディング表示（接続確認 → テーブル作成 → 設定保存） ----
-  var view = document.getElementById('izView'), loading = document.getElementById('izLoading');
-  function startLoading() {
-    if (!view || !loading) return;
-    view.setAttribute('hidden', '');
-    loading.removeAttribute('hidden');
-    var lis = loading.querySelectorAll('[data-ss]'), bar = document.getElementById('ldBar');
-    var i = 0;
-    var advance = function () {
-      lis.forEach(function (li, n) {
-        li.className = n < i ? 'ss-done' : n === i ? 'ss-active' : 'ss-pending';
-        var ic = li.querySelector('.ss-ic'), meta = li.querySelector('.ss-meta');
-        ic.innerHTML = n < i ? CHECK : n === i ? '<span class="spinner"></span>' : '';
-        meta.textContent = n < i ? '完了' : n === i ? '実行中…' : '待機中';
-      });
-      if (bar) bar.style.width = Math.round((i / lis.length) * 100) + '%';
-    };
-    advance();
-    // サーバー応答までの体感進捗（実際の遷移はサーバー応答で起きる）。
-    [900, 1900, 2900].forEach(function (ms, n) { setTimeout(function () { i = n + 1; advance(); }, ms); });
-  }
-  ['dbForm', 'adminForm'].forEach(function (id) {
-    var f = document.getElementById(id);
-    if (f) f.addEventListener('submit', function () {
-      Array.prototype.forEach.call(f.querySelectorAll('button[type=submit]'), function (b) { b.disabled = true; });
-      startLoading();
-    });
-  });
-})();
-</script>
+<script src="installer.js"></script>
 </body>
 </html>

--- a/public_html/installer.js
+++ b/public_html/installer.js
@@ -1,0 +1,161 @@
+/* NeNe Invoice — セットアップウィザード クライアント挙動
+ *
+ * CSP（script-src 'self'）下で動くよう外部ファイル化している（インライン不可）。
+ * 役割: パスワード表示切替 / ホストプリセット & コントロールパネル図 /
+ * 送信時のローディング（実際の疎通確認 + サブステップ進捗アニメーション）。
+ */
+(function () {
+  'use strict';
+
+  var EYE = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10s3-5.5 8-5.5S18 10 18 10s-3 5.5-8 5.5S2 10 2 10z"/><circle cx="10" cy="10" r="2.4"/></svg>';
+  var EYEOFF = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l14 14"/><path d="M8.2 8.3A2.4 2.4 0 0 0 10 12.4M5.5 5.7C3.4 7 2 10 2 10s3 5.5 8 5.5c1.4 0 2.6-.4 3.7-1M16 12.7c1.3-1.3 2-2.7 2-2.7s-3-5.5-8-5.5c-.5 0-1 .05-1.4.13"/></svg>';
+  var CHECK = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 10.5l4 4 8-9"/></svg>';
+  var XMARK = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M5 5l10 10M15 5L5 15"/></svg>';
+  var SPIN = '<span class="spinner"></span>';
+  var CHEVRON = '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M5 7.5l5 5 5-5"/></svg>';
+
+  function el(id) { return document.getElementById(id); }
+
+  /* ---------- パスワード表示切替 ---------- */
+  Array.prototype.forEach.call(document.querySelectorAll('.pw-eye'), function (btn) {
+    btn.addEventListener('click', function () {
+      var inp = el(btn.dataset.pw);
+      if (!inp) { return; }
+      var show = inp.type === 'password';
+      inp.type = show ? 'text' : 'password';
+      btn.innerHTML = show ? EYEOFF : EYE;
+    });
+  });
+
+  /* ---------- ホストプリセット + コントロールパネル図 ---------- */
+  var hostInput = el('db_host');
+  var cpHost = el('cpHost'), cpDb = el('cpDb'), cpUser = el('cpUser'), cpNote = el('cpNote');
+
+  Array.prototype.forEach.call(document.querySelectorAll('.host-chip'), function (chip) {
+    chip.addEventListener('click', function () {
+      Array.prototype.forEach.call(document.querySelectorAll('.host-chip'), function (c) {
+        c.classList.toggle('on', c === chip);
+      });
+      var d = chip.dataset;
+      if (cpHost) { cpHost.textContent = d.host; }
+      if (cpDb) { cpDb.textContent = d.db || 'yourname_invoice'; }
+      if (cpUser) { cpUser.textContent = d.user || 'yourname'; }
+      if (cpNote) { cpNote.innerHTML = d.note + ' 黄色の<b>ホスト名</b>を下のフォームにそのまま貼り付けてください。'; }
+      // 「その他」以外は記入例をホスト欄に流し込む（XXX 部分は要編集）。
+      if (hostInput && d.id !== 'other') { hostInput.value = d.host; }
+    });
+  });
+
+  var cpToggle = el('cpToggle'), cpDiagram = el('cpDiagram');
+  if (cpToggle && cpDiagram) {
+    cpToggle.innerHTML = 'コントロールパネルのどこを見る？' + CHEVRON;
+    cpToggle.addEventListener('click', function () {
+      var open = cpDiagram.hasAttribute('hidden');
+      if (open) { cpDiagram.removeAttribute('hidden'); cpToggle.classList.add('open'); }
+      else { cpDiagram.setAttribute('hidden', ''); cpToggle.classList.remove('open'); }
+    });
+  }
+
+  /* ---------- 送信時のローディング（疎通確認 + 進捗） ---------- */
+  // フォーム別サブステップ。実際の作業（接続・スキーマ・.env）はサーバー側で
+  // 1 リクエストにまとまっているため、各行はアニメーション上の段階表現。
+  // 成否（接続できたか等）は POST 応答の data-error から正しく反映する。
+  var SUBSTEPS = {
+    dbForm: [
+      { t: '接続を確認しています', d: 'データベースサーバーへ接続' },
+      { t: 'テーブルを作成しています', d: 'スキーマを適用中' },
+      { t: '設定を保存しています', d: '.env を書き出し中' }
+    ],
+    adminForm: [
+      { t: '管理者アカウントを作成しています', d: 'ユーザーを登録中' },
+      { t: 'セットアップを完了しています', d: '最終処理中' }
+    ]
+  };
+  var STEP_MS = 720;
+
+  var view = el('izView'), loading = el('izLoading');
+
+  function buildSubsteps(key) {
+    var ul = el('substeps');
+    ul.innerHTML = (SUBSTEPS[key] || SUBSTEPS.dbForm).map(function (s) {
+      return '<li data-ss class="ss-pending"><span class="ss-ic"></span>' +
+        '<div><div class="ss-t">' + s.t + '</div><div class="ss-d">' + s.d + '</div></div>' +
+        '<span class="ss-meta">待機中</span></li>';
+    }).join('');
+    return ul.querySelectorAll('[data-ss]').length;
+  }
+
+  function paint(active, doneAll, failIdx) {
+    var lis = el('substeps').querySelectorAll('[data-ss]');
+    Array.prototype.forEach.call(lis, function (li, n) {
+      var state;
+      if (failIdx === n) { state = 'fail'; }
+      else if (doneAll || n < active) { state = 'done'; }
+      else if (n === active) { state = 'active'; }
+      else { state = 'pending'; }
+      li.className = state === 'fail' ? 'ss-active' : 'ss-' + state;
+      var ic = li.querySelector('.ss-ic'), meta = li.querySelector('.ss-meta');
+      if (state === 'fail') { ic.innerHTML = XMARK; ic.style.color = 'var(--danger)'; meta.textContent = '失敗'; }
+      else if (state === 'done') { ic.innerHTML = CHECK; meta.textContent = '完了'; }
+      else if (state === 'active') { ic.innerHTML = SPIN; meta.textContent = '実行中…'; }
+      else { ic.innerHTML = ''; meta.textContent = '待機中'; }
+    });
+    var bar = el('ldBar');
+    if (bar) { bar.style.width = Math.round(((doneAll ? lis.length : active) / lis.length) * 100) + '%'; }
+  }
+
+  function render(html) {
+    document.open();
+    document.write(html);
+    document.close();
+  }
+
+  function run(form) {
+    var total = buildSubsteps(form.id);
+    view.setAttribute('hidden', '');
+    loading.removeAttribute('hidden');
+
+    var active = 0;
+    paint(active, false);
+    // 体感のための段階送り（最後の行は応答が返るまで「実行中…」のまま保持）。
+    var advancer = setInterval(function () {
+      if (active < total - 1) { active++; paint(active, false); }
+    }, STEP_MS);
+
+    var minDelay = new Promise(function (r) { setTimeout(r, STEP_MS * total + 350); });
+    var request = fetch(form.action, { method: 'POST', body: new FormData(form), credentials: 'same-origin' })
+      .then(function (resp) { return resp.text().then(function (html) { return { resp: resp, html: html }; }); });
+
+    Promise.all([request, minDelay]).then(function (out) {
+      clearInterval(advancer);
+      var resp = out[0].resp, html = out[0].html;
+      var doc = new DOMParser().parseFromString(html, 'text/html');
+      var hadError = doc.body && doc.body.getAttribute('data-error') === '1';
+
+      if (hadError) {
+        // 接続/検証に失敗 → 進行中の段を「失敗」にしてからエラー画面を表示。
+        paint(active, false, active);
+        setTimeout(function () { render(html); }, 650);
+      } else {
+        paint(total, true);
+        setTimeout(function () {
+          if (resp.redirected) { window.location.href = resp.url; }
+          else { render(html); }
+        }, 600);
+      }
+    }).catch(function () {
+      clearInterval(advancer);
+      window.location.reload();
+    });
+  }
+
+  ['dbForm', 'adminForm'].forEach(function (id) {
+    var f = el(id);
+    if (f) {
+      f.addEventListener('submit', function (e) {
+        e.preventDefault();
+        run(f);
+      });
+    }
+  });
+})();


### PR DESCRIPTION
Closes #484

ClaudeDesign 提供のセットアップウィザード（deep-green SaaS テーマ）に合わせ、`public_html/install.php` のプレゼン層を全面刷新。**バックエンドのロジックは完全維持**。

## 構造変更

- **要件チェックを独立画面化**（従来はステップ1のゲート）。合格 → 「セットアップを開始」、不合格 → 各項目の修正手順＋再読み込み。
- ルーティング: GET landing=要件 / `?step=1`=DB / `?step=2`=管理者 / 成功=完了。

## デザイン実装

| 要素 | 内容 |
| --- | --- |
| レイアウト | **split**（左ブランドパネル＋縦ステッパー＋trust バッジ／右フォーム）。モバイルは横ステッパーにフォールバック |
| DB 画面 | **ホストプリセットチップ**（さくら/ヘテムル/Xserver/ConoHa/その他）で記入例を自動入力、**コントロールパネル図**（折りたたみ）、パスワード表示切替、フィールド毎ツールチップ |
| 管理者画面 | **フィールド単位エラー**（会社名/メール/パスワード）＋バナー |
| ローディング | 送信時に **接続確認→テーブル作成→設定保存** のサブステップ進捗＋二重送信防止（バニラ JS） |
| 完了画面 | install.php 削除警告を強調＋次のステップ＋ログイン導線（設置ルート相対 `./`） |

- React 依存は撤去しバニラ JS 化。テーマ/レイアウト切替（デザインツールのパネル）は既定（light/split）固定。CSS はインライン（**自己完結 PHP・ビルド不可**の Tier A 制約）。
- 外部フォント `@import` は CSP（`style-src 'self'`）で読めないため不採用、フォントスタックのフォールバックに委ねる。

## バックエンド（維持）

要件チェック・DB 接続・スキーマ適用（`--` コメント分割対応済み #482）・`.env` 書き出し・組織/会社設定/管理者作成・各種ガード・`.installed`。管理者バリデーションのみ、デザインに合わせ**フィールド単位エラー**を返すよう拡張。

## 検証

- インストーラ疑似体験スタック（`compose.installer.yaml`）でクリーン DB に対し: landing（要件・合格）→ DB → 302（スキーマ適用）→ 管理者（per-field バリデーション動作）→ 完了 → `/auth/login` 200 を確認。
- `php -l` / `composer cs` green。
- ブラウザ確認用: `http://localhost:8595/install.php`（新デザインで起動済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)