### PR TITLE
feat(recurring): due な定期請求から下書き請求書を生成する (#503)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -62,7 +62,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `invoice.status` | `draft`, `issued`, `partially_paid`, `paid` |
 | invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
 | `payment.method` | `bank_transfer`, `cash`, `card`, `other` |
-| `line_item.parent_type` | `quote`, `invoice`, `template` |
+| `line_item.parent_type` | `quote`, `invoice`, `template`, `recurring_invoice` |
 | `line_item_suggestion.source` | `master`, `history` |
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
 | `user.status` | `active`, `invited` |

--- a/src/LineItem/LineItemParent.php
+++ b/src/LineItem/LineItemParent.php
@@ -7,11 +7,14 @@ namespace NeneInvoice\LineItem;
 /**
  * The parent a line item belongs to (polymorphic). Quotes and invoices are
  * documents; templates (#329) are reusable line presets that store their rows
- * here too, but never feed document totals or history suggestions.
+ * here too, but never feed document totals or history suggestions. Recurring
+ * invoices (#503) store their line *template* here, copied to a fresh draft
+ * invoice each period by the generation use case.
  */
 enum LineItemParent: string
 {
     case Quote = 'quote';
     case Invoice = 'invoice';
     case Template = 'template';
+    case RecurringInvoice = 'recurring_invoice';
 }

--- a/src/RecurringInvoice/GenerateDueRecurringInvoicesResult.php
+++ b/src/RecurringInvoice/GenerateDueRecurringInvoicesResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+/**
+ * Outcome of one generation run (#503): which schedules produced a draft invoice.
+ */
+final readonly class GenerateDueRecurringInvoicesResult
+{
+    /** @param list<array{recurring_invoice_id: int, invoice_id: int}> $generated */
+    public function __construct(
+        public array $generated,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return count($this->generated);
+    }
+}

--- a/src/RecurringInvoice/GenerateDueRecurringInvoicesUseCase.php
+++ b/src/RecurringInvoice/GenerateDueRecurringInvoicesUseCase.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use Closure;
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceRepositoryInterface;
+use NeneInvoice\Invoice\InvoiceResponse;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\Support\Jst;
+
+/**
+ * Generates **draft** invoices from recurring schedules that are due (#503).
+ *
+ * Each due schedule's line template (stored under `parent_type=recurring_invoice`)
+ * is copied into a fresh draft invoice — the same draft-creation path as
+ * {@see \NeneInvoice\Invoice\CreateInvoiceUseCase}, so totals are recomputed by
+ * the tax calculator (ADR 0004). Drafts carry no number and no qualified-invoice
+ * lock, so this step is compliance-light; **issuing/numbering is deliberately out
+ * of scope** (a later, tax-reviewed step). After generating, the schedule's
+ * `next_run_on` advances by its frequency and `last_run_on` is stamped.
+ *
+ * Idempotency: a schedule already run on the same date is skipped, and because
+ * `next_run_on` advances past `today` for the common (non-overdue) case, a second
+ * run on the same day produces nothing — so it never double-bills.
+ */
+final readonly class GenerateDueRecurringInvoicesUseCase
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): RecurringInvoiceRepositoryInterface $recurringFactory
+     * @param Closure(DatabaseQueryExecutorInterface): InvoiceRepositoryInterface $invoicesFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private RecurringInvoiceRepositoryInterface $recurring,
+        private LineItemRepositoryInterface $lineItems,
+        private ClientRepositoryInterface $clients,
+        private TaxCalculator $taxCalculator,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $recurringFactory,
+        private Closure $invoicesFactory,
+        private Closure $lineItemsFactory,
+        private Closure $auditFactory,
+        private ClockInterface $clock,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function execute(?int $actorUserId): GenerateDueRecurringInvoicesResult
+    {
+        $organizationId = $this->orgId->get();
+        $runDate        = Jst::of($this->clock->now())->format('Y-m-d');
+
+        $generated = [];
+
+        foreach ($this->recurring->findDue($runDate) as $schedule) {
+            $scheduleId = $schedule->id;
+            if ($scheduleId === null) {
+                continue;
+            }
+
+            // Already generated today (defensive against a same-day re-run).
+            if ($schedule->lastRunOn === $runDate) {
+                continue;
+            }
+
+            $template = $this->lineItems->findByParent(LineItemParent::RecurringInvoice, $scheduleId);
+            if ($template === []) {
+                continue; // nothing to bill — leave the schedule untouched
+            }
+
+            // Skip a schedule whose client was removed (or is cross-org): no invoice.
+            if ($this->clients->findById($schedule->clientId) === null) {
+                continue;
+            }
+
+            $inputs = array_map(
+                static fn (LineItem $line): LineItemInput => new LineItemInput(
+                    $line->description,
+                    $line->quantity,
+                    $line->unitPriceCents,
+                    $line->taxRateBps,
+                ),
+                $template,
+            );
+
+            $totals = $this->taxCalculator->calculate($inputs);
+
+            $invoiceId = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+                $actorUserId,
+                $organizationId,
+                $schedule,
+                $scheduleId,
+                $template,
+                $totals,
+                $runDate,
+            ): int {
+                $invoices  = ($this->invoicesFactory)($exec);
+                $lineItems = ($this->lineItemsFactory)($exec);
+                $recurring = ($this->recurringFactory)($exec);
+
+                $invoiceId = $invoices->save(new Invoice(
+                    organizationId: $organizationId,
+                    clientId: $schedule->clientId,
+                    status: InvoiceStatus::Draft,
+                    subtotalCents: $totals->subtotalCents,
+                    taxCents: $totals->taxCents,
+                    totalCents: $totals->totalCents,
+                    notes: $schedule->notes,
+                ));
+
+                $lineEntities = [];
+                foreach ($template as $index => $line) {
+                    $lineEntities[] = new LineItem(
+                        parentType: LineItemParent::Invoice,
+                        parentId: $invoiceId,
+                        description: $line->description,
+                        quantity: $line->quantity,
+                        unitPriceCents: $line->unitPriceCents,
+                        taxRateBps: $line->taxRateBps,
+                        sortOrder: $index,
+                    );
+                }
+                $lineItems->replaceForParent(LineItemParent::Invoice, $invoiceId, $lineEntities);
+
+                $saved = $invoices->findById($invoiceId);
+                if ($saved === null) {
+                    throw new LogicException('Invoice disappeared immediately after recurring generation.');
+                }
+
+                ($this->auditFactory)($exec)->record(
+                    $actorUserId,
+                    $organizationId,
+                    'invoice.created',
+                    'invoice',
+                    $invoiceId,
+                    null,
+                    InvoiceResponse::toArray($saved, $lineItems->findByParent(LineItemParent::Invoice, $invoiceId)),
+                );
+
+                // Advance the schedule anchored on its own next_run_on (no drift
+                // toward the run date) and stamp the last run.
+                $recurring->update(new RecurringInvoice(
+                    organizationId: $schedule->organizationId,
+                    clientId: $schedule->clientId,
+                    name: $schedule->name,
+                    frequency: $schedule->frequency,
+                    subtotalCents: $schedule->subtotalCents,
+                    taxCents: $schedule->taxCents,
+                    totalCents: $schedule->totalCents,
+                    nextRunOn: $schedule->frequency->nextRunDate($schedule->nextRunOn),
+                    lastRunOn: $runDate,
+                    isActive: $schedule->isActive,
+                    notes: $schedule->notes,
+                    id: $scheduleId,
+                    createdAt: $schedule->createdAt,
+                    updatedAt: $schedule->updatedAt,
+                ));
+
+                return $invoiceId;
+            });
+
+            $generated[] = ['recurring_invoice_id' => $scheduleId, 'invoice_id' => $invoiceId];
+        }
+
+        return new GenerateDueRecurringInvoicesResult($generated);
+    }
+}

