### PR TITLE
test: 全機能のバックエンド UT に境界値ケースを拡充する (#499)

### DIFF
--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -95,6 +95,27 @@ final class LoginUseCaseTest extends TestCase
         $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.7'));
     }
 
+    public function test_login_allowed_just_below_the_failure_ceiling(): void
+    {
+        $throttle = new InMemoryLoginThrottle();
+        for ($i = 0; $i < 9; $i++) {
+            $throttle->recordFailure('203.0.113.10');
+        }
+
+        $useCase = new LoginUseCase(
+            $this->repositoryWithUser('correct-horse'),
+            new LocalBearerTokenVerifier(self::SECRET),
+            $throttle,
+            $this->refreshIssuer(),
+        );
+
+        // 9 failures is one below the ceiling of 10: the correct password
+        // still authenticates (the block is `>= 10`, not `> 10`).
+        $output = $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.10'));
+
+        self::assertNotSame('', $output->token);
+    }
+
     public function test_a_failed_attempt_is_recorded_against_the_ip(): void
     {
         $throttle = new InMemoryLoginThrottle();

--- a/tests/Company/UpdateCompanySettingsHandlerTest.php
+++ b/tests/Company/UpdateCompanySettingsHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Company;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Validation\ValidationException;
+use NeneInvoice\Company\UpdateCompanySettingsHandler;
+use NeneInvoice\Company\UpdateCompanySettingsUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Boundary coverage for the billing-default ranges validated in
+ * {@see UpdateCompanySettingsHandler::validateBillingDefaults} (Issue #268):
+ * validity 1–3650, closing-day 1–31, month-offset 0–12, pay-day 1–31. Null is
+ * always allowed; out-of-range and non-integer values are 422s.
+ */
+final class UpdateCompanySettingsHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryCompanySettingsRepository $repository;
+    private UpdateCompanySettingsHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $holder = new RequestScopedHolder();
+        $holder->set(1);
+        $this->repository = new InMemoryCompanySettingsRepository($holder);
+        $useCase = new UpdateCompanySettingsUseCase(
+            $this->repository,
+            new ImmediateTransactionManager(),
+            fn () => $this->repository,
+            fn () => new RecordingAuditRecorder(),
+            $holder,
+        );
+        $this->handler = new UpdateCompanySettingsHandler($useCase, new JsonResponseFactory($this->psr17, $this->psr17));
+    }
+
+    /** @param array<string, mixed> $body */
+    private function request(array $body): ServerRequestInterface
+    {
+        return $this->psr17->createServerRequest('PUT', '/admin/company-settings')
+            ->withAttribute('nene2.auth.claims', ['sub' => 7, 'org' => 1, 'role' => 'admin'])
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode($body)));
+    }
+
+    #[DataProvider('outOfRangeCases')]
+    public function test_rejects_billing_default_out_of_range(string $field, int $value): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['legal_name' => 'Example KK', $field => $value]));
+    }
+
+    /** @return iterable<string, array{string, int}> */
+    public static function outOfRangeCases(): iterable
+    {
+        yield 'validity below min (0)'    => ['default_quote_validity_days', 0];
+        yield 'validity above max (3651)' => ['default_quote_validity_days', 3651];
+        yield 'closing below min (0)'     => ['default_payment_closing_day', 0];
+        yield 'closing above max (32)'    => ['default_payment_closing_day', 32];
+        yield 'month offset below min'    => ['default_payment_month_offset', -1];
+        yield 'month offset above max'    => ['default_payment_month_offset', 13];
+        yield 'pay day below min (0)'     => ['default_payment_pay_day', 0];
+        yield 'pay day above max (32)'    => ['default_payment_pay_day', 32];
+    }
+
+    #[DataProvider('inRangeBoundaries')]
+    public function test_accepts_billing_default_at_range_boundary(string $field, int $value): void
+    {
+        $response = $this->handler->handle($this->request(['legal_name' => 'Example KK', $field => $value]));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /** @return iterable<string, array{string, int}> */
+    public static function inRangeBoundaries(): iterable
+    {
+        yield 'validity min (1)'      => ['default_quote_validity_days', 1];
+        yield 'validity max (3650)'   => ['default_quote_validity_days', 3650];
+        yield 'closing min (1)'       => ['default_payment_closing_day', 1];
+        yield 'closing max (31)'      => ['default_payment_closing_day', 31];
+        yield 'month offset min (0)'  => ['default_payment_month_offset', 0];
+        yield 'month offset max (12)' => ['default_payment_month_offset', 12];
+        yield 'pay day min (1)'       => ['default_payment_pay_day', 1];
+        yield 'pay day max (31)'      => ['default_payment_pay_day', 31];
+    }
+
+    public function test_null_billing_defaults_are_accepted(): void
+    {
+        $response = $this->handler->handle($this->request([
+            'legal_name'                   => 'Example KK',
+            'default_quote_validity_days'  => null,
+            'default_payment_closing_day'  => null,
+            'default_payment_month_offset' => null,
+            'default_payment_pay_day'      => null,
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_non_integer_billing_default_is_rejected(): void
+    {
+        // A JSON string ("15") is not an int → out_of_range, not silently coerced.
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['legal_name' => 'Example KK', 'default_payment_closing_day' => '15']));
+    }
+}

--- a/tests/Compliance/RegistrationNumberTest.php
+++ b/tests/Compliance/RegistrationNumberTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\Compliance;
 
 use NeneInvoice\Compliance\RegistrationNumber;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RegistrationNumberTest extends TestCase
@@ -21,5 +22,65 @@ final class RegistrationNumberTest extends TestCase
         self::assertFalse(RegistrationNumber::isValid('T12345678901234')); // 14 digits
         self::assertFalse(RegistrationNumber::isValid('TABCDEFGHIJKLM'));  // letters
         self::assertFalse(RegistrationNumber::isValid(''));
+    }
+
+    /**
+     * Digit-count boundary around the required exactly-13. The valid case sits
+     * at 13; every neighbour (12 below, 14 above, and the degenerate 0/1) fails.
+     */
+    #[DataProvider('digitCountCases')]
+    public function test_digit_count_boundary(string $value, bool $expected): void
+    {
+        self::assertSame($expected, RegistrationNumber::isValid($value));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function digitCountCases(): iterable
+    {
+        yield 'T + 0 digits'  => ['T', false];
+        yield 'T + 1 digit'   => ['T1', false];
+        yield 'T + 12 digits' => ['T123456789012', false];
+        yield 'T + 13 digits' => ['T1234567890123', true];
+        yield 'T + 14 digits' => ['T12345678901234', false];
+        yield 'T + 15 digits' => ['T123456789012345', false];
+    }
+
+    /**
+     * Character-class and anchoring boundary: the prefix is a case-sensitive
+     * uppercase T, the 13 body characters must all be ASCII digits, and the
+     * `^...$` anchors reject any surrounding whitespace (length stays 14).
+     */
+    #[DataProvider('characterCases')]
+    public function test_character_and_anchoring_boundary(string $value, bool $expected): void
+    {
+        self::assertSame($expected, RegistrationNumber::isValid($value));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function characterCases(): iterable
+    {
+        yield 'lowercase t prefix'   => ['t1234567890123', false];
+        yield 'space inside digits'  => ['T123456 890123', false];
+        yield 'hyphen inside digits' => ['T123456-890123', false];
+        yield 'dot inside digits'    => ['T123456.890123', false];
+        yield 'letter inside digits' => ['T12345678901X3', false];
+        yield 'leading whitespace'   => [' T1234567890123', false];
+        yield 'trailing whitespace'  => ['T1234567890123 ', false];
+        yield 'all valid (control)'  => ['T0000000000000', true];
+    }
+
+    /**
+     * Known quirk, asserted to current behavior (not a desired outcome): the
+     * pattern anchors the tail with `$`, which in PCRE matches *before* a single
+     * trailing newline — so "T…\n" is accepted. Hardening to `\z` is a separate
+     * production change (see follow-up issue). This test documents the boundary
+     * so a future `\z` fix flips it deliberately rather than silently.
+     */
+    public function test_trailing_newline_is_currently_accepted(): void
+    {
+        self::assertTrue(RegistrationNumber::isValid("T1234567890123\n"));
+        // A newline anywhere but the very end is still rejected.
+        self::assertFalse(RegistrationNumber::isValid("T1234567890123\n\n"));
+        self::assertFalse(RegistrationNumber::isValid("\nT1234567890123"));
     }
 }

--- a/tests/DocumentSequence/DocumentNumberGeneratorTest.php
+++ b/tests/DocumentSequence/DocumentNumberGeneratorTest.php
@@ -9,8 +9,10 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\DocumentSequence\DocumentNumberGenerator;
+use NeneInvoice\DocumentSequence\DocumentSequenceRepositoryInterface;
 use NeneInvoice\DocumentSequence\DocumentType;
 use NeneInvoice\DocumentSequence\PdoDocumentSequenceRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DocumentNumberGeneratorTest extends TestCase
@@ -66,5 +68,41 @@ final class DocumentNumberGeneratorTest extends TestCase
         self::assertSame('EST-2027-001', $this->generator->next(DocumentType::Quote, 2027));
         // Original counter continues.
         self::assertSame('EST-2026-002', $this->generator->next(DocumentType::Quote, 2026));
+    }
+
+    /**
+     * The `%03d` format is a *minimum* width, not a cap: 1..999 are zero-padded
+     * to three digits, and the sequence rolls over to four+ digits past 999
+     * (EST-2026-1000) rather than truncating or wrapping. Uses a stub repository
+     * to drive exact sequence values without allocating a thousand rows.
+     */
+    #[DataProvider('formatCases')]
+    public function test_pads_to_three_digits_and_does_not_cap_past_999(int $sequence, string $expected): void
+    {
+        $generator = new DocumentNumberGenerator(new class ($sequence) implements DocumentSequenceRepositoryInterface {
+            public function __construct(private int $sequence)
+            {
+            }
+
+            public function nextNumber(string $docType, int $year): int
+            {
+                return $this->sequence;
+            }
+        });
+
+        self::assertSame($expected, $generator->next(DocumentType::Quote, 2026));
+    }
+
+    /** @return iterable<string, array{int, string}> */
+    public static function formatCases(): iterable
+    {
+        yield '1 -> 001'       => [1, 'EST-2026-001'];
+        yield '9 -> 009'       => [9, 'EST-2026-009'];
+        yield '10 -> 010'      => [10, 'EST-2026-010'];
+        yield '99 -> 099'      => [99, 'EST-2026-099'];
+        yield '100 -> 100'     => [100, 'EST-2026-100'];
+        yield '999 -> 999'     => [999, 'EST-2026-999'];
+        yield '1000 -> 1000'   => [1000, 'EST-2026-1000'];
+        yield '12345 -> 12345' => [12345, 'EST-2026-12345'];
     }
 }

