### PR TITLE
feat(multitenant): 組織の停止/更新 API（PATCH /admin/organizations/{id}） (#560)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -195,7 +195,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `getHealth` | System |
 | `login`, `refreshSession`, `logout`, `getCurrentUser` | Auth |
 | `listAuditLogs`, `exportAuditLogs` | Audit (admin oversight) |
-| `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
+| `listOrganizations`, `getOrganizationById`, `createOrganization`, `updateOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `getCompanySettings`, `updateCompanySettings` | Company (issuer profile, per org) |
 | `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient`, `exportClientsCsv`, `getClientsImportTemplate`, `importClientsCsv` | Client |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -369,6 +369,37 @@ paths:
           $ref: '#/components/responses/InsufficientCapability'
         '404':
           $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Organizations]
+      summary: Update organization
+      description: >-
+        Partial update (superadmin). Only the provided fields change; is_active
+        suspends (false) or reactivates (true) the tenant. slug and external_id
+        are immutable here.
+      operationId: updateOrganization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateOrganizationRequest'
+            example:
+              is_active: false
+      responses:
+        '200':
+          description: Organization updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/InsufficientCapability'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
     delete:
       tags: [Organizations]
       summary: Delete organization
@@ -2556,6 +2587,21 @@ components:
             Plaintext password for the tenant's initial admin (hashed
             server-side). Requires admin_email.
       required: [name, slug]
+    UpdateOrganizationRequest:
+      type: object
+      description: >-
+        Partial update of a tenant (superadmin only). Every field is optional;
+        at least one must be present (else 422). is_active suspends (false) or
+        reactivates (true) the tenant. slug and external_id are immutable here.
+      properties:
+        name:
+          type: string
+        plan:
+          type: string
+          description: Billing plan slug.
+        is_active:
+          type: boolean
+          description: false suspends the tenant (its users are locked out); true reactivates it.
     DownloadTokenResponse:
       type: object
       properties:

--- a/src/Organization/OrganizationRouteRegistrar.php
+++ b/src/Organization/OrganizationRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class OrganizationRouteRegistrar
         private ListOrganizationsHandler $listHandler,
         private GetOrganizationByIdHandler $getHandler,
         private CreateOrganizationHandler $createHandler,
+        private UpdateOrganizationHandler $updateHandler,
         private DeleteOrganizationHandler $deleteHandler,
     ) {
     }
@@ -26,11 +27,13 @@ final readonly class OrganizationRouteRegistrar
         $list = $this->listHandler;
         $get = $this->getHandler;
         $create = $this->createHandler;
+        $update = $this->updateHandler;
         $delete = $this->deleteHandler;
 
         $router->get('/admin/organizations', static fn (ServerRequestInterface $r) => $list->handle($r));
         $router->post('/admin/organizations', static fn (ServerRequestInterface $r) => $create->handle($r));
         $router->get('/admin/organizations/{id}', static fn (ServerRequestInterface $r) => $get->handle($r));
+        $router->patch('/admin/organizations/{id}', static fn (ServerRequestInterface $r) => $update->handle($r));
         $router->delete('/admin/organizations/{id}', static fn (ServerRequestInterface $r) => $delete->handle($r));
     }
 }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -39,6 +39,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
             ->set(ListOrganizationsUseCaseInterface::class, static fn (ContainerInterface $c): ListOrganizationsUseCase => new ListOrganizationsUseCase(self::repository($c)))
             ->set(GetOrganizationByIdUseCaseInterface::class, static fn (ContainerInterface $c): GetOrganizationByIdUseCase => new GetOrganizationByIdUseCase(self::repository($c)))
             ->set(CreateOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): CreateOrganizationUseCase => new CreateOrganizationUseCase(self::tx($c), self::organizationsFactory(), AuditServiceProvider::recorderFactory($c), self::initialAdminFactory()))
+            ->set(UpdateOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): UpdateOrganizationUseCase => new UpdateOrganizationUseCase(self::repository($c), self::tx($c), self::organizationsFactory(), AuditServiceProvider::recorderFactory($c)))
             ->set(DeleteOrganizationUseCaseInterface::class, static fn (ContainerInterface $c): DeleteOrganizationUseCase => new DeleteOrganizationUseCase(self::repository($c), self::tx($c), self::organizationsFactory(), AuditServiceProvider::recorderFactory($c)))
             ->set(
                 ListOrganizationsHandler::class,
@@ -58,6 +59,13 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 CreateOrganizationHandler::class,
                 static fn (ContainerInterface $c): CreateOrganizationHandler => new CreateOrganizationHandler(
                     self::createUseCase($c),
+                    self::json($c),
+                ),
+            )
+            ->set(
+                UpdateOrganizationHandler::class,
+                static fn (ContainerInterface $c): UpdateOrganizationHandler => new UpdateOrganizationHandler(
+                    self::updateUseCase($c),
                     self::json($c),
                 ),
             )
