### PR TITLE
feat(payment): 入金候補の確認→起票・候補生成・消込SQL (#505 増分5)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-06-30 (定期請求の実行ルート配線 #526 を実装＝看板機能が自動で回るように。#519–#523・Clear↔Invoice ライブ化・MFA 設計 #524/#525・ペルソナ評価 R1→R4 を反映)
+Last updated: 2026-07-01 (#505 銀行入金CSV自動消込: 増分④スコアリング merged＋増分⑤ 確認→起票／候補生成／消込SQL を実装。定期請求 #526 実装済。#519–#523・Clear↔Invoice ライブ化・MFA 設計 #524/#525・ペルソナ評価 R1→R4 を反映)
 
 ## Recently merged
 
@@ -420,7 +420,7 @@ Phase 1–3 後の運用・UX 強化と Phase 4 着手分（すべて merged）:
 
 優先（課金転換に直結する順）:
 1. ~~**#526（P0）定期請求の実行ルート配線（cron/CLI/リクエスト時 due）**~~ — ✅ **実装済（`feat/526-recurring-execution-route`）**。Tier B cron＋Tier A 自動、下書きのみ・冪等。看板機能が自動で回るようになった。
-2. **#505 銀行入金CSVの真の自動消込（P0・進行中）** — 渡辺の支払条件・佐藤のゲート（R4 再確認）。多増分エピックで進行: ①`bank_transactions` ステージング永続化（merged）②列マッピングCSVパーサ＋取込（Shift_JIS・冪等, merged）③名義ゆれ辞書(`payer_aliases`)＋カナ正規化（this）。残: ④スコアリング照合 ⑤確認→一括 `RecordPayment`（`external_reference=bank_reference`）⑥手数料差引許容〔税理士ゲート〕⑦HTTP+OpenAPI ⑧消込UI。**取込・照合は会計影響ゼロ／起票は税理士サインオフ済み RecordPayment 再利用**。
+2. **#505 銀行入金CSVの真の自動消込（P0・進行中）** — 渡辺の支払条件・佐藤のゲート（R4 再確認）。多増分エピックで進行: ①`bank_transactions` ステージング永続化 ②列マッピングCSVパーサ＋取込（Shift_JIS・冪等）③名義ゆれ辞書(`payer_aliases`)＋カナ正規化 ④スコアリング照合 いずれも **merged**。⑤確認→一括起票（`ConfirmMatchUseCase`＝税理士サインオフ済み `RecordPaymentUseCase` 再利用・`external_reference=bank_reference`・冪等・alias 学習・過入金は拒否）＋候補生成（`SuggestMatchesUseCase`）＋消込SQL（`PdoMatchCandidateRepository`）＝**this**。残: ⑥手数料差引 write-off・過入金按分〔税理士ゲート〕⑦HTTP+OpenAPI ⑧消込UI。**取込・照合は会計影響ゼロ／起票は税理士サインオフ済み RecordPayment 再利用**。
 3. **#527（P1）一括発行・一括メール** — 会計事務所セグメント（¥49,800）解錠（岡田）。
 4. **業種テンプレ**: #528（見積の単位欄/小数数量/工種内訳・中村）、#513（源泉徴収・清水）。
 5. **MFA（standalone TOTP）#524** — エンタープライズ信頼。**R4 では決め手に挙げた人ゼロ＝最優先でない**（裏で進行可）。

--- a/src/BankTransaction/BankTransactionValidationException.php
+++ b/src/BankTransaction/BankTransactionValidationException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use DomainException;
+
+/**
+ * Thrown when a reconciliation action is not allowed for a staged bank line (#505)
+ * — e.g. confirming a `debit` line, re-confirming a line already reconciled to a
+ * different invoice, or ignoring a line whose payment is already posted. Surfaces
+ * as 422.
+ *
+ * This is distinct from over-payment: recording the deposit reuses
+ * {@see \NeneInvoice\Payment\RecordPaymentUseCase}, whose own guards
+ * (over-allocation, draft invoice, future date) surface through the Payment
+ * exception handlers.
+ */
+final class BankTransactionValidationException extends DomainException
+{
+}

--- a/src/BankTransaction/ConfirmMatchResult.php
+++ b/src/BankTransaction/ConfirmMatchResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use NeneInvoice\Payment\RecordPaymentResult;
+
+/**
+ * Outcome of confirming a bank-line match (#505): the staged transaction advanced
+ * to `posted` (now linking `matchedInvoiceId` / `matchedPaymentId`) plus the
+ * {@see RecordPaymentResult} for the payment that was recorded — the invoice in
+ * its resulting state and the running total paid.
+ */
+final readonly class ConfirmMatchResult
+{
+    public function __construct(
+        public BankTransaction $transaction,
+        public RecordPaymentResult $payment,
+    ) {
+    }
+}

--- a/src/BankTransaction/ConfirmMatchUseCase.php
+++ b/src/BankTransaction/ConfirmMatchUseCase.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use NeneInvoice\Payment\RecordPaymentInput;
+use NeneInvoice\Payment\RecordPaymentUseCaseInterface;
+
+/**
+ * Confirms an operator's match of a staged bank deposit to an invoice and records
+ * the payment (#505, increment ⑤ — the first step that carries accounting weight).
+ *
+ * It does **not** implement any bookkeeping of its own: it reuses the
+ * tax-signed-off {@see RecordPaymentUseCaseInterface}, which is idempotent, guards
+ * over-payment, and writes the audit entry. The **exact** deposit amount is
+ * recorded — a deposit short of the balance leaves the remainder outstanding
+ * (a fee/short-payment write-off is a separate, tax-gated step, deliberately not
+ * done here — accounting-compliance.md). On success the line advances to `posted`
+ * and the remitter name is learned as a {@see PayerAlias} so future deposits from
+ * the same payer match automatically.
+ *
+ * Idempotent: the payment carries a deterministic idempotency key derived from the
+ * bank line, so a retried confirm returns the existing payment rather than
+ * double-posting; if a prior confirm recorded the payment but the status update did
+ * not land, re-confirming the same invoice reconciles the line without a duplicate.
+ */
+final readonly class ConfirmMatchUseCase
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private PayerAliasRepositoryInterface $aliases,
+        private RecordPaymentUseCaseInterface $recordPayment,
+    ) {
+    }
+
+    /**
+     * @throws BankTransactionNotFoundException
+     * @throws BankTransactionValidationException
+     * @throws \NeneInvoice\Invoice\InvoiceNotFoundException
+     * @throws \NeneInvoice\Payment\PaymentValidationException
+     * @throws \NeneInvoice\Payment\PaymentExceedsOutstandingException
+     */
+    public function execute(?int $actorUserId, int $bankTransactionId, int $invoiceId): ConfirmMatchResult
+    {
+        $transaction = $this->transactions->findById($bankTransactionId);
+
+        if ($transaction === null) {
+            throw new BankTransactionNotFoundException($bankTransactionId);
+        }
+
+        if ($transaction->direction !== BankTransactionDirection::Credit) {
+            throw new BankTransactionValidationException('Only credit (deposit) bank lines can be reconciled to an invoice.');
+        }
+
+        if ($transaction->status === BankTransactionStatus::Ignored) {
+            throw new BankTransactionValidationException('This bank line was ignored and cannot be reconciled.');
+        }
+
+        if ($transaction->status === BankTransactionStatus::Posted && $transaction->matchedInvoiceId !== $invoiceId) {
+            throw new BankTransactionValidationException('This bank line is already reconciled to a different invoice.');
+        }
+
+        // Reuse the tax-signed-off payment path. Idempotent on the bank line, so a
+        // retry (or a recovered half-applied confirm) never double-posts.
+        $result = $this->recordPayment->execute(
+            $actorUserId,
+            $invoiceId,
+            new RecordPaymentInput(
+                amountCents: $transaction->amountCents,
+                paidAt: $transaction->valueDate,
+                method: 'bank_transfer',
+                externalReference: $transaction->bankReference ?? $this->idempotencyKey($bankTransactionId),
+                idempotencyKey: $this->idempotencyKey($bankTransactionId),
+            ),
+        );
+
+        // Already posted to this same invoice: nothing to advance or learn again.
+        if ($transaction->status === BankTransactionStatus::Posted) {
+            return new ConfirmMatchResult($transaction, $result);
+        }
+
+        $posted = new BankTransaction(
+            organizationId: $transaction->organizationId,
+            valueDate: $transaction->valueDate,
+            direction: $transaction->direction,
+            amountCents: $transaction->amountCents,
+            payerName: $transaction->payerName,
+            description: $transaction->description,
+            bankReference: $transaction->bankReference,
+            status: BankTransactionStatus::Posted,
+            matchedInvoiceId: $invoiceId,
+            matchedPaymentId: $result->payment->id,
+            importedAt: $transaction->importedAt,
+            id: $transaction->id,
+            createdAt: $transaction->createdAt,
+            updatedAt: $transaction->updatedAt,
+        );
+        $this->transactions->update($posted);
+
+        $this->learnAlias($transaction->organizationId, $transaction->payerName, $result->invoice->clientId);
+
+        return new ConfirmMatchResult($posted, $result);
+    }
+
+    private function idempotencyKey(int $bankTransactionId): string
+    {
+        return sprintf('bank-txn-%d', $bankTransactionId);
+    }
+
+    private function learnAlias(int $organizationId, ?string $payerName, int $clientId): void
+    {
+        if ($payerName === null) {
+            return;
+        }
+
+        $normalized = PayerNameNormalizer::normalize($payerName);
+        if ($normalized === '') {
+            return;
+        }
+
+        // The repository re-forces the org from the request-scoped holder (ADR 0006);
+        // the id here just mirrors the source line's organization.
+        $this->aliases->upsert(new PayerAlias(
+            organizationId: $organizationId,
+            normalizedName: $normalized,
+            clientId: $clientId,
+        ));
+    }
+}

