### PR TITLE
feat(multitenant): 型B Phase 2 — superadmin/顧問先の per-route guard (#558)

### DIFF
--- a/frontend/src/app/require-role.test.tsx
+++ b/frontend/src/app/require-role.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setAuthToken } from '@/shared/api/client'
+import { I18nProvider } from '@/shared/i18n'
+import { server } from '@tests/msw/server'
+import { RequireRole } from './require-role'
+
+function meIs(role: string, organizationId: number | null): void {
+  server.use(
+    http.get('/admin/me', () =>
+      HttpResponse.json({ id: 1, email: 'x@example.com', role, organization_id: organizationId }),
+    ),
+  )
+}
+
+function renderAt(path: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return render(
+    <I18nProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route element={<RequireRole audience="org" />}>
+              <Route path="/dashboard" element={<div>DASHBOARD PAGE</div>} />
+            </Route>
+            <Route element={<RequireRole audience="superadmin" />}>
+              <Route path="/organizations" element={<div>ORGANIZATIONS PAGE</div>} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </I18nProvider>,
+  )
+}
+
+describe('RequireRole (型B Phase 2 per-route guard)', () => {
+  beforeEach(() => {
+    setAuthToken('seed')
+  })
+  afterEach(() => {
+    setAuthToken(null)
+  })
+
+  it('redirects an org-less superadmin from an org-scoped route to organization management', async () => {
+    meIs('superadmin', null)
+    renderAt('/dashboard')
+
+    expect(await screen.findByText('ORGANIZATIONS PAGE')).toBeInTheDocument()
+    expect(screen.queryByText('DASHBOARD PAGE')).not.toBeInTheDocument()
+  })
+
+  it('redirects a tenant operator from the superadmin-only organization route to the dashboard', async () => {
+    meIs('admin', 1)
+    renderAt('/organizations')
+
+    expect(await screen.findByText('DASHBOARD PAGE')).toBeInTheDocument()
+    expect(screen.queryByText('ORGANIZATIONS PAGE')).not.toBeInTheDocument()
+  })
+
+  it('lets a tenant operator use org-scoped routes', async () => {
+    meIs('admin', 1)
+    renderAt('/dashboard')
+
+    expect(await screen.findByText('DASHBOARD PAGE')).toBeInTheDocument()
+  })
+
+  it('lets a superadmin use organization management', async () => {
+    meIs('superadmin', null)
+    renderAt('/organizations')
+
+    expect(await screen.findByText('ORGANIZATIONS PAGE')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/require-role.tsx
+++ b/frontend/src/app/require-role.tsx
@@ -1,0 +1,47 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useCurrentUser } from '@/entities/auth'
+import { useTranslation } from '@/shared/i18n'
+import { Spinner } from '@/shared/ui'
+
+/**
+ * Route audiences (型B Phase 2). `org` routes are org-scoped (billing/dashboard)
+ * and need a tenant context; `superadmin` routes manage organizations
+ * cross-tenant.
+ */
+type Audience = 'org' | 'superadmin'
+
+/**
+ * Per-route role guard. A superadmin is org-less (cross-tenant host), so every
+ * org-scoped screen 404s for them — they are redirected to organization
+ * management; a tenant operator (admin/member/viewer) hitting the
+ * superadmin-only organization routes is redirected to their dashboard.
+ *
+ * This complements {@link AppShell}'s role-aware nav (which only hides links) by
+ * catching manually-typed or deep-linked URLs. It is UX only: the backend RBAC
+ * (capabilities) and {@link OrgGuardMiddleware} remain the real enforcement
+ * (ADR 0006) — this keeps operators off pages that would 404/403 for their role.
+ */
+export function RequireRole({ audience }: { audience: Audience }) {
+  const { t } = useTranslation()
+  const me = useCurrentUser(true)
+
+  if (me.isPending) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner label={t('admin.auth.restoringSession')} />
+      </div>
+    )
+  }
+
+  const isSuperadmin = me.data?.role === 'superadmin'
+
+  if (audience === 'superadmin' && !isSuperadmin) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  if (audience === 'org' && isSuperadmin) {
+    return <Navigate to="/organizations" replace />
+  }
+
+  return <Outlet />
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { routerBasename } from '@/shared/config/app-base'
 import { HomeRedirect } from '@/app/home-redirect'
+import { RequireRole } from '@/app/require-role'
 import { AppShell } from '@/pages/layout'
 import { AuditLogsPage } from '@/pages/audit-logs'
 import { BankReconciliationPage } from '@/pages/bank-reconciliation'
@@ -41,36 +42,51 @@ const router = createBrowserRouter(
       element: <AppShell />,
       children: [
         { index: true, element: <HomeRedirect /> },
-        { path: 'dashboard', element: <DashboardPage /> },
-        { path: 'invoices', element: <InvoicesPage /> },
-        { path: 'invoices/new', element: <InvoiceCreatePage /> },
-        { path: 'invoices/:id', element: <InvoiceDetailPage /> },
-        { path: 'clients', element: <ClientsPage /> },
-        { path: 'clients/new', element: <ClientCreatePage /> },
-        { path: 'clients/import', element: <ClientImportPage /> },
-        { path: 'clients/:id/edit', element: <ClientEditPage /> },
-        { path: 'items', element: <ItemsPage /> },
-        { path: 'items/new', element: <ItemCreatePage /> },
-        { path: 'items/import', element: <ItemImportPage /> },
-        { path: 'items/:id/edit', element: <ItemEditPage /> },
-        { path: 'quotes', element: <QuotesPage /> },
-        { path: 'quotes/new', element: <QuoteCreatePage /> },
-        { path: 'quotes/:id', element: <QuoteDetailPage /> },
-        { path: 'recurring', element: <RecurringPage /> },
-        { path: 'recurring/new', element: <RecurringCreatePage /> },
-        { path: 'recurring/:id/edit', element: <RecurringEditPage /> },
-        { path: 'bank-reconciliation', element: <BankReconciliationPage /> },
-        { path: 'templates', element: <TemplatesPage /> },
-        { path: 'templates/new', element: <TemplateCreatePage /> },
-        { path: 'templates/:id/edit', element: <TemplateEditPage /> },
-        { path: 'settings', element: <CompanySettingsPage /> },
-        { path: 'users', element: <UsersPage /> },
-        { path: 'users/new', element: <UserCreatePage /> },
-        { path: 'users/:id/edit', element: <UserEditPage /> },
-        { path: 'organizations', element: <OrganizationsPage /> },
-        { path: 'organizations/new', element: <OrganizationCreatePage /> },
-        { path: 'audit-logs', element: <AuditLogsPage /> },
-        { path: 'service-tokens', element: <ServiceTokensPage /> },
+        // Org-scoped screens need a tenant context; the org-less superadmin is
+        // redirected to organization management (型B Phase 2 — RequireRole).
+        {
+          element: <RequireRole audience="org" />,
+          children: [
+            { path: 'dashboard', element: <DashboardPage /> },
+            { path: 'invoices', element: <InvoicesPage /> },
+            { path: 'invoices/new', element: <InvoiceCreatePage /> },
+            { path: 'invoices/:id', element: <InvoiceDetailPage /> },
+            { path: 'clients', element: <ClientsPage /> },
+            { path: 'clients/new', element: <ClientCreatePage /> },
+            { path: 'clients/import', element: <ClientImportPage /> },
+            { path: 'clients/:id/edit', element: <ClientEditPage /> },
+            { path: 'items', element: <ItemsPage /> },
+            { path: 'items/new', element: <ItemCreatePage /> },
+            { path: 'items/import', element: <ItemImportPage /> },
+            { path: 'items/:id/edit', element: <ItemEditPage /> },
+            { path: 'quotes', element: <QuotesPage /> },
+            { path: 'quotes/new', element: <QuoteCreatePage /> },
+            { path: 'quotes/:id', element: <QuoteDetailPage /> },
+            { path: 'recurring', element: <RecurringPage /> },
+            { path: 'recurring/new', element: <RecurringCreatePage /> },
+            { path: 'recurring/:id/edit', element: <RecurringEditPage /> },
+            { path: 'bank-reconciliation', element: <BankReconciliationPage /> },
+            { path: 'templates', element: <TemplatesPage /> },
+            { path: 'templates/new', element: <TemplateCreatePage /> },
+            { path: 'templates/:id/edit', element: <TemplateEditPage /> },
+            { path: 'settings', element: <CompanySettingsPage /> },
+            { path: 'users', element: <UsersPage /> },
+            { path: 'users/new', element: <UserCreatePage /> },
+            { path: 'users/:id/edit', element: <UserEditPage /> },
+            { path: 'audit-logs', element: <AuditLogsPage /> },
+            { path: 'service-tokens', element: <ServiceTokensPage /> },
+          ],
+        },
+        // Cross-tenant organization management is superadmin-only; a tenant
+        // operator is redirected to their dashboard.
+        {
+          element: <RequireRole audience="superadmin" />,
+          children: [
+            { path: 'organizations', element: <OrganizationsPage /> },
+            { path: 'organizations/new', element: <OrganizationCreatePage /> },
+          ],
+        },
+        // Neutral (no tenant context, any role).
         { path: 'help', element: <HelpPage /> },
       ],
     },


### PR DESCRIPTION
Closes #558 ・ Refs #552（型B umbrella）, #556（Phase 2 slice 1）

## 何を
型B で org-less superadmin（ホスト）と顧問先 operator（org スコープ）が同一 SPA を使う際の、URL 手打ち/deep-link に対する **FE per-route role guard**。

## 背景（穴は FE のみ）
- **BE は既に堅い**: `OrgGuardMiddleware` が token-org≠resolved-org を 403（superadmin のみ cross-tenant 免除）、admin/member/viewer は `ManageOrganizations` capability 無しで `/admin/organizations` を 403。
- **FE の穴**: superadmin↔org-scoped の分離は `AppShell` の**ナビ出し分け（リンクを隠すだけ）**。URL を直叩きすると:
  - org-less superadmin が `/dashboard` 等 → org コンテキスト無し＝**404/壊れたページ**
  - 顧問先 admin が `/organizations` → BE 403 の**壊れたページ**

## 変更
- `app/require-role.tsx`: `audience=org` は org-less superadmin を `/organizations` へ、`audience=superadmin` は非 superadmin を `/dashboard` へ redirect。許可ロールは `<Outlet />`。
- `router.tsx`: org-scoped 群を `audience=org`、`organizations` 群を `audience=superadmin` の pathless layout route 配下へ。分類は `AppShell` の `NAV`/`SUPERADMIN_NAV` と一致。`help`/index/`*` は neutral（既存 `HomeRedirect`）。ルート数 31 保持・欠落なし。
- **BE 変更なし**: RBAC(capability)＋OrgGuard が正の enforcement（ADR 0006）。本ガードは UX 補強（壊れたページ回避）＝frontend-standards「RBAC は UX のみ」に整合。

## テスト
- `require-role.test.tsx` 4件（実 react-router＋MSW ロール）: superadmin→org route を `/organizations` へ・admin→`/organizations` を `/dashboard` へ・各許可ロール素通し。
- `npm run check` 緑（type/lint/format/test/knip/build-storybook）＋本番ビルド緑。

## セルフレビュー
- `docs/review/frontend.md`（レイヤード配置＝ガードは `app/`・境界 import 準拠・i18n・テスト MSW）。BE/会計/用語/OpenAPI 変更なし＝`compliance.md`/`middleware-security.md` 非該当（enforcement は既存 BE）。