@@ -82,17 +90,19 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                     $list = $c->get(ListOrganizationsHandler::class);
                     $get = $c->get(GetOrganizationByIdHandler::class);
                     $create = $c->get(CreateOrganizationHandler::class);
+                    $update = $c->get(UpdateOrganizationHandler::class);
                     $delete = $c->get(DeleteOrganizationHandler::class);
 
                     if (!$list instanceof ListOrganizationsHandler
                         || !$get instanceof GetOrganizationByIdHandler
                         || !$create instanceof CreateOrganizationHandler
+                        || !$update instanceof UpdateOrganizationHandler
                         || !$delete instanceof DeleteOrganizationHandler
                     ) {
                         throw new LogicException('Organization handler services are invalid.');
                     }
 
-                    return new OrganizationRouteRegistrar($list, $get, $create, $delete);
+                    return new OrganizationRouteRegistrar($list, $get, $create, $update, $delete);
                 },
             );
     }
@@ -159,6 +169,17 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
 
         if (!$u instanceof CreateOrganizationUseCase) {
             throw new LogicException('Create organization use case service is invalid.');
+        }
+
+        return $u;
+    }
+
+    private static function updateUseCase(ContainerInterface $c): UpdateOrganizationUseCase
+    {
+        $u = $c->get(UpdateOrganizationUseCaseInterface::class);
+
+        if (!$u instanceof UpdateOrganizationUseCase) {
+            throw new LogicException('Update organization use case service is invalid.');
         }
 
         return $u;

--- a/src/Organization/UpdateOrganizationHandler.php
+++ b/src/Organization/UpdateOrganizationHandler.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneInvoice\Auth\AuthContext;
+use NeneInvoice\Support\TextLimit;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `PATCH /admin/organizations/{id}` — superadmin updates a tenant. Partial:
+ * only the provided fields change. `is_active` suspends/reactivates the tenant;
+ * `name` / `plan` update it. A missing organization surfaces as 404 via the
+ * domain exception handler.
+ */
+final readonly class UpdateOrganizationHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private UpdateOrganizationUseCaseInterface $useCase,
+        private JsonResponseFactory $json,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $name = null;
+        $plan = null;
+        $isActive = null;
+        $provided = false;
+
+        // array_key_exists (not truthiness): `is_active: false` is a real value
+        // (suspend), distinct from the key being absent (leave unchanged).
+        if (array_key_exists('name', $body)) {
+            $raw = $body['name'];
+            if (!is_string($raw) || $raw === '') {
+                throw new ValidationException([new ValidationError('body.name', 'Name must be a non-empty string.', 'invalid')]);
+            }
+            TextLimit::check($raw, 'body.name', TextLimit::NAME);
+            $name = $raw;
+            $provided = true;
+        }
+
+        if (array_key_exists('plan', $body)) {
+            $raw = $body['plan'];
+            if (!is_string($raw) || $raw === '') {
+                throw new ValidationException([new ValidationError('body.plan', 'Plan must be a non-empty string.', 'invalid')]);
+            }
+            TextLimit::check($raw, 'body.plan', TextLimit::TINY);
+            $plan = $raw;
+            $provided = true;
+        }
+
+        if (array_key_exists('is_active', $body)) {
+            $raw = $body['is_active'];
+            if (!is_bool($raw)) {
+                throw new ValidationException([new ValidationError('body.is_active', 'is_active must be a boolean.', 'invalid')]);
+            }
+            $isActive = $raw;
+            $provided = true;
+        }
+
+        if (!$provided) {
+            throw new ValidationException([new ValidationError('body', 'At least one of name, plan, is_active is required.', 'required')]);
+        }
+
+        $organization = $this->useCase->execute(
+            AuthContext::userId($request),
+            $id,
+            new UpdateOrganizationInput($name, $plan, $isActive),
+        );
+
+        return $this->json->create(OrganizationResponse::toArray($organization));
+    }
+}