--- a/src/BankTransaction/IgnoreBankTransactionUseCase.php
+++ b/src/BankTransaction/IgnoreBankTransactionUseCase.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Dismisses a staged bank line the operator will not reconcile (#505) — bank fees,
+ * non-AR transfers, duplicates — moving it to `ignored` so it drops out of the
+ * matching queue. Staging-only: it touches no billing record. A line whose payment
+ * is already `posted` cannot be ignored; re-ignoring an ignored line is a no-op.
+ */
+final readonly class IgnoreBankTransactionUseCase
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+    ) {
+    }
+
+    /**
+     * @throws BankTransactionNotFoundException
+     * @throws BankTransactionValidationException
+     */
+    public function execute(int $bankTransactionId): BankTransaction
+    {
+        $transaction = $this->transactions->findById($bankTransactionId);
+
+        if ($transaction === null) {
+            throw new BankTransactionNotFoundException($bankTransactionId);
+        }
+
+        if ($transaction->status === BankTransactionStatus::Posted) {
+            throw new BankTransactionValidationException('A reconciled bank line cannot be ignored.');
+        }
+
+        if ($transaction->status === BankTransactionStatus::Ignored) {
+            return $transaction;
+        }
+
+        $ignored = new BankTransaction(
+            organizationId: $transaction->organizationId,
+            valueDate: $transaction->valueDate,
+            direction: $transaction->direction,
+            amountCents: $transaction->amountCents,
+            payerName: $transaction->payerName,
+            description: $transaction->description,
+            bankReference: $transaction->bankReference,
+            status: BankTransactionStatus::Ignored,
+            matchedInvoiceId: $transaction->matchedInvoiceId,
+            matchedPaymentId: $transaction->matchedPaymentId,
+            importedAt: $transaction->importedAt,
+            id: $transaction->id,
+            createdAt: $transaction->createdAt,
+            updatedAt: $transaction->updatedAt,
+        );
+        $this->transactions->update($ignored);
+
+        return $ignored;
+    }
+}

