### PR TITLE
feat(payment): 銀行CSVの列マッピング取込パーサ＋取込ユースケース (#505 増分2)

### DIFF
--- a/src/BankTransaction/BankCsvColumnMapping.php
+++ b/src/BankTransaction/BankCsvColumnMapping.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * How a particular bank's CSV columns map onto the canonical bank-line fields
+ * (#505). Banks differ in column order, headers, date format, encoding, and
+ * whether they expose a single signed amount or separate deposit/withdrawal
+ * columns — so reconciliation imports are driven by this mapping rather than a
+ * fixed template. Built-in starting points live in {@see BankImportPresets}.
+ *
+ * Columns are referenced by 0-based index (robust whether or not the file has a
+ * header row). Provide **either** `amountColumn` (a signed amount: positive =
+ * deposit, negative = withdrawal) **or** `creditColumn`/`debitColumn` (separate
+ * 入金/出金 columns).
+ */
+final readonly class BankCsvColumnMapping
+{
+    public const ENCODING_UTF8      = 'utf-8';
+    public const ENCODING_SHIFT_JIS = 'shift_jis';
+    public const ENCODING_AUTO      = 'auto';
+
+    public function __construct(
+        public int $valueDateColumn,
+        public string $dateFormat = 'Y/m/d',
+        public ?int $amountColumn = null,
+        public ?int $creditColumn = null,
+        public ?int $debitColumn = null,
+        public ?int $payerNameColumn = null,
+        public ?int $bankReferenceColumn = null,
+        public ?int $descriptionColumn = null,
+        public bool $hasHeader = true,
+        public string $encoding = self::ENCODING_AUTO,
+    ) {
+    }
+
+    /**
+     * Whether at least one amount source is configured. A mapping with no amount
+     * column cannot produce transactions and is rejected by the parser.
+     */
+    public function hasAmountSource(): bool
+    {
+        return $this->amountColumn !== null || $this->creditColumn !== null || $this->debitColumn !== null;
+    }
+}

--- a/src/BankTransaction/BankCsvParseResult.php
+++ b/src/BankTransaction/BankCsvParseResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Outcome of {@see BankCsvParser::parse()}. Either a whole-file `formatError`
+ * (encoding / size / no amount column) with no transactions, or the parsed
+ * credit/debit lines plus per-row `errors` for rows that could not be read
+ * (e.g. an unparseable date) — the readable rows still come through.
+ *
+ * @phpstan-type BankCsvRowError array{line: int, reason: string}
+ */
+final readonly class BankCsvParseResult
+{
+    /**
+     * @param list<BankTransaction>  $transactions
+     * @param list<BankCsvRowError>  $errors
+     */
+    private function __construct(
+        public ?string $formatError,
+        public array $transactions,
+        public array $errors,
+    ) {
+    }
+
+    public static function rejected(string $reason): self
+    {
+        return new self($reason, [], []);
+    }
+
+    /**
+     * @param list<BankTransaction> $transactions
+     * @param list<BankCsvRowError> $errors
+     */
+    public static function parsed(array $transactions, array $errors): self
+    {
+        return new self(null, $transactions, $errors);
+    }
+}

--- a/src/BankTransaction/BankCsvParser.php
+++ b/src/BankTransaction/BankCsvParser.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use DateTimeImmutable;
+use NeneInvoice\Support\CsvImport;
+
+/**
+ * Parses a bank statement CSV into staged {@see BankTransaction} lines (#505)
+ * using a per-bank {@see BankCsvColumnMapping}. Handles Shift_JIS (the common
+ * Japanese bank encoding) as well as UTF-8, strips a UTF-8 BOM, normalizes
+ * full-width digits, and tolerates thousands separators / currency marks in
+ * amount cells.
+ *
+ * Parsing produces `unmatched` staging rows only — it records no payment and has
+ * no accounting effect (matching/posting are later, compliance-reviewed steps).
+ */
+final class BankCsvParser
+{
+    public const MAX_BYTES = CsvImport::MAX_BYTES;
+
+    public static function parse(string $raw, BankCsvColumnMapping $mapping, int $maxRows = 5000): BankCsvParseResult
+    {
+        if (strlen($raw) > self::MAX_BYTES) {
+            return BankCsvParseResult::rejected(sprintf('ファイルサイズが上限（%d MB）を超えています。分割して取り込んでください。', intdiv(self::MAX_BYTES, 1_048_576)));
+        }
+
+        if (!$mapping->hasAmountSource()) {
+            return BankCsvParseResult::rejected('列マッピングに金額列（符号付き金額、または入金/出金列）が指定されていません。');
+        }
+
+        $utf8 = self::toUtf8($raw, $mapping->encoding);
+        if ($utf8 === null) {
+            return BankCsvParseResult::rejected('ファイルの文字コードを UTF-8 に変換できませんでした。エンコーディング指定（utf-8 / shift_jis）を確認してください。');
+        }
+
+        $records = self::readRecords($utf8);
+        if ($records === []) {
+            return BankCsvParseResult::rejected('ファイルが空です。');
+        }
+
+        $line = 0;
+        if ($mapping->hasHeader) {
+            array_shift($records);
+            $line = 1;
+        }
+
+        $transactions = [];
+        $errors       = [];
+
+        foreach ($records as $cells) {
+            ++$line;
+
+            if (self::isBlank($cells)) {
+                continue;
+            }
+
+            $result = self::mapRow($cells, $mapping);
+
+            if (is_string($result)) {
+                $errors[] = ['line' => $line, 'reason' => $result];
+
+                continue;
+            }
+
+            if ($result === null) {
+                continue; // not a money movement (zero amount)
+            }
+
+            $transactions[] = $result;
+
+            if (count($transactions) > $maxRows) {
+                return BankCsvParseResult::rejected(sprintf('行数が上限（%d 行）を超えています。分割して取り込んでください。', $maxRows));
+            }
+        }
+
+        return BankCsvParseResult::parsed($transactions, $errors);
+    }
+
+    /**
+     * @param list<string> $cells
+     * @return BankTransaction|string|null  a transaction, an error reason, or null to skip
+     */
+    private static function mapRow(array $cells, BankCsvColumnMapping $mapping): BankTransaction|string|null
+    {
+        $dateRaw = self::cell($cells, $mapping->valueDateColumn);
+        if ($dateRaw === '') {
+            return '日付列が空です。';
+        }
+
+        $date   = DateTimeImmutable::createFromFormat('!' . $mapping->dateFormat, $dateRaw);
+        $errors = DateTimeImmutable::getLastErrors();
+        if ($date === false || ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0))) {
+            return sprintf('日付『%s』を形式『%s』で解釈できませんでした。', $dateRaw, $mapping->dateFormat);
+        }
+
+        [$amountCents, $direction] = self::resolveAmount($cells, $mapping);
+        if ($amountCents === 0) {
+            return null;
+        }
+
+        return new BankTransaction(
+            organizationId: 0, // forced from the org holder at persistence
+            valueDate: $date->format('Y-m-d'),
+            direction: $direction,
+            amountCents: $amountCents,
+            payerName: self::optionalCell($cells, $mapping->payerNameColumn),
+            description: self::optionalCell($cells, $mapping->descriptionColumn),
+            bankReference: self::optionalCell($cells, $mapping->bankReferenceColumn),
+        );
+    }
+
+    /**
+     * @param list<string> $cells
+     * @return array{0: int, 1: BankTransactionDirection}
+     */
+    private static function resolveAmount(array $cells, BankCsvColumnMapping $mapping): array
+    {
+        if ($mapping->amountColumn !== null) {
+            $signed = self::toInt(self::cell($cells, $mapping->amountColumn));
+
+            return $signed >= 0
+                ? [$signed, BankTransactionDirection::Credit]
+                : [-$signed, BankTransactionDirection::Debit];
+        }
+
+        $credit = $mapping->creditColumn !== null ? self::toInt(self::cell($cells, $mapping->creditColumn)) : 0;
+        if ($credit !== 0) {
+            return [abs($credit), BankTransactionDirection::Credit];
+        }
+
+        $debit = $mapping->debitColumn !== null ? self::toInt(self::cell($cells, $mapping->debitColumn)) : 0;
+        if ($debit !== 0) {
+            return [abs($debit), BankTransactionDirection::Debit];
+        }
+
+        return [0, BankTransactionDirection::Credit];
+    }
+
+    /** @param list<string> $cells */
+    private static function optionalCell(array $cells, ?int $index): ?string
+    {
+        if ($index === null) {
+            return null;
+        }
+
+        $value = self::cell($cells, $index);
+
+        return $value !== '' ? $value : null;
+    }
+
+    /** @param list<string> $cells */
+    private static function cell(array $cells, int $index): string
+    {
+        return isset($cells[$index]) ? trim((string) $cells[$index]) : '';
+    }
+
+    /** Strips currency marks / separators and normalizes full-width digits to an int. */
+    private static function toInt(string $cell): int
+    {
+        $normalized = preg_replace('/[^0-9-]/', '', mb_convert_kana($cell, 'n'));
+        if ($normalized === null || $normalized === '' || $normalized === '-') {
+            return 0;
+        }
+
+        return (int) $normalized;
+    }
+
+    /** @return list<list<string>> */
+    private static function readRecords(string $raw): array
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        fwrite($handle, $raw);
+        rewind($handle);
+
+        $records = [];
+        while (($cells = fgetcsv($handle, 0, ',', '"', '')) !== false) {
+            $records[] = array_map(static fn ($c): string => $c ?? '', $cells);
+        }
+        fclose($handle);
+
+        return $records;
+    }
+
+    /** @param list<string> $cells */
+    private static function isBlank(array $cells): bool
+    {
+        foreach ($cells as $cell) {
+            if (trim($cell) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function toUtf8(string $raw, string $encoding): ?string
+    {
+        if (str_starts_with($raw, "\xEF\xBB\xBF")) {
+            $raw = substr($raw, 3);
+        }
+
+        $encoding = strtolower($encoding);
+
+        if ($encoding === BankCsvColumnMapping::ENCODING_UTF8) {
+            return mb_check_encoding($raw, 'UTF-8') ? $raw : null;
+        }
+
+        if ($encoding === BankCsvColumnMapping::ENCODING_SHIFT_JIS) {
+            return self::fromShiftJis($raw);
+        }
+
+        // auto: trust valid UTF-8, otherwise assume Shift_JIS (CP932).
+        if (mb_check_encoding($raw, 'UTF-8')) {
+            return $raw;
+        }
+
+        return self::fromShiftJis($raw);
+    }
+
+    private static function fromShiftJis(string $raw): ?string
+    {
+        $converted = mb_convert_encoding($raw, 'UTF-8', 'SJIS-win');
+
+        return mb_check_encoding($converted, 'UTF-8') ? $converted : null;
+    }
+}

--- a/src/BankTransaction/BankImportPresets.php
+++ b/src/BankTransaction/BankImportPresets.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Built-in column-mapping starting points for common Japanese bank CSV shapes
+ * (#505). These are sensible defaults an operator adjusts per bank — not
+ * authoritative specifications. The column-mapping engine ({@see BankCsvParser})
+ * is the real mechanism; presets just pre-fill the indices.
+ */
+final class BankImportPresets
+{
+    /**
+     * Separate deposit/withdrawal columns with a header row — the common net-bank
+     * statement shape (e.g. `日付,内容,お支払金額,お預り金額,残高`). Shift_JIS by
+     * default, as most Japanese banks export. Adjust the indices to the bank.
+     */
+    public static function netBankCreditDebit(): BankCsvColumnMapping
+    {
+        return new BankCsvColumnMapping(
+            valueDateColumn: 0,
+            dateFormat: 'Y/m/d',
+            debitColumn: 2,
+            creditColumn: 3,
+            payerNameColumn: 1,
+            descriptionColumn: 1,
+            hasHeader: true,
+            encoding: BankCsvColumnMapping::ENCODING_AUTO,
+        );
+    }
+
+    /**
+     * A single signed amount column (positive = deposit, negative = withdrawal)
+     * with a header row — e.g. `日付,金額,依頼人,摘要`.
+     */
+    public static function signedAmount(): BankCsvColumnMapping
+    {
+        return new BankCsvColumnMapping(
+            valueDateColumn: 0,
+            dateFormat: 'Y-m-d',
+            amountColumn: 1,
+            payerNameColumn: 2,
+            descriptionColumn: 3,
+            hasHeader: true,
+            encoding: BankCsvColumnMapping::ENCODING_AUTO,
+        );
+    }
+}

--- a/src/BankTransaction/ImportBankTransactionsResult.php
+++ b/src/BankTransaction/ImportBankTransactionsResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Outcome of {@see ImportBankTransactionsUseCase::execute()}.
+ *
+ * `formatError` (when non-null) means the whole file was rejected and nothing
+ * was imported. Otherwise `importedCount` rows were staged, `skippedDuplicateCount`
+ * were skipped because their `bank_reference` was already imported (idempotent
+ * re-import), and `rowErrors` lists rows that could not be parsed.
+ *
+ * @phpstan-type BankCsvRowError array{line: int, reason: string}
+ */
+final readonly class ImportBankTransactionsResult
+{
+    /**
+     * @param list<BankCsvRowError> $rowErrors
+     */
+    public function __construct(
+        public int $importedCount,
+        public int $skippedDuplicateCount,
+        public array $rowErrors,
+        public ?string $formatError,
+    ) {
+    }
+}

--- a/src/BankTransaction/ImportBankTransactionsUseCase.php
+++ b/src/BankTransaction/ImportBankTransactionsUseCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+/**
+ * Imports a bank statement CSV into staged {@see BankTransaction} rows (#505).
+ *
+ * Parses with {@see BankCsvParser}, then persists the lines in one transaction,
+ * skipping any whose `bank_reference` was already imported (idempotent
+ * re-import) and de-duplicating references within the same file. Staging only —
+ * it records **no payment**; matching a line to an invoice and recording a
+ * payment are later, compliance-reviewed steps (accounting-compliance.md).
+ */
+final readonly class ImportBankTransactionsUseCase
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $repositoryFactory
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $repositoryFactory,
+    ) {
+    }
+
+    public function execute(string $raw, BankCsvColumnMapping $mapping): ImportBankTransactionsResult
+    {
+        $parse = BankCsvParser::parse($raw, $mapping);
+
+        if ($parse->formatError !== null) {
+            return new ImportBankTransactionsResult(0, 0, [], $parse->formatError);
+        }
+
+        /** @var array{imported: int, skipped: int} $counts */
+        $counts = $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($parse): array {
+            $repository = ($this->repositoryFactory)($exec);
+            $imported   = 0;
+            $skipped    = 0;
+            $seen       = [];
+
+            foreach ($parse->transactions as $transaction) {
+                $reference = $transaction->bankReference;
+
+                if ($reference !== null) {
+                    if (isset($seen[$reference]) || $repository->findByBankReference($reference) !== null) {
+                        ++$skipped;
+
+                        continue;
+                    }
+
+                    $seen[$reference] = true;
+                }
+
+                $repository->save($transaction);
+                ++$imported;
+            }
+
+            return ['imported' => $imported, 'skipped' => $skipped];
+        });
+
+        return new ImportBankTransactionsResult($counts['imported'], $counts['skipped'], $parse->errors, null);
+    }
+}

