### PR TITLE
feat(multitenant): 型B Phase 2 — 顧問先SPAを /{slug}/ 配下で稼働（path slug-strip＋SPA app-base） (#556)

### DIFF
--- a/frontend/src/shared/config/app-base.test.ts
+++ b/frontend/src/shared/config/app-base.test.ts
@@ -23,3 +23,17 @@ describe('install base derivation (ADR 0015)', () => {
     expect(deriveApiBasePath('invoice/')).toBe('')
   })
 })
+
+describe('path tenancy app base (型B Phase 2)', () => {
+  it('org slug at root → "/acme" API prefix and basename', () => {
+    // Backend injects app-base=<install>/<slug>/; the same generic derivation
+    // scopes both the router and every API call under the slug.
+    expect(deriveApiBasePath('/acme/')).toBe('/acme')
+    expect(deriveRouterBasename('/acme')).toBe('/acme')
+  })
+
+  it('org slug under a subdirectory install → "/invoice/acme"', () => {
+    expect(deriveApiBasePath('/invoice/acme/')).toBe('/invoice/acme')
+    expect(deriveRouterBasename('/invoice/acme')).toBe('/invoice/acme')
+  })
+})

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -6,7 +6,9 @@ use Nene2\Config\AppConfig;
 use Nene2\Http\ResponseEmitter;
 use NeneInvoice\Http\BasePath;
 use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Http\SpaBasePlan;
 use NeneInvoice\Http\SpaShell;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -58,14 +60,33 @@ $request = $request
     ->withUri($request->getUri()->withPath($strippedPath))
     ->withAttribute(BasePath::REQUEST_ATTRIBUTE, $base);
 
+// Merge the install base (ADR 0015) with the path-tenancy org prefix (型B Phase
+// 2): under `path` mode a leading `/<slug>/` that names a real org makes the
+// shell serve the tenant SPA with `app-base=<base>/<slug>/`, so its router and
+// API calls stay under the slug. The slug lookup only runs in path mode.
+$modeRaw = $_ENV['TENANT_RESOLUTION'] ?? getenv('TENANT_RESOLUTION');
+$mode    = is_string($modeRaw) && $modeRaw !== '' ? $modeRaw : 'single';
+
+$spaPlan = SpaBasePlan::resolve(
+    $base,
+    $strippedPath,
+    $mode,
+    static function (string $slug) use ($container): bool {
+        $repository = $container->get(OrganizationRepositoryInterface::class);
+        assert($repository instanceof OrganizationRepositoryInterface);
+
+        return $repository->findBySlug($slug) !== null;
+    },
+);
+
 // Non-API GET/HEAD requests get the SPA shell (with the base injected), which
 // also serves deep-links / F5. Everything else goes to the JSON API router.
 $method = $request->getMethod();
 $response = null;
 