--- a/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
+++ b/tests/Invoice/ConvertQuoteToInvoiceUseCaseTest.php
@@ -18,6 +18,7 @@ use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
@@ -77,12 +78,23 @@ final class ConvertQuoteToInvoiceUseCaseTest extends TestCase
         self::assertSame('invoice.created', $this->audit->records[0]['action']);
     }
 
-    public function test_rejects_non_accepted_quote(): void
+    /** Only an accepted quote converts; every other status is rejected. */
+    #[DataProvider('nonAcceptedStatuses')]
+    public function test_rejects_conversion_of_non_accepted_quote(QuoteStatus $status): void
     {
-        $quoteId = $this->quote(QuoteStatus::Sent);
+        $quoteId = $this->quote($status);
 
         $this->expectException(QuoteValidationException::class);
         $this->useCase->execute(7, $quoteId);
+    }
+
+    /** @return iterable<string, array{QuoteStatus}> */
+    public static function nonAcceptedStatuses(): iterable
+    {
+        yield 'draft'    => [QuoteStatus::Draft];
+        yield 'sent'     => [QuoteStatus::Sent];
+        yield 'rejected' => [QuoteStatus::Rejected];
+        yield 'expired'  => [QuoteStatus::Expired];
     }
 
     public function test_rejects_re_conversion_of_already_converted_quote(): void

