### PR TITLE
feat(recurring): 定期請求の CRUD ユースケース層を追加する (#503)

### DIFF
--- a/src/RecurringInvoice/CreateRecurringInvoiceInput.php
+++ b/src/RecurringInvoice/CreateRecurringInvoiceInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use NeneInvoice\LineItem\LineItemInput;
+
+final readonly class CreateRecurringInvoiceInput
+{
+    /** @param list<LineItemInput> $lines */
+    public function __construct(
+        public int $clientId,
+        public string $name,
+        public RecurringFrequency $frequency,
+        public string $firstRunOn,
+        public array $lines,
+        public bool $isActive = true,
+        public ?string $notes = null,
+    ) {
+    }
+}

--- a/src/RecurringInvoice/CreateRecurringInvoiceUseCase.php
+++ b/src/RecurringInvoice/CreateRecurringInvoiceUseCase.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use Closure;
+use DateTimeImmutable;
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
+
+/**
+ * Creates a recurring-billing schedule: validates the client and lines, computes
+ * totals (TaxCalculator, ADR 0004), then persists the header + line template
+ * (`parent_type=recurring_invoice`) atomically and records an audit entry.
+ *
+ * This only stores the schedule. Generating draft invoices is
+ * {@see GenerateDueRecurringInvoicesUseCase}; issuing is a separate, tax-reviewed step.
+ */
+final readonly class CreateRecurringInvoiceUseCase
+{
+    /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
+    private const ALLOWED_TAX_RATES_BPS = [800, 1000];
+
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): RecurringInvoiceRepositoryInterface $recurringFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $recurringFactory,
+        private Closure $lineItemsFactory,
+        private ClientRepositoryInterface $clients,
+        private TaxCalculator $taxCalculator,
+        private Closure $auditFactory,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /** @throws RecurringInvoiceValidationException */
+    public function execute(?int $actorUserId, CreateRecurringInvoiceInput $input): RecurringInvoiceWithLines
+    {
+        $organizationId = $this->orgId->get();
+
+        if (trim($input->name) === '') {
+            throw new RecurringInvoiceValidationException('A recurring invoice requires a name.');
+        }
+
+        if ($this->clients->findById($input->clientId) === null) {
+            throw new RecurringInvoiceValidationException('The selected client does not exist in your organization.');
+        }
+
+        if (!self::isValidDate($input->firstRunOn)) {
+            throw new RecurringInvoiceValidationException('The first run date must be a valid date (YYYY-MM-DD).');
+        }
+
+        if ($input->lines === []) {
+            throw new RecurringInvoiceValidationException('A recurring invoice requires at least one line item.');
+        }
+
+        foreach ($input->lines as $line) {
+            if (!in_array($line->taxRateBps, self::ALLOWED_TAX_RATES_BPS, true)) {
+                throw new RecurringInvoiceValidationException(sprintf('Tax rate %d bps is not allowed (use 1000 or 800).', $line->taxRateBps));
+            }
+            if ($line->quantity <= 0) {
+                throw new RecurringInvoiceValidationException('Line item quantity must be greater than zero.');
+            }
+            if ($line->unitPriceCents < 0) {
+                throw new RecurringInvoiceValidationException('Line item unit price must not be negative.');
+            }
+        }
+
+        $totals = $this->taxCalculator->calculate($input->lines);
+
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
+            $organizationId,
+            $input,
+            $totals,
+        ): RecurringInvoiceWithLines {
+            $recurring = ($this->recurringFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
+
+            $id = $recurring->save(new RecurringInvoice(
+                organizationId: $organizationId,
+                clientId: $input->clientId,
+                name: $input->name,
+                frequency: $input->frequency,
+                subtotalCents: $totals->subtotalCents,
+                taxCents: $totals->taxCents,
+                totalCents: $totals->totalCents,
+                nextRunOn: $input->firstRunOn,
+                isActive: $input->isActive,
+                notes: $input->notes,
+            ));
+
+            $entities = [];
+            foreach ($input->lines as $index => $line) {
+                $entities[] = new LineItem(
+                    parentType: LineItemParent::RecurringInvoice,
+                    parentId: $id,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $index,
+                );
+            }
+            $lineItems->replaceForParent(LineItemParent::RecurringInvoice, $id, $entities);
+
+            $saved = $recurring->findById($id);
+            if ($saved === null) {
+                throw new LogicException('Recurring invoice disappeared immediately after creation.');
+            }
+
+            $result = new RecurringInvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::RecurringInvoice, $id));
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'recurring_invoice.created', 'recurring_invoice', $id, null, RecurringInvoiceResponse::toArray($result->schedule, $result->lines));
+
+            return $result;
+        });
+    }
+
+    private static function isValidDate(string $value): bool
+    {
+        $parsed = DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        return $parsed !== false && $parsed->format('Y-m-d') === $value;
+    }
+}