-if (($method === 'GET' || $method === 'HEAD') && !BasePath::isApiPath($strippedPath)) {
+if (($method === 'GET' || $method === 'HEAD') && !BasePath::isApiPath($spaPlan->spaPath)) {
     $shell = new SpaShell($projectRoot . '/public_html/admin/index.html', $psr17Factory, $psr17Factory);
-    $response = $shell->serve($base);
+    $response = $shell->serve($spaPlan->assetBase, $spaPlan->appBase);
 }
 
 if ($response === null) {

--- a/src/Http/SpaBasePlan.php
+++ b/src/Http/SpaBasePlan.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+/**
+ * Decides how the SPA shell is served for a request, merging the two independent
+ * URL axes (型B Phase 2):
+ *
+ *  - the install base path (ADR 0015), detected from `SCRIPT_NAME`; and
+ *  - the org slug prefix of path tenancy (`/acme/...`), present only in `path`
+ *    resolution mode.
+ *
+ * The front controller serves the shell *before* the router (so SPA deep-links
+ * never hit the org resolver's 404-on-unresolved), which is why this decision
+ * lives here rather than in the middleware pipeline. Three outputs:
+ *
+ *  - {@see $assetBase} — install base only; static assets are one physical copy
+ *    under `admin/`, never under a slug.
+ *  - {@see $appBase} — install base plus the tenant slug, injected as `app-base`
+ *    so the SPA router basename and every API call stay under `/<slug>/`.
+ *  - {@see $spaPath} — the slug-stripped, base-relative path used to decide
+ *    shell-vs-API ({@see BasePath::isApiPath()}), matching the canonical path the
+ *    router will ultimately see after {@see \NeneInvoice\Organization\Resolution\OrgResolverMiddleware}
+ *    strips the slug.
+ *
+ * Outside `path` mode the slug axis is absent: app base equals asset base and the
+ * path is unchanged, preserving single/subdomain/custom-domain behaviour exactly.
+ */
+final readonly class SpaBasePlan
+{
+    private function __construct(
+        public string $assetBase,
+        public string $appBase,
+        public string $spaPath,
+    ) {
+    }
+
+    /**
+     * @param string                 $installBase  normalized install base (`''` or `/invoice`)
+     * @param string                 $strippedPath request path with the install base already removed
+     * @param string                 $mode         TENANT_RESOLUTION value (`single` / `path` / `subdomain` / `custom_domain`)
+     * @param callable(string): bool $slugExists   true when the segment names a real organization (called only in path mode)
+     */
+    public static function resolve(string $installBase, string $strippedPath, string $mode, callable $slugExists): self
+    {
+        if ($mode !== 'path') {
+            return new self($installBase, $installBase, $strippedPath);
+        }
+
+        $parts     = explode('/', ltrim($strippedPath, '/'), 2);
+        $candidate = $parts[0];
+
+        // No first segment (install root), or the segment is not a tenant slug
+        // (e.g. the org-less superadmin route `/organizations`): serve at the
+        // install base with no slug prefix.
+        if ($candidate === '' || !$slugExists($candidate)) {
+            return new self($installBase, $installBase, $strippedPath);
+        }
+
+        return new self(
+            assetBase: $installBase,
+            appBase: $installBase . '/' . $candidate,
+            spaPath: '/' . ($parts[1] ?? ''),
+        );
+    }
+}

--- a/src/Http/SpaShell.php
+++ b/src/Http/SpaShell.php
@@ -10,16 +10,21 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Serves the built admin SPA shell for non-API routes, injecting the detected
- * install base so one artifact works at any path (ADR 0015).
+ * install base so one artifact works at any path (ADR 0015) — and, under path
+ * tenancy, the org prefix so the tenant SPA runs under `/<slug>/` (型B Phase 2).
  *
  * Two tags are injected into `<head>` — both CSP-safe (no inline script, which
- * `script-src 'self'` would block):
+ * `script-src 'self'` would block). They intentionally use *different* bases:
  *
- * - `<base href="<base>/admin/">` so the shell's relative asset references
+ * - `<base href="<assetBase>/admin/">` so the shell's relative asset references
  *   (`./assets/…`, built by Vite with `base: './'`) resolve to the real files
- *   under `admin/`, even though the shell itself is served from the install root.
- * - `<meta name="app-base" content="<base>/">` which the frontend reads to set
- *   the router basename and prefix every API call.
+ *   under `admin/`. Assets are a single physical copy under the install root, so
+ *   this is the install base only — never the org slug.
+ * - `<meta name="app-base" content="<appBase>/">` which the frontend reads to set
+ *   the router basename and prefix every API call. This is the install base plus
+ *   the tenant slug (`/invoice/acme`) in path mode, so the tenant SPA routes and
+ *   calls stay under `/<slug>/`; it equals the install base when there is no slug
+ *   (single/subdomain installs, or the org-less superadmin shell).
  *
  * Serving the shell through the front controller (rather than a static file)
  * also fixes SPA deep-links / F5: any non-API GET returns the shell.
@@ -36,8 +41,11 @@ final readonly class SpaShell
     /**
      * Returns the base-injected shell, or null when the built shell is absent
      * (e.g. a backend-only checkout) so the caller can fall back to the API.
+     *
+     * @param string $assetBase install base for static assets (`''` at root, `/invoice`)
+     * @param string $appBase   install base plus tenant slug for router/API (`''`, `/invoice`, `/invoice/acme`)
      */
-    public function serve(string $base): ?ResponseInterface
+    public function serve(string $assetBase, string $appBase): ?ResponseInterface
     {
         if (!is_file($this->shellPath)) {
             return null;
@@ -51,17 +59,17 @@ final readonly class SpaShell
 
         $response = $this->responseFactory->createResponse(200)
             ->withHeader('Content-Type', 'text/html; charset=UTF-8')
-            ->withBody($this->streamFactory->createStream($this->inject($html, $base)));
+            ->withBody($this->streamFactory->createStream($this->inject($html, $assetBase, $appBase)));
 
         return $response;
     }
 
-    private function inject(string $html, string $base): string
+    private function inject(string $html, string $assetBase, string $appBase): string
     {
-        $assetBase = htmlspecialchars($base . '/admin/', ENT_QUOTES);
-        $appBase = htmlspecialchars($base . '/', ENT_QUOTES);
+        $assetHref = htmlspecialchars($assetBase . '/admin/', ENT_QUOTES);
+        $appHref = htmlspecialchars($appBase . '/', ENT_QUOTES);
 
-        $tags = "<head>\n    <base href=\"{$assetBase}\" />\n    <meta name=\"app-base\" content=\"{$appBase}\" />";
+        $tags = "<head>\n    <base href=\"{$assetHref}\" />\n    <meta name=\"app-base\" content=\"{$appHref}\" />";
 
         // Inject right after the opening <head> so <base> precedes any relative
         // URL. If the marker is absent (unexpected), serve the shell unchanged.

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -86,10 +86,20 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
 
         $this->orgId->set($org->id ?? 0);
 
-        return $handler->handle(
-            $request->withAttribute('nene2.org.id', $org->id)
-                ->withAttribute('nene2.org.slug', $org->slug),
-        );
+        $request = $request->withAttribute('nene2.org.id', $org->id)
+            ->withAttribute('nene2.org.slug', $org->slug);
+
+        // Path-based tenancy carries the slug in the URL (`/org1/admin/...`).
+        // Strip it now — before the bearer-token / capability guards (which gate
+        // on `/admin` · `/api` prefixes) and the router run — so they see the
+        // canonical `/admin/...` path. This is the first middleware, so the
+        // rewrite propagates to the whole downstream pipeline.
+        if ($this->strategy instanceof PathScopedResolutionStrategyInterface) {
+            $uri     = $request->getUri();
+            $request = $request->withUri($uri->withPath($this->strategy->stripPrefix($uri->getPath())));
+        }
+
+        return $handler->handle($request);
     }
 
     /**

--- a/src/Organization/Resolution/PathPrefixResolutionStrategy.php
+++ b/src/Organization/Resolution/PathPrefixResolutionStrategy.php
@@ -12,8 +12,12 @@ use Psr\Http\Message\ServerRequestInterface;
  * Best for shared-host deployments where wildcard subdomains are not available.
  * Bypass paths (health, auth, service API, public download, superadmin org
  * management) return null so the middleware passes them through unresolved.
+ *
+ * Because the slug lives in the path, this strategy also strips it once resolved
+ * ({@see PathScopedResolutionStrategyInterface}) so `/org1/admin/...` reaches the
+ * `/admin/...` routes.
  */
-final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrategyInterface
+final readonly class PathPrefixResolutionStrategy implements PathScopedResolutionStrategyInterface
 {
     /** @var list<string> */
     private const BYPASS_PREFIXES = [
@@ -38,5 +42,15 @@ final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrate
         $candidate = $parts[0];
 
         return $candidate !== '' ? $candidate : null;
+    }
+
+    /**
+     * Drops the leading slug segment: `/org1/admin/x` → `/admin/x`, `/org1` → `/`.
+     */
+    public function stripPrefix(string $path): string
+    {
+        $parts = explode('/', ltrim($path, '/'), 2);
+
+        return '/' . ($parts[1] ?? '');
     }
 }

--- a/src/Organization/Resolution/PathScopedResolutionStrategyInterface.php
+++ b/src/Organization/Resolution/PathScopedResolutionStrategyInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization\Resolution;
+
+/**
+ * A resolution strategy that carries the org identifier in the request *path*
+ * (as opposed to the host or an env var), and therefore must remove that segment
+ * before the router matches routes registered without the tenant prefix.
+ *
+ * Only {@see PathPrefixResolutionStrategy} needs this: `/org1/admin/...` must
+ * become `/admin/...` so the existing `/admin/...` routes match (型B path
+ * tenancy). Host- and env-based strategies leave the path untouched and do not
+ * implement this interface.
+ *
+ * The strip runs inside {@see OrgResolverMiddleware}, which is the first entry in
+ * the pipeline — so every downstream middleware (bearer-token / capability, which
+ * gate on `/admin` · `/api` prefixes) and the router see the canonical,
+ * tenant-stripped path. Stripping later would let a `/org1/admin/...` request
+ * slip past the prefix-based auth guards.
+ */
+interface PathScopedResolutionStrategyInterface extends OrgResolutionStrategyInterface
+{
+    /**
+     * Removes the leading org path segment this strategy consumed, returning the
+     * router-facing path (always leading-slash; `/` when nothing remains). Only
+     * called after {@see OrgResolutionStrategyInterface::resolve()} returned a
+     * non-null identifier for this request.
+     */
+    public function stripPrefix(string $path): string;
+}

--- a/tests/Http/PathTenancyRoutingTest.php
+++ b/tests/Http/PathTenancyRoutingTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Routing\Router;
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
+use NeneInvoice\Organization\Resolution\PathPrefixResolutionStrategy;
+use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * End-to-end proof of 型B path tenancy: a `/<slug>/admin/...` request resolves
+ * the org and reaches the `/admin/...` route (registered without the tenant
+ * prefix), scoped to that org — exercising the real OrgResolverMiddleware, the
+ * PathPrefixResolutionStrategy, and the real NENE2 Router together.
+ */
+final class PathTenancyRoutingTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private InMemoryOrganizationRepository $orgs;
+    private Router $router;
+    private int $acmeId;
+    private int $betaId;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->orgs  = new InMemoryOrganizationRepository();
+
+        $this->acmeId = $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+        $this->betaId = $this->orgs->save(new Organization(name: 'Beta', slug: 'beta', plan: 'free', isActive: true));
+
+        // Route registered WITHOUT any tenant prefix, as the app registers it.
+        $this->router = new Router();
+        $this->router->get('/admin/dashboard', function (ServerRequestInterface $request): ResponseInterface {
+            $response = $this->psr17->createResponse(200);
+            $response->getBody()->write((string) json_encode([
+                'org_id'   => $request->getAttribute('nene2.org.id'),
+                'org_slug' => $request->getAttribute('nene2.org.slug'),
+            ]));
+
+            return $response;
+        });
+    }
+
+    private function dispatch(string $path): ResponseInterface
+    {
+        $middleware = new OrgResolverMiddleware(
+            new RequestScopedHolder(),
+            $this->orgs,
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+            new PathPrefixResolutionStrategy(),
+            false,
+        );
+
+        $request = $this->psr17->createServerRequest('GET', "https://host.example{$path}");
+
+        return $middleware->process($request, $this->router);
+    }
+
+    public function test_tenant_prefix_reaches_admin_route_scoped_to_that_org(): void
+    {
+        $response = $this->dispatch('/acme/admin/dashboard');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertSame($this->acmeId, $payload['org_id']);
+        self::assertSame('acme', $payload['org_slug']);
+    }
+
+    public function test_different_tenant_prefix_scopes_to_its_own_org(): void
+    {
+        $response = $this->dispatch('/beta/admin/dashboard');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertSame($this->betaId, $payload['org_id']);
+        self::assertSame('beta', $payload['org_slug']);
+    }
+
+    public function test_missing_tenant_prefix_is_404(): void
+    {
+        // In path mode there is no sole-org fallback: `/admin/...` with no slug
+        // treats `admin` as the (non-existent) slug and 404s before routing.
+        $response = $this->dispatch('/admin/dashboard');
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('organization-not-found', (string) $response->getBody());
+    }
+
+    public function test_unknown_tenant_prefix_is_404(): void
+    {
+        $response = $this->dispatch('/ghost/admin/dashboard');
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('organization-not-found', (string) $response->getBody());
+    }
+}