--- a/tests/Invoice/CreateInvoiceUseCaseTest.php
+++ b/tests/Invoice/CreateInvoiceUseCaseTest.php
@@ -18,6 +18,7 @@ use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CreateInvoiceUseCaseTest extends TestCase
@@ -105,5 +106,122 @@ final class CreateInvoiceUseCaseTest extends TestCase
             clientId: $clientId,
             lines: [new LineItemInput('Std', 1, 1000, 500)],
         ));
+    }
+
+    /** Only 800/1000 bps are allowed; every adjacent value is rejected (§3). */
+    #[DataProvider('disallowedTaxRates')]
+    public function test_rejects_tax_rate_outside_allowed_set(int $rateBps): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1, 1000, $rateBps)],
+        ));
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function disallowedTaxRates(): iterable
+    {
+        yield '0 bps'            => [0];
+        yield '799 (below 8%)'   => [799];
+        yield '801 (above 8%)'   => [801];
+        yield '999 (below 10%)'  => [999];
+        yield '1001 (above 10%)' => [1001];
+        yield '2000 (20%)'       => [2000];
+        yield 'negative'         => [-800];
+    }
+
+    #[DataProvider('allowedTaxRates')]
+    public function test_accepts_allowed_tax_rate(int $rateBps): void
+    {
+        $clientId = $this->client();
+
+        $result = $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1, 1000, $rateBps)],
+        ));
+
+        self::assertSame(InvoiceStatus::Draft, $result->invoice->status);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function allowedTaxRates(): iterable
+    {
+        yield '8% (lower boundary)'  => [800];
+        yield '10% (upper boundary)' => [1000];
+    }
+
+    public function test_rejects_zero_quantity(): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 0, 1000, 1000)],
+        ));
+    }
+
+    public function test_rejects_negative_quantity(): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', -1, 1000, 1000)],
+        ));
+    }
+
+    public function test_accepts_minimum_quantity_of_one(): void
+    {
+        $clientId = $this->client();
+
+        $result = $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1, 1000, 1000)],
+        ));
+
+        self::assertSame(1000, $result->invoice->subtotalCents);
+    }
+
+    public function test_accepts_large_quantity_without_overflow(): void
+    {
+        $clientId = $this->client();
+
+        $result = $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1_000_000, 1000, 1000)],
+        ));
+
+        self::assertSame(1_000_000_000, $result->invoice->subtotalCents);
+        self::assertSame(100_000_000, $result->invoice->taxCents);
+    }
+
+    public function test_rejects_negative_unit_price(): void
+    {
+        $clientId = $this->client();
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1, -1, 1000)],
+        ));
+    }
+
+    public function test_accepts_zero_unit_price(): void
+    {
+        $clientId = $this->client();
+
+        // Zero is the lower boundary of the >= 0 rule (free/discount lines).
+        $result = $this->useCase->execute(7, new CreateInvoiceInput(
+            clientId: $clientId,
+            lines: [new LineItemInput('X', 1, 0, 1000)],
+        ));
+
+        self::assertSame(0, $result->invoice->subtotalCents);
+        self::assertSame(0, $result->invoice->taxCents);
     }
 }

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -25,6 +25,7 @@ use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class IssueInvoiceUseCaseTest extends TestCase
@@ -177,5 +178,47 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $this->expectException(InvoiceNotFoundException::class);
         $this->holder->set(2);
         $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
+    }
+
+    public function test_non_qualified_issue_succeeds_even_when_registration_configured(): void
+    {
+        // The registration number is required only for qualified invoices; a
+        // non-qualified issue must still succeed when one happens to be set.
+        $this->registerIssuer();
+        $id = $this->draftInvoice();
+
+        $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: false));
+
+        self::assertSame(InvoiceStatus::Issued, $result->invoice->status);
+        self::assertFalse($result->invoice->isQualifiedInvoice);
+    }
+
+    /** Only a draft is issuable; issued/partially_paid/paid are all immutable. */
+    #[DataProvider('nonDraftStatuses')]
+    public function test_non_draft_invoice_cannot_be_issued(InvoiceStatus $status): void
+    {
+        $this->registerIssuer();
+        $id = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: 5,
+            status: $status,
+            subtotalCents: 2000,
+            taxCents: 200,
+            totalCents: 2200,
+        ));
+        $this->lineItems->replaceForParent(LineItemParent::Invoice, $id, [
+            new LineItem(LineItemParent::Invoice, $id, 'Std', 1, 2000, 1000, sortOrder: 0),
+        ]);
+
+        $this->expectException(InvoiceValidationException::class);
+        $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: true));
+    }
+
+    /** @return iterable<string, array{InvoiceStatus}> */
+    public static function nonDraftStatuses(): iterable
+    {
+        yield 'issued'         => [InvoiceStatus::Issued];
+        yield 'partially_paid' => [InvoiceStatus::PartiallyPaid];
+        yield 'paid'           => [InvoiceStatus::Paid];
     }
 }

--- a/tests/InvoiceDownloadToken/InvoiceDownloadTokenTest.php
+++ b/tests/InvoiceDownloadToken/InvoiceDownloadTokenTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\InvoiceDownloadToken;
+
+use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadToken;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class InvoiceDownloadTokenTest extends TestCase
+{
+    /**
+     * Expiry is inclusive of the boundary (`expiresAt <= now`): the exact expiry
+     * instant is already expired, one second earlier is still valid.
+     */
+    #[DataProvider('expiryCases')]
+    public function test_is_expired(string $now, bool $expected): void
+    {
+        $token = new InvoiceDownloadToken(
+            invoiceId: 1,
+            organizationId: 1,
+            tokenHash: 'hash',
+            expiresAt: '2026-06-13 12:00:00',
+            createdAt: '2026-06-06 12:00:00',
+        );
+
+        self::assertSame($expected, $token->isExpired($now));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function expiryCases(): iterable
+    {
+        yield 'one second before -> valid'   => ['2026-06-13 11:59:59', false];
+        yield 'exactly at expiry -> expired' => ['2026-06-13 12:00:00', true];
+        yield 'one second after -> expired'  => ['2026-06-13 12:00:01', true];
+    }
+}

--- a/tests/Item/ImportItemsCsvUseCaseTest.php
+++ b/tests/Item/ImportItemsCsvUseCaseTest.php
@@ -149,4 +149,57 @@ final class ImportItemsCsvUseCaseTest extends TestCase
         self::assertFalse($result->accepted);
         self::assertNotNull($result->formatError);
     }
