### PR TITLE
feat(org): external_id によるテナント解決 findByExternalId を追加する (#492)

### DIFF
--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -12,6 +12,14 @@ interface OrganizationRepositoryInterface
 
     public function findByCustomDomain(string $domain): ?Organization;
 
+    /**
+     * Resolve a tenant by its federation link (`organizations.external_id`,
+     * value `org_external_id`; ADR 0016 §2). Suite-mode SSO maps a suite
+     * assertion's `org_external_id` to the local org with this. Returns null in
+     * standalone installs (the column is null there).
+     */
+    public function findByExternalId(string $externalId): ?Organization;
+
     /** @return list<Organization> */
     public function findAll(int $limit, int $offset): array;
 

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -46,6 +46,16 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         return $row !== null ? $this->mapRow($row) : null;
     }
 
+    public function findByExternalId(string $externalId): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE external_id = ?',
+            [$externalId],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
     /** @return list<Organization> */
     public function findAll(int $limit, int $offset): array
     {

--- a/tests/Organization/PdoOrganizationRepositoryTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryTest.php
@@ -125,4 +125,68 @@ final class PdoOrganizationRepositoryTest extends TestCase
         self::assertNull($this->repository->findById($id));
         self::assertSame(0, $this->repository->count());
     }
+
+    public function test_external_id_round_trips_and_resolves(): void
+    {
+        // Suite-first: an org created with its federation link set (ADR 0016 §2).
+        $id = $this->repository->save(new Organization(
+            name: 'Suite Org',
+            slug: 'suite-org',
+            plan: 'free',
+            isActive: true,
+            externalId: 'org-ext-abc',
+        ));
+
+        $byId = $this->repository->findById($id);
+        self::assertNotNull($byId);
+        self::assertSame('org-ext-abc', $byId->externalId);
+
+        $byExternalId = $this->repository->findByExternalId('org-ext-abc');
+        self::assertNotNull($byExternalId);
+        self::assertSame($id, $byExternalId->id);
+    }
+
+    public function test_find_by_external_id_returns_null_when_unset_or_unknown(): void
+    {
+        // Standalone: external_id is null; lookups by a federation UUID find nothing.
+        $this->repository->save(new Organization(name: 'Standalone', slug: 'standalone', plan: 'free', isActive: true));
+
+        self::assertNull($this->repository->findByExternalId('org-ext-missing'));
+    }
+
+    public function test_allows_multiple_organizations_with_null_external_id(): void
+    {
+        // Standalone installs (the default) leave external_id null. The unique
+        // index must NOT collapse multiple null-link orgs (NULLs are distinct).
+        $this->repository->save(new Organization(name: 'Org A', slug: 'org-a', plan: 'free', isActive: true));
+        $this->repository->save(new Organization(name: 'Org B', slug: 'org-b', plan: 'free', isActive: true));
+
+        self::assertSame(2, $this->repository->count());
+    }
+
+    public function test_external_id_is_unique_when_set(): void
+    {
+        // The federation link is 1:1 — two orgs cannot share one org_external_id
+        // (merge is impossible by construction, ADR 0016 §2). The unique index
+        // enforces this at the DB level.
+        // NOTE: today a constraint violation on save() is surfaced as a slug
+        // conflict (the save() mapping assumes slug is the only business-unique
+        // key); refining this to an external_id-specific error is #495's concern.
+        $this->repository->save(new Organization(
+            name: 'First',
+            slug: 'first',
+            plan: 'free',
+            isActive: true,
+            externalId: 'org-ext-dup',
+        ));
+
+        $this->expectException(OrganizationSlugConflictException::class);
+        $this->repository->save(new Organization(
+            name: 'Second',
+            slug: 'second',
+            plan: 'free',
+            isActive: true,
+            externalId: 'org-ext-dup',
+        ));
+    }
 }

--- a/tests/Support/InMemoryOrganizationRepository.php
+++ b/tests/Support/InMemoryOrganizationRepository.php
@@ -45,6 +45,17 @@ final class InMemoryOrganizationRepository implements OrganizationRepositoryInte
         return null;
     }
 
+    public function findByExternalId(string $externalId): ?Organization
+    {
+        foreach ($this->byId as $organization) {
+            if ($organization->externalId === $externalId) {
+                return $organization;
+            }
+        }
+
+        return null;
+    }
+
     /** @return list<Organization> */
     public function findAll(int $limit, int $offset): array
     {


### PR DESCRIPTION
Closes #492

## 概要

Suite federation（ADR 0016 §2）に向けて、`organizations.external_id` をキーにテナントを解決する `findByExternalId()` をリポジトリに追加する。suite モードの SSO で、suite アサーションの `org_external_id` をローカル org に対応付ける用途。standalone install では `external_id` は null のため、検索しても null を返す。

`external_id` 列・unique index・schema parity（MySQL / SQLite）は既存（#20 で導入済み）。本 PR は解決メソッドとその境界テストを追加する。

## 変更

- `OrganizationRepositoryInterface::findByExternalId(string): ?Organization`
- `PdoOrganizationRepository` / `InMemoryOrganizationRepository`（テスト support）に実装
- 境界テスト 4 件: round-trip / 未設定・未知 → null / 複数 null 許容（NULL は distinct）/ set 時の 1:1 一意性

> 注: set 時の一意制約違反は現状 slug conflict として表面化する（save() のマッピングが slug を唯一の業務一意キーと仮定）。external_id 専用エラーへの精緻化は #495 の範囲。

## federation エピック上の位置

#492（本 PR）→ #493 NENE_SUITE_MODE → #494 アサーション検証 + JIT → #495 join/leave + 組織リンク UI。

## セルフレビュー

`docs/review/backend-api.md` に準拠（命名は terminology レジストリと一致、org スコープ、`composer check` green）。