--- a/tests/BankTransaction/BankCsvParserTest.php
+++ b/tests/BankTransaction/BankCsvParserTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use NeneInvoice\BankTransaction\BankCsvColumnMapping;
+use NeneInvoice\BankTransaction\BankCsvParser;
+use NeneInvoice\BankTransaction\BankImportPresets;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use PHPUnit\Framework\TestCase;
+
+final class BankCsvParserTest extends TestCase
+{
+    public function test_signed_amount_layout_splits_credit_and_debit(): void
+    {
+        $csv = <<<CSV
+        日付,金額,依頼人,摘要
+        2026-06-30,"11,000",カ）サンプル,振込
+        2026-06-29,-3000,,ATM出金
+        2026-06-28,0,,残高のみ
+        CSV;
+
+        $result = BankCsvParser::parse($csv, BankImportPresets::signedAmount());
+
+        self::assertNull($result->formatError);
+        self::assertSame([], $result->errors);
+        self::assertCount(2, $result->transactions); // zero-amount row skipped
+
+        $credit = $result->transactions[0];
+        self::assertSame('2026-06-30', $credit->valueDate);
+        self::assertSame(BankTransactionDirection::Credit, $credit->direction);
+        self::assertSame(11000, $credit->amountCents);
+        self::assertSame('カ）サンプル', $credit->payerName);
+        self::assertSame('振込', $credit->description);
+
+        $debit = $result->transactions[1];
+        self::assertSame(BankTransactionDirection::Debit, $debit->direction);
+        self::assertSame(3000, $debit->amountCents);
+    }
+
+    public function test_separate_credit_debit_columns(): void
+    {
+        $csv = <<<CSV
+        日付,内容,お支払金額,お預り金額,残高
+        2026/06/30,振込 カ）サンプル,,11000,111000
+        2026/06/29,引落 デンキ,3000,,108000
+        CSV;
+
+        $result = BankCsvParser::parse($csv, BankImportPresets::netBankCreditDebit());
+
+        self::assertNull($result->formatError);
+        self::assertCount(2, $result->transactions);
+        self::assertSame(BankTransactionDirection::Credit, $result->transactions[0]->direction);
+        self::assertSame(11000, $result->transactions[0]->amountCents);
+        self::assertSame('振込 カ）サンプル', $result->transactions[0]->payerName);
+        self::assertSame(BankTransactionDirection::Debit, $result->transactions[1]->direction);
+        self::assertSame(3000, $result->transactions[1]->amountCents);
+    }
+
+    public function test_shift_jis_is_decoded(): void
+    {
+        $utf8 = "日付,金額,依頼人,摘要\n2026-06-30,5000,カ）ネネショウカイ,振込\n";
+        $sjis = mb_convert_encoding($utf8, 'SJIS-win', 'UTF-8');
+
+        $result = BankCsvParser::parse($sjis, BankImportPresets::signedAmount());
+
+        self::assertNull($result->formatError);
+        self::assertCount(1, $result->transactions);
+        self::assertSame('カ）ネネショウカイ', $result->transactions[0]->payerName);
+        self::assertSame(5000, $result->transactions[0]->amountCents);
+    }
+
+    public function test_unparseable_date_becomes_a_row_error_others_still_parse(): void
+    {
+        $csv = <<<CSV
+        日付,金額,依頼人,摘要
+        2026-06-30,1000,カ）A,振込
+        not-a-date,2000,カ）B,振込
+        CSV;
+
+        $result = BankCsvParser::parse($csv, BankImportPresets::signedAmount());
+
+        self::assertNull($result->formatError);
+        self::assertCount(1, $result->transactions);
+        self::assertCount(1, $result->errors);
+        self::assertSame(3, $result->errors[0]['line']);
+    }
+
+    public function test_mapping_without_amount_source_is_rejected(): void
+    {
+        $result = BankCsvParser::parse("日付\n2026-06-30\n", new BankCsvColumnMapping(valueDateColumn: 0));
+
+        self::assertNotNull($result->formatError);
+        self::assertSame([], $result->transactions);
+    }
+
+    public function test_bank_reference_column_is_captured(): void
+    {
+        $csv = <<<CSV
+        日付,金額,依頼人,摘要,取引ID
+        2026-06-30,7000,カ）A,振込,TX-001
+        CSV;
+
+        $mapping = new BankCsvColumnMapping(
+            valueDateColumn: 0,
+            dateFormat: 'Y-m-d',
+            amountColumn: 1,
+            payerNameColumn: 2,
+            descriptionColumn: 3,
+            bankReferenceColumn: 4,
+        );
+
+        $result = BankCsvParser::parse($csv, $mapping);
+
+        self::assertCount(1, $result->transactions);
+        self::assertSame('TX-001', $result->transactions[0]->bankReference);
+    }
+}