--- a/src/RecurringInvoice/DeleteRecurringInvoiceUseCase.php
+++ b/src/RecurringInvoice/DeleteRecurringInvoiceUseCase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+/**
+ * Soft-deletes a recurring schedule (the line template rows are left in place;
+ * the soft-deleted header hides them). The delete and its audit commit together.
+ */
+final readonly class DeleteRecurringInvoiceUseCase
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): RecurringInvoiceRepositoryInterface $recurringFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private RecurringInvoiceRepositoryInterface $recurring,
+        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $recurringFactory,
+        private Closure $auditFactory,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /** @throws RecurringInvoiceNotFoundException */
+    public function execute(?int $actorUserId, int $id): void
+    {
+        $organizationId = $this->orgId->get();
+
+        $existing = $this->recurring->findById($id);
+        if ($existing === null) {
+            throw new RecurringInvoiceNotFoundException($id);
+        }
+
+        $before = RecurringInvoiceResponse::toArray(
+            $existing,
+            $this->lineItems->findByParent(LineItemParent::RecurringInvoice, $id),
+        );
+
+        $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $organizationId, $id, $before): void {
+            ($this->recurringFactory)($exec)->delete($id);
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'recurring_invoice.deleted', 'recurring_invoice', $id, $before, null);
+        });
+    }
+}

--- a/src/RecurringInvoice/GetRecurringInvoiceByIdUseCase.php
+++ b/src/RecurringInvoice/GetRecurringInvoiceByIdUseCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+
+final readonly class GetRecurringInvoiceByIdUseCase
+{
+    public function __construct(
+        private RecurringInvoiceRepositoryInterface $recurring,
+        private LineItemRepositoryInterface $lineItems,
+    ) {
+    }
+
+    /** @throws RecurringInvoiceNotFoundException */
+    public function execute(int $id): RecurringInvoiceWithLines
+    {
+        $schedule = $this->recurring->findById($id);
+
+        if ($schedule === null) {
+            throw new RecurringInvoiceNotFoundException($id);
+        }
+
+        return new RecurringInvoiceWithLines(
+            $schedule,
+            $this->lineItems->findByParent(LineItemParent::RecurringInvoice, $id),
+        );
+    }
+}

--- a/src/RecurringInvoice/ListRecurringInvoicesResult.php
+++ b/src/RecurringInvoice/ListRecurringInvoicesResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+final readonly class ListRecurringInvoicesResult
+{
+    /** @param list<RecurringInvoice> $items */
+    public function __construct(
+        public array $items,
+        public int $total,
+    ) {
+    }
+}

--- a/src/RecurringInvoice/ListRecurringInvoicesUseCase.php
+++ b/src/RecurringInvoice/ListRecurringInvoicesUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+final readonly class ListRecurringInvoicesUseCase
+{
+    public function __construct(
+        private RecurringInvoiceRepositoryInterface $recurring,
+    ) {
+    }
+
+    public function execute(int $limit, int $offset): ListRecurringInvoicesResult
+    {
+        return new ListRecurringInvoicesResult(
+            $this->recurring->findByOrganization($limit, $offset),
+            $this->recurring->countByOrganization(),
+        );
+    }
+}

