### PR TITLE
feat(payment): 入金候補のスコアリング照合エンジン (#505 増分4)

### DIFF
--- a/src/BankTransaction/BankTransactionMatcher.php
+++ b/src/BankTransaction/BankTransactionMatcher.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Scores unpaid invoices against a bank deposit to suggest reconciliations (#505).
+ *
+ * Pure and deterministic: it combines three signals — amount fit, a learned
+ * {@see PayerAlias} hit, and remitter↔client name similarity — into an
+ * explainable score, and returns the candidates ranked best-first. It only
+ * *suggests*; recording a payment is a separate, operator-confirmed,
+ * compliance-reviewed step (accounting-compliance.md), so the fee tolerance here
+ * affects ranking only, never a write-off.
+ *
+ * Only `credit` (入金) transactions are matched against receivables.
+ */
+final class BankTransactionMatcher
+{
+    public const SCORE_AMOUNT_EXACT      = 50;
+    public const SCORE_AMOUNT_WITHIN_FEE = 35;
+    public const SCORE_AMOUNT_PARTIAL    = 15;
+    public const SCORE_AMOUNT_OVER       = 5;
+    public const SCORE_ALIAS             = 40;
+    public const SCORE_NAME_EXACT        = 30;
+    public const SCORE_NAME_CONTAINS     = 18;
+    public const SCORE_NAME_SIMILAR_MAX  = 15;
+
+    /** Largest common bank-transfer fee (JPY): a deposit short by up to this is likely fee-netted. */
+    public const FEE_TOLERANCE_CENTS = 880;
+
+    /** Minimum similar_text ratio (0..1) for a name to contribute. */
+    public const NAME_SIMILAR_THRESHOLD = 0.6;
+
+    /**
+     * @param list<MatchCandidate> $candidates
+     * @param ?int                 $aliasClientId client the remitter is already mapped to, if any
+     * @return list<MatchSuggestion> best-first
+     */
+    public static function suggest(BankTransaction $transaction, array $candidates, ?int $aliasClientId = null): array
+    {
+        if ($transaction->direction !== BankTransactionDirection::Credit) {
+            return [];
+        }
+
+        $payer = $transaction->payerName !== null ? PayerNameNormalizer::normalize($transaction->payerName) : '';
+
+        $suggestions = [];
+        foreach ($candidates as $candidate) {
+            [$score, $reasons] = self::scoreCandidate($transaction, $candidate, $aliasClientId, $payer);
+
+            if ($score > 0) {
+                $suggestions[] = new MatchSuggestion($candidate->invoiceId, $candidate->clientId, $score, $reasons);
+            }
+        }
+
+        // Best score first; ties broken by invoice id ascending (deterministic).
+        usort($suggestions, static fn (MatchSuggestion $a, MatchSuggestion $b): int => ($b->score <=> $a->score) ?: ($a->invoiceId <=> $b->invoiceId));
+
+        return $suggestions;
+    }
+
+    /**
+     * @return array{0: int, 1: list<string>}
+     */
+    private static function scoreCandidate(BankTransaction $transaction, MatchCandidate $candidate, ?int $aliasClientId, string $payer): array
+    {
+        $score   = 0;
+        $reasons = [];
+
+        $amount      = $transaction->amountCents;
+        $outstanding = $candidate->outstandingCents;
+
+        if ($amount === $outstanding) {
+            $score    += self::SCORE_AMOUNT_EXACT;
+            $reasons[] = 'amount-exact';
+        } elseif ($amount < $outstanding && ($outstanding - $amount) <= self::FEE_TOLERANCE_CENTS) {
+            $score    += self::SCORE_AMOUNT_WITHIN_FEE;
+            $reasons[] = 'amount-within-fee';
+        } elseif ($amount < $outstanding) {
+            $score    += self::SCORE_AMOUNT_PARTIAL;
+            $reasons[] = 'amount-partial';
+        } else {
+            $score    += self::SCORE_AMOUNT_OVER;
+            $reasons[] = 'amount-over';
+        }
+
+        if ($aliasClientId !== null && $candidate->clientId === $aliasClientId) {
+            $score    += self::SCORE_ALIAS;
+            $reasons[] = 'payer-alias';
+
+            return [$score, $reasons];
+        }
+
+        $client = $candidate->clientName !== null ? PayerNameNormalizer::normalize($candidate->clientName) : '';
+        if ($payer !== '' && $client !== '') {
+            if ($payer === $client) {
+                $score    += self::SCORE_NAME_EXACT;
+                $reasons[] = 'name-exact';
+            } elseif (str_contains($client, $payer) || str_contains($payer, $client)) {
+                $score    += self::SCORE_NAME_CONTAINS;
+                $reasons[] = 'name-contains';
+            } else {
+                $ratio = self::similarity($payer, $client);
+                if ($ratio >= self::NAME_SIMILAR_THRESHOLD) {
+                    $score    += (int) round($ratio * self::SCORE_NAME_SIMILAR_MAX);
+                    $reasons[] = 'name-similar';
+                }
+            }
+        }
+
+        return [$score, $reasons];
+    }
+
+    private static function similarity(string $a, string $b): float
+    {
+        $percent = 0.0;
+        similar_text($a, $b, $percent);
+
+        return $percent / 100;
+    }
+}

--- a/src/BankTransaction/MatchCandidate.php
+++ b/src/BankTransaction/MatchCandidate.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * An unpaid invoice a bank deposit might settle (#505), handed to
+ * {@see BankTransactionMatcher} for scoring. `outstandingCents` is the
+ * still-owed balance; `clientName` is the buyer's name (ideally `name_kana`),
+ * normalized by the matcher for comparison against the remitter.
+ */
+final readonly class MatchCandidate
+{
+    public function __construct(
+        public int $invoiceId,
+        public int $clientId,
+        public int $outstandingCents,
+        public ?string $clientName = null,
+    ) {
+    }
+}

--- a/src/BankTransaction/MatchSuggestion.php
+++ b/src/BankTransaction/MatchSuggestion.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * A scored invoice candidate for a bank deposit (#505): the higher the `score`,
+ * the more confident the match. `reasons` lists the signals that contributed
+ * (e.g. `amount-exact`, `payer-alias`, `name-exact`) so the operator sees *why*
+ * it was suggested. A suggestion is advice only — recording a payment is a
+ * separate, operator-confirmed, compliance-reviewed step.
+ */
+final readonly class MatchSuggestion
+{
+    /**
+     * @param list<string> $reasons
+     */
+    public function __construct(
+        public int $invoiceId,
+        public int $clientId,
+        public int $score,
+        public array $reasons,
+    ) {
+    }
+}

--- a/tests/BankTransaction/BankTransactionMatcherTest.php
+++ b/tests/BankTransaction/BankTransactionMatcherTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use NeneInvoice\BankTransaction\BankTransactionMatcher;
+use NeneInvoice\BankTransaction\MatchCandidate;
+use PHPUnit\Framework\TestCase;
+
+final class BankTransactionMatcherTest extends TestCase
+{
+    private function credit(int $amountCents, ?string $payer = null): BankTransaction
+    {
+        return new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-30',
+            direction: BankTransactionDirection::Credit,
+            amountCents: $amountCents,
+            payerName: $payer,
+        );
+    }
+
+    public function test_exact_amount_and_alias_scores_highest(): void
+    {
+        $candidates = [
+            new MatchCandidate(invoiceId: 1, clientId: 5, outstandingCents: 11000, clientName: 'ネネショウカイ'),
+            new MatchCandidate(invoiceId: 2, clientId: 9, outstandingCents: 5000, clientName: 'アアショウジ'),
+        ];
+
+        $suggestions = BankTransactionMatcher::suggest($this->credit(11000, 'ｶ)ﾈﾈ'), $candidates, aliasClientId: 5);
+
+        self::assertSame(1, $suggestions[0]->invoiceId);
+        self::assertSame(
+            BankTransactionMatcher::SCORE_AMOUNT_EXACT + BankTransactionMatcher::SCORE_ALIAS,
+            $suggestions[0]->score,
+        );
+        self::assertContains('amount-exact', $suggestions[0]->reasons);
+        self::assertContains('payer-alias', $suggestions[0]->reasons);
+    }
+
+    public function test_deposit_short_by_a_transfer_fee_is_recognized(): void
+    {
+        $candidates  = [new MatchCandidate(invoiceId: 1, clientId: 5, outstandingCents: 11000)];
+        $suggestions = BankTransactionMatcher::suggest($this->credit(10780), $candidates);
+
+        self::assertContains('amount-within-fee', $suggestions[0]->reasons);
+        self::assertSame(BankTransactionMatcher::SCORE_AMOUNT_WITHIN_FEE, $suggestions[0]->score);
+    }
+
+    public function test_name_match_without_alias(): void
+    {
+        $candidates = [new MatchCandidate(invoiceId: 1, clientId: 5, outstandingCents: 11000, clientName: 'ネネシヨウカイ（カ')];
+
+        $suggestions = BankTransactionMatcher::suggest($this->credit(11000, 'ｶ)ﾈﾈｼﾖｳｶｲ'), $candidates);
+
+        self::assertContains('name-exact', $suggestions[0]->reasons);
+        self::assertSame(
+            BankTransactionMatcher::SCORE_AMOUNT_EXACT + BankTransactionMatcher::SCORE_NAME_EXACT,
+            $suggestions[0]->score,
+        );
+    }
+
+    public function test_results_are_ranked_best_first(): void
+    {
+        $candidates = [
+            new MatchCandidate(invoiceId: 1, clientId: 1, outstandingCents: 3000),        // amount-over (deposit > owed)
+            new MatchCandidate(invoiceId: 2, clientId: 2, outstandingCents: 11000),       // amount-exact
+            new MatchCandidate(invoiceId: 3, clientId: 3, outstandingCents: 30000),       // amount-partial
+        ];
+
+        $suggestions = BankTransactionMatcher::suggest($this->credit(11000), $candidates);
+
+        self::assertSame([2, 3, 1], array_map(static fn ($s): int => $s->invoiceId, $suggestions));
+    }
+
+    public function test_partial_payment_is_scored_low_not_zero(): void
+    {
+        $candidates  = [new MatchCandidate(invoiceId: 1, clientId: 5, outstandingCents: 30000)];
+        $suggestions = BankTransactionMatcher::suggest($this->credit(8000), $candidates);
+
+        self::assertContains('amount-partial', $suggestions[0]->reasons);
+        self::assertSame(BankTransactionMatcher::SCORE_AMOUNT_PARTIAL, $suggestions[0]->score);
+    }
+
+    public function test_debit_transactions_are_not_matched(): void
+    {
+        $debit = new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-30',
+            direction: BankTransactionDirection::Debit,
+            amountCents: 11000,
+        );
+
+        self::assertSame([], BankTransactionMatcher::suggest($debit, [new MatchCandidate(1, 5, 11000)]));
+    }
+}


### PR DESCRIPTION
## 概要

**#505 増分4**。入金（`credit`）の銀行明細に対し、未回収請求書を**採点してランキング**する純粋関数。**候補提示のみ**で入金起票はしない（会計影響なし）。

## スコアリング（説明可能・決定的）

3シグナルを加点し、`reasons` 付きでスコア降順に整列（debit は対象外）:

| シグナル | 加点 |
|---|---|
| 金額 完全一致 | +50 |
| 金額 手数料ショート（≤¥880 不足） | +35 |
| 金額 一部入金 | +15 |
| 金額 過入金 | +5 |
| 名義辞書（payer_alias）ヒット | +40 |
| 名義 完全一致 / 包含 / 類似(similar_text≥0.6) | +30 / +18 / 最大+15 |

`MatchCandidate`（invoiceId/clientId/outstandingCents/clientName）→ `MatchSuggestion`（score/reasons）。

> **コンプライアンス**: 手数料許容は**ランキング用のみ**で write-off ではない。入金起票・手数料差引は税理士ゲートの別増分。

## 検証

- `composer check` 緑（**810 tests** / PHPStan max / cs / OpenAPI / MCP）。
- 完全一致＋辞書が最上位／手数料ショート認識／辞書なしの名義一致／スコア降順整列／一部入金は低スコア非ゼロ／debit は空。

## 後続増分

5. **⑤確認→一括 `RecordPayment`**（alias 学習・`external_reference=bank_reference`・冪等）
6. **⑥手数料差引許容**（税理士ゲート）
7. **⑦HTTP＋OpenAPI**（取込/候補/確認）/ **⑧消込ワークベンチ UI**

Refs #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)