--- a/tests/BankTransaction/ImportBankTransactionsUseCaseTest.php
+++ b/tests/BankTransaction/ImportBankTransactionsUseCaseTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankCsvColumnMapping;
+use NeneInvoice\BankTransaction\ImportBankTransactionsUseCase;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryBankTransactionRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ImportBankTransactionsUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryBankTransactionRepository $repository;
+    private ImportBankTransactionsUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new InMemoryBankTransactionRepository($this->holder);
+        $this->useCase    = new ImportBankTransactionsUseCase(
+            new ImmediateTransactionManager(),
+            fn () => $this->repository,
+        );
+    }
+
+    private function mapping(): BankCsvColumnMapping
+    {
+        return new BankCsvColumnMapping(
+            valueDateColumn: 0,
+            dateFormat: 'Y-m-d',
+            amountColumn: 1,
+            payerNameColumn: 2,
+            descriptionColumn: 3,
+            bankReferenceColumn: 4,
+        );
+    }
+
+    public function test_imports_rows_and_scopes_them_to_the_org(): void
+    {
+        $csv = "日付,金額,依頼人,摘要,取引ID\n2026-06-30,11000,カ）A,振込,TX1\n2026-06-29,5000,カ）B,振込,TX2\n";
+
+        $result = $this->useCase->execute($csv, $this->mapping());
+
+        self::assertNull($result->formatError);
+        self::assertSame(2, $result->importedCount);
+        self::assertSame(0, $result->skippedDuplicateCount);
+        self::assertSame(2, $this->repository->countByOrganization());
+
+        $this->holder->set(2);
+        self::assertSame(0, $this->repository->countByOrganization()); // org-scoped
+    }
+
+    public function test_reimport_skips_already_imported_references(): void
+    {
+        $csv = "日付,金額,依頼人,摘要,取引ID\n2026-06-30,11000,カ）A,振込,TX1\n";
+
+        self::assertSame(1, $this->useCase->execute($csv, $this->mapping())->importedCount);
+
+        $second = $this->useCase->execute($csv, $this->mapping());
+        self::assertSame(0, $second->importedCount);
+        self::assertSame(1, $second->skippedDuplicateCount);
+        self::assertSame(1, $this->repository->countByOrganization()); // no duplicate
+    }
+
+    public function test_duplicate_reference_within_one_file_is_skipped(): void
+    {
+        $csv = "日付,金額,依頼人,摘要,取引ID\n2026-06-30,11000,カ）A,振込,TX1\n2026-06-30,11000,カ）A,振込,TX1\n";
+
+        $result = $this->useCase->execute($csv, $this->mapping());
+
+        self::assertSame(1, $result->importedCount);
+        self::assertSame(1, $result->skippedDuplicateCount);
+    }
+
+    public function test_format_error_imports_nothing(): void
+    {
+        $result = $this->useCase->execute("日付\n2026-06-30\n", new BankCsvColumnMapping(valueDateColumn: 0));
+
+        self::assertNotNull($result->formatError);
+        self::assertSame(0, $result->importedCount);
+        self::assertSame(0, $this->repository->countByOrganization());
+    }
+}