--- a/src/RecurringInvoice/RecurringFrequency.php
+++ b/src/RecurringInvoice/RecurringFrequency.php
@@ -4,14 +4,44 @@ declare(strict_types=1);
 
 namespace NeneInvoice\RecurringInvoice;
 
+use DateTimeImmutable;
+
 /**
  * How often a {@see RecurringInvoice} schedule generates a new invoice
  * (#503). String values are registered in `docs/explanation/terminology.md` §2.
- * Date advancement (next_run_on math) lives in the generation use case so the
- * month-end edge is handled in one place, not here.
  */
 enum RecurringFrequency: string
 {
     case Monthly = 'monthly';
     case Quarterly = 'quarterly';
+
+    private function months(): int
+    {
+        return match ($this) {
+            self::Monthly => 1,
+            self::Quarterly => 3,
+        };
+    }
+
+    /**
+     * The next run date after `$from` (a `Y-m-d` calendar date), advancing by the
+     * frequency and **clamping the day to the target month's length** so the 31st
+     * lands on the last day of a shorter month (e.g. 2026-01-31 monthly → 2026-02-28).
+     *
+     * Known limitation: a schedule anchored on the 29–31 then continues on the
+     * clamped day after a short month rather than restoring the original day —
+     * a dedicated anchor-day column is a follow-up (#503).
+     */
+    public function nextRunDate(string $from): string
+    {
+        $date = new DateTimeImmutable($from);
+        $day  = (int) $date->format('j');
+
+        $firstOfTarget = $date->modify('first day of this month')->modify('+' . $this->months() . ' months');
+        $targetDay     = min($day, (int) $firstOfTarget->format('t'));
+
+        return $firstOfTarget
+            ->setDate((int) $firstOfTarget->format('Y'), (int) $firstOfTarget->format('n'), $targetDay)
+            ->format('Y-m-d');
+    }
 }

