### PR TITLE
test: 日付依存テストを FixedClock 由来に統一する (#538)

### DIFF
--- a/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
+++ b/tests/Dashboard/GetDashboardSummaryUseCaseTest.php
@@ -18,6 +18,8 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 
     private InMemoryPaymentRepository $payments;
 
+    private FixedClock $clock;
+
     private GetDashboardSummaryUseCase $useCase;
 
     protected function setUp(): void
@@ -26,7 +28,8 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $holder->set(1);
         $this->invoices = new InMemoryInvoiceRepository($holder);
         $this->payments = new InMemoryPaymentRepository($holder);
-        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, $this->payments, new FixedClock());
+        $this->clock    = new FixedClock();
+        $this->useCase  = new GetDashboardSummaryUseCase($this->invoices, $this->payments, $this->clock);
     }
 
     public function test_empty_organization_returns_zeros(): void
@@ -55,9 +58,10 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
         $issue = function (string $issuedAt, int $cents): void {
             $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: $cents, taxCents: 0, totalCents: $cents, issuedAt: $issuedAt));
         };
-        $issue(date('Y-m-01 10:00:00'), 3000); // this month, day 1
-        $issue(date('Y-m-01 10:00:00', (int) strtotime('first day of last month')), 4000); // last month, day 1
-        $issue(date('Y-m-01 10:00:00', (int) strtotime('-1 year')), 5000); // same month last year, day 1
+        $now = $this->clock->now();
+        $issue($now->format('Y-m') . '-01 10:00:00', 3000); // this month, day 1
+        $issue($now->modify('first day of last month')->format('Y-m') . '-01 10:00:00', 4000); // last month, day 1
+        $issue($now->modify('-1 year')->format('Y-m') . '-01 10:00:00', 5000); // same month last year, day 1
 
         $summary = $this->useCase->execute();
 
@@ -70,8 +74,9 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 
     public function test_billed_metrics_and_monthly_trend(): void
     {
-        $thisMonth = date('Y-m-10 09:00:00');
-        $lastMonth = date('Y-m-10 09:00:00', (int) strtotime('first day of last month'));
+        $now       = $this->clock->now();
+        $thisMonth = $now->format('Y-m') . '-10 09:00:00';
+        $lastMonth = $now->modify('first day of last month')->format('Y-m') . '-10 09:00:00';
 
         // Issued this month: 1000 + 2000 (paid still counts as issued).
         $this->invoices->save(new Invoice(organizationId: 1, clientId: 1, status: InvoiceStatus::Issued, subtotalCents: 1000, taxCents: 0, totalCents: 1000, issuedAt: $thisMonth));
@@ -88,7 +93,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 
         self::assertCount(6, $summary->monthlyBilled);
         // Last bucket is the current month (oldest→newest).
-        self::assertSame(date('Y-m'), $summary->monthlyBilled[5]['month']);
+        self::assertSame($this->clock->now()->format('Y-m'), $summary->monthlyBilled[5]['month']);
         self::assertSame(3000, $summary->monthlyBilled[5]['billed_cents']);
         self::assertSame(2, $summary->monthlyBilled[5]['count']);
         self::assertSame(5000, $summary->monthlyBilled[4]['billed_cents']);
@@ -97,7 +102,7 @@ final class GetDashboardSummaryUseCaseTest extends TestCase
 
     public function test_received_this_month_sums_current_month_payments(): void
     {
-        $thisMonth = date('Y-m-15 12:00:00');
+        $thisMonth = $this->clock->now()->format('Y-m') . '-15 12:00:00';
         $this->payments->save(new \NeneInvoice\Payment\Payment(organizationId: 1, invoiceId: 1, amountCents: 4200, paidAt: $thisMonth));
 
         $summary = $this->useCase->execute();

--- a/tests/Invoice/IssueInvoiceUseCaseTest.php
+++ b/tests/Invoice/IssueInvoiceUseCaseTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Invoice;
 
-use DateTimeImmutable;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\Company\PaymentTerms;
@@ -36,6 +35,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
     private InMemoryLineItemRepository $lineItems;
     private InMemoryCompanySettingsRepository $companySettings;
     private RecordingAuditRecorder $audit;
+    private FixedClock $clock;
     private IssueInvoiceUseCase $useCase;
 
     protected function setUp(): void
@@ -46,6 +46,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
         $this->lineItems = new InMemoryLineItemRepository();
         $this->companySettings = new InMemoryCompanySettingsRepository();
         $this->audit = new RecordingAuditRecorder();
+        $this->clock = new FixedClock();
         $this->useCase = new IssueInvoiceUseCase(
             $this->invoices,
             $this->lineItems,
@@ -54,7 +55,7 @@ final class IssueInvoiceUseCaseTest extends TestCase
             new ImmediateTransactionManager(),
             fn () => $this->invoices,
             fn () => $this->audit,
-            new FixedClock(),
+            $this->clock,
             $this->holder,
         );
     }
@@ -114,7 +115,9 @@ final class IssueInvoiceUseCaseTest extends TestCase
 
         $result = $this->useCase->execute(7, $id, new IssueInvoiceInput(qualified: false));
 
-        $expected = (new PaymentTerms(null, 1, null))->dueDateFrom(new DateTimeImmutable('today'));
+        // Derive the expected due date from the same clock the use case uses, not
+        // real "today" — otherwise this drifts a month at every month boundary (#538).
+        $expected = (new PaymentTerms(null, 1, null))->dueDateFrom($this->clock->now());
         self::assertSame($expected, substr((string) $result->invoice->dueAt, 0, 10));
     }
 


### PR DESCRIPTION
## 概要

`main` の単体テストが **2026-07-01（月境界）以降 CI 赤**になっていた 4 件を修正する。use case は `FixedClock`（2026-06-06）で動くのに、テスト側が実クロックで seed / assert していたため、実「今月」と FixedClock の「今月」がずれて失敗していた（`fixedclock-test-time-dependence`）。

## 対象テスト（修正前は失敗）

- `Dashboard\GetDashboardSummaryUseCaseTest::test_year_over_year_and_daily_cumulative`
- `Dashboard\GetDashboardSummaryUseCaseTest::test_billed_metrics_and_monthly_trend`
- `Dashboard\GetDashboardSummaryUseCaseTest::test_received_this_month_sums_current_month_payments`
- `Invoice\IssueInvoiceUseCaseTest::test_applies_company_payment_terms_default_due_date`

## 変更

- **GetDashboardSummaryUseCaseTest**: 共有 `FixedClock` を保持し、`date('Y-m-…')` / `strtotime('first day of last month')` / `strtotime('-1 year')` / `date('Y-m')` を `$this->clock->now()` 由来（`modify()` で先月・前年）に置換。
- **IssueInvoiceUseCaseTest**: 支払条件の期待値を `new DateTimeImmutable('today')` から `$this->clock->now()` 由来へ。未使用の `DateTimeImmutable` import を削除。

挙動変更なし・**テストのみ**。

## 検証

`composer check` 緑（810 tests / phpstan No errors / cs clean / OpenAPI valid / MCP valid）。

## セルフレビュー

- [x] 実クロック参照を排除し FixedClock 由来に統一（決定性）
- [x] 挙動変更なし・テストのみ（コンプラ・命名・OpenAPI 影響なし）
- [x] `composer check` ローカル緑

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)