--- a/src/RecurringInvoice/RecurringInvoiceResponse.php
+++ b/src/RecurringInvoice/RecurringInvoiceResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemResponse;
+
+/**
+ * Serializes a {@see RecurringInvoice} to its snake_case JSON representation.
+ * When line items are supplied they are nested under `line_items`.
+ */
+final class RecurringInvoiceResponse
+{
+    /**
+     * @param list<LineItem>|null $lines
+     * @return array<string, mixed>
+     */
+    public static function toArray(RecurringInvoice $schedule, ?array $lines = null, ?string $clientName = null): array
+    {
+        $data = [
+            'id' => $schedule->id,
+            'organization_id' => $schedule->organizationId,
+            'client_id' => $schedule->clientId,
+            'client_name' => $clientName,
+            'name' => $schedule->name,
+            'frequency' => $schedule->frequency->value,
+            'subtotal_cents' => $schedule->subtotalCents,
+            'tax_cents' => $schedule->taxCents,
+            'total_cents' => $schedule->totalCents,
+            'next_run_on' => $schedule->nextRunOn,
+            'last_run_on' => $schedule->lastRunOn,
+            'is_active' => $schedule->isActive,
+            'notes' => $schedule->notes,
+            'created_at' => $schedule->createdAt,
+            'updated_at' => $schedule->updatedAt,
+        ];
+
+        if ($lines !== null) {
+            $data['line_items'] = array_map(static fn (LineItem $l): array => LineItemResponse::toArray($l), $lines);
+        }
+
+        return $data;
+    }
+}

--- a/src/RecurringInvoice/RecurringInvoiceValidationException.php
+++ b/src/RecurringInvoice/RecurringInvoiceValidationException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use DomainException;
+
+/**
+ * Thrown when recurring-invoice input is invalid (unknown client, empty lines,
+ * disallowed tax rate, malformed run date, etc.). Surfaces as 422.
+ */
+final class RecurringInvoiceValidationException extends DomainException
+{
+}

--- a/src/RecurringInvoice/RecurringInvoiceWithLines.php
+++ b/src/RecurringInvoice/RecurringInvoiceWithLines.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use NeneInvoice\LineItem\LineItem;
+
+final readonly class RecurringInvoiceWithLines
+{
+    /** @param list<LineItem> $lines */
+    public function __construct(
+        public RecurringInvoice $schedule,
+        public array $lines,
+    ) {
+    }
+}

--- a/src/RecurringInvoice/UpdateRecurringInvoiceInput.php
+++ b/src/RecurringInvoice/UpdateRecurringInvoiceInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use NeneInvoice\LineItem\LineItemInput;
+
+final readonly class UpdateRecurringInvoiceInput
+{
+    /** @param list<LineItemInput> $lines */
+    public function __construct(
+        public int $clientId,
+        public string $name,
+        public RecurringFrequency $frequency,
+        public string $nextRunOn,
+        public array $lines,
+        public bool $isActive,
+        public ?string $notes = null,
+    ) {
+    }
+}