--- a/tests/RecurringInvoice/GenerateDueRecurringInvoicesUseCaseTest.php
+++ b/tests/RecurringInvoice/GenerateDueRecurringInvoicesUseCaseTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\RecurringInvoice;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Client\Client;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\RecurringInvoice\GenerateDueRecurringInvoicesUseCase;
+use NeneInvoice\RecurringInvoice\RecurringFrequency;
+use NeneInvoice\RecurringInvoice\RecurringInvoice;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryRecurringInvoiceRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class GenerateDueRecurringInvoicesUseCaseTest extends TestCase
+{
+    // FixedClock JST date.
+    private const TODAY = '2026-06-06';
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryRecurringInvoiceRepository $recurring;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private InMemoryInvoiceRepository $invoices;
+    private RecordingAuditRecorder $audit;
+    private GenerateDueRecurringInvoicesUseCase $useCase;
+    private int $clientId;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->recurring = new InMemoryRecurringInvoiceRepository($this->holder);
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->clients = new InMemoryClientRepository($this->holder);
+        $this->invoices = new InMemoryInvoiceRepository($this->holder);
+        $this->audit = new RecordingAuditRecorder();
+        $this->clientId = $this->clients->save(new Client(organizationId: 1, name: '顧問先 株式会社'));
+
+        $this->useCase = new GenerateDueRecurringInvoicesUseCase(
+            $this->recurring,
+            $this->lineItems,
+            $this->clients,
+            new TaxCalculator(),
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->invoices,
+            fn () => $this->lineItems,
+            fn () => $this->audit,
+            new FixedClock(),
+            $this->holder,
+        );
+    }
+
+    private function seed(string $nextRunOn, bool $active = true, bool $withLines = true, ?int $clientId = null): int
+    {
+        $id = $this->recurring->save(new RecurringInvoice(
+            organizationId: 1,
+            clientId: $clientId ?? $this->clientId,
+            name: '月次顧問料',
+            frequency: RecurringFrequency::Monthly,
+            subtotalCents: 15000,
+            taxCents: 1400,
+            totalCents: 16400,
+            nextRunOn: $nextRunOn,
+            isActive: $active,
+            notes: '今月分の顧問料です。',
+        ));
+
+        if ($withLines) {
+            $this->lineItems->replaceForParent(LineItemParent::RecurringInvoice, $id, [
+                new LineItem(LineItemParent::RecurringInvoice, $id, 'コンサルティング', 1, 10000, 1000, sortOrder: 0),
+                new LineItem(LineItemParent::RecurringInvoice, $id, '軽減税率品', 1, 5000, 800, sortOrder: 1),
+            ]);
+        }
+
+        return $id;
+    }
+
+    public function test_generates_draft_invoice_and_advances_schedule(): void
+    {
+        $id = $this->seed('2026-06-01');
+
+        $result = $this->useCase->execute(7);
+
+        self::assertSame(1, $result->count());
+        $invoiceId = $result->generated[0]['invoice_id'];
+        self::assertSame($id, $result->generated[0]['recurring_invoice_id']);
+
+        $invoice = $this->invoices->findById($invoiceId);
+        self::assertNotNull($invoice);
+        self::assertSame(InvoiceStatus::Draft, $invoice->status);
+        self::assertNull($invoice->invoiceNumber); // numbered only at issue
+        self::assertSame(15000, $invoice->subtotalCents);
+        self::assertSame(1400, $invoice->taxCents);
+        self::assertSame(16400, $invoice->totalCents);
+        self::assertCount(2, $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId));
+        self::assertSame('invoice.created', $this->audit->records[0]['action']);
+
+        $schedule = $this->recurring->findById($id);
+        self::assertNotNull($schedule);
+        self::assertSame('2026-07-01', $schedule->nextRunOn);
+        self::assertSame(self::TODAY, $schedule->lastRunOn);
+        self::assertTrue($schedule->isActive);
+    }
+
+    public function test_same_day_rerun_is_idempotent(): void
+    {
+        $this->seed('2026-06-01');
+
+        self::assertSame(1, $this->useCase->execute(7)->count());
+        self::assertSame(0, $this->useCase->execute(7)->count());
+        self::assertSame(1, $this->invoices->count()); // no duplicate
+    }
+
+    public function test_future_schedule_is_not_generated(): void
+    {
+        $this->seed('2026-07-01');
+
+        self::assertSame(0, $this->useCase->execute(7)->count());
+        self::assertSame(0, $this->invoices->count());
+    }
+
+    public function test_inactive_schedule_is_not_generated(): void
+    {
+        $this->seed('2026-06-01', active: false);
+
+        self::assertSame(0, $this->useCase->execute(7)->count());
+    }
+
+    public function test_schedule_without_line_template_is_skipped_and_untouched(): void
+    {
+        $id = $this->seed('2026-06-01', withLines: false);
+
+        self::assertSame(0, $this->useCase->execute(7)->count());
+
+        $schedule = $this->recurring->findById($id);
+        self::assertNotNull($schedule);
+        self::assertSame('2026-06-01', $schedule->nextRunOn); // not advanced
+        self::assertNull($schedule->lastRunOn);
+    }
+
+    public function test_schedule_for_missing_client_is_skipped(): void
+    {
+        $this->seed('2026-06-01', clientId: 999); // no such client in org
+
+        self::assertSame(0, $this->useCase->execute(7)->count());
+        self::assertSame(0, $this->invoices->count());
+    }
+
+    public function test_overdue_schedule_advances_one_period_anchored_not_to_today(): void
+    {
+        $id = $this->seed('2026-04-10'); // overdue (before today)
+
+        self::assertSame(1, $this->useCase->execute(7)->count());
+
+        $schedule = $this->recurring->findById($id);
+        self::assertNotNull($schedule);
+        // Anchored on its own next_run_on, advances exactly one period — it does
+        // not jump to the run date.
+        self::assertSame('2026-05-10', $schedule->nextRunOn);
+        self::assertSame(self::TODAY, $schedule->lastRunOn);
+    }
+}