--- a/src/BankTransaction/MatchCandidateRepositoryInterface.php
+++ b/src/BankTransaction/MatchCandidateRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Reads the open receivables a bank deposit could settle (#505): issued /
+ * partially-paid invoices with a positive outstanding balance, joined with the
+ * buyer's name for matching. Org-scoped like every other repository (ADR 0006).
+ *
+ * Read-only — it never records a payment; posting is a separate, operator-confirmed,
+ * compliance-reviewed step (accounting-compliance.md).
+ */
+interface MatchCandidateRepositoryInterface
+{
+    /** @return list<OpenReceivable> open receivables with outstanding > 0, invoice id ascending */
+    public function findOpenReceivables(): array;
+}

--- a/src/BankTransaction/OpenReceivable.php
+++ b/src/BankTransaction/OpenReceivable.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * An unpaid invoice a bank deposit might settle (#505), as read from the ledger
+ * for reconciliation. `outstandingCents` is the still-owed balance
+ * (`total_cents` minus non-void payments); `clientName` is the buyer's
+ * human-readable name and `clientNameKana` its kana reading (used by the matcher
+ * for remitter comparison, as bank lines carry kana).
+ *
+ * This is a read projection for matching, not a billing record — no accounting
+ * weight until an operator confirms and a payment is recorded.
+ */
+final readonly class OpenReceivable
+{
+    public function __construct(
+        public int $invoiceId,
+        public int $clientId,
+        public int $outstandingCents,
+        public ?string $invoiceNumber = null,
+        public ?string $clientName = null,
+        public ?string $clientNameKana = null,
+    ) {
+    }
+
+    /**
+     * The name the matcher scores against: the kana reading when present (bank
+     * remitter names are kana), otherwise the display name.
+     */
+    public function matchName(): ?string
+    {
+        return $this->clientNameKana ?? $this->clientName;
+    }
+}

--- a/src/BankTransaction/PdoMatchCandidateRepository.php
+++ b/src/BankTransaction/PdoMatchCandidateRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * Reads open receivables for reconciliation matching (#505). Computes each
+ * invoice's outstanding balance as `total_cents` minus non-void payments — the
+ * same net-outstanding definition used by the dashboard aging query
+ * ({@see \NeneInvoice\Payment\PdoPaymentRepository::agingBuckets()}).
+ *
+ * Booleans are compared with `TRUE`/`FALSE` and statuses with quoted string
+ * literals so the SQL is portable across sqlite / mysql / pgsql.
+ */
+final readonly class PdoMatchCandidateRepository implements MatchCandidateRepositoryInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgId resolved organization for this request
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedHolder $orgId,
+    ) {
+    }
+
+    /** @return list<OpenReceivable> */
+    public function findOpenReceivables(): array
+    {
+        $rows = $this->query->fetchAll(
+            "SELECT t.invoice_id, t.client_id, t.invoice_number, t.outstanding_cents,
+                    c.name AS client_name, c.name_kana AS client_name_kana
+             FROM (
+                SELECT i.id AS invoice_id, i.client_id, i.invoice_number, i.total_cents,
+                       i.total_cents - COALESCE(SUM(CASE WHEN p.is_deleted = FALSE THEN p.amount_cents ELSE 0 END), 0) AS outstanding_cents
+                FROM invoices i
+                LEFT JOIN payments p ON p.invoice_id = i.id
+                WHERE i.organization_id = ? AND i.is_deleted = FALSE AND i.status IN ('issued', 'partially_paid')
+                GROUP BY i.id, i.client_id, i.invoice_number, i.total_cents
+             ) t
+             LEFT JOIN clients c ON c.id = t.client_id
+             WHERE t.outstanding_cents > 0
+             ORDER BY t.invoice_id ASC",
+            [$this->orgId->get()],
+        );
+
+        return array_map(fn (array $row): OpenReceivable => $this->mapRow($row), $rows);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): OpenReceivable
+    {
+        return new OpenReceivable(
+            invoiceId: (int) $row['invoice_id'],
+            clientId: (int) $row['client_id'],
+            outstandingCents: (int) $row['outstanding_cents'],
+            invoiceNumber: isset($row['invoice_number']) && $row['invoice_number'] !== '' ? (string) $row['invoice_number'] : null,
+            clientName: isset($row['client_name']) && $row['client_name'] !== '' ? (string) $row['client_name'] : null,
+            clientNameKana: isset($row['client_name_kana']) && $row['client_name_kana'] !== '' ? (string) $row['client_name_kana'] : null,
+        );
+    }
+}

--- a/src/BankTransaction/SuggestMatchesUseCase.php
+++ b/src/BankTransaction/SuggestMatchesUseCase.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * Suggests invoices a staged bank deposit might settle (#505).
+ *
+ * Loads the open receivables, resolves any learned {@see PayerAlias} for the
+ * remitter, and runs the pure {@see BankTransactionMatcher} to score and rank
+ * them, then enriches each suggestion with the invoice number, client name, and
+ * outstanding balance for display. Read-only: it records no payment (matching has
+ * zero accounting impact — accounting-compliance.md); only `credit` lines yield
+ * suggestions.
+ */
+final readonly class SuggestMatchesUseCase
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private MatchCandidateRepositoryInterface $candidates,
+        private PayerAliasRepositoryInterface $aliases,
+    ) {
+    }
+
+    /**
+     * @return list<SuggestedMatch> best-first
+     *
+     * @throws BankTransactionNotFoundException
+     */
+    public function execute(int $bankTransactionId): array
+    {
+        $transaction = $this->transactions->findById($bankTransactionId);
+
+        if ($transaction === null) {
+            throw new BankTransactionNotFoundException($bankTransactionId);
+        }
+
+        $aliasClientId = $this->resolveAlias($transaction->payerName);
+
+        $receivables = $this->candidates->findOpenReceivables();
+
+        $matchCandidates = array_map(
+            static fn (OpenReceivable $r): MatchCandidate => new MatchCandidate(
+                invoiceId: $r->invoiceId,
+                clientId: $r->clientId,
+                outstandingCents: $r->outstandingCents,
+                clientName: $r->matchName(),
+            ),
+            $receivables,
+        );
+
+        /** @var array<int, OpenReceivable> $byInvoiceId */
+        $byInvoiceId = [];
+        foreach ($receivables as $receivable) {
+            $byInvoiceId[$receivable->invoiceId] = $receivable;
+        }
+
+        $suggestions = BankTransactionMatcher::suggest($transaction, $matchCandidates, $aliasClientId);
+
+        // Every suggestion's invoice id came from a candidate we built out of
+        // $byInvoiceId, so the lookup always resolves.
+        return array_map(static function (MatchSuggestion $s) use ($byInvoiceId): SuggestedMatch {
+            $receivable = $byInvoiceId[$s->invoiceId];
+
+            return new SuggestedMatch(
+                invoiceId: $s->invoiceId,
+                clientId: $s->clientId,
+                outstandingCents: $receivable->outstandingCents,
+                score: $s->score,
+                reasons: $s->reasons,
+                invoiceNumber: $receivable->invoiceNumber,
+                clientName: $receivable->clientName,
+            );
+        }, $suggestions);
+    }
+
+    private function resolveAlias(?string $payerName): ?int
+    {
+        if ($payerName === null) {
+            return null;
+        }
+
+        $normalized = PayerNameNormalizer::normalize($payerName);
+        if ($normalized === '') {
+            return null;
+        }
+
+        return $this->aliases->findByNormalizedName($normalized)?->clientId;
+    }
+}