--- a/src/RecurringInvoice/UpdateRecurringInvoiceUseCase.php
+++ b/src/RecurringInvoice/UpdateRecurringInvoiceUseCase.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\RecurringInvoice;
+
+use Closure;
+use DateTimeImmutable;
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Audit\AuditRecorderInterface;
+use NeneInvoice\Client\ClientRepositoryInterface;
+use NeneInvoice\LineItem\LineItem;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\LineItemRepositoryInterface;
+use NeneInvoice\LineItem\TaxCalculator;
+
+/**
+ * Edits a recurring schedule: re-validates the client and lines, recomputes
+ * totals (ADR 0004), replaces the line template, and persists the header +
+ * lines atomically with an audit entry (before/after).
+ */
+final readonly class UpdateRecurringInvoiceUseCase
+{
+    /** Allowed consumption tax rates in basis points (accounting-compliance §3). */
+    private const ALLOWED_TAX_RATES_BPS = [800, 1000];
+
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): RecurringInvoiceRepositoryInterface $recurringFactory
+     * @param Closure(DatabaseQueryExecutorInterface): LineItemRepositoryInterface $lineItemsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     * @param RequestScopedHolder<int> $orgId
+     */
+    public function __construct(
+        private RecurringInvoiceRepositoryInterface $recurring,
+        private LineItemRepositoryInterface $lineItems,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $recurringFactory,
+        private Closure $lineItemsFactory,
+        private ClientRepositoryInterface $clients,
+        private TaxCalculator $taxCalculator,
+        private Closure $auditFactory,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /**
+     * @throws RecurringInvoiceNotFoundException
+     * @throws RecurringInvoiceValidationException
+     */
+    public function execute(?int $actorUserId, int $id, UpdateRecurringInvoiceInput $input): RecurringInvoiceWithLines
+    {
+        $organizationId = $this->orgId->get();
+
+        $existing = $this->recurring->findById($id);
+        if ($existing === null) {
+            throw new RecurringInvoiceNotFoundException($id);
+        }
+
+        if (trim($input->name) === '') {
+            throw new RecurringInvoiceValidationException('A recurring invoice requires a name.');
+        }
+
+        if ($this->clients->findById($input->clientId) === null) {
+            throw new RecurringInvoiceValidationException('The selected client does not exist in your organization.');
+        }
+
+        if (!self::isValidDate($input->nextRunOn)) {
+            throw new RecurringInvoiceValidationException('The next run date must be a valid date (YYYY-MM-DD).');
+        }
+
+        if ($input->lines === []) {
+            throw new RecurringInvoiceValidationException('A recurring invoice requires at least one line item.');
+        }
+
+        foreach ($input->lines as $line) {
+            if (!in_array($line->taxRateBps, self::ALLOWED_TAX_RATES_BPS, true)) {
+                throw new RecurringInvoiceValidationException(sprintf('Tax rate %d bps is not allowed (use 1000 or 800).', $line->taxRateBps));
+            }
+            if ($line->quantity <= 0) {
+                throw new RecurringInvoiceValidationException('Line item quantity must be greater than zero.');
+            }
+            if ($line->unitPriceCents < 0) {
+                throw new RecurringInvoiceValidationException('Line item unit price must not be negative.');
+            }
+        }
+
+        $before = RecurringInvoiceResponse::toArray($existing, $this->lineItems->findByParent(LineItemParent::RecurringInvoice, $id));
+        $totals = $this->taxCalculator->calculate($input->lines);
+
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use (
+            $actorUserId,
+            $organizationId,
+            $id,
+            $input,
+            $existing,
+            $totals,
+            $before,
+        ): RecurringInvoiceWithLines {
+            $recurring = ($this->recurringFactory)($exec);
+            $lineItems = ($this->lineItemsFactory)($exec);
+
+            $recurring->update(new RecurringInvoice(
+                organizationId: $existing->organizationId,
+                clientId: $input->clientId,
+                name: $input->name,
+                frequency: $input->frequency,
+                subtotalCents: $totals->subtotalCents,
+                taxCents: $totals->taxCents,
+                totalCents: $totals->totalCents,
+                nextRunOn: $input->nextRunOn,
+                lastRunOn: $existing->lastRunOn,
+                isActive: $input->isActive,
+                notes: $input->notes,
+                id: $id,
+                createdAt: $existing->createdAt,
+                updatedAt: $existing->updatedAt,
+            ));
+
+            $entities = [];
+            foreach ($input->lines as $index => $line) {
+                $entities[] = new LineItem(
+                    parentType: LineItemParent::RecurringInvoice,
+                    parentId: $id,
+                    description: $line->description,
+                    quantity: $line->quantity,
+                    unitPriceCents: $line->unitPriceCents,
+                    taxRateBps: $line->taxRateBps,
+                    sortOrder: $index,
+                );
+            }
+            $lineItems->replaceForParent(LineItemParent::RecurringInvoice, $id, $entities);
+
+            $saved = $recurring->findById($id);
+            if ($saved === null) {
+                throw new LogicException('Recurring invoice disappeared immediately after update.');
+            }
+
+            $result = new RecurringInvoiceWithLines($saved, $lineItems->findByParent(LineItemParent::RecurringInvoice, $id));
+
+            ($this->auditFactory)($exec)->record($actorUserId, $organizationId, 'recurring_invoice.updated', 'recurring_invoice', $id, $before, RecurringInvoiceResponse::toArray($result->schedule, $result->lines));
+
+            return $result;
+        });
+    }
+
+    private static function isValidDate(string $value): bool
+    {
+        $parsed = DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        return $parsed !== false && $parsed->format('Y-m-d') === $value;
+    }
+}