--- a/src/Organization/UpdateOrganizationInput.php
+++ b/src/Organization/UpdateOrganizationInput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+/**
+ * Mutable fields of a tenant for {@see UpdateOrganizationUseCase}. Every field is
+ * optional (PATCH semantics): a null value means "leave unchanged". Presence is
+ * decided at the HTTP boundary — `is_active: false` is a real value (suspend), so
+ * the handler distinguishes an absent key from a false value before constructing
+ * this.
+ *
+ * `slug` (URL identity) and `external_id` (federation link, ADR 0016) are
+ * intentionally immutable here and are not part of this input.
+ */
+final readonly class UpdateOrganizationInput
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $plan = null,
+        public ?bool $isActive = null,
+    ) {
+    }
+}

--- a/src/Organization/UpdateOrganizationUseCase.php
+++ b/src/Organization/UpdateOrganizationUseCase.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+use Closure;
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use NeneInvoice\Audit\AuditRecorderInterface;
+
+/**
+ * Updates a tenant's mutable fields — including `is_active`, which suspends
+ * (`false`) or reactivates (`true`) the organization. Suspending it makes
+ * OrgResolverMiddleware return 403 for that tenant's requests (ADR 0006), so the
+ * host can lock a managed tenant out without deleting its data.
+ *
+ * `slug` and `external_id` are preserved from the existing record — they are not
+ * mutable through this path. The change is recorded as `organization.updated`
+ * with before/after snapshots in the same transaction as the write.
+ */
+final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizationsFactory
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditFactory
+     */
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+        private DatabaseTransactionManagerInterface $tx,
+        private Closure $organizationsFactory,
+        private Closure $auditFactory,
+    ) {
+    }
+
+    public function execute(?int $actorUserId, int $id, UpdateOrganizationInput $input): Organization
+    {
+        $existing = $this->organizations->findById($id);
+
+        if ($existing === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        $updated = new Organization(
+            name: $input->name ?? $existing->name,
+            slug: $existing->slug,
+            plan: $input->plan ?? $existing->plan,
+            isActive: $input->isActive ?? $existing->isActive,
+            id: $existing->id,
+            externalId: $existing->externalId,
+            customDomain: $existing->customDomain,
+            createdAt: $existing->createdAt,
+            updatedAt: $existing->updatedAt,
+        );
+
+        return $this->tx->transactional(function (DatabaseQueryExecutorInterface $exec) use ($actorUserId, $id, $existing, $updated): Organization {
+            $organizations = ($this->organizationsFactory)($exec);
+            $organizations->update($updated);
+
+            $fresh = $organizations->findById($id);
+
+            if ($fresh === null) {
+                throw new LogicException('Organization disappeared immediately after update.');
+            }
+
+            ($this->auditFactory)($exec)->record(
+                $actorUserId,
+                $id,
+                'organization.updated',
+                'organization',
+                $id,
+                OrganizationResponse::toArray($existing),
+                OrganizationResponse::toArray($fresh),
+            );
+
+            return $fresh;
+        });
+    }
+}

--- a/src/Organization/UpdateOrganizationUseCaseInterface.php
+++ b/src/Organization/UpdateOrganizationUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Organization;
+
+interface UpdateOrganizationUseCaseInterface
+{
+    /** @throws OrganizationNotFoundException */
+    public function execute(?int $actorUserId, int $id, UpdateOrganizationInput $input): Organization;
+}

--- a/tests/OpenApi/OpenApiContractTest.php
+++ b/tests/OpenApi/OpenApiContractTest.php
@@ -34,6 +34,7 @@ final class OpenApiContractTest extends TestCase
         'listOrganizations',
         'getOrganizationById',
         'createOrganization',
+        'updateOrganization',
         'deleteOrganization',
         'listUsers',
         'getUserById',

--- a/tests/Organization/OrganizationUseCasesTest.php
+++ b/tests/Organization/OrganizationUseCasesTest.php
@@ -12,6 +12,8 @@ use NeneInvoice\Organization\GetOrganizationByIdUseCase;
 use NeneInvoice\Organization\ListOrganizationsUseCase;
 use NeneInvoice\Organization\OrganizationNotFoundException;
 use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\Organization\UpdateOrganizationInput;
+use NeneInvoice\Organization\UpdateOrganizationUseCase;
 use NeneInvoice\Tests\Support\ImmediateTransactionManager;
 use NeneInvoice\Tests\Support\InMemoryInitialAdminRepository;
 use NeneInvoice\Tests\Support\InMemoryOrganizationRepository;
@@ -143,5 +145,54 @@ final class OrganizationUseCasesTest extends TestCase
 
         $this->expectException(OrganizationNotFoundException::class);
         $delete->execute(1, $id);