--- a/src/BankTransaction/SuggestedMatch.php
+++ b/src/BankTransaction/SuggestedMatch.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\BankTransaction;
+
+/**
+ * A scored invoice suggestion for a bank deposit (#505), enriched for display:
+ * the {@see BankTransactionMatcher} score and `reasons` plus the invoice number,
+ * client name, and outstanding balance the operator needs to decide. Advice only —
+ * recording a payment is a separate, operator-confirmed step.
+ */
+final readonly class SuggestedMatch
+{
+    /**
+     * @param list<string> $reasons signals that contributed (e.g. amount-exact, payer-alias)
+     */
+    public function __construct(
+        public int $invoiceId,
+        public int $clientId,
+        public int $outstandingCents,
+        public int $score,
+        public array $reasons,
+        public ?string $invoiceNumber = null,
+        public ?string $clientName = null,
+    ) {
+    }
+}

--- a/tests/BankTransaction/ConfirmMatchUseCaseTest.php
+++ b/tests/BankTransaction/ConfirmMatchUseCaseTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use NeneInvoice\BankTransaction\BankTransactionStatus;
+use NeneInvoice\BankTransaction\BankTransactionValidationException;
+use NeneInvoice\BankTransaction\ConfirmMatchUseCase;
+use NeneInvoice\BankTransaction\PayerNameNormalizer;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Payment\PaymentExceedsOutstandingException;
+use NeneInvoice\Payment\RecordPaymentUseCase;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\ImmediateTransactionManager;
+use NeneInvoice\Tests\Support\InMemoryBankTransactionRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryPayerAliasRepository;
+use NeneInvoice\Tests\Support\InMemoryPaymentRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class ConfirmMatchUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryPayerAliasRepository $aliases;
+    private InMemoryPaymentRepository $payments;
+    private InMemoryInvoiceRepository $invoices;
+    private RecordingAuditRecorder $audit;
+    private ConfirmMatchUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->transactions = new InMemoryBankTransactionRepository($this->holder);
+        $this->aliases      = new InMemoryPayerAliasRepository($this->holder);
+        $this->payments     = new InMemoryPaymentRepository($this->holder);
+        $this->invoices     = new InMemoryInvoiceRepository($this->holder);
+        $this->audit        = new RecordingAuditRecorder();
+
+        $recordPayment = new RecordPaymentUseCase(
+            $this->payments,
+            $this->invoices,
+            new ImmediateTransactionManager(),
+            fn () => $this->payments,
+            fn () => $this->invoices,
+            fn () => $this->audit,
+            new FixedClock(),
+            $this->holder,
+        );
+
+        $this->useCase = new ConfirmMatchUseCase($this->transactions, $this->aliases, $recordPayment);
+    }
+
+    private function issuedInvoice(int $totalCents = 11000, int $clientId = 7): int
+    {
+        return $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: $clientId,
+            status: InvoiceStatus::Issued,
+            subtotalCents: $totalCents,
+            taxCents: 0,
+            totalCents: $totalCents,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-29 00:00:00',
+        ));
+    }
+
+    // FixedClock day is 2026-06-06 (JST); a bank value date on/before it clears the
+    // "payment cannot be dated in the future" guard.
+    private function credit(int $amountCents = 11000, ?string $payerName = 'カ）サンプルセイサクシヨ', ?string $bankReference = 'TXN-0001'): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-05',
+            direction: BankTransactionDirection::Credit,
+            amountCents: $amountCents,
+            payerName: $payerName,
+            bankReference: $bankReference,
+        ));
+    }
+
+    public function test_confirm_records_payment_marks_posted_and_learns_alias(): void
+    {
+        $invoiceId = $this->issuedInvoice(11000, 7);
+        $txnId     = $this->credit(11000, 'カ）サンプルセイサクシヨ', 'TXN-1');
+
+        $result = $this->useCase->execute(3, $txnId, $invoiceId);
+
+        self::assertSame(BankTransactionStatus::Posted, $result->transaction->status);
+        self::assertSame($invoiceId, $result->transaction->matchedInvoiceId);
+        self::assertSame($result->payment->payment->id, $result->transaction->matchedPaymentId);
+
+        self::assertSame(InvoiceStatus::Paid, $result->payment->invoice->status);
+        self::assertSame(11000, $result->payment->payment->amountCents);
+        self::assertSame('bank_transfer', $result->payment->payment->method);
+        self::assertSame('TXN-1', $result->payment->payment->externalReference);
+        self::assertSame(sprintf('bank-txn-%d', $txnId), $result->payment->payment->idempotencyKey);
+
+        $alias = $this->aliases->findByNormalizedName(PayerNameNormalizer::normalize('カ）サンプルセイサクシヨ'));
+        self::assertNotNull($alias);
+        self::assertSame(7, $alias->clientId);
+
+        self::assertNotEmpty($this->audit->records);
+        self::assertSame('payment.recorded', $this->audit->records[0]['action']);
+
+        $reloaded = $this->transactions->findById($txnId);
+        self::assertNotNull($reloaded);
+        self::assertSame(BankTransactionStatus::Posted, $reloaded->status);
+    }
+
+    public function test_short_deposit_records_partial_payment_without_writeoff(): void
+    {
+        $invoiceId = $this->issuedInvoice(11000, 7);
+        $txnId     = $this->credit(10120, 'サンプル', 'TXN-2'); // short by 880 (fee tolerance)
+
+        $result = $this->useCase->execute(3, $txnId, $invoiceId);
+
+        self::assertSame(InvoiceStatus::PartiallyPaid, $result->payment->invoice->status);
+        self::assertSame(10120, $result->payment->totalPaidCents);
+        self::assertSame(BankTransactionStatus::Posted, $result->transaction->status);
+    }
+
+    public function test_overpayment_is_rejected_and_line_stays_unmatched(): void
+    {
+        $invoiceId = $this->issuedInvoice(5000, 7);
+        $txnId     = $this->credit(11000, 'サンプル', 'TXN-3');
+
+        try {
+            $this->useCase->execute(3, $txnId, $invoiceId);
+            self::fail('Expected PaymentExceedsOutstandingException.');
+        } catch (PaymentExceedsOutstandingException $e) {
+            self::assertSame(5000, $e->outstandingCents);
+        }
+
+        $reloaded = $this->transactions->findById($txnId);
+        self::assertNotNull($reloaded);
+        self::assertSame(BankTransactionStatus::Unmatched, $reloaded->status);
+        self::assertSame([], $this->payments->findByInvoice($invoiceId));
+    }
+
+    public function test_debit_line_cannot_be_confirmed(): void
+    {
+        $invoiceId = $this->issuedInvoice(11000, 7);
+        $txnId     = $this->transactions->save(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-05',
+            direction: BankTransactionDirection::Debit,
+            amountCents: 11000,
+            payerName: 'サンプル',
+            bankReference: 'TXN-DEBIT',
+        ));
+
+        $this->expectException(BankTransactionValidationException::class);
+        $this->useCase->execute(3, $txnId, $invoiceId);
+    }
+
+    public function test_retry_is_idempotent_and_does_not_double_post(): void
+    {
+        $invoiceId = $this->issuedInvoice(11000, 7);
+        $txnId     = $this->credit(11000, 'サンプル', 'TXN-5');
+
+        $first  = $this->useCase->execute(3, $txnId, $invoiceId);
+        $second = $this->useCase->execute(3, $txnId, $invoiceId);
+
+        self::assertSame($first->payment->payment->id, $second->payment->payment->id);
+        self::assertCount(1, $this->payments->findByInvoice($invoiceId));
+    }
+
+    public function test_confirm_to_a_different_invoice_after_posting_is_rejected(): void
+    {
+        $invoiceA = $this->issuedInvoice(11000, 7);
+        $invoiceB = $this->issuedInvoice(11000, 8);
+        $txnId    = $this->credit(11000, 'サンプル', 'TXN-6');
+
+        $this->useCase->execute(3, $txnId, $invoiceA);
+
+        $this->expectException(BankTransactionValidationException::class);
+        $this->useCase->execute(3, $txnId, $invoiceB);
+    }
+}