--- a/tests/RecurringInvoice/CreateRecurringInvoiceUseCaseTest.php
+++ b/tests/RecurringInvoice/CreateRecurringInvoiceUseCaseTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\RecurringInvoice;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Client\Client;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\RecurringInvoice\CreateRecurringInvoiceInput;
+use NeneInvoice\RecurringInvoice\CreateRecurringInvoiceUseCase;
+use NeneInvoice\RecurringInvoice\RecurringFrequency;
+use NeneInvoice\RecurringInvoice\RecurringInvoiceValidationException;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryRecurringInvoiceRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class CreateRecurringInvoiceUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryRecurringInvoiceRepository $recurring;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private RecordingAuditRecorder $audit;
+    private CreateRecurringInvoiceUseCase $useCase;
+    private int $clientId;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->recurring = new InMemoryRecurringInvoiceRepository($this->holder);
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->clients = new InMemoryClientRepository($this->holder);
+        $this->audit = new RecordingAuditRecorder();
+        $this->clientId = $this->clients->save(new Client(organizationId: 1, name: '顧問先'));
+
+        $this->useCase = new CreateRecurringInvoiceUseCase(
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->lineItems,
+            $this->clients,
+            new TaxCalculator(),
+            fn () => $this->audit,
+            $this->holder,
+        );
+    }
+
+    /** @param list<LineItemInput>|null $lines */
+    private function input(?int $clientId = null, ?array $lines = null, string $firstRunOn = '2026-07-01', string $name = '月次顧問料'): CreateRecurringInvoiceInput
+    {
+        return new CreateRecurringInvoiceInput(
+            clientId: $clientId ?? $this->clientId,
+            name: $name,
+            frequency: RecurringFrequency::Monthly,
+            firstRunOn: $firstRunOn,
+            lines: $lines ?? [new LineItemInput('コンサル', 1, 10000, 1000), new LineItemInput('軽減', 1, 5000, 800)],
+        );
+    }
+
+    public function test_creates_schedule_with_totals_lines_and_audit(): void
+    {
+        $result = $this->useCase->execute(7, $this->input());
+
+        self::assertSame('月次顧問料', $result->schedule->name);
+        self::assertSame(RecurringFrequency::Monthly, $result->schedule->frequency);
+        self::assertSame(15000, $result->schedule->subtotalCents);
+        self::assertSame(1400, $result->schedule->taxCents);
+        self::assertSame(16400, $result->schedule->totalCents);
+        self::assertSame('2026-07-01', $result->schedule->nextRunOn);
+        self::assertTrue($result->schedule->isActive);
+        self::assertCount(2, $result->lines);
+        self::assertSame(LineItemParent::RecurringInvoice, $result->lines[0]->parentType);
+        self::assertSame('recurring_invoice.created', $this->audit->records[0]['action']);
+    }
+
+    public function test_rejects_unknown_client(): void
+    {
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(clientId: 999));
+    }
+
+    public function test_rejects_cross_org_client(): void
+    {
+        $other = $this->clients->save(new Client(organizationId: 2, name: '他社'));
+
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(clientId: $other));
+    }
+
+    public function test_rejects_empty_lines(): void
+    {
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(lines: []));
+    }
+
+    public function test_rejects_empty_name(): void
+    {
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(name: '  '));
+    }
+
+    public function test_rejects_disallowed_tax_rate(): void
+    {
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(lines: [new LineItemInput('x', 1, 1000, 500)]));
+    }
+
+    public function test_rejects_malformed_first_run_date(): void
+    {
+        $this->expectException(RecurringInvoiceValidationException::class);
+        $this->useCase->execute(7, $this->input(firstRunOn: '2026-13-40'));
+    }
+}

