### PR TITLE
[P1] fix(release): リリースZIPに resources/（IPAexフォント）を同梱 (#550)

### DIFF
--- a/docker/installer-demo/setup.sh
+++ b/docker/installer-demo/setup.sh
@@ -15,7 +15,7 @@ rm -rf "$DEST"
 mkdir -p "$DEST/var"
 
 # リリース ZIP（tools/build-release.sh）と同じ構成。
-for d in src vendor database public_html; do
+for d in src vendor database public_html resources; do
   cp -r "$ROOT/$d" "$DEST/$d"
 done
 cp "$ROOT/composer.json" "$ROOT/phinx.php" "$ROOT/.env.example" "$DEST/"

--- a/tests/Installer/ReleaseContentsTest.php
+++ b/tests/Installer/ReleaseContentsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Installer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Tier A release ZIP against missing runtime files (#550).
+ *
+ * `tools/build-release.sh` copies a hand-listed set of directories into the
+ * release artifact. When code loads a file from a repository-root directory at
+ * runtime (e.g. {@see \NeneInvoice\Pdf\MpdfFactory} reading the bundled IPAex
+ * fonts from `resources/fonts/`), that directory MUST be in the release — else a
+ * fresh install works for everything except that path, as happened when
+ * `resources/` was omitted and every invoice/quote PDF 500'd with
+ * "Cannot find TTF TrueType font file". This test fails if `src/` references a
+ * repo-root directory at runtime that the release script does not copy.
+ */
+final class ReleaseContentsTest extends TestCase
+{
+    private const CORE_DIRS = ['src', 'vendor', 'database', 'public_html', 'resources'];
+
+    private static function releaseScript(): string
+    {
+        return (string) file_get_contents(dirname(__DIR__, 2) . '/tools/build-release.sh');
+    }
+
+    public function test_release_bundles_the_core_runtime_directories(): void
+    {
+        $script = self::releaseScript();
+
+        foreach (self::CORE_DIRS as $dir) {
+            self::assertMatchesRegularExpression(
+                '#cp\s+-r\s+"\$ROOT/' . preg_quote($dir, '#') . '"#',
+                $script,
+                "build-release.sh must copy the '{$dir}/' directory into the release.",
+            );
+        }
+    }
+
+    /**
+     * Every repo-root directory that `src/` loads at runtime (via
+     * `__DIR__ . '/../../<dir>/...'`) must be shipped by the release script.
+     */
+    public function test_release_ships_every_repo_root_dir_that_src_loads_at_runtime(): void
+    {
+        $root   = dirname(__DIR__, 2);
+        $script = self::releaseScript();
+
+        /** @var array<string, true> $referenced */
+        $referenced = [];
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($root . '/src'));
+
+        foreach ($files as $file) {
+            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $code = (string) file_get_contents($file->getPathname());
+
+            if (preg_match_all('#__DIR__\s*\.\s*\'/\.\./\.\./([^/\']+)#', $code, $m) > 0) {
+                foreach ($m[1] as $dir) {
+                    $referenced[$dir] = true;
+                }
+            }
+        }
+
+        self::assertArrayHasKey('resources', $referenced, 'Expected MpdfFactory to reference resources/ (test sanity).');
+
+        foreach (array_keys($referenced) as $dir) {
+            self::assertMatchesRegularExpression(
+                '#cp\s+-r\s+"\$ROOT/' . preg_quote($dir, '#') . '"#',
+                $script,
+                "src/ loads '{$dir}/' at runtime, so build-release.sh must ship it (#550).",
+            );
+        }
+    }
+}

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -45,6 +45,10 @@ cp -r "$ROOT/src"                 "$WORK/src"
 cp -r "$ROOT/vendor"              "$WORK/vendor"
 cp -r "$ROOT/database"            "$WORK/database"
 cp -r "$ROOT/public_html"         "$WORK/public_html"
+# resources/fonts holds the bundled IPAex fonts that MpdfFactory loads at PDF
+# render time (resources/fonts/ipaexg.ttf). Without this the installed app throws
+# "Cannot find TTF TrueType font file" and every invoice/quote PDF 500s (#550).
+cp -r "$ROOT/resources"           "$WORK/resources"
 cp    "$ROOT/.env.example"        "$WORK/.env.example"
 cp    "$ROOT/phinx.php"           "$WORK/phinx.php"
 cp    "$ROOT/composer.json"       "$WORK/composer.json"


### PR DESCRIPTION
## 概要（捨てコンテナ実機テストで発見・P1）
リリースZIPから**設置したインスタンスで見積/請求 PDF 生成が 500**:
`Mpdf\MpdfException: Cannot find TTF TrueType font file "ipaexg.ttf" in configured font directories.`

`tools/build-release.sh` の同梱対象が `src/vendor/database/public_html/.env.example/phinx.php/composer.json` のみで **`resources/` を含んでいなかった**。`src/Pdf/MpdfFactory.php` は日本語フォントを `resources/fonts/`（`ipaexg.ttf`/`ipaexm.ttf`、IPA Font License）から読むため、設置後にフォント解決失敗→mPDF 例外→500。開発はリポジトリ直実行で resources/ があるため再現せず、**全設置インスタンスで PDF が壊れていた**（会計上の中核出力）。

## 修正
- **tools/build-release.sh**: `resources/` を同梱。
- **docker/installer-demo/setup.sh**: `resources` を展開対象に追加（デモも同欠落）。
- **tests/Installer/ReleaseContentsTest**: 回帰ガード。コア runtime ディレクトリの同梱＋「`src/` が `__DIR__.'/../../<dir>'` で実行時参照する repo 直下ディレクトリはリリースが必ず同梱」を検証（欠落クラスの再発防止）。

## 検証（実機）
修正後 ZIP に `resources/fonts/ipaexg.ttf` を確認 → 捨てコンテナで bootstrap 設置 → 請求書発行 → `GET /admin/invoices/1/pdf` が **200 application/pdf**（IPAexGothic 見出し＋Sun-ExtA 本文の有効な PDF）。`composer check` 緑（839 tests / phpstan / cs / openapi / mcp）。

## 注
ZIP は 74→84MB（IPAex 同梱）。ペイロード肥大は ADR 0020 遅延フォントパック（#548）で別途対応。

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)