--- a/tests/RecurringInvoice/RecurringFrequencyTest.php
+++ b/tests/RecurringInvoice/RecurringFrequencyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\RecurringInvoice;
+
+use NeneInvoice\RecurringInvoice\RecurringFrequency;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RecurringFrequencyTest extends TestCase
+{
+    /**
+     * Day-of-month is preserved and clamped to the target month's length; the
+     * 31st of a long month lands on the last day of a shorter one.
+     */
+    #[DataProvider('nextRunCases')]
+    public function test_next_run_date(RecurringFrequency $frequency, string $from, string $expected): void
+    {
+        self::assertSame($expected, $frequency->nextRunDate($from));
+    }
+
+    /** @return iterable<string, array{RecurringFrequency, string, string}> */
+    public static function nextRunCases(): iterable
+    {
+        yield 'monthly mid-month'        => [RecurringFrequency::Monthly, '2026-06-15', '2026-07-15'];
+        yield 'monthly 31st -> Feb clamp' => [RecurringFrequency::Monthly, '2026-01-31', '2026-02-28'];
+        yield 'monthly Feb -> Mar'       => [RecurringFrequency::Monthly, '2026-02-28', '2026-03-28'];
+        yield 'monthly year rollover'    => [RecurringFrequency::Monthly, '2026-12-10', '2027-01-10'];
+        yield 'monthly 30th -> Feb clamp' => [RecurringFrequency::Monthly, '2026-03-30', '2026-04-30'];
+        yield 'quarterly'                => [RecurringFrequency::Quarterly, '2026-01-15', '2026-04-15'];
+        yield 'quarterly year rollover'  => [RecurringFrequency::Quarterly, '2026-11-30', '2027-02-28'];
+    }
+}