--- a/tests/RecurringInvoice/RecurringInvoiceCrudUseCasesTest.php
+++ b/tests/RecurringInvoice/RecurringInvoiceCrudUseCasesTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\RecurringInvoice;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Client\Client;
+use NeneInvoice\LineItem\LineItemInput;
+use NeneInvoice\LineItem\LineItemParent;
+use NeneInvoice\LineItem\TaxCalculator;
+use NeneInvoice\RecurringInvoice\CreateRecurringInvoiceInput;
+use NeneInvoice\RecurringInvoice\CreateRecurringInvoiceUseCase;
+use NeneInvoice\RecurringInvoice\DeleteRecurringInvoiceUseCase;
+use NeneInvoice\RecurringInvoice\GetRecurringInvoiceByIdUseCase;
+use NeneInvoice\RecurringInvoice\ListRecurringInvoicesUseCase;
+use NeneInvoice\RecurringInvoice\RecurringFrequency;
+use NeneInvoice\RecurringInvoice\RecurringInvoiceNotFoundException;
+use NeneInvoice\RecurringInvoice\UpdateRecurringInvoiceInput;
+use NeneInvoice\RecurringInvoice\UpdateRecurringInvoiceUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\InMemoryRecurringInvoiceRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class RecurringInvoiceCrudUseCasesTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryRecurringInvoiceRepository $recurring;
+    private InMemoryLineItemRepository $lineItems;
+    private InMemoryClientRepository $clients;
+    private RecordingAuditRecorder $audit;
+    private int $clientId;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->recurring = new InMemoryRecurringInvoiceRepository($this->holder);
+        $this->lineItems = new InMemoryLineItemRepository();
+        $this->clients = new InMemoryClientRepository($this->holder);
+        $this->audit = new RecordingAuditRecorder();
+        $this->clientId = $this->clients->save(new Client(organizationId: 1, name: '顧問先'));
+    }
+
+    private function createUseCase(): CreateRecurringInvoiceUseCase
+    {
+        return new CreateRecurringInvoiceUseCase(
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->lineItems,
+            $this->clients,
+            new TaxCalculator(),
+            fn () => $this->audit,
+            $this->holder,
+        );
+    }
+
+    private function seed(string $name = '月次顧問料', string $firstRunOn = '2026-07-01'): int
+    {
+        return $this->createUseCase()->execute(7, new CreateRecurringInvoiceInput(
+            clientId: $this->clientId,
+            name: $name,
+            frequency: RecurringFrequency::Monthly,
+            firstRunOn: $firstRunOn,
+            lines: [new LineItemInput('コンサル', 1, 10000, 1000)],
+        ))->schedule->id ?? 0;
+    }
+
+    public function test_list_returns_items_and_total_with_paging(): void
+    {
+        $this->seed('A');
+        $this->seed('B');
+        $this->seed('C');
+
+        $useCase = new ListRecurringInvoicesUseCase($this->recurring);
+
+        $page = $useCase->execute(2, 0);
+        self::assertSame(3, $page->total);
+        self::assertCount(2, $page->items);
+        self::assertSame('C', $page->items[0]->name); // newest first
+    }
+
+    public function test_get_returns_schedule_with_lines(): void
+    {
+        $id = $this->seed();
+        $useCase = new GetRecurringInvoiceByIdUseCase($this->recurring, $this->lineItems);
+
+        $result = $useCase->execute($id);
+        self::assertSame($id, $result->schedule->id);
+        self::assertCount(1, $result->lines);
+        self::assertSame(LineItemParent::RecurringInvoice, $result->lines[0]->parentType);
+    }
+
+    public function test_get_unknown_id_throws(): void
+    {
+        $useCase = new GetRecurringInvoiceByIdUseCase($this->recurring, $this->lineItems);
+
+        $this->expectException(RecurringInvoiceNotFoundException::class);
+        $useCase->execute(999);
+    }
+
+    public function test_update_replaces_lines_recomputes_totals_and_audits(): void
+    {
+        $id = $this->seed();
+        $useCase = $this->updateUseCase();
+
+        $result = $useCase->execute(7, $id, new UpdateRecurringInvoiceInput(
+            clientId: $this->clientId,
+            name: '改定 顧問料',
+            frequency: RecurringFrequency::Quarterly,
+            nextRunOn: '2026-09-01',
+            lines: [new LineItemInput('コンサル', 2, 10000, 1000), new LineItemInput('軽減', 1, 5000, 800)],
+            isActive: false,
+        ));
+
+        self::assertSame('改定 顧問料', $result->schedule->name);
+        self::assertSame(RecurringFrequency::Quarterly, $result->schedule->frequency);
+        self::assertSame('2026-09-01', $result->schedule->nextRunOn);
+        self::assertFalse($result->schedule->isActive);
+        self::assertSame(25000, $result->schedule->subtotalCents); // 2×10000 + 5000
+        self::assertSame(2400, $result->schedule->taxCents);       // 2000 + 400
+        self::assertCount(2, $result->lines);
+
+        $actions = array_map(static fn ($r) => $r['action'], $this->audit->records);
+        self::assertContains('recurring_invoice.updated', $actions);
+
+        // The line template was replaced (2 rows now).
+        self::assertCount(2, $this->lineItems->findByParent(LineItemParent::RecurringInvoice, $id));
+    }
+
+    public function test_update_unknown_id_throws(): void
+    {
+        $useCase = $this->updateUseCase();
+
+        $this->expectException(RecurringInvoiceNotFoundException::class);
+        $useCase->execute(7, 999, new UpdateRecurringInvoiceInput(
+            clientId: $this->clientId,
+            name: 'x',
+            frequency: RecurringFrequency::Monthly,
+            nextRunOn: '2026-07-01',
+            lines: [new LineItemInput('x', 1, 1000, 1000)],
+            isActive: true,
+        ));
+    }
+
+    public function test_delete_soft_deletes_and_audits(): void
+    {
+        $id = $this->seed();
+        $useCase = new DeleteRecurringInvoiceUseCase(
+            $this->recurring,
+            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->audit,
+            $this->holder,
+        );
+
+        $useCase->execute(7, $id);
+
+        self::assertNull($this->recurring->findById($id));
+        $actions = array_map(static fn ($r) => $r['action'], $this->audit->records);
+        self::assertContains('recurring_invoice.deleted', $actions);
+    }
+
+    public function test_delete_unknown_id_throws(): void
+    {
+        $useCase = new DeleteRecurringInvoiceUseCase(
+            $this->recurring,
+            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->audit,
+            $this->holder,
+        );
+
+        $this->expectException(RecurringInvoiceNotFoundException::class);
+        $useCase->execute(7, 999);
+    }
+
+    private function updateUseCase(): UpdateRecurringInvoiceUseCase
+    {
+        return new UpdateRecurringInvoiceUseCase(
+            $this->recurring,
+            $this->lineItems,
+            new ImmediateTransactionManager(),
+            fn () => $this->recurring,
+            fn () => $this->lineItems,
+            $this->clients,
+            new TaxCalculator(),
+            fn () => $this->audit,
+            $this->holder,
+        );
+    }
+}