--- a/tests/BankTransaction/IgnoreBankTransactionUseCaseTest.php
+++ b/tests/BankTransaction/IgnoreBankTransactionUseCaseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use NeneInvoice\BankTransaction\BankTransactionNotFoundException;
+use NeneInvoice\BankTransaction\BankTransactionStatus;
+use NeneInvoice\BankTransaction\BankTransactionValidationException;
+use NeneInvoice\BankTransaction\IgnoreBankTransactionUseCase;
+use NeneInvoice\Tests\Support\InMemoryBankTransactionRepository;
+use PHPUnit\Framework\TestCase;
+
+final class IgnoreBankTransactionUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryBankTransactionRepository $transactions;
+    private IgnoreBankTransactionUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->transactions = new InMemoryBankTransactionRepository($this->holder);
+        $this->useCase      = new IgnoreBankTransactionUseCase($this->transactions);
+    }
+
+    private function stage(BankTransactionStatus $status = BankTransactionStatus::Unmatched): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-05',
+            direction: BankTransactionDirection::Credit,
+            amountCents: 11000,
+            payerName: 'サンプル',
+            bankReference: 'TXN-IGN',
+            status: $status,
+        ));
+    }
+
+    public function test_ignore_marks_line_ignored(): void
+    {
+        $id = $this->stage();
+
+        $result = $this->useCase->execute($id);
+
+        self::assertSame(BankTransactionStatus::Ignored, $result->status);
+        $reloaded = $this->transactions->findById($id);
+        self::assertNotNull($reloaded);
+        self::assertSame(BankTransactionStatus::Ignored, $reloaded->status);
+    }
+
+    public function test_ignoring_an_ignored_line_is_a_no_op(): void
+    {
+        $id = $this->stage(BankTransactionStatus::Ignored);
+
+        $result = $this->useCase->execute($id);
+
+        self::assertSame(BankTransactionStatus::Ignored, $result->status);
+    }
+
+    public function test_posted_line_cannot_be_ignored(): void
+    {
+        $id = $this->stage(BankTransactionStatus::Posted);
+
+        $this->expectException(BankTransactionValidationException::class);
+        $this->useCase->execute($id);
+    }
+
+    public function test_missing_transaction_throws(): void
+    {
+        $this->expectException(BankTransactionNotFoundException::class);
+        $this->useCase->execute(999);
+    }
+}