--- a/tests/Http/SpaBasePlanTest.php
+++ b/tests/Http/SpaBasePlanTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use NeneInvoice\Http\SpaBasePlan;
+use PHPUnit\Framework\TestCase;
+
+final class SpaBasePlanTest extends TestCase
+{
+    /** @var callable(string): bool */
+    private $never;
+
+    protected function setUp(): void
+    {
+        // Non-path modes must not touch the org repository.
+        $this->never = function (string $slug): bool {
+            self::fail("slug existence must not be checked outside path mode (got '{$slug}')");
+        };
+    }
+
+    public function test_single_mode_uses_install_base_for_both_and_keeps_path(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/dashboard', 'single', $this->never);
+
+        self::assertSame('', $plan->assetBase);
+        self::assertSame('', $plan->appBase);
+        self::assertSame('/dashboard', $plan->spaPath);
+    }
+
+    public function test_single_mode_under_subdirectory(): void
+    {
+        $plan = SpaBasePlan::resolve('/invoice', '/invoices/5', 'single', $this->never);
+
+        self::assertSame('/invoice', $plan->assetBase);
+        self::assertSame('/invoice', $plan->appBase);
+        self::assertSame('/invoices/5', $plan->spaPath);
+    }
+
+    public function test_subdomain_mode_never_prefixes_a_slug(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/acme/dashboard', 'subdomain', $this->never);
+
+        self::assertSame('', $plan->appBase);
+        self::assertSame('/acme/dashboard', $plan->spaPath);
+    }
+
+    public function test_path_mode_real_slug_prefixes_app_base_and_strips_spa_path(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/acme/dashboard', 'path', fn (string $s): bool => $s === 'acme');
+
+        // Assets stay install-relative (single physical copy); router/API get the slug.
+        self::assertSame('', $plan->assetBase);
+        self::assertSame('/acme', $plan->appBase);
+        self::assertSame('/dashboard', $plan->spaPath);
+    }
+
+    public function test_path_mode_api_path_under_slug_is_stripped_for_the_api_decision(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/acme/admin/dashboard', 'path', fn (string $s): bool => $s === 'acme');
+
+        self::assertSame('/acme', $plan->appBase);
+        self::assertSame('/admin/dashboard', $plan->spaPath);
+    }
+
+    public function test_path_mode_slug_only_yields_root_spa_path(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/acme', 'path', fn (string $s): bool => $s === 'acme');
+
+        self::assertSame('/acme', $plan->appBase);
+        self::assertSame('/', $plan->spaPath);
+    }
+
+    public function test_path_mode_unknown_first_segment_is_org_less(): void
+    {
+        // Superadmin SPA route (org-less): first segment is not a tenant slug.
+        $plan = SpaBasePlan::resolve('', '/organizations', 'path', fn (string $s): bool => $s === 'acme');
+
+        self::assertSame('', $plan->appBase);
+        self::assertSame('/organizations', $plan->spaPath);
+    }
+
+    public function test_path_mode_root_is_org_less(): void
+    {
+        $plan = SpaBasePlan::resolve('', '/', 'path', fn (string $s): bool => $s === 'acme');
+
+        self::assertSame('', $plan->appBase);
+        self::assertSame('/', $plan->spaPath);
+    }
+
+    public function test_path_mode_composes_with_subdirectory_install(): void
+    {
+        // Installed under /invoice, tenant acme: app base is /invoice/acme.
+        $plan = SpaBasePlan::resolve('/invoice', '/acme/invoices', 'path', fn (string $s): bool => $s === 'acme');
+
+        self::assertSame('/invoice', $plan->assetBase);
+        self::assertSame('/invoice/acme', $plan->appBase);
+        self::assertSame('/invoices', $plan->spaPath);
+    }
+}