+
+    public function test_zero_price_is_accepted(): void
+    {
+        // 0 is the lower boundary of the non-negative rule (ctype_digit('0') is true).
+        $result = $this->useCase()->execute(1, $this->csv([
+            ['items/v1', '', 'Free sample', '0', '10'],
+        ]), false);
+
+        self::assertTrue($result->accepted);
+        self::assertSame(1, $result->created);
+        self::assertSame(0, $this->repo->findForExport(new ItemListFilter())[0]->defaultUnitPriceCents);
+    }
+
+    public function test_large_price_is_accepted(): void
+    {
+        $result = $this->useCase()->execute(1, $this->csv([
+            ['items/v1', '', 'Pricey', '999999999', '10'],
+        ]), false);
+
+        self::assertTrue($result->accepted);
+        self::assertSame(999999999, $this->repo->findForExport(new ItemListFilter())[0]->defaultUnitPriceCents);
+    }
+
+    public function test_empty_description_is_rejected_as_required(): void
+    {
+        $result = $this->useCase()->execute(1, $this->csv([
+            ['items/v1', '', '', '100', '10'],
+        ]), false);
+
+        self::assertFalse($result->accepted);
+        self::assertSame('required', $result->errors[0]['code']);
+    }
+
+    public function test_empty_price_is_rejected_as_required(): void
+    {
+        $result = $this->useCase()->execute(1, $this->csv([
+            ['items/v1', '', 'x', '', '10'],
+        ]), false);
+
+        self::assertFalse($result->accepted);
+        self::assertSame('required', $result->errors[0]['code']);
+    }
+
+    public function test_id_zero_is_treated_as_not_found(): void
+    {
+        // id '0' parses as a digit but no item 0 exists → not-found (not invalid_id).
+        $result = $this->useCase()->execute(1, $this->csv([
+            ['items/v1', '0', 'x', '100', '10'],
+        ]), false);
+
+        self::assertFalse($result->accepted);
+        self::assertSame('item_not_found', $result->errors[0]['code']);
+    }
 }

--- a/tests/LineItem/TaxCalculatorTest.php
+++ b/tests/LineItem/TaxCalculatorTest.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Tests\LineItem;
 
 use NeneInvoice\LineItem\LineItemInput;
 use NeneInvoice\LineItem\TaxCalculator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class TaxCalculatorTest extends TestCase
@@ -88,5 +89,77 @@ final class TaxCalculatorTest extends TestCase
         ]);
 
         self::assertSame(1, $result->taxCents);
+    }
+
+    /**
+     * Half-up rounding flips just-below vs just-above the tie point, for both
+     * statutory rates (ADR 0004). 10% has exact .5-cent ties (at 5¢, 15¢);
+     * 8% never lands exactly on .5 so the flip sits between two integers.
+     */
+    #[DataProvider('roundingBoundaryCases')]
+    public function test_half_up_rounding_boundary(int $unitPriceCents, int $rateBps, int $expectedTaxCents): void
+    {
+        $result = $this->calculator->calculate([
+            new LineItemInput('X', 1, $unitPriceCents, $rateBps),
+        ]);
+
+        self::assertSame($expectedTaxCents, $result->taxCents);
+    }
+
+    /** @return iterable<string, array{int, int, int}> */
+    public static function roundingBoundaryCases(): iterable
+    {
+        // 10% (1000 bps): flip 0→1 at the 0.5¢ tie (5¢); the tie rounds up.
+        yield '10% 4c -> 0 (below half)'  => [4, 1000, 0];
+        yield '10% 5c -> 1 (exact half)'  => [5, 1000, 1];
+        yield '10% 6c -> 1 (above half)'  => [6, 1000, 1];
+        yield '10% 14c -> 1 (below 1.5)'  => [14, 1000, 1];
+        yield '10% 15c -> 2 (exact 1.5)'  => [15, 1000, 2];
+        // 8% (800 bps): flip 0→1 between 6¢ (0.48) and 7¢ (0.56) — no exact tie.
+        yield '8% 6c -> 0 (below half)'   => [6, 800, 0];
+        yield '8% 7c -> 1 (above half)'   => [7, 800, 1];
+        // 8% flip 1→2 between 18¢ (1.44) and 19¢ (1.52).
+        yield '8% 18c -> 1 (below 1.5)'   => [18, 800, 1];
+        yield '8% 19c -> 2 (above 1.5)'   => [19, 800, 2];
+    }
+
+    public function test_zero_amount_line_contributes_zero_tax(): void
+    {
+        // A zero-priced line is valid input (use cases reject only negatives).
+        $result = $this->calculator->calculate([
+            new LineItemInput('Free sample', 1, 0, 1000),
+        ]);
+
+        self::assertSame(0, $result->subtotalCents);
+        self::assertSame(0, $result->taxCents);
+        self::assertSame(0, $result->totalCents);
+        self::assertCount(1, $result->breakdown);
+        self::assertSame(0, $result->breakdown[0]->taxCents);
+    }
+
+    public function test_zero_line_mixed_with_non_zero_line(): void
+    {
+        // The zero line joins its rate group without changing the rounded tax.
+        $result = $this->calculator->calculate([
+            new LineItemInput('Free', 1, 0, 1000),
+            new LineItemInput('Paid', 1, 1000, 1000),
+        ]);
+
+        self::assertSame(1000, $result->subtotalCents);
+        self::assertSame(100, $result->taxCents);
+        self::assertSame(1100, $result->totalCents);
+        self::assertCount(1, $result->breakdown);
+    }
+
+    public function test_large_amount_does_not_overflow(): void
+    {
+        // ¥999,999,999 × 10% = ¥99,999,999.9 → half-up → ¥100,000,000.
+        $result = $this->calculator->calculate([
+            new LineItemInput('Big', 1, 999_999_999, 1000),
+        ]);
+
+        self::assertSame(999_999_999, $result->subtotalCents);
+        self::assertSame(100_000_000, $result->taxCents);
+        self::assertSame(1_099_999_999, $result->totalCents);
     }
 }