+    }
+
+    private function updateUseCase(): UpdateOrganizationUseCase
+    {
+        return new UpdateOrganizationUseCase($this->repo, new ImmediateTransactionManager(), fn () => $this->repo, fn () => $this->audit);
+    }
+
+    public function test_update_changes_fields_suspends_and_audits_before_after(): void
+    {
+        $id = $this->createUseCase()->execute(1, new CreateOrganizationInput('Acme', 'acme'))->id;
+        self::assertNotNull($id);
+
+        $result = $this->updateUseCase()->execute(7, $id, new UpdateOrganizationInput(name: 'Acme Renamed', plan: 'pro', isActive: false));
+
+        self::assertSame('Acme Renamed', $result->name);
+        self::assertSame('pro', $result->plan);
+        self::assertFalse($result->isActive);
+        self::assertSame('acme', $result->slug); // slug is immutable
+
+        // records[0] = organization.created, records[1] = organization.updated
+        self::assertSame('organization.updated', $this->audit->records[1]['action']);
+        self::assertSame(7, $this->audit->records[1]['actor_user_id']);
+        self::assertSame($id, $this->audit->records[1]['organization_id']);
+        self::assertIsArray($this->audit->records[1]['before']);
+        self::assertIsArray($this->audit->records[1]['after']);
+        self::assertTrue($this->audit->records[1]['before']['is_active']);
+        self::assertFalse($this->audit->records[1]['after']['is_active']);
+        self::assertSame('Acme', $this->audit->records[1]['before']['name']);
+        self::assertSame('Acme Renamed', $this->audit->records[1]['after']['name']);
+    }
+
+    public function test_update_partial_toggles_is_active_and_preserves_other_fields(): void
+    {
+        $id = $this->createUseCase()->execute(1, new CreateOrganizationInput('Acme', 'acme', 'pro'))->id;
+        self::assertNotNull($id);
+
+        $suspended = $this->updateUseCase()->execute(1, $id, new UpdateOrganizationInput(isActive: false));
+        self::assertFalse($suspended->isActive);
+        self::assertSame('Acme', $suspended->name); // unchanged
+        self::assertSame('pro', $suspended->plan);  // unchanged
+
+        $reactivated = $this->updateUseCase()->execute(1, $id, new UpdateOrganizationInput(isActive: true));
+        self::assertTrue($reactivated->isActive);
+    }
+
+    public function test_update_throws_when_missing(): void
+    {
+        $this->expectException(OrganizationNotFoundException::class);
+        $this->updateUseCase()->execute(1, 999, new UpdateOrganizationInput(name: 'Ghost'));
     }
 }

--- a/tests/Organization/UpdateOrganizationHandlerTest.php
+++ b/tests/Organization/UpdateOrganizationHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationException;
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\UpdateOrganizationHandler;
+use NeneInvoice\Organization\UpdateOrganizationInput;
+use NeneInvoice\Organization\UpdateOrganizationUseCaseInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Boundary coverage for `PATCH /admin/organizations/{id}`: partial fields are
+ * captured (with `is_active: false` treated as a real value, not absence), and
+ * an empty or mistyped patch is a 422 (ValidationException).
+ */
+final class UpdateOrganizationHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private UpdateOrganizationHandler $handler;
+    private UpdateOrganizationUseCaseInterface $useCase;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+
+        $this->useCase = new class () implements UpdateOrganizationUseCaseInterface {
+            public ?UpdateOrganizationInput $captured = null;
+            public ?int $capturedId = null;
+
+            public function execute(?int $actorUserId, int $id, UpdateOrganizationInput $input): Organization
+            {
+                $this->captured = $input;
+                $this->capturedId = $id;
+
+                return new Organization(
+                    name: $input->name ?? 'Acme',
+                    slug: 'acme',
+                    plan: $input->plan ?? 'free',
+                    isActive: $input->isActive ?? true,
+                    id: $id,
+                );
+            }
+        };
+
+        $this->handler = new UpdateOrganizationHandler($this->useCase, new JsonResponseFactory($this->psr17, $this->psr17));
+    }
+
+    private function captured(): ?UpdateOrganizationInput
+    {
+        // @phpstan-ignore-next-line property.notFound (anonymous-class spy field)
+        return $this->useCase->captured;
+    }
+
+    /** @param array<string, mixed> $body */
+    private function request(array $body): ServerRequestInterface
+    {
+        return $this->psr17->createServerRequest('PATCH', '/admin/organizations/5')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '5'])
+            ->withAttribute('nene2.auth.claims', ['sub' => 7, 'org' => null, 'role' => 'superadmin'])
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode($body)));
+    }
+
+    public function test_suspends_via_is_active_false_and_captures_id(): void
+    {
+        $response = $this->handler->handle($this->request(['is_active' => false]));
+
+        self::assertSame(200, $response->getStatusCode());
+        $captured = $this->captured();
+        self::assertNotNull($captured);
+        self::assertFalse($captured->isActive);
+        self::assertNull($captured->name);
+        self::assertNull($captured->plan);
+        // @phpstan-ignore-next-line property.notFound (anonymous-class spy field)
+        self::assertSame(5, $this->useCase->capturedId);
+    }
+
+    public function test_captures_name_and_plan(): void
+    {
+        $this->handler->handle($this->request(['name' => 'Renamed', 'plan' => 'pro']));
+
+        $captured = $this->captured();
+        self::assertNotNull($captured);
+        self::assertSame('Renamed', $captured->name);
+        self::assertSame('pro', $captured->plan);
+        self::assertNull($captured->isActive);
+    }
+
+    public function test_rejects_empty_patch(): void
+    {
+        // A valid but empty JSON object `{}` — nothing to change → 422.
+        $request = $this->psr17->createServerRequest('PATCH', '/admin/organizations/5')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => '5'])
+            ->withAttribute('nene2.auth.claims', ['sub' => 7, 'org' => null, 'role' => 'superadmin'])
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream('{}'));
+
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($request);
+    }
+
+    public function test_rejects_non_boolean_is_active(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['is_active' => 'yes']));
+    }
+
+    public function test_rejects_empty_name(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->handler->handle($this->request(['name' => '']));
+    }
+}