### PR DESCRIPTION
Refs #503（永続化 #519・生成 #520 に続く第3増分。これ単体では close しない）

## スコープ

定期請求スケジュールの **作成 / 一覧 / 取得 / 編集 / 削除** ドメイン層。**HTTP 結線・OpenAPI とフロント管理UI（/recurring）は次の増分**。auto-issue（採番・適格請求書ロック）は税理士確認ゲートのため本PRでも触れない（下書きテンプレの永続のみ）。

## 変更（src/RecurringInvoice/）

- `CreateRecurringInvoiceUseCase` — client 在組織・明細非空・税率(800/1000)・数量>0・単価>=0・名称・`firstRunOn` 日付を検証 → `TaxCalculator` で totals（ADR 0004）→ ヘッダ＋明細テンプレ（`LineItemParent::RecurringInvoice`）をトランザクション保存 → `recurring_invoice.created` 監査
- `UpdateRecurringInvoiceUseCase` — 再検証・totals 再計算・明細置換・`recurring_invoice.updated`（before/after）
- `DeleteRecurringInvoiceUseCase` — 論理削除＋`recurring_invoice.deleted`
- `ListRecurringInvoicesUseCase`（findByOrganization＋count）/ `GetRecurringInvoiceByIdUseCase`（+lines）
- DTO: `RecurringInvoiceWithLines` / `RecurringInvoiceResponse`(toArray) / `Create`・`Update`Input / `ListRecurringInvoicesResult` / `RecurringInvoiceValidationException`

## テスト

`CreateRecurringInvoiceUseCaseTest`（totals/明細/監査・不明/越境client・空明細・空名称・不正税率・不正日付）、`RecurringInvoiceCrudUseCasesTest`（list 件数/ページング・get(+lines)/not-found・update 置換/再計算/監査・delete 論理削除/監査・各 not-found）。`composer check` 緑。

## 後続（#503 の残り）
- **HTTP 結線＋OpenAPI**: `GET/POST /admin/recurring-invoices`, `GET/PATCH/DELETE /admin/recurring-invoices/{id}`（operationId 登録・Capability=manage_billing・契約テスト）
- **フロント管理UI** `/recurring`（一覧・作成・編集・有効/停止）
- 実行トリガー（Tier B cron / Tier A リクエスト時 due チェック）
- **自動 issue（採番・適格請求書）＝税理士サインオフ必須**

セルフレビュー: `docs/review/backend-api.md` / `docs/review/compliance.md`（下書きテンプレのみ・採番/発行なし＝逸脱なし）。