### PR TITLE
fix(multitenant): /admin/me を org リゾルバの bypass に加える (#552)

### DIFF
--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -38,6 +38,11 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         '/api/',
         '/invoices/download/',
         '/admin/organizations',
+        // Self-service identity: `/admin/me` returns the caller's own record from
+        // token claims (user lookup is by id, not org-scoped), so it needs no org
+        // context. Bypassing lets a cross-tenant superadmin (organization_id NULL)
+        // bootstrap the admin SPA where there is no org in the URL (#552).
+        '/admin/me',
     ];
 
     /**

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -64,7 +64,7 @@ final class OrgResolverMiddlewareTest extends TestCase
     {
         $handler = $this->passthroughHandler();
 
-        foreach (['/health', '/auth/login', '/api/invoices', '/invoices/download/x', '/admin/organizations'] as $path) {
+        foreach (['/health', '/auth/login', '/api/invoices', '/invoices/download/x', '/admin/organizations', '/admin/me'] as $path) {
             $request  = $this->psr17->createServerRequest('GET', "https://app.example.com{$path}");
             $response = $this->middleware('', false)->process($request, $handler);
             self::assertSame(200, $response->getStatusCode(), "bypass failed for {$path}");


### PR DESCRIPTION
## 概要
型B Phase 1（superadmin プロビジョニング）の前提となる小 BE 修正。

path 方式のマルチテナントで **superadmin（organization_id NULL）が SPA を起動すると `/admin/me` が 404**（org リゾルバが先頭セグメント "admin" を組織スラッグと誤解）。`/admin/me` は token claims ＋ id 直引き（`UserRepository::findById` は org 非スコープ）で自分の情報を返すだけ＝**org 文脈不要**。bypass に追加しても通常ユーザーは挙動不変で、org 無し superadmin の SPA ブートが通る。

- `OrgResolverMiddleware::BYPASS_PREFIXES` に `/admin/me` 追加。
- `OrgResolverMiddlewareTest` の bypass ケースに `/admin/me` 追加。

`composer check` 緑（phpstan / cs / resolver tests）。

Refs #552（Phase 1 の残り＝プロビジョニング endpoint＋組織管理 FE は後続 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)