--- a/tests/Payment/RecordPaymentUseCaseTest.php
+++ b/tests/Payment/RecordPaymentUseCaseTest.php
@@ -182,4 +182,71 @@ final class RecordPaymentUseCaseTest extends TestCase
         $this->holder->set(2);
         $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000));
     }
+
+    public function test_one_cent_short_of_total_stays_partially_paid(): void
+    {
+        // Boundary just below full: status uses `>=`, so total-1 is partial.
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2199));
+
+        self::assertSame(InvoiceStatus::PartiallyPaid, $result->invoice->status);
+        self::assertSame(2199, $result->totalPaidCents);
+    }
+
+    public function test_exact_payment_equal_to_total_is_paid(): void
+    {
+        // Boundary at full: total exactly flips to paid (not over-payment).
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2200));
+
+        self::assertSame(InvoiceStatus::Paid, $result->invoice->status);
+    }
+
+    public function test_cumulative_crossing_the_full_boundary_exactly(): void
+    {
+        // 2199 (partial) then the final 1¢ lands exactly on the total → paid.
+        $id = $this->issuedInvoice(2200);
+
+        $partial = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 2199));
+        self::assertSame(InvoiceStatus::PartiallyPaid, $partial->invoice->status);
+
+        $full = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1));
+        self::assertSame(InvoiceStatus::Paid, $full->invoice->status);
+        self::assertSame(2200, $full->totalPaidCents);
+    }
+
+    public function test_idempotent_replay_ignores_a_different_amount(): void
+    {
+        // The replay returns the original payment verbatim; the new amount on the
+        // retried request is ignored (it never double-books or re-validates).
+        $id = $this->issuedInvoice(2200);
+        $first = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 800, idempotencyKey: 'k1'));
+        $second = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 500, idempotencyKey: 'k1'));
+
+        self::assertSame($first->payment->id, $second->payment->id);
+        self::assertSame(800, $second->payment->amountCents);
+        self::assertSame(800, $this->payments->totalPaidForInvoice($id));
+    }
+
+    public function test_paid_at_today_is_accepted(): void
+    {
+        // The future-date guard compares JST calendar dates; today (the fixed
+        // clock's JST date, 2026-06-06) is the inclusive upper boundary.
+        $id = $this->issuedInvoice(2200);
+
+        $result = $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000, paidAt: '2026-06-06'));
+
+        self::assertSame('2026-06-06', $result->payment->paidAt);
+    }
+
+    public function test_paid_at_tomorrow_is_rejected(): void
+    {
+        // One day past the fixed clock's JST date → future → rejected.
+        $id = $this->issuedInvoice(2200);
+
+        $this->expectException(PaymentValidationException::class);
+        $this->useCase->execute(7, $id, new RecordPaymentInput(amountCents: 1000, paidAt: '2026-06-07'));
+    }
 }

--- a/tests/PaymentLink/PaymentLinkTest.php
+++ b/tests/PaymentLink/PaymentLinkTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\PaymentLink;
+
+use NeneInvoice\PaymentLink\PaymentLink;
+use NeneInvoice\PaymentLink\PaymentLinkStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentLinkTest extends TestCase
+{
+    private function link(PaymentLinkStatus $status, string $expiresAt): PaymentLink
+    {
+        return new PaymentLink(
+            organizationId: 1,
+            invoiceId: 1,
+            tokenHash: 'hash',
+            gateway: 'payjp',
+            status: $status,
+            expiresAt: $expiresAt,
+        );
+    }
+
+    /**
+     * Expiry is inclusive of the boundary: `isExpired` uses `<=`, so the exact
+     * expiry instant is already expired.
+     */
+    #[DataProvider('expiryCases')]
+    public function test_is_expired(string $now, bool $expected): void
+    {
+        self::assertSame($expected, $this->link(PaymentLinkStatus::Active, '2026-06-06 12:00:00')->isExpired($now));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function expiryCases(): iterable
+    {
+        yield 'one second before -> not expired' => ['2026-06-06 11:59:59', false];
+        yield 'exactly at expiry -> expired'     => ['2026-06-06 12:00:00', true];
+        yield 'one second after -> expired'      => ['2026-06-06 12:00:01', true];
+    }
+
+    /**
+     * Payable requires Active status AND not-yet-expired; the expiry boundary
+     * and any non-Active status both make it unpayable.
+     */
+    #[DataProvider('payableCases')]
+    public function test_is_payable(PaymentLinkStatus $status, string $now, bool $expected): void
+    {
+        self::assertSame($expected, $this->link($status, '2026-06-06 12:00:00')->isPayable($now));
+    }
+
+    /** @return iterable<string, array{PaymentLinkStatus, string, bool}> */
+    public static function payableCases(): iterable
+    {
+        yield 'active before expiry'  => [PaymentLinkStatus::Active, '2026-06-06 11:59:59', true];
+        yield 'active at expiry'      => [PaymentLinkStatus::Active, '2026-06-06 12:00:00', false];
+        yield 'active after expiry'   => [PaymentLinkStatus::Active, '2026-06-06 12:00:01', false];
+        yield 'paid before expiry'    => [PaymentLinkStatus::Paid, '2026-06-06 11:59:59', false];
+        yield 'revoked before expiry' => [PaymentLinkStatus::Revoked, '2026-06-06 11:59:59', false];
+    }
+}

--- a/tests/Quote/ChangeQuoteStatusUseCaseTest.php
+++ b/tests/Quote/ChangeQuoteStatusUseCaseTest.php
@@ -86,6 +86,47 @@ final class ChangeQuoteStatusUseCaseTest extends TestCase
         $this->useCase->execute(7, $id, QuoteStatus::Rejected);
     }
 
