### PR TITLE
feat(payment): 銀行入金CSV自動消込の基盤＝bank_transactions ステージング永続化 (#505 増分1)

### DIFF
--- a/database/migrations/20260630000000_create_bank_transactions_table.php
+++ b/database/migrations/20260630000000_create_bank_transactions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBankTransactionsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('bank_transactions')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('value_date', 'date', ['null' => false])
+            ->addColumn('direction', 'string', ['limit' => 8, 'null' => false])
+            ->addColumn('amount_cents', 'integer', ['null' => false])
+            ->addColumn('payer_name', 'string', ['limit' => 255, 'null' => true])
+            ->addColumn('description', 'string', ['limit' => 512, 'null' => true])
+            ->addColumn('bank_reference', 'string', ['limit' => 255, 'null' => true])
+            ->addColumn('status', 'string', ['limit' => 16, 'null' => false, 'default' => 'unmatched'])
+            ->addColumn('matched_invoice_id', 'integer', ['null' => true])
+            ->addColumn('matched_payment_id', 'integer', ['null' => true])
+            ->addColumn('imported_at', 'datetime', ['null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['organization_id'], ['name' => 'idx_bank_transactions_organization_id'])
+            ->addIndex(['organization_id', 'status'], ['name' => 'idx_bank_transactions_status'])
+            ->addIndex(['organization_id', 'bank_reference'], ['name' => 'idx_bank_transactions_bank_reference'])
+            ->create();
+    }
+}

--- a/database/schema/bank_transactions.sql
+++ b/database/schema/bank_transactions.sql
@@ -1,0 +1,26 @@
+-- Schema snapshot for the bank_transactions table (SQLite dialect, used by repository tests).
+-- Production DDL is applied via database/migrations/ (Phinx). Keep this in sync.
+-- A bank_transaction is one line imported from a bank deposit CSV (#505) — the staging
+-- area for auto-reconciliation (自動消込). Amounts are integer cents (ADR 0004); value_date
+-- is a JST calendar date. Importing only stages rows; matching and posting a payment are
+-- separate, compliance-reviewed concerns (accounting-compliance.md) — staging records nothing.
+-- direction: credit | debit. status: unmatched | matched | posted | ignored.
+CREATE TABLE IF NOT EXISTS bank_transactions (
+    id                 INTEGER      NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id    INTEGER      NOT NULL,
+    value_date         DATE         NOT NULL,
+    direction          VARCHAR(8)   NOT NULL,
+    amount_cents       INTEGER      NOT NULL,
+    payer_name         VARCHAR(255),
+    description        VARCHAR(512),
+    bank_reference     VARCHAR(255),
+    status             VARCHAR(16)  NOT NULL DEFAULT 'unmatched',
+    matched_invoice_id INTEGER,
+    matched_payment_id INTEGER,
+    imported_at        DATETIME     NOT NULL,
+    created_at         DATETIME     NOT NULL,
+    updated_at         DATETIME     NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_bank_transactions_organization_id ON bank_transactions (organization_id);
+CREATE INDEX IF NOT EXISTS idx_bank_transactions_status ON bank_transactions (organization_id, status);
+CREATE INDEX IF NOT EXISTS idx_bank_transactions_bank_reference ON bank_transactions (organization_id, bank_reference);

--- a/database/schema/mysql/schema.sql
+++ b/database/schema/mysql/schema.sql
@@ -326,3 +326,30 @@ CREATE TABLE IF NOT EXISTS `recurring_invoices` (
     KEY `idx_recurring_invoices_organization_id` (`organization_id`),
     KEY `idx_recurring_invoices_due` (`organization_id`, `is_active`, `next_run_on`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------------
+-- bank_transactions — staging for bank-deposit CSV auto-reconciliation (#505).
+-- One line imported from a bank CSV; integer cents (ADR 0004); value_date is a
+-- calendar date. Importing only stages rows — matching/posting a payment is a
+-- separate, compliance-reviewed step. direction: credit | debit.
+-- status: unmatched | matched | posted | ignored.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `bank_transactions` (
+    `id`                 INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `organization_id`    INT          NOT NULL,
+    `value_date`         DATE         NOT NULL,
+    `direction`          VARCHAR(8)   NOT NULL,
+    `amount_cents`       INT          NOT NULL,
+    `payer_name`         VARCHAR(255) DEFAULT NULL,
+    `description`        VARCHAR(512) DEFAULT NULL,
+    `bank_reference`     VARCHAR(255) DEFAULT NULL,
+    `status`             VARCHAR(16)  NOT NULL DEFAULT 'unmatched',
+    `matched_invoice_id` INT          DEFAULT NULL,
+    `matched_payment_id` INT          DEFAULT NULL,
+    `imported_at`        DATETIME     NOT NULL,
+    `created_at`         DATETIME     NOT NULL,
+    `updated_at`         DATETIME     NOT NULL,
+    KEY `idx_bank_transactions_organization_id` (`organization_id`),
+    KEY `idx_bank_transactions_status` (`organization_id`, `status`),
+    KEY `idx_bank_transactions_bank_reference` (`organization_id`, `bank_reference`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -47,6 +47,7 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 | Number generator | `DocumentSequence` | `document_sequences` | — |
 | Integration credential | `ServiceToken` | `service_tokens` | `service_token_id` |
 | Recurring billing | `RecurringInvoice` | `recurring_invoices` | `recurring_invoice_id` |
+| Bank line (入金明細) | `BankTransaction` | `bank_transactions` | `bank_transaction_id` |
 
 Domain folders are **PascalCase singular**; tables are **snake_case plural**.
 
@@ -70,6 +71,8 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `payment_link.status` | `active`, `paid`, `revoked` (expiry derived from `expires_at`, not stored) |
 | `payment_link.gateway` | `payjp` (launch gateway — ADR 0013) |
 | `recurring_invoice.frequency` | `monthly`, `quarterly` (#503) |
+| `bank_transaction.status` | `unmatched`, `matched`, `posted`, `ignored` (#505) |
+| `bank_transaction.direction` | `credit`, `debit` (#505) |
 | `company_settings.pdf_template` | `standard` (default), `modern`, `classic` (見積/請求 PDF レイアウト — Issue #449) |
 | `company_settings.pdf_spacing` | `small`, `medium` (default), `large` (PDF 余白スケール大中小 — Issue #449) |
 | `company_settings.pdf_heading_font` | `gothic` (default), `mincho` (PDF 見出しフォント — Issue #449) |
@@ -112,6 +115,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Client fields | `name_kana`, `contact_name`, `billing_address` | `kana`, `furigana`, `name_reading`, `contact`, `address` |
 | Item master defaults | `default_unit_price_cents`, `default_tax_rate_bps` | `default_price_cents`, `item_price_cents`, `default_rate`, `unit_price` |
 | Recurring-billing fields | `frequency` (values §2), `next_run_on`, `last_run_on` (calendar dates like `valid_until`), `is_active` | `interval`, `cycle`, `next_run`, `last_run`, `active`, `enabled` |
+| Bank-transaction fields | `value_date`, `direction` (values §2), `amount_cents`, `payer_name`, `bank_reference`, `status` (values §2), `matched_invoice_id`, `matched_payment_id`, `imported_at` | `date`, `txn_type`, `cr_dr`, `amount`, `payer`, `remitter`, `ref`, `bank_ref`, `ext_ref`, `matched_id` |
 | Service-token fields | `jti`, `subject`, `label`, `scopes`, `created_by`, `expires_at`, `revoked_at`, `ttl_seconds` | `jwt_id`, `name`, `scope`, `created_user_id`, `expiry`, `revoked`, `ttl` |
 | Payment-link fields | `token_hash`, `gateway`, `gateway_session_id`, `status`, `expires_at`, `paid_at`, `revoked_at` | `token`, `session`, `provider`, `expiry`, `paid`, `revoked` |
 | Gateway-settings fields | `gateway`, `public_key_masked`, `secret_set`, `webhook_token_set`, `configured`, `ok`, `detail` (`connected`/`not_configured`/`invalid_credentials`/`unreachable`) | `secret_key`, `api_key`, `public_key`, `status` |

--- a/src/BankTransaction/BankTransaction.php
+++ b/src/BankTransaction/BankTransaction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * One line imported from a bank deposit CSV (#505): the staging unit for
+ * auto-reconciliation (自動消込). Amounts are integer cents (ADR 0004) and
+ * `valueDate` is a JST calendar date (`Y-m-d`).
+ *
+ * A bank transaction is raw imported data, not a billing record — it carries no
+ * accounting weight until an operator confirms a match and a payment is recorded
+ * (a later, compliance-reviewed step). `bankReference` is the bank's own line
+ * identifier, used to skip re-importing the same line and, on posting, to seed
+ * the payment's `external_reference`.
+ */
+final readonly class BankTransaction
+{
+    public function __construct(
+        public int $organizationId,
+        public string $valueDate,
+        public BankTransactionDirection $direction,
+        public int $amountCents,
+        public ?string $payerName = null,
+        public ?string $description = null,
+        public ?string $bankReference = null,
+        public BankTransactionStatus $status = BankTransactionStatus::Unmatched,
+        public ?int $matchedInvoiceId = null,
+        public ?int $matchedPaymentId = null,
+        public ?string $importedAt = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/BankTransaction/BankTransactionDirection.php
+++ b/src/BankTransaction/BankTransactionDirection.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Direction of an imported bank line (#505). Receivable reconciliation (消込)
+ * matches `credit` (入金) lines; `debit` lines are imported for completeness but
+ * are not candidates for matching against invoices.
+ */
+enum BankTransactionDirection: string
+{
+    case Credit = 'credit';
+    case Debit  = 'debit';
+}

--- a/src/BankTransaction/BankTransactionNotFoundException.php
+++ b/src/BankTransaction/BankTransactionNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use RuntimeException;
+
+final class BankTransactionNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $bankTransactionId)
+    {
+        parent::__construct(sprintf('Bank transaction %d was not found.', $bankTransactionId));
+    }
+}

--- a/src/BankTransaction/BankTransactionRepositoryInterface.php
+++ b/src/BankTransaction/BankTransactionRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+interface BankTransactionRepositoryInterface
+{
+    public function save(BankTransaction $transaction): int;
+
+    public function findById(int $id): ?BankTransaction;
+
+    /** @return list<BankTransaction> */
+    public function findByOrganization(int $limit, int $offset): array;
+
+    public function countByOrganization(): int;
+
+    /**
+     * The org-scoped row already imported with this bank line identifier, or
+     * null. Used to skip re-importing the same line (idempotent import).
+     */
+    public function findByBankReference(string $bankReference): ?BankTransaction;
+
+    /** @throws BankTransactionNotFoundException */
+    public function update(BankTransaction $transaction): void;
+}

--- a/src/BankTransaction/BankTransactionStatus.php
+++ b/src/BankTransaction/BankTransactionStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Reconciliation state of an imported bank line (#505).
+ *
+ * - `unmatched`: imported, not yet linked to an invoice (the default).
+ * - `matched`: an operator linked it to an invoice but no payment is recorded yet.
+ * - `posted`: a payment was recorded from it (links `matched_payment_id`).
+ * - `ignored`: an operator dismissed it (fees, non-AR transfers, duplicates).
+ *
+ * Posting a payment is a separate, compliance-reviewed step (accounting-compliance.md);
+ * importing only ever produces `unmatched` rows.
+ */
+enum BankTransactionStatus: string
+{
+    case Unmatched = 'unmatched';
+    case Matched   = 'matched';
+    case Posted    = 'posted';
+    case Ignored   = 'ignored';
+}

--- a/src/BankTransaction/PdoBankTransactionRepository.php
+++ b/src/BankTransaction/PdoBankTransactionRepository.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+final readonly class PdoBankTransactionRepository implements BankTransactionRepositoryInterface
+{
+    private const COLUMNS = 'id, organization_id, value_date, direction, amount_cents, payer_name, description, bank_reference, status, matched_invoice_id, matched_payment_id, imported_at, created_at, updated_at';
+
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    public function save(BankTransaction $transaction): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        // The organization is forced from the request-scoped holder.
+        $this->query->execute(
+            'INSERT INTO bank_transactions (organization_id, value_date, direction, amount_cents, payer_name, description, bank_reference, status, matched_invoice_id, matched_payment_id, imported_at, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->orgId->get(),
+                $transaction->valueDate,
+                $transaction->direction->value,
+                $transaction->amountCents,
+                $transaction->payerName,
+                $transaction->description,
+                $transaction->bankReference,
+                $transaction->status->value,
+                $transaction->matchedInvoiceId,
+                $transaction->matchedPaymentId,
+                $transaction->importedAt ?? $now,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findById(int $id): ?BankTransaction
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId->get()],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<BankTransaction> */
+    public function findByOrganization(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions
+             WHERE organization_id = ?
+             ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+            [$this->orgId->get(), $limit, $offset],
+        );
+
+        return array_map(fn (array $row): BankTransaction => $this->mapRow($row), $rows);
+    }
+
+    public function countByOrganization(): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS cnt FROM bank_transactions WHERE organization_id = ?',
+            [$this->orgId->get()],
+        );
+
+        return $row !== null ? (int) $row['cnt'] : 0;
+    }
+
+    public function findByBankReference(string $bankReference): ?BankTransaction
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions
+             WHERE organization_id = ? AND bank_reference = ?
+             ORDER BY id ASC LIMIT 1',
+            [$this->orgId->get(), $bankReference],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function update(BankTransaction $transaction): void
+    {
+        if ($transaction->id === null) {
+            throw new BankTransactionNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $affected = $this->query->execute(
+            'UPDATE bank_transactions SET value_date = ?, direction = ?, amount_cents = ?, payer_name = ?, description = ?, bank_reference = ?, status = ?, matched_invoice_id = ?, matched_payment_id = ?, updated_at = ?
+             WHERE id = ? AND organization_id = ?',
+            [
+                $transaction->valueDate,
+                $transaction->direction->value,
+                $transaction->amountCents,
+                $transaction->payerName,
+                $transaction->description,
+                $transaction->bankReference,
+                $transaction->status->value,
+                $transaction->matchedInvoiceId,
+                $transaction->matchedPaymentId,
+                $now,
+                $transaction->id,
+                $this->orgId->get(),
+            ],
+        );
+
+        if ($affected === 0 && $this->findById($transaction->id) === null) {
+            throw new BankTransactionNotFoundException($transaction->id);
+        }
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): BankTransaction
+    {
+        return new BankTransaction(
+            organizationId: (int) $row['organization_id'],
+            valueDate: (string) $row['value_date'],
+            direction: BankTransactionDirection::from((string) $row['direction']),
+            amountCents: (int) $row['amount_cents'],
+            payerName: isset($row['payer_name']) && $row['payer_name'] !== '' ? (string) $row['payer_name'] : null,
+            description: isset($row['description']) && $row['description'] !== '' ? (string) $row['description'] : null,
+            bankReference: isset($row['bank_reference']) && $row['bank_reference'] !== '' ? (string) $row['bank_reference'] : null,
+            status: BankTransactionStatus::from((string) $row['status']),
+            matchedInvoiceId: isset($row['matched_invoice_id']) ? (int) $row['matched_invoice_id'] : null,
+            matchedPaymentId: isset($row['matched_payment_id']) ? (int) $row['matched_payment_id'] : null,
+            importedAt: (string) $row['imported_at'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/tests/BankTransaction/PdoBankTransactionRepositoryTest.php
+++ b/tests/BankTransaction/PdoBankTransactionRepositoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use NeneInvoice\BankTransaction\BankTransactionNotFoundException;
+use NeneInvoice\BankTransaction\BankTransactionStatus;
+use NeneInvoice\BankTransaction\PdoBankTransactionRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PdoBankTransactionRepositoryTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private PdoBankTransactionRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/bank_transactions.sql');
+        self::assertIsString($schema);
+        $pdo->exec($schema);
+
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoBankTransactionRepository(
+            new PdoDatabaseQueryExecutor($factory, $pdo),
+            $this->holder,
+        );
+    }
+
+    private function line(
+        string $valueDate = '2026-06-30',
+        int $amountCents = 11000,
+        ?string $payerName = 'カ）サンプルセイサクシヨ',
+        ?string $bankReference = 'TXN-0001',
+        BankTransactionDirection $direction = BankTransactionDirection::Credit,
+    ): BankTransaction {
+        return new BankTransaction(
+            organizationId: 1,
+            valueDate: $valueDate,
+            direction: $direction,
+            amountCents: $amountCents,
+            payerName: $payerName,
+            description: '振込',
+            bankReference: $bankReference,
+        );
+    }
+
+    public function test_save_and_find_round_trips_all_fields(): void
+    {
+        $id = $this->repository->save($this->line());
+
+        $found = $this->repository->findById($id);
+        self::assertNotNull($found);
+        self::assertSame($id, $found->id);
+        self::assertSame(1, $found->organizationId);
+        self::assertSame('2026-06-30', $found->valueDate);
+        self::assertSame(BankTransactionDirection::Credit, $found->direction);
+        self::assertSame(11000, $found->amountCents);
+        self::assertSame('カ）サンプルセイサクシヨ', $found->payerName);
+        self::assertSame('振込', $found->description);
+        self::assertSame('TXN-0001', $found->bankReference);
+        self::assertSame(BankTransactionStatus::Unmatched, $found->status);
+        self::assertNull($found->matchedInvoiceId);
+        self::assertNull($found->matchedPaymentId);
+        self::assertNotNull($found->importedAt);
+    }
+
+    public function test_list_is_newest_value_date_first_with_count(): void
+    {
+        $this->repository->save($this->line(valueDate: '2026-06-01', bankReference: 'A'));
+        $this->repository->save($this->line(valueDate: '2026-06-30', bankReference: 'B'));
+        $this->repository->save($this->line(valueDate: '2026-06-15', bankReference: 'C'));
+
+        $rows = $this->repository->findByOrganization(10, 0);
+        self::assertCount(3, $rows);
+        self::assertSame('2026-06-30', $rows[0]->valueDate);
+        self::assertSame('2026-06-15', $rows[1]->valueDate);
+        self::assertSame('2026-06-01', $rows[2]->valueDate);
+        self::assertSame(3, $this->repository->countByOrganization());
+    }
+
+    public function test_reads_are_scoped_to_the_organization(): void
+    {
+        $id = $this->repository->save($this->line());
+
+        $this->holder->set(2);
+        self::assertNull($this->repository->findById($id));
+        self::assertSame([], $this->repository->findByOrganization(10, 0));
+        self::assertSame(0, $this->repository->countByOrganization());
+        self::assertNull($this->repository->findByBankReference('TXN-0001'));
+    }
+
+    public function test_find_by_bank_reference_supports_idempotent_import(): void
+    {
+        $this->repository->save($this->line(bankReference: 'TXN-0001'));
+
+        self::assertNotNull($this->repository->findByBankReference('TXN-0001'));
+        self::assertNull($this->repository->findByBankReference('TXN-9999'));
+    }
+
+    public function test_update_changes_status_and_match(): void
+    {
+        $id    = $this->repository->save($this->line());
+        $saved = $this->repository->findById($id);
+        self::assertNotNull($saved);
+
+        $this->repository->update(new BankTransaction(
+            organizationId: $saved->organizationId,
+            valueDate: $saved->valueDate,
+            direction: $saved->direction,
+            amountCents: $saved->amountCents,
+            payerName: $saved->payerName,
+            description: $saved->description,
+            bankReference: $saved->bankReference,
+            status: BankTransactionStatus::Posted,
+            matchedInvoiceId: 42,
+            matchedPaymentId: 7,
+            importedAt: $saved->importedAt,
+            id: $saved->id,
+            createdAt: $saved->createdAt,
+            updatedAt: $saved->updatedAt,
+        ));
+
+        $updated = $this->repository->findById($id);
+        self::assertNotNull($updated);
+        self::assertSame(BankTransactionStatus::Posted, $updated->status);
+        self::assertSame(42, $updated->matchedInvoiceId);
+        self::assertSame(7, $updated->matchedPaymentId);
+    }
+
+    public function test_update_missing_row_throws(): void
+    {
+        $this->expectException(BankTransactionNotFoundException::class);
+
+        $this->repository->update(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-30',
+            direction: BankTransactionDirection::Credit,
+            amountCents: 1000,
+            id: 999,
+        ));
+    }
+}


### PR DESCRIPTION
## 概要

**#505（銀行入金CSVの自動消込）エピックの第1増分**。取り込んだ銀行明細を保持する**ステージング永続化層**を追加する。#503（定期請求）と同様に増分PRで進める。

この増分は**取込（staging）のみ**で、照合（matching）・入金起票（posting）は**含めない** → 会計影響なし・コンプライアンス軽量。起票は税理士サインオフ済みの `RecordPaymentUseCase`（冪等・`external_reference`・過入金ガード）を後続増分で再利用する。

## 変更

- `bank_transactions` テーブル（org スコープ）+ `BankTransaction` エンティティ + `BankTransactionDirection`（credit/debit）/ `BankTransactionStatus`（unmatched/matched/posted/ignored）enum
- `BankTransactionRepositoryInterface` + `PdoBankTransactionRepository`（save / findById / findByOrganization / countByOrganization / **findByBankReference**〔冪等再取込のため〕/ update）
- **スキーマ3点同期**: Phinx migration + SQLite snapshot + installer `mysql/schema.sql`（`SchemaParityTest` 緑）
- **用語レジストリ**更新（§1 エンティティ / §2 status・direction / §3 fields）

## コンプライアンス

bank_transaction は billing record ではなく**取込生データ**。`is_deleted` を持たず、status `ignored` で除外する。**入金起票には一切踏み込まない**（accounting-compliance.md）。手数料差引の write-off は後続増分で**税理士ゲート**として扱う。

## 検証

- `composer check` 緑: **783 tests**（+6）/ PHPStan max 685 files / php-cs-fixer / OpenAPI / MCP。
- repo テスト: 往復・新しい順・**org 隔離**・`bank_reference` 冪等・update/NotFound。
- ephemeral SQLite で `phinx migrate` を実行し、テーブル（14列・3索引）生成を確認。

## 後続増分（このPRには含めない）

1. **②CSV パーサ**: 全銀協フォーマット＋列マッピング保存（formula-injection 安全な既存 `Csv`/`CsvImport` 基盤を流用、Tier A 可）→ `unmatched` 行を生成
2. **③名義ゆれ辞書（payer_alias）＋スコアリング照合**: 金額一致＋依頼人名＋未回収(`outstanding_cents`)で候補提示
3. **④確認→一括起票**: 既存 `RecordPayment`（`idempotency_key` / `external_reference=bank_reference`）へ
4. **⑤手数料差引許容・一部/過入金区別・保留キュー**（税理士ゲート）
5. **⑥消込ワークベンチ UI**

Refs #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)