### PR TITLE
docs: README/CLAUDE/AGENTS を最新状態に同期する (#531)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ This file is the entry point for AI agents working on NeNe Invoice.
 - Commit messages: `docs/development/commit-conventions.md`
 - AI tool policy: `docs/integrations/ai-tools.md`
 - Roadmap: `docs/roadmap.md`
-- Milestones: `docs/milestones/2026-05-governance-and-foundation.md`
+- Milestones: `docs/milestones/` (latest: `2026-06-financial-cluster-and-recurring.md`)
+- Handover (current status + open tasks): `docs/handover/2026-06-28-status-and-next.md`
 
 ## Operating Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Ops / MCP         ──→         │
 
 ## 現在の開発状況
 
-> **最終更新: 2026-06-17**（`docs/todo/current.md` が正本）
+> **最終更新: 2026-06-28**（`docs/todo/current.md` が正本）
 
 | フェーズ | 状態 |
 | --- | --- |
@@ -28,7 +28,7 @@ Ops / MCP         ──→         │
 | Phase 2 管理 UI（React）＋ 適格請求書 PDF ＋ ダッシュボード ＋ 監査ログ ＋ ja/en | ✅ 完了 |
 | Phase 3 Tier A 共有ホスティング（インストーラ・リリース ZIP・運用ガイド） | ✅ 完了 |
 | セキュリティ診断 Round 1–2 | ✅ 完了（指摘修正済み） |
-| Phase 4 エコシステム連携（Records / Concierge・決済GW） | 🔄 進行中（CSV エクスポート・一覧の検索/フィルタ/ソート・言語切替UI・service token 運用・カード決済（PAY.JP；決済リンク/webhook/設定UI・ADR 0013）・認証セッション永続化（サイレント再認証・ADR 0014）は実装済み。残り: Records カタログ連携・Concierge webhook・remember-me/タイムアウト #464・リリース前セキュリティレビュー #465） |
+| Phase 4 エコシステム連携（財務クラスタ・決済GW・managed） | 🔄 進行中。実装/設計済み: CSV・検索/フィルタ/ソート・言語切替・service token・カード決済（PAY.JP・ADR 0013）・認証セッション永続化（ADR 0014）・**定期請求（#519–#523, `/recurring`）**・**NeNe Clear 実接続（契約検証済み）**・**MFA 設計（#524・`docs/design/mfa-totp.md`・Suite ADR 0025 準拠）**。残り: **定期請求の実行ルート配線 #526（P0・最優先）**・自動issue（採番=税理士ゲート）・MFA 実装・銀行自動消込 #505・一括発行 #527・業種テンプレ #528/#513・Records カタログ・Concierge webhook・#464/#465。戦略: clear=現金の楔 / **invoice=財務クラスタの土台** / Suite=managed クラウド。詳細 → `docs/handover/2026-06-28-status-and-next.md`、ペルソナ評価 → `docs/research/persona-review-2026-06-27/` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ NeNe Invoice is an open-source billing platform built on [NENE2](https://github.
 
 ## Quick Start
 
-**Status:** Phases 0–3 shipped — multi-tenant billing API, React admin UI, qualified-invoice PDF, payments, audit logging, bilingual (ja/en) UI with a language switcher, and list search / filter / sort are all in place, plus the Tier A shared-hosting install path and two security-assessment rounds. Phase 4 (sibling-product integration) is in progress: CSV export, service-token management, optional hosted card payments (PAY.JP — pay links, webhook, gateway settings; [ADR 0013](./docs/adr/0013-launch-payment-gateway-payjp.md)), and silent re-authentication via an httpOnly refresh cookie ([ADR 0014](./docs/adr/0014-auth-session-persistence-refresh-cookie.md)) have landed.
+**Status:** Phases 0–3 shipped — multi-tenant billing API, React admin UI, qualified-invoice PDF, payments, audit logging, bilingual (ja/en) UI with a language switcher, and list search / filter / sort are all in place, plus the Tier A shared-hosting install path and two security-assessment rounds. Phase 4 (sibling-product integration) is in progress: CSV export, service-token management, optional hosted card payments (PAY.JP — pay links, webhook, gateway settings; [ADR 0013](./docs/adr/0013-launch-payment-gateway-payjp.md)), and silent re-authentication via an httpOnly refresh cookie ([ADR 0014](./docs/adr/0014-auth-session-persistence-refresh-cookie.md)) have landed. **Recurring billing** (定期請求 — schedule → auto-draft generation, `/recurring`) and a contract-verified upstream link to **NeNe Clear** (reconciliation / dunning) are in; **MFA (standalone TOTP)** is designed ([`docs/design/mfa-totp.md`](./docs/design/mfa-totp.md), conforming to Suite ADR 0025). Managed-cloud delivery is provided by **NeNe Suite** (free-trial / VPS-migration / paid-guarantee). See [`docs/handover/2026-06-28-status-and-next.md`](./docs/handover/2026-06-28-status-and-next.md).
 
 ### Option A — Docker (recommended, fastest)
 
@@ -65,10 +65,14 @@ Shared-hosting / production install uses the web installer (`public_html/install
 
 ```
 Admin UI (React SPA)  ──→  NeNe Invoice API (NENE2 / PHP 8.4)  ──→  MySQL / SQLite
-Ops / MCP             ──→            │
+Ops / MCP             ──→            │  ▲
+NeNe Clear ──HTTP /api/*─────────────┘  │   (reconciliation / dunning — Invoice = billing SSOT)
                                      ↓ HTTP (optional)
                           NeNe Records / NeNe Concierge
 ```
+
+Managed-cloud delivery is orchestrated by **NeNe Suite** (federation IdP + installer); Invoice's
+path into it is the `organizations.external_id` federation link (#492) and the federation epic.
 
 - **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository (org-scoped, ADR 0006)
 - **Money**: integer cents everywhere — no floats; tax rounded once per rate (ADR 0004)
@@ -85,7 +89,7 @@ Ops / MCP             ──→            │
 | 2 | Admin UI (React) + qualified-invoice PDF + dashboard + audit log + ja/en | ✅ |
 | 3 | Tier A shared hosting — installer, release ZIP, operator guide | ✅ |
 | Sec | Security assessment rounds 1–2 (findings fixed) | ✅ |
-| 4 | Ecosystem integration (Records / Concierge, payment gateway) | 🔄 In progress — CSV export ✅ |
+| 4 | Ecosystem integration — CSV export ✅, service tokens ✅, PAY.JP ✅, refresh-cookie auth ✅, **recurring billing** (`/recurring`) ✅ (execution route #526 pending), live **NeNe Clear** link ✅, **MFA design** ✅ (impl pending) | 🔄 In progress |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
@@ -122,7 +126,9 @@ Part of the [hideyukiMORI NeNe portfolio](https://github.com/hideyukiMORI):
 | [nene-records](https://github.com/hideyukiMORI/nene-records) | CMS · optional product catalog |
 | [nene-corpus](https://github.com/hideyukiMORI/nene-corpus) | Knowledge chat |
 | [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Scenario chat · optional leads |
-| **nene-invoice** | Quote · invoice · payment (this repo) |
+| [nene-clear](https://github.com/hideyukiMORI/nene-clear) | Reconciliation · dunning — downstream consumer of this billing SSOT |
+| [nene-suite](https://github.com/hideyukiMORI/nene-suite) | Multi-app installer · federation IdP · managed cloud |
+| **nene-invoice** | Quote · invoice · payment — financial-cluster foundation (this repo) |
 
 ## Contributing
 


### PR DESCRIPTION
Closes #531

直近の実装・戦略（定期請求 #519–#523、Clear↔Invoice 実接続、MFA 設計 #524、managed-first・財務クラスタ・NeNe Suite）を README・CLAUDE.md・AGENTS.md に反映し、#529 で更新済みの TODO/roadmap/milestone/handover と整合させる（docs-only）。

## 変更
- **README.md**: Quick Start ステータス（定期請求 `/recurring`・Clear 上流連携・MFA 設計・Suite managed cloud）／Current Status 表 Phase 4 を具体化／Architecture 図に **NeNe Clear**（→ `/api/*`）を追加＋Suite 注記／Ecosystem 表に **nene-clear・nene-suite** を追加し invoice を「財務クラスタの土台」と明記。
- **CLAUDE.md**: 「現在の開発状況」の最終更新（→2026-06-28）＋ Phase 4 行を刷新（定期請求／Clear 実接続／MFA 設計／managed 戦略／次優先 #526／handover・ペルソナ評価へのリンク）。
- **AGENTS.md**: Milestones を最新（2026-06）に＋引き継ぎ書リンクを追加。

レビュー: `docs/review/docs-policy.md`。