### PR TITLE
fix(compliance): 登録番号バリデータの末尾改行受理を解消する (#500)

### DIFF
--- a/src/Compliance/RegistrationNumber.php
+++ b/src/Compliance/RegistrationNumber.php
@@ -11,10 +11,14 @@ namespace NeneInvoice\Compliance;
  * (see `docs/explanation/accounting-compliance.md` §4).
  *
  * Used by both the buyer (Client) and the issuer (CompanySettings).
+ *
+ * The tail is anchored with `\z` (absolute end of string), not `$`: in PCRE `$`
+ * also matches *before* a trailing newline, which would let "T…\n" slip through
+ * as valid (#500). `\z` enforces the exact T+13 form with nothing after it.
  */
 final class RegistrationNumber
 {
-    public const PATTERN = '/^T[0-9]{13}$/';
+    public const PATTERN = '/^T[0-9]{13}\z/';
 
     public static function isValid(string $value): bool
     {

--- a/tests/Compliance/RegistrationNumberTest.php
+++ b/tests/Compliance/RegistrationNumberTest.php
@@ -48,7 +48,8 @@ final class RegistrationNumberTest extends TestCase
     /**
      * Character-class and anchoring boundary: the prefix is a case-sensitive
      * uppercase T, the 13 body characters must all be ASCII digits, and the
-     * `^...$` anchors reject any surrounding whitespace (length stays 14).
+     * `^...\z` anchors reject any surrounding whitespace — including a trailing
+     * newline, which a `$` anchor would have let through (#500).
      */
     #[DataProvider('characterCases')]
     public function test_character_and_anchoring_boundary(string $value, bool $expected): void
@@ -59,28 +60,26 @@ final class RegistrationNumberTest extends TestCase
     /** @return iterable<string, array{string, bool}> */
     public static function characterCases(): iterable
     {
-        yield 'lowercase t prefix'   => ['t1234567890123', false];
-        yield 'space inside digits'  => ['T123456 890123', false];
-        yield 'hyphen inside digits' => ['T123456-890123', false];
-        yield 'dot inside digits'    => ['T123456.890123', false];
-        yield 'letter inside digits' => ['T12345678901X3', false];
-        yield 'leading whitespace'   => [' T1234567890123', false];
-        yield 'trailing whitespace'  => ['T1234567890123 ', false];
-        yield 'all valid (control)'  => ['T0000000000000', true];
+        yield 'lowercase t prefix'    => ['t1234567890123', false];
+        yield 'space inside digits'   => ['T123456 890123', false];
+        yield 'hyphen inside digits'  => ['T123456-890123', false];
+        yield 'dot inside digits'     => ['T123456.890123', false];
+        yield 'letter inside digits'  => ['T12345678901X3', false];
+        yield 'leading whitespace'    => [' T1234567890123', false];
+        yield 'trailing whitespace'   => ['T1234567890123 ', false];
+        yield 'trailing newline'      => ["T1234567890123\n", false];
+        yield 'leading newline'       => ["\nT1234567890123", false];
+        yield 'embedded newline'      => ["T1234567890123\n\n", false];
+        yield 'all valid (control)'   => ['T0000000000000', true];
     }
 
     /**
-     * Known quirk, asserted to current behavior (not a desired outcome): the
-     * pattern anchors the tail with `$`, which in PCRE matches *before* a single
-     * trailing newline — so "T…\n" is accepted. Hardening to `\z` is a separate
-     * production change (see follow-up issue). This test documents the boundary
-     * so a future `\z` fix flips it deliberately rather than silently.
+     * Regression for #500: the `\z` tail anchor rejects a value with a trailing
+     * newline. A `$` anchor matches before a final newline in PCRE, which used to
+     * accept "T…\n"; this guards against that hardening being reverted.
      */
-    public function test_trailing_newline_is_currently_accepted(): void
+    public function test_trailing_newline_is_rejected(): void
     {
-        self::assertTrue(RegistrationNumber::isValid("T1234567890123\n"));
-        // A newline anywhere but the very end is still rejected.
-        self::assertFalse(RegistrationNumber::isValid("T1234567890123\n\n"));
-        self::assertFalse(RegistrationNumber::isValid("\nT1234567890123"));
+        self::assertFalse(RegistrationNumber::isValid("T1234567890123\n"));
     }
 }


### PR DESCRIPTION
Closes #500

## 概要

`RegistrationNumber::PATTERN` の末尾アンカーを `$` → `\z` に変更し、登録番号（T+13桁）の検証が**末尾改行付きの値を受理してしまう**問題を解消する。

PCRE では `$` が文字列末尾の単一改行の直前にもマッチするため、`"T1234567890123\n"` が `isValid()` で `true` になっていた（#499 の境界値テスト拡充中に発見）。`\z`（文字列の絶対末尾）に変更し、T+13 の厳密一致を強制して後続文字を一切許容しない。

## 変更

- `src/Compliance/RegistrationNumber.php`: `/^T[0-9]{13}$/` → `/^T[0-9]{13}\z/`
- `tests/Compliance/RegistrationNumberTest.php`:
  - #499 で現挙動を記録していた `test_trailing_newline_is_currently_accepted`（true 期待）を `test_trailing_newline_is_rejected`（false）へ反転＝回帰テスト化
  - `characterCases` に `trailing newline` / `leading newline` / `embedded newline` を `false` で追加

## コンプライアンス

ルール本体（**T + 13桁・構文のみ**、`accounting-compliance.md` §4）は不変。会計挙動は変わらず、本来 invalid であるべき不正入力を正しく弾くだけの厳密化のため、税理士サインオフは不要（`docs/review/compliance.md` 準拠）。buyer(Client) / issuer(CompanySettings) 共通の単一実装に一括適用される。

## 確認

`composer check` green（723 tests / PHPStan 0 / cs / openapi / mcp）。