+    public function test_sent_to_rejected_is_allowed(): void
+    {
+        $id = $this->draft();
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
+
+        $quote = $this->useCase->execute(7, $id, QuoteStatus::Rejected);
+        self::assertSame(QuoteStatus::Rejected, $quote->status);
+    }
+
+    public function test_sent_to_expired_is_allowed(): void
+    {
+        $id = $this->draft();
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
+
+        $quote = $this->useCase->execute(7, $id, QuoteStatus::Expired);
+        self::assertSame(QuoteStatus::Expired, $quote->status);
+    }
+
+    public function test_rejected_is_terminal(): void
+    {
+        $id = $this->draft();
+        $this->useCase->execute(7, $id, QuoteStatus::Sent);
+        $this->useCase->execute(7, $id, QuoteStatus::Rejected);
+
+        $this->expectException(InvalidStateTransitionException::class);
+        $this->useCase->execute(7, $id, QuoteStatus::Accepted);
+    }
+
+    public function test_issued_at_is_set_once_and_preserved_across_transitions(): void
+    {
+        $id = $this->draft();
+
+        $sent = $this->useCase->execute(7, $id, QuoteStatus::Sent);
+        $issuedAt = $sent->issuedAt;
+        self::assertNotNull($issuedAt);
+
+        // Accepting must not re-stamp issued_at (it marks first-send only).
+        $accepted = $this->useCase->execute(7, $id, QuoteStatus::Accepted);
+        self::assertSame($issuedAt, $accepted->issuedAt);
+    }
+
     public function test_cross_organization_quote_not_found(): void
     {
         $id = $this->draft();

--- a/tests/Quote/CreateQuoteUseCaseTest.php
+++ b/tests/Quote/CreateQuoteUseCaseTest.php
@@ -24,6 +24,7 @@ use NeneInvoice\Tests\Support\InMemoryDocumentSequenceRepository;
 use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
 use NeneInvoice\Tests\Support\InMemoryQuoteRepository;
 use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CreateQuoteUseCaseTest extends TestCase
@@ -145,5 +146,82 @@ final class CreateQuoteUseCaseTest extends TestCase
     {
         $this->expectException(QuoteValidationException::class);
         $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, 500)]));
+    }
+
+    /** Only 800/1000 bps are allowed; every adjacent value is rejected (§3). */
+    #[DataProvider('disallowedTaxRates')]
+    public function test_rejects_tax_rate_outside_allowed_set(int $rateBps): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, $rateBps)]));
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function disallowedTaxRates(): iterable
+    {
+        yield '0 bps'              => [0];
+        yield '799 (below 8%)'     => [799];
+        yield '801 (above 8%)'     => [801];
+        yield '999 (below 10%)'    => [999];
+        yield '1001 (above 10%)'   => [1001];
+        yield '2000 (20%)'         => [2000];
+        yield 'negative'           => [-800];
+    }
+
+    #[DataProvider('allowedTaxRates')]
+    public function test_accepts_allowed_tax_rate(int $rateBps): void
+    {
+        $result = $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, $rateBps)]));
+
+        self::assertSame(QuoteStatus::Draft, $result->quote->status);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function allowedTaxRates(): iterable
+    {
+        yield '8% (lower boundary)'  => [800];
+        yield '10% (upper boundary)' => [1000];
+    }
+
+    public function test_rejects_zero_quantity(): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 0, 1000, 1000)]));
+    }
+
+    public function test_rejects_negative_quantity(): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', -1, 1000, 1000)]));
+    }
+
+    public function test_accepts_minimum_quantity_of_one(): void
+    {
+        $result = $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 1000, 1000)]));
+
+        self::assertSame(1000, $result->quote->subtotalCents);
+    }
+
+    public function test_accepts_large_quantity_without_overflow(): void
+    {
+        $result = $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1_000_000, 1000, 1000)]));
+
+        self::assertSame(1_000_000_000, $result->quote->subtotalCents);
+        self::assertSame(100_000_000, $result->quote->taxCents);
+    }
+
+    public function test_rejects_negative_unit_price(): void
+    {
+        $this->expectException(QuoteValidationException::class);
+        $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, -1, 1000)]));
+    }
+
+    public function test_accepts_zero_unit_price(): void
+    {
+        // Zero is the lower boundary of the >= 0 rule (free/discount lines).
+        $result = $this->useCase->execute(1, new CreateQuoteInput($this->clientId, [new LineItemInput('X', 1, 0, 1000)]));
+
+        self::assertSame(0, $result->quote->subtotalCents);
+        self::assertSame(0, $result->quote->taxCents);
     }
 }

--- a/tests/Quote/QuoteStatusTest.php
+++ b/tests/Quote/QuoteStatusTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Quote;
+
+use NeneInvoice\Quote\QuoteStatus;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class QuoteStatusTest extends TestCase
+{
+    /**
+     * Exhaustive 5×5 transition matrix. Only draft→sent and
+     * sent→{accepted,rejected,expired} are legal; self-transitions and every
+     * move out of a terminal state (accepted/rejected/expired) are illegal.
+     */
+    #[DataProvider('transitionMatrix')]
+    public function test_can_transition_to(QuoteStatus $from, QuoteStatus $to, bool $expected): void
+    {
+        self::assertSame($expected, $from->canTransitionTo($to));
+    }
+
+    /** @return iterable<string, array{QuoteStatus, QuoteStatus, bool}> */
+    public static function transitionMatrix(): iterable
+    {
+        $legal = ['Draft->Sent', 'Sent->Accepted', 'Sent->Rejected', 'Sent->Expired'];
+
+        foreach (QuoteStatus::cases() as $from) {
+            foreach (QuoteStatus::cases() as $to) {
+                $key = $from->name . '->' . $to->name;
+                yield $key => [$from, $to, in_array($key, $legal, true)];
+            }
+        }
+    }
+
+    public function test_terminal_states_have_no_outgoing_transitions(): void
+    {
+        foreach ([QuoteStatus::Accepted, QuoteStatus::Rejected, QuoteStatus::Expired] as $terminal) {
+            foreach (QuoteStatus::cases() as $target) {
+                self::assertFalse(
+                    $terminal->canTransitionTo($target),
+                    sprintf('%s must be terminal but allowed → %s', $terminal->name, $target->name),
+                );
+            }
+        }
+    }
+
+    public function test_no_state_can_transition_to_itself(): void
+    {
+        foreach (QuoteStatus::cases() as $state) {
+            self::assertFalse($state->canTransitionTo($state), $state->name . ' allowed a self-transition');
+        }
+    }
+}