### PR DESCRIPTION
Closes #560 ・ Refs #552（型B umbrella）

## 何を
組織管理 API は list/create/get/delete のみで **停止/再開・更新**が無かった。superadmin（ホスト）が顧問先 org を運用停止・再開・改名・プラン変更できる `PATCH /admin/organizations/{id}` を追加（おまかせ運用パックの一部）。

## 変更
- **`PATCH /admin/organizations/{id}`**（superadmin 専用・既存 `ManageOrganizations` capability で自動ゲート＝CapabilityResolver は `/admin/organizations*` を全メソッド ManageOrganizations にマップ）。partial update:
  - `is_active`（bool）＝**停止(false)/再開(true)**。停止すると `OrgResolverMiddleware` が当該 org を 403 でロックアウト（データは残す）。
  - `name` / `plan`＝更新。
  - `array_key_exists` で「`is_active:false`」と「キー欠落（変更なし）」を区別。
- **immutable**: `slug`（URL 同一性）・`external_id`（federation・ADR 0016）は既存値を保持（このPATCHでは変更不可）。
- 監査 `organization.updated`（before/after）を write と**同一 tx** で記録。既存の `update(Organization)` 永続化＋`OrganizationNotFoundException`(404) を再利用。
- Delete フローの写しで実装（Handler→UseCase→repo・tx＋audit factory）。OpenAPI `updateOrganization`＋`UpdateOrganizationRequest`、用語レジストリ登録。

## テスト / 検証
- `composer check` 緑（880 tests・PHPStan L8・cs・OpenAPI・MCP・**DI boot** 含む）。
- UseCase テスト: 停止/再開・name/plan 更新・**slug 不変**・404・監査 before/after。
- Handler テスト: partial capture・`is_active:false` vs 欠落・空patch/非bool/空name→422・`{id}` 抽出。
- OpenApiContractTest: `updateOrganization` operationId 登録・spec 整合。
- **実 HTTP（非破壊）**: PATCH 無token→401／admin(非superadmin)→**403 insufficient-capability**（route 結線＋capability ゲートを Apache 経由で確認・org 無変更）。live の 200 更新は superadmin が要るため UseCase/Handler テスト＋同型 Delete の live 挙動でカバー。

## 非スコープ
- `custom_domain`/`external_id` の更新（federation/ドメイン検証は別）。一括操作。superadmin 用の組織管理 UI からの停止導線（FE は別スライス）。

## セルフレビュー
- `docs/review/backend-api.md`（Handler→UseCase→repo・snake_case・partial 検証・監査 tx 内）・`docs/review/middleware-security.md`（superadmin-only capability ゲート維持・cross-tenant は superadmin の正当権限）。`compliance.md` 非該当（請求/税/採番/PDF 不変）。用語・OpenAPI 更新済。