--- a/tests/Http/SpaShellTest.php
+++ b/tests/Http/SpaShellTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use NeneInvoice\Http\SpaShell;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+final class SpaShellTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private string $shellPath;
+
+    protected function setUp(): void
+    {
+        $this->psr17     = new Psr17Factory();
+        $this->shellPath = tempnam(sys_get_temp_dir(), 'shell') ?: '';
+        file_put_contents($this->shellPath, "<!doctype html>\n<html>\n<head>\n<title>NeNe</title>\n</head>\n<body></body>\n</html>");
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->shellPath !== '' && is_file($this->shellPath)) {
+            unlink($this->shellPath);
+        }
+    }
+
+    private function shell(): SpaShell
+    {
+        return new SpaShell($this->shellPath, $this->psr17, $this->psr17);
+    }
+
+    public function test_root_install_injects_root_asset_and_app_base(): void
+    {
+        $response = $this->shell()->serve('', '');
+        self::assertNotNull($response);
+
+        $html = (string) $response->getBody();
+        self::assertStringContainsString('<base href="/admin/" />', $html);
+        self::assertStringContainsString('<meta name="app-base" content="/" />', $html);
+        self::assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function test_path_tenant_diverges_asset_base_from_app_base(): void
+    {
+        // Installed under /invoice, tenant acme: assets stay install-relative,
+        // the app (router + API) is scoped to the slug.
+        $response = $this->shell()->serve('/invoice', '/invoice/acme');
+        self::assertNotNull($response);
+
+        $html = (string) $response->getBody();
+        self::assertStringContainsString('<base href="/invoice/admin/" />', $html);
+        self::assertStringContainsString('<meta name="app-base" content="/invoice/acme/" />', $html);
+    }
+
+    public function test_missing_shell_returns_null(): void
+    {
+        $shell = new SpaShell($this->shellPath . '.absent', $this->psr17, $this->psr17);
+
+        self::assertNull($shell->serve('', ''));
+    }
+}

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -9,6 +9,7 @@ use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\Organization\Organization;
 use NeneInvoice\Organization\Resolution\EnvResolutionStrategy;
 use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