--- a/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
+++ b/tests/ServiceApi/ListServiceInvoicesHandlerTest.php
@@ -98,4 +98,96 @@ final class ListServiceInvoicesHandlerTest extends TestCase
         self::assertCount(1, $body['items']);
         self::assertSame('INV-OPEN', $body['items'][0]['invoice_number']);
     }
+
+    public function test_multiple_status_values_are_all_included(): void
+    {
+        $body = $this->listBody($this->seedOpenAndPaid(), ['status' => 'issued,paid']);
+
+        self::assertSame(2, $body['total']);
+    }
+
+    public function test_invalid_status_token_is_silently_dropped(): void
+    {
+        // Contract §2.1: unknown status tokens are ignored, not rejected.
+        $body = $this->listBody($this->seedOpenAndPaid(), ['status' => 'issued,bogus']);
+
+        self::assertSame(1, $body['total']);
+        self::assertIsArray($body['items']);
+        self::assertSame('INV-OPEN', $body['items'][0]['invoice_number']);
+    }
+
+    public function test_empty_status_applies_no_status_filter(): void
+    {
+        $body = $this->listBody($this->seedOpenAndPaid(), ['status' => '']);
+
+        self::assertSame(2, $body['total']);
+    }
+
+    public function test_client_id_filter_narrows_results(): void
+    {
+        $body = $this->listBody($this->seedOpenAndPaid(), ['client_id' => '9']);
+
+        self::assertSame(1, $body['total']);
+        self::assertIsArray($body['items']);
+        self::assertSame('INV-PAID', $body['items'][0]['invoice_number']);
+    }
+
+    public function test_non_numeric_client_id_is_ignored(): void
+    {
+        $body = $this->listBody($this->seedOpenAndPaid(), ['client_id' => 'abc']);
+
+        self::assertSame(2, $body['total']);
+    }
+
+    public function test_outstanding_gt_selects_only_open_invoices(): void
+    {
+        // outstanding_gt=0 = "open receivables"; the fully-paid invoice is excluded.
+        $body = $this->listBody($this->seedOpenAndPaid(), ['outstanding_gt' => '0']);
+
+        self::assertSame(1, $body['total']);
+        self::assertIsArray($body['items']);
+        self::assertSame('INV-OPEN', $body['items'][0]['invoice_number']);
+    }
+
+    public function test_offset_beyond_total_returns_empty_page_but_real_total(): void
+    {
+        $body = $this->listBody($this->seedOpenAndPaid(), ['limit' => '10', 'offset' => '100']);
+
+        self::assertSame(2, $body['total']);
+        self::assertSame([], $body['items']);
+    }
+
+    private function seedOpenAndPaid(): InMemoryInvoiceRepository
+    {
+        $invoices = new InMemoryInvoiceRepository();
+        $invoices->save(new Invoice(organizationId: 1, clientId: 5, status: InvoiceStatus::Issued, subtotalCents: 2000, taxCents: 0, totalCents: 2000, invoiceNumber: 'INV-OPEN', issuedAt: '2026-02-01 00:00:00'));
+        $invoices->save(new Invoice(organizationId: 1, clientId: 9, status: InvoiceStatus::Paid, subtotalCents: 1000, taxCents: 0, totalCents: 1000, invoiceNumber: 'INV-PAID', issuedAt: '2026-01-01 00:00:00'));
+
+        return $invoices;
+    }
+
+    /**
+     * Drives the handler with the given query params and returns the decoded body.
+     *
+     * @param array<string, string> $query
+     * @return array<string, mixed>
+     */
+    private function listBody(InMemoryInvoiceRepository $invoices, array $query): array
+    {
+        $psr17 = new Psr17Factory();
+        $handler = new ListServiceInvoicesHandler(
+            new ListInvoicesUseCase($invoices, new InMemoryPaymentRepository()),
+            new JsonResponseFactory($psr17, $psr17),
+            new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        $request = $psr17->createServerRequest('GET', '/api/invoices')
+            ->withQueryParams($query)
+            ->withAttribute('nene2.auth.claims', ['org' => 1, 'scopes' => ['read:invoices']]);
+
+        $body = json_decode((string) $handler->handle($request)->getBody(), true);
+        self::assertIsArray($body);
+
+        return $body;
+    }
 }

--- a/tests/Support/CsvImportTest.php
+++ b/tests/Support/CsvImportTest.php
@@ -66,4 +66,49 @@ final class CsvImportTest extends TestCase
         self::assertFalse($parse->rows[1]['well_formed']); // 3 cells vs 2
         self::assertSame(4, $parse->rows[1]['line']); // blank line 3 was skipped
     }
