### PR TITLE
docs(adr): ADR 0016/0018 を accepted に昇格

### DIFF
--- a/docs/adr/0016-conform-to-suite-federation-contract.md
+++ b/docs/adr/0016-conform-to-suite-federation-contract.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-proposed
+accepted (2026-06-19 — conformance to NeNe Suite ADR 0012, accepted 2026-06-19;
+inherits the 2026-05-31 公認会計士・税理士 sign-off and introduces no new compliance
+obligation. The security review of asymmetric assertion verification / key handling is
+an implementation-time follow-up per Suite ADR 0012, not a precondition of this
+decision.)
 
 ## Context
 
@@ -138,7 +142,7 @@ compliance obligation** (no change to immutability, numbering, rounding, retenti
 - Normative contract: **NeNe Suite ADR 0012 (accepted 2026-06-19)** — owns the
   enrollment, JWKS, claim, and roster schema.
 - Issue: `#486`
-- PR: `#000`
+- PR: `#489`
 - Terminology: `docs/explanation/terminology.md` §6 (Suite federation, cross-repo).
 - Related: ADR 0002 (separate from siblings / HTTP-only), ADR 0006 (multi-tenancy /
   roles), ADR 0014 (auth session / cookies), ADR 0015 (location-independent install /

--- a/docs/adr/0018-self-update-via-signed-artifacts-and-origin.md
+++ b/docs/adr/0018-self-update-via-signed-artifacts-and-origin.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-proposed
+accepted (2026-06-19 — direction and boundary decision. The security / failure-mode
+review of the in-process Tier A updater (signature verification, maintenance gate,
+partial-write handling) is an implementation-time follow-up, not a precondition of
+this decision. Announcements + free-tier house ads are deferred to ADR 0019.)
 
 ## Context
 
@@ -188,7 +191,7 @@ ADR being `proposed` does not yet freeze identifiers).
 ## Related
 
 - Issue: `#487`
-- PR: `#000`
+- PR: `#488`
 - Related: ADR 0003 (dual deployment / release ZIP), ADR 0002 (separate from
   siblings / HTTP-only), ADR 0006 (multi-tenancy), ADR 0015 (location-independent
   install), `docs/explanation/accounting-compliance.md` (immutability / numbering),


### PR DESCRIPTION
## 概要
マージ済みの ADR 0016（Suite federation 準拠, #489）と ADR 0018（self-update + private Origin, #488）の `## Status` を `proposed` → `accepted` に昇格し、各 ADR の `PR:` を実 PR 番号で補完。

- **ADR 0016**: Suite ADR 0012（accepted 2026-06-19）への conformance。会計士・税理士 sign-off 継承・新規 compliance 義務なし。IdP/非対称鍵のセキュリティレビューは Suite ADR 0012 で「実装時 follow-up」。
- **ADR 0018**: self-update + private Origin の方向決定。in-process updater のセキュリティ/失敗モードレビューは実装時 follow-up。

## 種別
ドキュメントのみ（status 行 ＋ PR 番号）。コード/スキーマ変更なし。

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)