+use NeneInvoice\Organization\Resolution\PathPrefixResolutionStrategy;
 use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
 use NeneInvoice\Tests\Support\RecordingRequestHandler;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -43,6 +44,17 @@ final class OrgResolverMiddlewareTest extends TestCase
             $this->problemDetails,
             new EnvResolutionStrategy($slug),
             $fallback,
+        );
+    }
+
+    private function pathMiddleware(): OrgResolverMiddleware
+    {
+        return new OrgResolverMiddleware(
+            $this->holder,
+            $this->orgs,
+            $this->problemDetails,
+            new PathPrefixResolutionStrategy(),
+            false,
         );
     }
 
@@ -121,5 +133,50 @@ final class OrgResolverMiddlewareTest extends TestCase
         $response = $this->middleware('', true)->process($request, $this->passthroughHandler());
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_path_strategy_strips_resolved_slug_from_downstream_path(): void
+    {
+        $id = $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $handler = $this->passthroughHandler();
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/acme/admin/invoices');
+
+        $response = $this->pathMiddleware()->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($id, $this->holder->get());
+
+        $seen = $handler->seen;
+        self::assertNotNull($seen);
+        // The router (registered as /admin/...) must see the tenant prefix removed.
+        self::assertSame('/admin/invoices', $seen->getUri()->getPath());
+        self::assertSame($id, $seen->getAttribute('nene2.org.id'));
+        self::assertSame('acme', $seen->getAttribute('nene2.org.slug'));
+    }
+
+    public function test_env_strategy_leaves_downstream_path_untouched(): void
+    {
+        $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $handler = $this->passthroughHandler();
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices');
+
+        $this->middleware('acme', false)->process($request, $handler);
+
+        // Host/env strategies do not carry the slug in the path, so nothing is stripped.
+        self::assertSame('/admin/invoices', $handler->seen?->getUri()->getPath());
+    }
+
+    public function test_path_strategy_bypass_path_is_not_rewritten(): void
+    {
+        $handler = $this->passthroughHandler();
+        // Superadmin org management is a bypass: no org, and the path is untouched.
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/organizations');
+
+        $response = $this->pathMiddleware()->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('/admin/organizations', $handler->seen?->getUri()->getPath());
     }
 }