+
+    public function test_accepts_upload_exactly_at_byte_cap_and_rejects_one_over(): void
+    {
+        // The cap is `strlen > maxBytes`: exactly at the cap is accepted, one over rejected.
+        $csv = "__template,name\nclients/v1,Acme\n";
+        $size = strlen($csv);
+
+        $atCap = CsvImport::parse($csv, self::HEADER, maxRows: 5000, maxBytes: $size);
+        self::assertNull($atCap->formatError);
+
+        $overByOne = CsvImport::parse($csv, self::HEADER, maxRows: 5000, maxBytes: $size - 1);
+        self::assertNotNull($overByOne->formatError);
+        self::assertStringContainsString('ファイルサイズ', $overByOne->formatError);
+    }
+
+    public function test_accepts_exactly_max_rows_and_rejects_one_more(): void
+    {
+        // The cap is `count(rows) > maxRows`: exactly maxRows is accepted, +1 rejected.
+        $header = "__template,name\n";
+
+        $atCap = CsvImport::parse($header . "c/v1,A\nc/v1,B\n", self::HEADER, maxRows: 2);
+        self::assertNull($atCap->formatError);
+        self::assertCount(2, $atCap->rows);
+
+        $over = CsvImport::parse($header . "c/v1,A\nc/v1,B\nc/v1,C\n", self::HEADER, maxRows: 2);
+        self::assertNotNull($over->formatError);
+        self::assertStringContainsString('行数', $over->formatError);
+    }
+
+    public function test_rejects_truly_empty_file(): void
+    {
+        $parse = CsvImport::parse('', self::HEADER);
+
+        self::assertNotNull($parse->formatError);
+        self::assertStringContainsString('空', $parse->formatError);
+    }
+
+    public function test_header_only_is_accepted_with_zero_rows(): void
+    {
+        // Contrast with the truly-empty case: a header and no data rows is valid.
+        $parse = CsvImport::parse("__template,name\n", self::HEADER);
+
+        self::assertNull($parse->formatError);
+        self::assertSame([], $parse->rows);
+    }
 }

--- a/tests/User/PasswordPolicyTest.php
+++ b/tests/User/PasswordPolicyTest.php
@@ -24,6 +24,13 @@ final class PasswordPolicyTest extends TestCase
         PasswordPolicy::assert(str_repeat('a', PasswordPolicy::MIN_LENGTH - 1));
     }
 
+    public function test_accepts_a_password_at_the_maximum_length(): void
+    {
+        PasswordPolicy::assert(str_repeat('a', PasswordPolicy::MAX_LENGTH));
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function test_rejects_a_password_above_the_maximum_length(): void
     {
         $this->expectException(ValidationException::class);


### PR DESCRIPTION
Closes #499

## 概要

バックエンド UT に **境界値ケース**を全機能横断で厚く追加する。境界の just-inside / just-outside の両側（off-by-one、許容集合の隣接値、ゼロ/負値、ちょうど上限/下限、状態遷移の全マトリクス、ページング端、日付境界）を確認する。**test-only**（本番コード変更なし）。日付依存は `FixedClock`(2026-06-06T03:00:00Z) を基準に決定的。

`564 → 716 tests`（**+152**）/ `composer check` green（PHPUnit + PHPStan + cs + openapi + mcp）。

## 追加した境界（ドメイン別）

**税/コンプラ**
- 税率: 許容集合 {800,1000} の隣接 `799/801/999/1001`・`0`・`2000`・負値を reject、`800/1000` を accept（Quote/Invoice 両 UseCase）
- 数量: `0`/`-1` reject、`1`(下限) / `1,000,000`(大量・非オーバーフロー) accept
- 単価: `-1` reject、`0`(下限) accept
- 半額丸め(ADR 0004): 10% `4¢→0 / 5¢→1 / 6¢→1`、8% `6¢→0 / 7¢→1` ほか 1.5 近傍、零額行・大額(¥999,999,999→税¥100,000,000)
- 登録番号 T+13: 桁数 `0/1/12/13/14/15`、文字種（小文字 t・空白・記号・前後空白）

**見積/請求ライフサイクル**
- `QuoteStatus` 5×5 遷移マトリクス（合法4・非合法21）＋終端状態＋自己遷移
- 変換ゲート: `draft/sent/rejected/expired` は全て reject（accepted のみ可）
- 発行ゲート: `issued/partially_paid/paid` は発行不可、非適格は登録番号があっても発行可
- 採番フォーマット: `%03d` は最小幅（999→`1000` でロールオーバー、cap なし）

**入金/ServiceAPI**
- 部分↔完済の `total-1`(部分) / `total`(完済) 境界、累積でちょうど完済
- 冪等リプレイ（同キーで金額違い → 元の支払を返し二重計上しない）
- `paid_at` 当日(受理) / 翌日(reject) 境界
- `PaymentLink::isExpired/isPayable` の満了同時刻境界（`<=`）＋ status 組合せ
- ServiceAPI フィルタ: 複数 status / 不正 status は黙殺 / 空 status / client_id 数値・非数値 / outstanding_gt=0 / offset 末尾超過

**認証/会社**
- 会社請求デフォルト範囲: 有効日数 `1–3650`・締め日 `1–31`・月オフセット `0–12`・支払日 `1–31` の両側＋null＋非整数（**従来ゼロ被覆**）
- login throttle 上限手前（`9` 回は許可、ceiling は `>=10`）
- パスワード最大長ちょうど `256`(accept)

**品目/CSV/トークン**
- 品目 CSV: 価格 `0`(accept)・大額・必須空（品目名/価格）・`id=0`→not found
- CsvImport: 行数ちょうど(maxRows) / +1、バイト数ちょうど(maxBytes) / -1、真の空ファイル vs ヘッダのみ
- DownloadToken `isExpired` 満了同時刻境界

## 派生 issue

境界値確認の過程で `RegistrationNumber::PATTERN` が**末尾改行を受理**する PCRE `$` クォークを発見（`T1234567890123\n` が valid）。test-only の本 PR では現挙動を `RegistrationNumberTest::test_trailing_newline_is_currently_accepted` に記録し、本番修正（`$`→`\z`）は **#500** として別途起票。

## セルフレビュー

`docs/review/backend-api.md` / `docs/review/compliance.md`（税・採番・入金の境界は会計コンプラ正本に整合、識別子は terminology レジストリと一致）。PHPUnit 13 の `#[DataProvider]` 属性使用、FixedClock 基準で日付決定的。