--- a/tests/Support/InMemoryBankTransactionRepository.php
+++ b/tests/Support/InMemoryBankTransactionRepository.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionNotFoundException;
+use NeneInvoice\BankTransaction\BankTransactionRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database). `save` forces the org from
+ * the request-scoped holder and reads are org-scoped, mirroring
+ * {@see \NeneInvoice\BankTransaction\PdoBankTransactionRepository}.
+ */
+final class InMemoryBankTransactionRepository implements BankTransactionRepositoryInterface
+{
+    /** @var array<int, BankTransaction> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
+    public function save(BankTransaction $transaction): int
+    {
+        $id              = $this->nextId++;
+        $this->byId[$id] = $this->copy($transaction, $id, $this->orgId->get());
+
+        return $id;
+    }
+
+    public function findById(int $id): ?BankTransaction
+    {
+        $transaction = $this->byId[$id] ?? null;
+
+        return $transaction !== null && $transaction->organizationId === $this->orgId->get() ? $transaction : null;
+    }
+
+    /** @return list<BankTransaction> */
+    public function findByOrganization(int $limit, int $offset): array
+    {
+        return array_slice($this->mine(), $offset, $limit);
+    }
+
+    public function countByOrganization(): int
+    {
+        return count($this->mine());
+    }
+
+    public function findByBankReference(string $bankReference): ?BankTransaction
+    {
+        foreach ($this->mine() as $transaction) {
+            if ($transaction->bankReference === $bankReference) {
+                return $transaction;
+            }
+        }
+
+        return null;
+    }
+
+    public function update(BankTransaction $transaction): void
+    {
+        if ($transaction->id === null || $this->findById($transaction->id) === null) {
+            throw new BankTransactionNotFoundException($transaction->id ?? 0);
+        }
+
+        $this->byId[$transaction->id] = $this->copy($transaction, $transaction->id, $this->orgId->get());
+    }
+
+    /** @return list<BankTransaction> newest first (value_date desc, id desc), org-scoped */
+    private function mine(): array
+    {
+        $mine = array_values(array_filter(
+            $this->byId,
+            fn (BankTransaction $t): bool => $t->organizationId === $this->orgId->get(),
+        ));
+
+        usort($mine, static fn (BankTransaction $a, BankTransaction $b): int => [$b->valueDate, $b->id ?? 0] <=> [$a->valueDate, $a->id ?? 0]);
+
+        return $mine;
+    }
+
+    private function copy(BankTransaction $transaction, int $id, int $organizationId): BankTransaction
+    {
+        return new BankTransaction(
+            organizationId: $organizationId,
+            valueDate: $transaction->valueDate,
+            direction: $transaction->direction,
+            amountCents: $transaction->amountCents,
+            payerName: $transaction->payerName,
+            description: $transaction->description,
+            bankReference: $transaction->bankReference,
+            status: $transaction->status,
+            matchedInvoiceId: $transaction->matchedInvoiceId,
+            matchedPaymentId: $transaction->matchedPaymentId,
+            importedAt: $transaction->importedAt ?? '2026-06-06 00:00:00',
+            id: $id,
+            createdAt: $transaction->createdAt ?? '2026-06-06 00:00:00',
+            updatedAt: '2026-06-06 00:00:00',
+        );
+    }
+}