--- a/tests/Organization/Resolution/ResolutionStrategiesTest.php
+++ b/tests/Organization/Resolution/ResolutionStrategiesTest.php
@@ -54,6 +54,23 @@ final class ResolutionStrategiesTest extends TestCase
         }
     }
 
+    public function test_path_prefix_strips_slug_segment_for_routing(): void
+    {
+        $strategy = new PathPrefixResolutionStrategy();
+
+        self::assertSame('/admin/invoices', $strategy->stripPrefix('/acme/admin/invoices'));
+        self::assertSame('/admin/me', $strategy->stripPrefix('/acme/admin/me'));
+        self::assertSame('/auth/login', $strategy->stripPrefix('/acme/auth/login'));
+    }
+
+    public function test_path_prefix_strip_returns_root_when_only_slug(): void
+    {
+        $strategy = new PathPrefixResolutionStrategy();
+
+        self::assertSame('/', $strategy->stripPrefix('/acme'));
+        self::assertSame('/', $strategy->stripPrefix('/acme/'));
+    }
+
     public function test_subdomain_extracts_label(): void
     {
         $strategy = new SubdomainResolutionStrategy('example.com');


### PR DESCRIPTION
Closes #556 ・ Refs #552（型B Phase 2 umbrella）

## 何を
型B（provisioning superadmin＋顧問先ごとログイン）の **path テナンシー**を end-to-end で成立させる第1スライス。顧問先＝org を `/{slug}/` 配下で普通にブラウザから使えるようにする。

## 確認で判明した gap（着手前調査）
- `PathPrefixResolutionStrategy` は slug を抽出するが **誰も path から slug を除去していなかった**。NENE2 Router は full path を anchored regex で照合するため、`/{slug}/admin/*` は `/admin/*` ルートに一致せず 404（＝過去の「`/acme/admin/dashboard`→200」は成立していなかった）。
- SPA シェルは install base（ADR 0015）だけを注入し **org slug を注入しない**ため、`/{slug}/` で開いても SPA の router basename / apiUrl が slug を向かなかった。

## 変更
- **BE slug-strip ルーティング**: `OrgResolverMiddleware` が path モードで解決済み slug を URL から剥がす（新 `PathScopedResolutionStrategyInterface` を `PathPrefixResolutionStrategy` が実装）。**最前段**で剥がすため、`/admin`・`/api` prefix で判定する bearer-token / capability ガードと Router が canonical パスを見る（後段だと prefix 認証をすり抜けるので最前段が必須）。
- **BE SPA app-base**: `SpaShell` を asset-base / app-base に分離注入。純粋・testable な `SpaBasePlan` が install base × org slug prefix を合流し、`/{slug}/…` のシェルに `app-base=<install>/<slug>/` を注入。アセットの `<base href>` は install 相対のまま（実体1コピー）。slug 判定は org リポジトリの `findBySlug`（path モードのみ DB 参照）。
- **FE**: `app-base.ts` は multi-segment 対応済でロジック変更なし・テスト追加のみ。

## 非スコープ / 不変
- 非 path モード（single/subdomain/custom_domain）・出荷済み単一テナント installer は無変更（回帰なし）。
- 認証は `uniq_users_email`（email グローバル一意）ゆえ org はユーザーレコードから決まりグローバルのまま。
- superadmin per-route guard・組織停止/更新 API・PWA 発行・おまかせ運用パックは別スライス。

## テスト / 実機検証
- `composer check` 緑（872 tests・PHPStan L8・cs・OpenAPI・MCP）。`npm run check` 緑。
- 新規: `PathTenancyRoutingTest`（実 Router＋実 middleware で `/acme/admin/dashboard`→org スコープ、`/admin/dashboard`→404）、`SpaBasePlanTest`、`SpaShellTest`、strategy/middleware の strip テスト、FE app-base slug テスト。
- **実 HTTP + MySQL（path モード・捨てサーバ）**: `/default/`→200＋`app-base=/default/`・`base=/admin/`／`/default/admin/dashboard` 無token→**401**・token→**200**（`organization_id:1` スコープ）／`/admin/dashboard`(prefix無)→404／`/organizations`(org-less)→`app-base=/`。
- **単一モード :8510 回帰なし**（`app-base=/`・401/200）。

## セルフレビュー
- **`docs/review/middleware-security.md`**（最重要・実施済）: slug-strip を認証ガードの**最前段**に置くことで `/{slug}/admin/*` が canonical `/admin/*` で bearer-token ガードに到達＝admin ルートは保護維持（実 HTTP で無token→401 を確認）。download 系（`/invoices/download/`）は bypass で無影響。ログ/CORS/Problem Details 変更なし。
- `docs/review/backend-api.md`・`docs/review/frontend.md` で確認。会計/税/採番/PDF 変更なし＝`docs/review/compliance.md` 非該当。新 operationId / Problem Details slug なし＝用語レジストリ・OpenAPI 不変。
