### PR TITLE
feat(recurring): 定期請求スケジュールの永続化レイヤを追加する (#503)

### DIFF
--- a/database/migrations/20260627000000_create_recurring_invoices_table.php
+++ b/database/migrations/20260627000000_create_recurring_invoices_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateRecurringInvoicesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('recurring_invoices')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('client_id', 'integer', ['null' => false])
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('frequency', 'string', ['limit' => 16, 'null' => false])
+            ->addColumn('subtotal_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('tax_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('total_cents', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('next_run_on', 'date', ['null' => false])
+            ->addColumn('last_run_on', 'date', ['null' => true])
+            ->addColumn('is_active', 'boolean', ['null' => false, 'default' => true])
+            ->addColumn('notes', 'text', ['null' => true])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_recurring_invoices_organization_id'])
+            ->addIndex(['organization_id', 'is_active', 'next_run_on'], ['name' => 'idx_recurring_invoices_due'])
+            ->create();
+    }
+}

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -300,3 +300,29 @@ CREATE TABLE IF NOT EXISTS `templates` (
     `updated_at`      DATETIME     NOT NULL,
     KEY `idx_templates_organization_id` (`organization_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- recurring_invoices — recurring-billing schedules (#503). Generates an invoice
+-- every period (顧問料・保守費・管理料・月謝). Line template lives in line_items;
+-- next_run_on/last_run_on are calendar dates. frequency: monthly | quarterly.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `recurring_invoices` (
+    `id`              INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id` INT          NOT NULL,
+    `client_id`       INT          NOT NULL,
+    `name`            VARCHAR(255) NOT NULL,
+    `frequency`       VARCHAR(16)  NOT NULL,
+    `subtotal_cents`  INT          NOT NULL DEFAULT 0,
+    `tax_cents`       INT          NOT NULL DEFAULT 0,
+    `total_cents`     INT          NOT NULL DEFAULT 0,
+    `next_run_on`     DATE         NOT NULL,
+    `last_run_on`     DATE         DEFAULT NULL,
+    `is_active`       TINYINT(1)   NOT NULL DEFAULT 1,
+    `notes`           TEXT         DEFAULT NULL,
+    `is_deleted`      TINYINT(1)   NOT NULL DEFAULT 0,
+    `deleted_at`      DATETIME     DEFAULT NULL,
+    `created_at`      DATETIME     NOT NULL,
+    `updated_at`      DATETIME     NOT NULL,
+    KEY `idx_recurring_invoices_organization_id` (`organization_id`),
+    KEY `idx_recurring_invoices_due` (`organization_id`, `is_active`, `next_run_on`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/schema/recurring_invoices.sql
+++ b/database/schema/recurring_invoices.sql
@@ -1,0 +1,26 @@
+-- Schema snapshot for the recurring_invoices table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- A recurring_invoice is a billing schedule (#503) that generates an invoice every
+-- period (顧問料・保守費・管理料・月謝). The line template lives in line_items; totals are
+-- integer cents (ADR 0004). next_run_on / last_run_on are calendar dates (like valid_until).
+-- frequency: monthly | quarterly. Generation/issue are separate, compliance-reviewed concerns.
+CREATE TABLE IF NOT EXISTS recurring_invoices (
+    id              INTEGER      NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER      NOT NULL,
+    client_id       INTEGER      NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    frequency       VARCHAR(16)  NOT NULL,
+    subtotal_cents  INTEGER      NOT NULL DEFAULT 0,
+    tax_cents       INTEGER      NOT NULL DEFAULT 0,
+    total_cents     INTEGER      NOT NULL DEFAULT 0,
+    next_run_on     DATE         NOT NULL,
+    last_run_on     DATE,
+    is_active       BOOLEAN      NOT NULL DEFAULT 1,
+    notes           TEXT,
+    is_deleted      BOOLEAN      NOT NULL DEFAULT 0,
+    deleted_at      DATETIME,
+    created_at      DATETIME     NOT NULL,
+    updated_at      DATETIME     NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_recurring_invoices_organization_id ON recurring_invoices (organization_id);
+CREATE INDEX IF NOT EXISTS idx_recurring_invoices_due ON recurring_invoices (organization_id, is_active, next_run_on);

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -46,6 +46,7 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 | Payment link | `PaymentLink` | `payment_links` | `payment_link_id` |
 | Number generator | `DocumentSequence` | `document_sequences` | — |
 | Integration credential | `ServiceToken` | `service_tokens` | `service_token_id` |
+| Recurring billing | `RecurringInvoice` | `recurring_invoices` | `recurring_invoice_id` |
 
 Domain folders are **PascalCase singular**; tables are **snake_case plural**.
 
@@ -68,6 +69,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | service_token status (computed) | `active`, `revoked` |
 | `payment_link.status` | `active`, `paid`, `revoked` (expiry derived from `expires_at`, not stored) |
 | `payment_link.gateway` | `payjp` (launch gateway — ADR 0013) |
+| `recurring_invoice.frequency` | `monthly`, `quarterly` (#503) |
 | `company_settings.pdf_template` | `standard` (default), `modern`, `classic` (見積/請求 PDF レイアウト — Issue #449) |
 | `company_settings.pdf_spacing` | `small`, `medium` (default), `large` (PDF 余白スケール大中小 — Issue #449) |
 | `company_settings.pdf_heading_font` | `gothic` (default), `mincho` (PDF 見出しフォント — Issue #449) |
@@ -109,6 +111,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Billing defaults (issuer) | `default_quote_validity_days`, `default_payment_closing_day`, `default_payment_month_offset`, `default_payment_pay_day` | `quote_validity`, `closing_day`, `payment_site`, `pay_day`, `net_days` |
 | Client fields | `name_kana`, `contact_name`, `billing_address` | `kana`, `furigana`, `name_reading`, `contact`, `address` |
 | Item master defaults | `default_unit_price_cents`, `default_tax_rate_bps` | `default_price_cents`, `item_price_cents`, `default_rate`, `unit_price` |
+| Recurring-billing fields | `frequency` (values §2), `next_run_on`, `last_run_on` (calendar dates like `valid_until`), `is_active` | `interval`, `cycle`, `next_run`, `last_run`, `active`, `enabled` |
 | Service-token fields | `jti`, `subject`, `label`, `scopes`, `created_by`, `expires_at`, `revoked_at`, `ttl_seconds` | `jwt_id`, `name`, `scope`, `created_user_id`, `expiry`, `revoked`, `ttl` |
 | Payment-link fields | `token_hash`, `gateway`, `gateway_session_id`, `status`, `expires_at`, `paid_at`, `revoked_at` | `token`, `session`, `provider`, `expiry`, `paid`, `revoked` |
 | Gateway-settings fields | `gateway`, `public_key_masked`, `secret_set`, `webhook_token_set`, `configured`, `ok`, `detail` (`connected`/`not_configured`/`invalid_credentials`/`unreachable`) | `secret_key`, `api_key`, `public_key`, `status` |

--- a/src/RecurringInvoice/PdoRecurringInvoiceRepository.php
+++ b/src/RecurringInvoice/PdoRecurringInvoiceRepository.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoRecurringInvoiceRepository implements RecurringInvoiceRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, client_id, name, frequency, subtotal_cents, tax_cents, total_cents, next_run_on, last_run_on, is_active, notes, is_deleted, created_at, updated_at';
+
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function save(RecurringInvoice $schedule): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        // The organization is forced from the request-scoped holder.
+        $this->query->execute(
+            'INSERT INTO recurring_invoices (organization_id, client_id, name, frequency, subtotal_cents, tax_cents, total_cents, next_run_on, last_run_on, is_active, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, ?)',
+            [
+                $this->orgId->get(),
+                $schedule->clientId,
+                $schedule->name,
+                $schedule->frequency->value,
+                $schedule->subtotalCents,
+                $schedule->taxCents,
+                $schedule->totalCents,
+                $schedule->nextRunOn,
+                $schedule->lastRunOn,
+                $schedule->isActive ? 1 : 0,
+                $schedule->notes,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findById(int $id): ?RecurringInvoice
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM recurring_invoices WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<RecurringInvoice> */
+    public function findByOrganization(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM recurring_invoices
+             WHERE organization_id = ? AND is_deleted = FALSE
+             ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$this->orgId->get(), $limit, $offset],
+        );
+
+        return array_map(fn (array $row): RecurringInvoice => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM recurring_invoices WHERE organization_id = ? AND is_deleted = FALSE',
+            [$this->orgId->get()],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    /** @return list<RecurringInvoice> */
+    public function findDue(string $onDate): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM recurring_invoices
+             WHERE organization_id = ? AND is_deleted = FALSE AND is_active = TRUE AND next_run_on <= ?
+             ORDER BY next_run_on ASC, id ASC',
+            [$this->orgId->get(), $onDate],
+        );
+
+        return array_map(fn (array $row): RecurringInvoice => $this->mapRow($row), $rows);
+    }
+
+    public function update(RecurringInvoice $schedule): void
+    {
+        if ($schedule->id === null) {
+            throw new RecurringInvoiceNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE recurring_invoices SET client_id = ?, name = ?, frequency = ?, subtotal_cents = ?, tax_cents = ?, total_cents = ?, next_run_on = ?, last_run_on = ?, is_active = ?, notes = ?, updated_at = ?
+             WHERE id = ? AND organization_id = ? AND is_deleted = FALSE',
+            [
+                $schedule->clientId,
+                $schedule->name,
+                $schedule->frequency->value,
+                $schedule->subtotalCents,
+                $schedule->taxCents,
+                $schedule->totalCents,
+                $schedule->nextRunOn,
+                $schedule->lastRunOn,
+                $schedule->isActive ? 1 : 0,
+                $schedule->notes,
+                $now,
+                $schedule->id,
+                $this->orgId->get(),
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($schedule->id) === null) {
+            throw new RecurringInvoiceNotFoundException($schedule->id);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new RecurringInvoiceNotFoundException($id);
+        }
+
+        $this->query->execute(
+            'UPDATE recurring_invoices SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
+            [date('Y-m-d H:i:s'), $id, $this->orgId->get()],
+        );
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): RecurringInvoice
+    {
+        return new RecurringInvoice(
+            organizationId: (int) $row['organization_id'],
+            clientId: (int) $row['client_id'],
+            name: (string) $row['name'],
+            frequency: RecurringFrequency::from((string) $row['frequency']),
+            subtotalCents: (int) $row['subtotal_cents'],
+            taxCents: (int) $row['tax_cents'],
+            totalCents: (int) $row['total_cents'],
+            nextRunOn: (string) $row['next_run_on'],
+            lastRunOn: isset($row['last_run_on']) && $row['last_run_on'] !== '' ? (string) $row['last_run_on'] : null,
+            isActive: (bool) $row['is_active'],
+            notes: isset($row['notes']) && $row['notes'] !== '' ? (string) $row['notes'] : null,
+            isDeleted: (bool) $row['is_deleted'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/RecurringInvoice/RecurringFrequency.php
+++ b/src/RecurringInvoice/RecurringFrequency.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+/**
+ * How often a {@see RecurringInvoice} schedule generates a new invoice
+ * (#503). String values are registered in `docs/explanation/terminology.md` §2.
+ * Date advancement (next_run_on math) lives in the generation use case so the
+ * month-end edge is handled in one place, not here.
+ */
+enum RecurringFrequency: string
+{
+    case Monthly = 'monthly';
+    case Quarterly = 'quarterly';
+}

--- a/src/RecurringInvoice/RecurringInvoice.php
+++ b/src/RecurringInvoice/RecurringInvoice.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+/**
+ * A recurring-billing schedule (#503): a reusable template that generates an
+ * invoice every period (顧問料・保守費・管理料・月謝 等). The line template lives in
+ * `line_items` (polymorphic) and is attached/loaded separately, mirroring how
+ * quotes and invoices keep their rows — totals here are integer cents (ADR 0004),
+ * computed from the template lines by the create use case (a later PR).
+ *
+ * `nextRunOn` / `lastRunOn` are calendar dates (`Y-m-d`), like `valid_until`.
+ * This entity only persists the schedule; generating draft invoices and issuing
+ * them are separate, compliance-reviewed concerns.
+ */
+final readonly class RecurringInvoice
+{
+    public function __construct(
+        public int $organizationId,
+        public int $clientId,
+        public string $name,
+        public RecurringFrequency $frequency,
+        public int $subtotalCents,
+        public int $taxCents,
+        public int $totalCents,
+        public string $nextRunOn,
+        public ?string $lastRunOn = null,
+        public bool $isActive = true,
+        public ?string $notes = null,
+        public bool $isDeleted = false,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/RecurringInvoice/RecurringInvoiceNotFoundException.php
+++ b/src/RecurringInvoice/RecurringInvoiceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use RuntimeException;
+
+final class RecurringInvoiceNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Recurring invoice {$id} not found.");
+    }
+}

--- a/src/RecurringInvoice/RecurringInvoiceRepositoryInterface.php
+++ b/src/RecurringInvoice/RecurringInvoiceRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+interface RecurringInvoiceRepositoryInterface
+{
+    public function save(RecurringInvoice $schedule): int;
+
+    public function findById(int $id): ?RecurringInvoice;
+
+    /** @return list<RecurringInvoice> */
+    public function findByOrganization(int $limit, int $offset): array;
+
+    public function countByOrganization(): int;
+
+    /**
+     * Active, non-deleted schedules whose next run is due on or before the given
+     * JST calendar date (`Y-m-d`), oldest-due first. Org-scoped via the holder —
+     * the request-time due check (Tier A) and a future all-org cron variant
+     * (Tier B) build on this.
+     *
+     * @return list<RecurringInvoice>
+     */
+    public function findDue(string $onDate): array;
+
+    public function update(RecurringInvoice $schedule): void;
+
+    public function delete(int $id): void;
+}

--- a/tests/RecurringInvoice/PdoRecurringInvoiceRepositoryTest.php
+++ b/tests/RecurringInvoice/PdoRecurringInvoiceRepositoryTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\RecurringInvoice;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\RecurringInvoice\PdoRecurringInvoiceRepository;
+use NeneInvoice\RecurringInvoice\RecurringFrequency;
+use NeneInvoice\RecurringInvoice\RecurringInvoice;
+use NeneInvoice\RecurringInvoice\RecurringInvoiceNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class PdoRecurringInvoiceRepositoryTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private PdoRecurringInvoiceRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/recurring_invoices.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoRecurringInvoiceRepository(
+            new PdoDatabaseQueryExecutor($factory, $pdo),
+            $this->holder,
+        );
+    }
+
+    private function schedule(
+        string $name = '月次顧問料',
+        string $nextRunOn = '2026-07-01',
+        bool $isActive = true,
+        RecurringFrequency $frequency = RecurringFrequency::Monthly,
+    ): RecurringInvoice {
+        return new RecurringInvoice(
+            organizationId: 1,
+            clientId: 5,
+            name: $name,
+            frequency: $frequency,
+            subtotalCents: 50000,
+            taxCents: 5000,
+            totalCents: 55000,
+            nextRunOn: $nextRunOn,
+            isActive: $isActive,
+            notes: 'ご利用ありがとうございます。',
+        );
+    }
+
+    public function test_save_and_find_round_trips_all_fields(): void
+    {
+        $id = $this->repository->save($this->schedule(frequency: RecurringFrequency::Quarterly));
+
+        $found = $this->repository->findById($id);
+        self::assertNotNull($found);
+        self::assertSame($id, $found->id);
+        self::assertSame('月次顧問料', $found->name);
+        self::assertSame(RecurringFrequency::Quarterly, $found->frequency);
+        self::assertSame(55000, $found->totalCents);
+        self::assertSame('2026-07-01', $found->nextRunOn);
+        self::assertNull($found->lastRunOn);
+        self::assertTrue($found->isActive);
+        self::assertSame('ご利用ありがとうございます。', $found->notes);
+    }
+
+    public function test_reads_are_scoped_to_the_organization(): void
+    {
+        $id = $this->repository->save($this->schedule());
+
+        $this->holder->set(2);
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->countByOrganization());
+    }
+
+    public function test_find_by_organization_lists_newest_first_with_paging(): void
+    {
+        $this->repository->save($this->schedule(name: 'A'));
+        $this->repository->save($this->schedule(name: 'B'));
+        $this->repository->save($this->schedule(name: 'C'));
+
+        self::assertSame(3, $this->repository->countByOrganization());
+
+        $page = $this->repository->findByOrganization(2, 0);
+        self::assertCount(2, $page);
+        self::assertSame('C', $page[0]->name); // newest (highest id) first
+        self::assertSame('B', $page[1]->name);
+
+        $rest = $this->repository->findByOrganization(2, 2);
+        self::assertCount(1, $rest);
+        self::assertSame('A', $rest[0]->name);
+    }
+
+    public function test_find_due_returns_active_schedules_on_or_before_date_oldest_first(): void
+    {
+        $this->repository->save($this->schedule(name: 'past', nextRunOn: '2026-06-15'));
+        $this->repository->save($this->schedule(name: 'boundary', nextRunOn: '2026-07-01'));
+        $this->repository->save($this->schedule(name: 'future', nextRunOn: '2026-07-02'));
+        $this->repository->save($this->schedule(name: 'inactive-due', nextRunOn: '2026-06-01', isActive: false));
+
+        $due = $this->repository->findDue('2026-07-01');
+
+        // boundary (== date) is inclusive; future excluded; inactive excluded.
+        self::assertSame(['past', 'boundary'], array_map(static fn ($s) => $s->name, $due));
+    }
+
+    public function test_find_due_excludes_the_day_after(): void
+    {
+        $this->repository->save($this->schedule(nextRunOn: '2026-07-02'));
+
+        self::assertSame([], $this->repository->findDue('2026-07-01'));
+    }
+
+    public function test_update_persists_changes_and_advances_run_dates(): void
+    {
+        $id = $this->repository->save($this->schedule());
+        $current = $this->repository->findById($id);
+        self::assertNotNull($current);
+
+        $this->repository->update(new RecurringInvoice(
+            organizationId: $current->organizationId,
+            clientId: $current->clientId,
+            name: '改定後 顧問料',
+            frequency: $current->frequency,
+            subtotalCents: 60000,
+            taxCents: 6000,
+            totalCents: 66000,
+            nextRunOn: '2026-08-01',
+            lastRunOn: '2026-07-01',
+            isActive: false,
+            notes: $current->notes,
+            id: $current->id,
+        ));
+
+        $updated = $this->repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame('改定後 顧問料', $updated->name);
+        self::assertSame(66000, $updated->totalCents);
+        self::assertSame('2026-08-01', $updated->nextRunOn);
+        self::assertSame('2026-07-01', $updated->lastRunOn);
+        self::assertFalse($updated->isActive);
+    }
+
+    public function test_soft_delete_hides_the_schedule(): void
+    {
+        $id = $this->repository->save($this->schedule());
+
+        $this->repository->delete($id);
+
+        self::assertNull($this->repository->findById($id));
+        self::assertSame(0, $this->repository->countByOrganization());
+    }
+
+    public function test_update_unknown_id_throws(): void
+    {
+        $this->expectException(RecurringInvoiceNotFoundException::class);
+        $this->repository->update($this->schedule()); // id null
+    }
+
+    public function test_delete_unknown_id_throws(): void
+    {
+        $this->expectException(RecurringInvoiceNotFoundException::class);
+        $this->repository->delete(999);
+    }
+}

--- a/tests/Support/InMemoryRecurringInvoiceRepository.php
+++ b/tests/Support/InMemoryRecurringInvoiceRepository.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\RecurringInvoice\RecurringInvoice;
+use NeneInvoice\RecurringInvoice\RecurringInvoiceNotFoundException;
+use NeneInvoice\RecurringInvoice\RecurringInvoiceRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database). Reads are scoped to the
+ * request-scoped org holder, mirroring {@see \NeneInvoice\RecurringInvoice\PdoRecurringInvoiceRepository}.
+ */
+final class InMemoryRecurringInvoiceRepository implements RecurringInvoiceRepositoryInterface
+{
+    /** @var array<int, RecurringInvoice> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
+    public function save(RecurringInvoice $schedule): int
+    {
+        $id = $this->nextId++;
+        $this->byId[$id] = $this->withId($schedule, $id, $schedule->isDeleted);
+
+        return $id;
+    }
+
+    public function findById(int $id): ?RecurringInvoice
+    {
+        $schedule = $this->byId[$id] ?? null;
+
+        return $schedule !== null && !$schedule->isDeleted && $schedule->organizationId === $this->orgId->get()
+            ? $schedule
+            : null;
+    }
+
+    /** @return list<RecurringInvoice> */
+    public function findByOrganization(int $limit, int $offset): array
+    {
+        return array_slice($this->mine(), $offset, $limit);
+    }
+
+    public function countByOrganization(): int
+    {
+        return count($this->mine());
+    }
+
+    /** @return list<RecurringInvoice> */
+    public function findDue(string $onDate): array
+    {
+        $due = array_values(array_filter(
+            $this->mine(),
+            static fn (RecurringInvoice $s): bool => $s->isActive && $s->nextRunOn <= $onDate,
+        ));
+
+        usort($due, static fn (RecurringInvoice $a, RecurringInvoice $b): int => [$a->nextRunOn, $a->id ?? 0] <=> [$b->nextRunOn, $b->id ?? 0]);
+
+        return $due;
+    }
+
+    public function update(RecurringInvoice $schedule): void
+    {
+        if ($schedule->id === null || $this->findById($schedule->id) === null) {
+            throw new RecurringInvoiceNotFoundException($schedule->id ?? 0);
+        }
+
+        $this->byId[$schedule->id] = $this->withId($schedule, $schedule->id, false);
+    }
+
+    public function delete(int $id): void
+    {
+        $existing = $this->findById($id);
+
+        if ($existing === null) {
+            throw new RecurringInvoiceNotFoundException($id);
+        }
+
+        $this->byId[$id] = $this->withId($existing, $id, true);
+    }
+
+    /** @return list<RecurringInvoice> newest first, org-scoped, excluding deleted */
+    private function mine(): array
+    {
+        $mine = array_values(array_filter(
+            $this->byId,
+            fn (RecurringInvoice $s): bool => $s->organizationId === $this->orgId->get() && !$s->isDeleted,
+        ));
+
+        usort($mine, static fn (RecurringInvoice $a, RecurringInvoice $b): int => ($b->id ?? 0) <=> ($a->id ?? 0));
+
+        return $mine;
+    }
+
+    private function withId(RecurringInvoice $s, int $id, bool $isDeleted): RecurringInvoice
+    {
+        return new RecurringInvoice(
+            organizationId: $s->organizationId,
+            clientId: $s->clientId,
+            name: $s->name,
+            frequency: $s->frequency,
+            subtotalCents: $s->subtotalCents,
+            taxCents: $s->taxCents,
+            totalCents: $s->totalCents,
+            nextRunOn: $s->nextRunOn,
+            lastRunOn: $s->lastRunOn,
+            isActive: $s->isActive,
+            notes: $s->notes,
+            isDeleted: $isDeleted,
+            id: $id,
+            createdAt: $s->createdAt ?? '2026-06-06 00:00:00',
+            updatedAt: '2026-06-06 00:00:00',
+        );
+    }
+}


### PR DESCRIPTION
Refs #503（本機能の最初の増分。これ単体では #503 を close しない）

## 背景

ペルソナ評価 第2ラウンドで確定した**「次の一手」＝定期請求**（first_move 5票/TOP3 10票、最小労力×最大採用増）の土台。継続請求（顧問料・保守費・管理料・月謝）の手作業発行を解消する。

## スコープ（安全な永続化レイヤのみ）

発行を伴わない部分だけを本PRに切り出した（Quote が「永続化PR→作成PR」と段階分割したのと同じ進め方）。**生成（下書き）→自動issue（採番・適格請求書）は後続PRで、accounting-compliance.md＋税理士確認のうえ実装**する。

## 変更

- `RecurringInvoice` エンティティ ＋ `RecurringFrequency`（`monthly`/`quarterly`）enum
- `RecurringInvoiceRepositoryInterface` ＋ `PdoRecurringInvoiceRepository`
  - org スコープ（RequestScopedHolder）・論理削除・newest-first ページング
  - `findDue(date)` = active かつ未削除かつ `next_run_on <= date`（当日含む・oldest-due 先）。Tier A=リクエスト時 due チェック／Tier B=cron の土台
- `InMemoryRecurringInvoiceRepository`（テスト support）
- Phinx migration ＋ `database/schema/recurring_invoices.sql`（SQLite）＋ **installer `mysql/schema.sql` にも追加**（スキーマパリティ／`SchemaParityTest` 緑）
- terminology レジストリに `recurring_invoices` / `recurring_invoice.frequency` / `next_run_on`・`last_run_on`（`valid_until` 同様の暦日）等を登録

明細テンプレは line_items を後続PRで流用（Quote 同様ヘッダ先行）。totals は cents（ADR 0004）。

## テスト

`PdoRecurringInvoiceRepositoryTest`（round-trip / org 分離 / ページング / `findDue` の当日含む・翌日除外・inactive 除外・順序 / update / 論理削除 / not-found）。`composer check` 緑（**732 tests** / PHPStan / cs / openapi / mcp）。

## 後続（#503 の残り）
1. 生成 use case（下書き請求書を line_items 流用で起票、`CreateInvoiceUseCase` 再利用）
2. 月次一括発行・一括メール、自動issue（税理士確認ゲート）
3. 管理UI（/recurring 一覧・作成・次回生成プレビュー・一時停止）

セルフレビュー: `docs/review/backend-api.md` / `docs/review/database.md` / `docs/review/compliance.md`（採番・発行は本PR対象外＝逸脱なし）。