### PR DESCRIPTION
Refs #503（永続化レイヤ #519 に続く第2増分。これ単体では close しない）

## スコープ

due な定期請求スケジュールから **下書き請求書** を生成する。**発行（採番・適格請求書ロック）は対象外**＝税理士確認ゲートが要るため後続PRに分割。下書きは番号も適格フラグも持たず編集可能なので、コンプラ的に軽い（`CreateInvoiceUseCase` と同じ下書き生成経路・税計算は ADR 0004 で再計算）。

## 変更

- `LineItemParent::RecurringInvoice` 追加 — スケジュールの**明細テンプレ**を `line_items` に保持（Quote/Invoice/Template と同じ polymorphic 流用）。terminology §2 に登録
- `RecurringFrequency::nextRunDate(from)` — 周期前進。**日付は対象月の長さにクランプ**（2026-01-31 monthly → 2026-02-28）。29–31 アンカーのドリフトは既知の制約（anchor-day 列は follow-up）
- `GenerateDueRecurringInvoicesUseCase`
  - `findDue(runDate=JST today)` → 各スケジュールのテンプレ明細を新規 draft invoice にコピー、`TaxCalculator` で totals 再計算、`invoice.created` 監査
  - schedule を**自分の next_run_on を起点に**1周期前進（run 日へ寄らない）＋ `last_run_on` 記録
  - 1スケジュール = 1トランザクション。**当日再実行は冪等**（next_run_on が当日を超える＋ `last_run_on == runDate` ガードで二重請求しない）。明細なし／顧客が削除済み（cross-org 含む）はスキップ

## テスト

- `RecurringFrequencyTest` — 月跨ぎ・年跨ぎ・月末クランプ
- `GenerateDueRecurringInvoicesUseCaseTest` — 生成＋スケジュール前進 / 当日冪等 / 未来・inactive・明細なし・顧客不在のスキップ / overdue のアンカー前進
- `composer check` 緑（**746 tests** / PHPStan / cs / openapi / mcp）

## 後続（#503 の残り）
- 作成/一覧/編集（スケジュールを line_items 込みで作る use case + 管理UI /recurring）
- 月次一括発行・一括メール、**自動 issue（採番・適格請求書）＝税理士確認ゲート**
- 実行トリガー（Tier B cron `tools/run-recurring.php` / Tier A リクエスト時 due チェック）

セルフレビュー: `docs/review/backend-api.md` / `docs/review/compliance.md`（下書き生成のみ・採番/発行なし＝逸脱なし）。