--- a/tests/BankTransaction/PdoMatchCandidateRepositoryTest.php
+++ b/tests/BankTransaction/PdoMatchCandidateRepositoryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\PdoMatchCandidateRepository;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class PdoMatchCandidateRepositoryTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private PdoMatchCandidateRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo     = $factory->create();
+
+        foreach (['invoices', 'payments', 'clients'] as $table) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/' . $table . '.sql');
+            self::assertIsString($schema);
+            $pdo->exec($schema);
+        }
+
+        $this->seed($pdo);
+
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->repository = new PdoMatchCandidateRepository(
+            new PdoDatabaseQueryExecutor($factory, $pdo),
+            $this->holder,
+        );
+    }
+
+    private function seed(PDO $pdo): void
+    {
+        $now = '2026-06-01 00:00:00';
+
+        $pdo->exec("INSERT INTO clients (id, organization_id, name, name_kana, created_at, updated_at) VALUES
+            (7, 1, 'サンプル製作所', 'サンプルセイサクシヨ', '{$now}', '{$now}'),
+            (8, 1, 'べつ商店', 'ベツシヨウテン', '{$now}', '{$now}'),
+            (9, 2, 'よそのorg', 'ヨソノオルグ', '{$now}', '{$now}')");
+
+        // 100: issued, outstanding 11000 (a voided 1000 payment must not reduce it)
+        // 101: partially_paid, 20000 - 5000 = 15000 outstanding
+        // 102: paid -> excluded by status
+        // 103: draft -> excluded by status
+        // 104: issued but fully paid (5000/5000) -> excluded by HAVING > 0
+        // 200: org 2 -> excluded by org scope
+        $pdo->exec("INSERT INTO invoices (id, organization_id, client_id, status, invoice_number, subtotal_cents, tax_cents, total_cents, is_qualified_invoice, is_deleted, created_at, updated_at) VALUES
+            (100, 1, 7, 'issued',         'INV-100', 11000, 0, 11000, 0, 0, '{$now}', '{$now}'),
+            (101, 1, 8, 'partially_paid', 'INV-101', 20000, 0, 20000, 0, 0, '{$now}', '{$now}'),
+            (102, 1, 7, 'paid',           'INV-102',  3000, 0,  3000, 0, 0, '{$now}', '{$now}'),
+            (103, 1, 7, 'draft',          NULL,       4000, 0,  4000, 0, 0, '{$now}', '{$now}'),
+            (104, 1, 8, 'issued',         'INV-104',  5000, 0,  5000, 0, 0, '{$now}', '{$now}'),
+            (200, 2, 9, 'issued',         'INV-200',  9999, 0,  9999, 0, 0, '{$now}', '{$now}')");
+
+        $pdo->exec("INSERT INTO payments (id, organization_id, invoice_id, amount_cents, paid_at, is_deleted, created_at, updated_at) VALUES
+            (1, 1, 100, 1000, '{$now}', 1, '{$now}', '{$now}'),
+            (2, 1, 101, 5000, '{$now}', 0, '{$now}', '{$now}'),
+            (3, 1, 104, 5000, '{$now}', 0, '{$now}', '{$now}')");
+    }
+
+    public function test_returns_only_open_receivables_with_outstanding_ordered_by_id(): void
+    {
+        $receivables = $this->repository->findOpenReceivables();
+
+        self::assertCount(2, $receivables);
+        self::assertSame([100, 101], array_map(static fn ($r): int => $r->invoiceId, $receivables));
+    }
+
+    public function test_outstanding_ignores_voided_payments_and_subtracts_valid_ones(): void
+    {
+        $receivables = $this->repository->findOpenReceivables();
+
+        self::assertSame(11000, $receivables[0]->outstandingCents); // voided 1000 ignored
+        self::assertSame(15000, $receivables[1]->outstandingCents); // 20000 - 5000
+    }
+
+    public function test_projects_invoice_number_and_client_names(): void
+    {
+        $first = $this->repository->findOpenReceivables()[0];
+
+        self::assertSame('INV-100', $first->invoiceNumber);
+        self::assertSame('サンプル製作所', $first->clientName);
+        self::assertSame('サンプルセイサクシヨ', $first->clientNameKana);
+        self::assertSame('サンプルセイサクシヨ', $first->matchName());
+    }
+
+    public function test_is_org_scoped(): void
+    {
+        $this->holder->set(2);
+
+        $receivables = $this->repository->findOpenReceivables();
+
+        self::assertCount(1, $receivables);
+        self::assertSame(200, $receivables[0]->invoiceId);
+    }
+}

--- a/tests/BankTransaction/SuggestMatchesUseCaseTest.php
+++ b/tests/BankTransaction/SuggestMatchesUseCaseTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\BankTransaction;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\BankTransaction;
+use NeneInvoice\BankTransaction\BankTransactionDirection;
+use NeneInvoice\BankTransaction\BankTransactionNotFoundException;
+use NeneInvoice\BankTransaction\OpenReceivable;
+use NeneInvoice\BankTransaction\PayerAlias;
+use NeneInvoice\BankTransaction\PayerNameNormalizer;
+use NeneInvoice\BankTransaction\SuggestMatchesUseCase;
+use NeneInvoice\Tests\Support\InMemoryBankTransactionRepository;
+use NeneInvoice\Tests\Support\InMemoryMatchCandidateRepository;
+use NeneInvoice\Tests\Support\InMemoryPayerAliasRepository;
+use PHPUnit\Framework\TestCase;
+
+final class SuggestMatchesUseCaseTest extends TestCase
+{
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $holder;
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryPayerAliasRepository $aliases;
+
+    protected function setUp(): void
+    {
+        $this->holder = new RequestScopedHolder();
+        $this->holder->set(1);
+        $this->transactions = new InMemoryBankTransactionRepository($this->holder);
+        $this->aliases      = new InMemoryPayerAliasRepository($this->holder);
+    }
+
+    /**
+     * @param list<OpenReceivable> $receivables
+     */
+    private function useCase(array $receivables): SuggestMatchesUseCase
+    {
+        return new SuggestMatchesUseCase(
+            $this->transactions,
+            new InMemoryMatchCandidateRepository($receivables),
+            $this->aliases,
+        );
+    }
+
+    private function credit(int $amountCents = 11000, ?string $payerName = 'カ）サンプルセイサクシヨ'): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-30',
+            direction: BankTransactionDirection::Credit,
+            amountCents: $amountCents,
+            payerName: $payerName,
+            bankReference: 'TXN-0001',
+        ));
+    }
+
+    public function test_ranks_exact_amount_and_name_match_first_with_display_fields(): void
+    {
+        $id = $this->credit(11000);
+
+        $suggestions = $this->useCase([
+            new OpenReceivable(invoiceId: 20, clientId: 8, outstandingCents: 5000, invoiceNumber: 'INV-2026-020', clientName: 'べつ商店', clientNameKana: 'ベツシヨウテン'),
+            new OpenReceivable(invoiceId: 10, clientId: 7, outstandingCents: 11000, invoiceNumber: 'INV-2026-010', clientName: 'サンプル製作所', clientNameKana: 'サンプルセイサクシヨ'),
+        ])->execute($id);
+
+        self::assertNotEmpty($suggestions);
+        self::assertSame(10, $suggestions[0]->invoiceId);
+        self::assertSame('INV-2026-010', $suggestions[0]->invoiceNumber);
+        self::assertSame('サンプル製作所', $suggestions[0]->clientName);
+        self::assertSame(11000, $suggestions[0]->outstandingCents);
+        self::assertContains('amount-exact', $suggestions[0]->reasons);
+        self::assertContains('name-exact', $suggestions[0]->reasons);
+        // The exact match outranks the unrelated smaller receivable.
+        self::assertGreaterThan($suggestions[1]->score, $suggestions[0]->score);
+    }
+
+    public function test_learned_alias_pulls_its_client_to_the_top(): void
+    {
+        $id      = $this->credit(9000, 'フリガナフメイ');
+        $payerId = $this->aliases->upsert(new PayerAlias(
+            organizationId: 1,
+            normalizedName: PayerNameNormalizer::normalize('フリガナフメイ'),
+            clientId: 42,
+        ));
+        self::assertGreaterThan(0, $payerId);
+
+        $suggestions = $this->useCase([
+            new OpenReceivable(invoiceId: 30, clientId: 9, outstandingCents: 9000, invoiceNumber: 'INV-2026-030', clientName: '別会社', clientNameKana: 'ベツガイシヤ'),
+            new OpenReceivable(invoiceId: 31, clientId: 42, outstandingCents: 9000, invoiceNumber: 'INV-2026-031', clientName: 'エイリアス先', clientNameKana: 'エイリアスサキ'),
+        ])->execute($id);
+
+        self::assertSame(31, $suggestions[0]->invoiceId);
+        self::assertContains('payer-alias', $suggestions[0]->reasons);
+    }
+
+    public function test_debit_line_yields_no_suggestions(): void
+    {
+        $id = $this->transactions->save(new BankTransaction(
+            organizationId: 1,
+            valueDate: '2026-06-30',
+            direction: BankTransactionDirection::Debit,
+            amountCents: 11000,
+            payerName: 'テスト',
+            bankReference: 'TXN-DEBIT',
+        ));
+
+        $suggestions = $this->useCase([
+            new OpenReceivable(invoiceId: 10, clientId: 7, outstandingCents: 11000, invoiceNumber: 'INV-2026-010'),
+        ])->execute($id);
+
+        self::assertSame([], $suggestions);
+    }
+
+    public function test_missing_transaction_throws(): void
+    {
+        $this->expectException(BankTransactionNotFoundException::class);
+
+        $this->useCase([])->execute(999);
+    }
+}