### PR DESCRIPTION
## 概要

**#505 増分2**。任意の銀行入金CSVを「**列マッピング＋プリセット**」で `bank_transactions` ステージング行に取り込むパーサと取込ユースケース（増分1の永続化層を利用）。**取込のみで照合・入金起票は行わない**（会計影響なし・コンプライアンス軽量）。

採用方針: 汎用 列マッピング＋プリセット（ご選択どおり）。

## 変更

- **`BankCsvColumnMapping`**: 列を 0-index で対応付け。**単一符号付き金額列**（＋=入金/−=出金）／**入金・出金別列**の双方に対応。日付フォーマット・ヘッダ有無・エンコーディングを指定可。
- **`BankCsvParser`**: **Shift_JIS(CP932)/UTF-8 自動判定**＋BOM除去、全角数字正規化、`¥`・桁区切りの除去、符号/別列から `direction` 判定、不正日付は行エラー化（他行は通す）、ゼロ金額行スキップ、サイズ/行数上限（既存 `CsvImport` 基盤を踏襲・formula-injection 安全）。
- **`BankImportPresets`**: ネット銀行(入出金別列)・単一符号付き金額の汎用プリセット（設置先で列番号を調整する出発点）。
- **`ImportBankTransactionsUseCase`**: パース→1トランザクションで保存。`bank_reference` による**冪等取込**（DB既存＋同一ファイル内の重複をスキップ）。`formatError` 時は0件。

## コンプライアンス

ステージングのみ。**入金起票・採番には一切踏み込まない**（accounting-compliance.md）。起票は後続増分で税理士サインオフ済みの `RecordPayment` を再利用。

## 検証

- `composer check` 緑: **793 tests**（+10）/ PHPStan max 694 files / php-cs-fixer / OpenAPI / MCP。
- パーサ: 符号付き／入出金別列／**Shift_JIS 復号**／不正日付の行エラー化／金額列なし拒否／参照列取得。
- ユースケース: 取込・**org スコープ**・再取込スキップ・同一ファイル内重複・format エラーで0件。

## 後続増分（このPRには含めない）

3. **③名義ゆれ辞書（payer_alias・カナ正規化）＋スコアリング照合**（金額一致＋依頼人名＋`outstanding_cents`）
4. **④確認→一括 `RecordPayment`**（`external_reference=bank_reference`・冪等）
5. **⑤手数料差引許容・一部/過入金・保留キュー**（税理士ゲート）
6. **⑥HTTP 結線＋OpenAPI**（`POST /admin/bank-transactions/import`・一覧）
7. **⑦消込ワークベンチ UI**

Refs #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)