--- a/tests/Support/InMemoryMatchCandidateRepository.php
+++ b/tests/Support/InMemoryMatchCandidateRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use NeneInvoice\BankTransaction\MatchCandidateRepositoryInterface;
+use NeneInvoice\BankTransaction\OpenReceivable;
+
+/**
+ * In-memory fake for {@see \NeneInvoice\BankTransaction\SuggestMatchesUseCase}
+ * tests: returns a canned set of open receivables (the ledger read is covered by
+ * {@see \NeneInvoice\BankTransaction\PdoMatchCandidateRepository} integration).
+ */
+final class InMemoryMatchCandidateRepository implements MatchCandidateRepositoryInterface
+{
+    /** @param list<OpenReceivable> $receivables */
+    public function __construct(private array $receivables = [])
+    {
+    }
+
+    /** @return list<OpenReceivable> */
+    public function findOpenReceivables(): array
+    {
+        return $this->receivables;
+    }
+}

--- a/tests/Support/InMemoryPayerAliasRepository.php
+++ b/tests/Support/InMemoryPayerAliasRepository.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Support;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\BankTransaction\PayerAlias;
+use NeneInvoice\BankTransaction\PayerAliasNotFoundException;
+use NeneInvoice\BankTransaction\PayerAliasRepositoryInterface;
+
+/**
+ * In-memory fake for use-case tests (no database). `upsert` forces the org from
+ * the request-scoped holder and keys on (org, normalized_name), mirroring
+ * {@see \NeneInvoice\BankTransaction\PdoPayerAliasRepository}.
+ */
+final class InMemoryPayerAliasRepository implements PayerAliasRepositoryInterface
+{
+    /** @var array<int, PayerAlias> */
+    private array $byId = [];
+    private int $nextId = 1;
+
+    /** @var RequestScopedHolder<int> */
+    private RequestScopedHolder $orgId;
+
+    /** @param RequestScopedHolder<int>|null $orgId */
+    public function __construct(?RequestScopedHolder $orgId = null)
+    {
+        if ($orgId === null) {
+            $orgId = new RequestScopedHolder();
+            $orgId->set(1);
+        }
+
+        $this->orgId = $orgId;
+    }
+
+    public function upsert(PayerAlias $alias): int
+    {
+        $existing = $this->findByNormalizedName($alias->normalizedName);
+
+        if ($existing !== null && $existing->id !== null) {
+            $this->byId[$existing->id] = $this->copy($alias, $existing->id, $this->orgId->get());
+
+            return $existing->id;
+        }
+
+        $id              = $this->nextId++;
+        $this->byId[$id] = $this->copy($alias, $id, $this->orgId->get());
+
+        return $id;
+    }
+
+    public function findById(int $id): ?PayerAlias
+    {
+        $alias = $this->byId[$id] ?? null;
+
+        return $alias !== null && $alias->organizationId === $this->orgId->get() ? $alias : null;
+    }
+
+    public function findByNormalizedName(string $normalizedName): ?PayerAlias
+    {
+        foreach ($this->byId as $alias) {
+            if ($alias->organizationId === $this->orgId->get() && $alias->normalizedName === $normalizedName) {
+                return $alias;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<PayerAlias> */
+    public function findByOrganization(int $limit, int $offset): array
+    {
+        $mine = array_values(array_filter(
+            $this->byId,
+            fn (PayerAlias $a): bool => $a->organizationId === $this->orgId->get(),
+        ));
+
+        usort($mine, static fn (PayerAlias $a, PayerAlias $b): int => strcmp($a->normalizedName, $b->normalizedName));
+
+        return array_slice($mine, $offset, $limit);
+    }
+
+    public function countByOrganization(): int
+    {
+        return count(array_filter(
+            $this->byId,
+            fn (PayerAlias $a): bool => $a->organizationId === $this->orgId->get(),
+        ));
+    }
+
+    public function delete(int $id): void
+    {
+        if ($this->findById($id) === null) {
+            throw new PayerAliasNotFoundException($id);
+        }
+
+        unset($this->byId[$id]);
+    }
+
+    private function copy(PayerAlias $alias, int $id, int $organizationId): PayerAlias
+    {
+        return new PayerAlias(
+            organizationId: $organizationId,
+            normalizedName: $alias->normalizedName,
+            clientId: $alias->clientId,
+            id: $id,
+            createdAt: $alias->createdAt ?? '2026-06-06 00:00:00',
+            updatedAt: '2026-06-06 00:00:00',
+        );
+    }
+}


### PR DESCRIPTION
## 概要

銀行入金CSV自動消込（#505）の増分⑤。**初めて入金を起票する**工程で、①〜④（staging 永続化・CSVパーサ・名義辞書・スコアリング）に続く。取込・照合の**会計影響ゼロ**（staging のみ）を維持し、起票は**税理士サインオフ済み（2026-05-30）の `RecordPaymentUseCase` を再利用**する別工程として実装する。

## 変更（`src/BankTransaction/`）

- **SuggestMatchesUseCase** — 取引→未回収 invoice 候補（`PdoMatchCandidateRepository`）→ `payer_alias` 参照 → `BankTransactionMatcher` で採点 → `invoice_number` / `client_name` / `outstanding_cents` を付けて返す。`credit` のみ・読み取り専用。
- **ConfirmMatchUseCase** — 銀行入金額そのままを `RecordPayment` で起票（`external_reference=bank_reference`、冪等キー `bank-txn-<id>`）。成功で `status→posted`・`matched_invoice_id`/`matched_payment_id` 確定・名義を `payer_alias` へ学習。
- **IgnoreBankTransactionUseCase** — 手数料/非AR/重複を `ignored` に（`posted` は不可・再 ignore は no-op）。
- **PdoMatchCandidateRepository** — `issued`/`partially_paid` × `outstanding>0` を client 名付きで取得（`is_deleted = FALSE`・status を文字列リテラルで比較する方言中立SQL）。
- DTO: `OpenReceivable` / `SuggestedMatch` / `ConfirmMatchResult`、例外 `BankTransactionValidationException`、read port `MatchCandidateRepositoryInterface`。

## コンプライアンス（非交渉）

- 取込・照合＝**会計影響ゼロ**（staging のみ、billing record ではない）。
- 起票＝**銀行入金額そのまま**。**銀行額 < 未回収**は部分入金として記録し残額は未回収のまま（**write-off しない**）。**銀行額 > 未回収**は RecordPayment の overpayment ガードで**拒否**（人手対応）。
- **手数料差引 write-off・過入金の自動按分は税理士ゲート**＝本 PR 対象外（#505 に残す）。

## テスト（+18・単体）

- 過入金拒否 / 冪等リトライ（二重起票なし）/ 部分入金（write-off なし）/ 別 invoice への再確認拒否 / debit 拒否 / alias 学習 / org 境界。
- `PdoMatchCandidateRepository` の消込SQL（void 入金の除外・outstanding 計算・org スコープ・client 名射影）。
- InMemory 版 `payer_alias` / `match_candidate` リポジトリを追加。

## 検証

`composer check` 緑（828 tests / phpstan No errors / cs clean / OpenAPI valid / MCP valid）。※ #538（日付フレーキー）マージ後の main に rebase 済み。

## セルフレビュー

- [x] Handler→UseCase→RepositoryInterface→PdoRepository 準拠
- [x] 会計影響ゼロの staging と、税理士サインオフ済み RecordPayment 再利用の分離を厳守
- [x] 金額は integer cents / SQL は方言中立（`is_deleted = FALSE`）
- [x] org スコープ（ADR 0006）
- [x] `composer check` ローカル緑

後続: ⑦ HTTP+OpenAPI、⑧ 消込UI。⑥ 手数料 write-off は税理士ゲート。

Refs #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)