### PR TITLE
feat(installer): 管理者/組織作成を InstallApplication ユースケースへ抽出 (#579)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
  * テーマ）に準拠。React プロトタイプを自己完結 PHP + バニラ JS に移植している。
  */
 
+use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Install\DatabaseSchemaApplier;
 use Nene2\Install\EnvironmentWriter;
 use Nene2\Install\ProvisioningProbe;
@@ -24,6 +25,12 @@ use Nene2\Install\ReInstallationGuard;
 use Nene2\Install\ServerRequirementChecker;
 use Nene2\Install\ServerRequirements;
 use Nene2\Install\TenantConfigurationValidator;
+use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Install\InstallApplication;
+use NeneInvoice\Install\InstallConfig;
+use NeneInvoice\Install\PdoInstallProvisioningRepository;
+use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
+use NeneInvoice\Organization\PdoOrganizationRepository;
 use Phinx\Config\Config;
 
 define('ROOT', dirname(__DIR__));
@@ -673,45 +680,45 @@ if (!$payloadPresent) {
                         // 分岐の権威は書き込み済み .env の TENANT_RESOLUTION。
                         $isSingle = (string) ($env['TENANT_RESOLUTION'] ?? 'single') === 'single';
 
-                        $dsn = sprintf(
-                            'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
-                            $env['DB_HOST'] ?? 'localhost',
-                            $env['DB_PORT'] ?? '3306',
-                            $env['DB_NAME'] ?? '',
-                        );
-                        $pdo = new PDO($dsn, $env['DB_USER'] ?? '', $env['DB_PASSWORD'] ?? '', [
-                            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                        ]);
+                        // 生 SQL をやめ、テスト済みユースケースへ委譲する（S3-2 #579）。
+                        // container を boot し、書き込み済み .env の DB 設定で組織/管理者を
+                        // 作成する。single は CreateOrganizationUseCase の org+admin 原子生成
+                        // （監査つき）を再利用し company_settings をシード、multi は
+                        // superadmin（organization_id=NULL）を作成する。
+                        $container = (new RuntimeContainerFactory(ROOT))->create();
 
-                        $now  = date('Y-m-d H:i:s');
-                        $hash = password_hash($adminPassword, PASSWORD_BCRYPT);
+                        $createOrganization = $container->get(CreateOrganizationUseCaseInterface::class);
+                        $queryExecutor      = $container->get(DatabaseQueryExecutorInterface::class);
 
-                        if ($isSingle) {
-                            // 単一組織: 組織 + company_settings + admin（organization_id 紐付け）。
-                            $orgSlug = preg_replace('/[^a-z0-9\-]/', '-', strtolower($companyName)) ?: 'default';
-                            $pdo->prepare('INSERT INTO organizations (name, slug, plan, is_active, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)')
-                                ->execute([$companyName, $orgSlug, 'free', $now, $now]);
-                            $orgId = (int) $pdo->lastInsertId();
-
-                            $pdo->prepare('INSERT INTO company_settings (organization_id, legal_name, created_at, updated_at) VALUES (?, ?, ?, ?)')
-                                ->execute([$orgId, $companyName, $now, $now]);
-
-                            $pdo->prepare('INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-                                ->execute([$adminEmail, $hash, 'admin', $orgId, 'active', $now, $now]);
-                        } else {
-                            // 複数組織: superadmin（organization_id=NULL / クロステナント）。
-                            // 組織・company_settings は作らない（superadmin が API 経由で追加。
-                            // 組織管理 UI は未提供 = #546 の注意喚起どおり上級者向け運用）。
-                            $pdo->prepare('INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-                                ->execute([$adminEmail, $hash, 'superadmin', null, 'active', $now, $now]);
+                        if (
+                            !$createOrganization instanceof CreateOrganizationUseCaseInterface
+                            || !$queryExecutor instanceof DatabaseQueryExecutorInterface
+                        ) {
+                            throw new RuntimeException('アプリケーションコンテナの構成が正しくありません。');
                         }
+
+                        $orgSlug = $isSingle
+                            ? (preg_replace('/[^a-z0-9\-]/', '-', strtolower($companyName)) ?: 'default')
+                            : '';
+
+                        (new InstallApplication(
+                            $createOrganization,
+                            new PdoOrganizationRepository($queryExecutor),
+                            new PdoInstallProvisioningRepository($queryExecutor),
+                        ))->install(new InstallConfig(
+                            isSingle: $isSingle,
+                            organizationName: $companyName,
+                            organizationSlug: $orgSlug,
+                            adminEmail: $adminEmail,
+                            adminPassword: $adminPassword,
+                        ));
 
                         $reinstallGuard->markInstalled(date('c'));
 
                         $success = true;
                     } catch (PDOException $e) {
                         $errors[] = 'データベースエラー: ' . $e->getMessage();
-                    } catch (RuntimeException $e) {
+                    } catch (\Throwable $e) {
                         $errors[] = $e->getMessage();
                     }
                 }

--- a/src/Install/InstallApplication.php
+++ b/src/Install/InstallApplication.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+use LogicException;
+use NeneInvoice\Organization\CreateOrganizationInput;
+use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\User\UserEmailConflictException;
+
+/**
+ * First-run onboarding for the Tier A web installer: turns a freshly migrated
+ * database into a usable instance. Extracted out of `public_html/install.php`
+ * (which used to do the inserts inline as raw SQL) so the provisioning is a
+ * single, unit-tested seam.
+ *
+ * Two shapes, decided by {@see InstallConfig::$isSingle}:
+ *  - single: an organization + its `company_settings` + an `admin` bound to it.
+ *    Reuses {@see CreateOrganizationUseCaseInterface}, which creates the org and
+ *    its initial admin in one transaction with an audit trail (ADR 0006 / 0008).
+ *  - multi: a cross-tenant `superadmin` (organization_id = NULL); no org is
+ *    created (the running app's superadmin provisions tenants later).
+ *
+ * Idempotent on the org slug / admin email so a concurrent double-submit resolves
+ * the existing rows instead of erroring — the installer's re-install guard is the
+ * primary defense, this is the second layer.
+ */
+final readonly class InstallApplication
+{
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $createOrganization,
+        private OrganizationRepositoryInterface $organizations,
+        private InstallProvisioningRepositoryInterface $provisioning,
+    ) {
+    }
+
+    public function install(InstallConfig $config): InstallResult
+    {
+        return $config->isSingle
+            ? $this->installSingleTenant($config)
+            : $this->installSuperadmin($config);
+    }
+
+    private function installSingleTenant(InstallConfig $config): InstallResult
+    {
+        try {
+            // Creates the org AND its initial admin in one transaction; the admin
+            // is bound to the just-created org id, never a request-scoped one.
+            $organization = $this->createOrganization->execute(null, new CreateOrganizationInput(
+                name: $config->organizationName,
+                slug: $config->organizationSlug,
+                adminEmail: $config->adminEmail,
+                adminPassword: $config->adminPassword,
+            ));
+
+            $organizationId = $organization->id
+                ?? throw new LogicException('Organization was created without an id.');
+
+            $this->provisioning->seedCompanySettings($organizationId, $config->organizationName);
+
+            return new InstallResult(
+                organizationId: $organizationId,
+                organizationCreated: true,
+                adminEmail: $config->adminEmail,
+                adminCreated: true,
+                isSingle: true,
+            );
+        } catch (OrganizationSlugConflictException) {
+            // Concurrent double-submit: the org already exists. Resolve it and
+            // report "already existed" rather than provisioning a second time.
+            $existing = $this->organizations->findBySlug($config->organizationSlug);
+
+            if ($existing === null || $existing->id === null) {
+                throw new LogicException('Organization slug conflict but the organization could not be resolved.');
+            }
+
+            return new InstallResult(
+                organizationId: $existing->id,
+                organizationCreated: false,
+                adminEmail: $config->adminEmail,
+                adminCreated: false,
+                isSingle: true,
+            );
+        }
+    }
+
+    private function installSuperadmin(InstallConfig $config): InstallResult
+    {
+        $passwordHash = password_hash($config->adminPassword, PASSWORD_DEFAULT);
+
+        try {
+            $this->provisioning->createInitialSuperadmin($config->adminEmail, $passwordHash);
+            $adminCreated = true;
+        } catch (UserEmailConflictException) {
+            // Concurrent double-submit: the superadmin already exists.
+            $adminCreated = false;
+        }
+
+        return new InstallResult(
+            organizationId: null,
+            organizationCreated: false,
+            adminEmail: $config->adminEmail,
+            adminCreated: $adminCreated,
+            isSingle: false,
+        );
+    }
+}

--- a/src/Install/InstallConfig.php
+++ b/src/Install/InstallConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+/**
+ * The first-run inputs the web installer collects on its administrator step.
+ *
+ * `isSingle` decides the shape of what gets provisioned (see {@see InstallApplication}):
+ * a single-tenant install creates an organization + company settings + an `admin`
+ * bound to it, whereas a multi-tenant install creates a cross-tenant `superadmin`
+ * (organization_id = NULL) and leaves org creation to the running app. For the
+ * multi-tenant case `organizationName` / `organizationSlug` are unused.
+ */
+final readonly class InstallConfig
+{
+    public function __construct(
+        public bool $isSingle,
+        public string $organizationName,
+        public string $organizationSlug,
+        public string $adminEmail,
+        public string $adminPassword,
+    ) {
+    }
+}

--- a/src/Install/InstallProvisioningRepositoryInterface.php
+++ b/src/Install/InstallProvisioningRepositoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+
+/**
+ * First-run bootstrap inserts that the ordinary org-scoped use cases cannot make.
+ *
+ * These are deliberately install-only, cross-tenant operations (like
+ * {@see \NeneInvoice\Organization\InitialAdminRepositoryInterface}): seeding a
+ * new org's company settings, and creating the very first `superadmin` — the
+ * latter is refused by {@see \NeneInvoice\User\CreateUserUseCase} (superadmin is
+ * not assignable through the tenant API, ADR 0006), so the installer needs its
+ * own path.
+ */
+interface InstallProvisioningRepositoryInterface
+{
+    /**
+     * Seeds the `company_settings` row (issuer profile) for a freshly created
+     * organization with its legal name; every other field keeps its column
+     * default until the admin fills the profile in.
+     */
+    public function seedCompanySettings(int $organizationId, string $legalName): void;
+
+    /**
+     * Inserts the cross-tenant first `superadmin` (organization_id = NULL).
+     *
+     * @throws UserEmailConflictException when the (globally unique) email is taken
+     */
+    public function createInitialSuperadmin(string $email, string $passwordHash): User;
+}

--- a/src/Install/InstallResult.php
+++ b/src/Install/InstallResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+/**
+ * What {@see InstallApplication::install()} provisioned. The `*Created` flags are
+ * false when an idempotent re-run found the row already present (concurrent
+ * double-submit), so callers can report "created" vs "already existed" without a
+ * second query. `organizationId` is null for a multi-tenant (superadmin) install.
+ */
+final readonly class InstallResult
+{
+    public function __construct(
+        public ?int $organizationId,
+        public bool $organizationCreated,
+        public string $adminEmail,
+        public bool $adminCreated,
+        public bool $isSingle,
+    ) {
+    }
+}

--- a/src/Install/PdoInstallProvisioningRepository.php
+++ b/src/Install/PdoInstallProvisioningRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+
+/**
+ * Cross-tenant first-run inserts for the web installer. Mirrors
+ * {@see \NeneInvoice\Organization\PdoInitialAdminRepository}: the organization id
+ * is supplied by the caller (or NULL for a superadmin) rather than a
+ * request-scoped holder, which the org-scoped repositories cannot express.
+ */
+final readonly class PdoInstallProvisioningRepository implements InstallProvisioningRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function seedCompanySettings(int $organizationId, string $legalName): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO company_settings (organization_id, legal_name, created_at, updated_at)
+             VALUES (?, ?, ?, ?)',
+            [$organizationId, $legalName, $now, $now],
+        );
+    }
+
+    public function createInitialSuperadmin(string $email, string $passwordHash): User
+    {
+        $now  = date('Y-m-d H:i:s');
+        $role = Role::Superadmin;
+
+        try {
+            $this->query->execute(
+                'INSERT INTO users (email, password_hash, role, organization_id, status, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)',
+                [$email, $passwordHash, $role->value, null, 'active', $now, $now],
+            );
+        } catch (DatabaseConstraintException $e) {
+            // users.email is globally UNIQUE — surface a clean domain conflict.
+            throw new UserEmailConflictException($email, $e);
+        }
+
+        return new User(
+            email: $email,
+            passwordHash: $passwordHash,
+            role: $role,
+            organizationId: null,
+            status: 'active',
+            id: $this->query->lastInsertId(),
+            createdAt: $now,
+            updatedAt: $now,
+        );
+    }
+}

--- a/tests/Install/InstallApplicationIntegrationTest.php
+++ b/tests/Install/InstallApplicationIntegrationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Install;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use NeneInvoice\Install\InstallApplication;
+use NeneInvoice\Install\InstallConfig;
+use NeneInvoice\Install\PdoInstallProvisioningRepository;
+use NeneInvoice\Organization\CreateOrganizationUseCase;
+use NeneInvoice\Organization\PdoInitialAdminRepository;
+use NeneInvoice\Organization\PdoOrganizationRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises {@see InstallApplication} against a real (file-backed) SQLite database
+ * with the REAL {@see CreateOrganizationUseCase} (real repositories, transaction
+ * manager and audit) plus the real Pdo provisioning repo — i.e. exactly the
+ * collaboration `public_html/install.php` wires up, minus the container boot.
+ *
+ * Proves the rows the installer must land: single → organization + admin +
+ * company_settings; multi → a cross-tenant superadmin and nothing else.
+ */
+final class InstallApplicationIntegrationTest extends TestCase
+{
+    private string $dbPath;
+    private PdoConnectionFactory $factory;
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nene_install_it_');
+        self::assertIsString($path);
+        $this->dbPath = $path;
+
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: $this->dbPath,
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $this->factory = new PdoConnectionFactory($config);
+
+        $pdo = $this->factory->create();
+        foreach (['organizations.sql', 'users.sql', 'company_settings.sql'] as $file) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . '/database/schema/' . $file);
+            self::assertIsString($schema);
+            $pdo->exec($schema);
+        }
+
+        $this->executor = new PdoDatabaseQueryExecutor($this->factory, $pdo);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function application(): InstallApplication
+    {
+        $createOrganization = new CreateOrganizationUseCase(
+            new PdoDatabaseTransactionManager($this->factory),
+            static fn ($exec) => new PdoOrganizationRepository($exec),
+            static fn () => new RecordingAuditRecorder(),
+            static fn ($exec) => new PdoInitialAdminRepository($exec),
+        );
+
+        return new InstallApplication(
+            $createOrganization,
+            new PdoOrganizationRepository($this->executor),
+            new PdoInstallProvisioningRepository($this->executor),
+        );
+    }
+
+    public function test_single_tenant_provisions_org_admin_and_company_settings(): void
+    {
+        $result = $this->application()->install(new InstallConfig(
+            isSingle: true,
+            organizationName: '山田商店',
+            organizationSlug: 'yamada',
+            adminEmail: 'owner@example.com',
+            adminPassword: 'correct horse battery',
+        ));
+
+        self::assertTrue($result->organizationCreated);
+        self::assertTrue($result->adminCreated);
+        self::assertNotNull($result->organizationId);
+
+        $org = $this->executor->fetchOne('SELECT name, slug, plan FROM organizations WHERE id = ?', [$result->organizationId]);
+        self::assertNotNull($org);
+        self::assertSame('山田商店', (string) $org['name']);
+        self::assertSame('yamada', (string) $org['slug']);
+        self::assertSame('free', (string) $org['plan']);
+
+        $admin = $this->executor->fetchOne('SELECT role, organization_id, status, password_hash FROM users WHERE email = ?', ['owner@example.com']);
+        self::assertNotNull($admin);
+        self::assertSame('admin', (string) $admin['role']);
+        self::assertSame($result->organizationId, (int) $admin['organization_id']);
+        self::assertSame('active', (string) $admin['status']);
+        self::assertTrue(password_verify('correct horse battery', (string) $admin['password_hash']));
+
+        $company = $this->executor->fetchOne('SELECT legal_name FROM company_settings WHERE organization_id = ?', [$result->organizationId]);
+        self::assertNotNull($company);
+        self::assertSame('山田商店', (string) $company['legal_name']);
+    }
+
+    public function test_multi_tenant_provisions_cross_tenant_superadmin_without_org(): void
+    {
+        $result = $this->application()->install(new InstallConfig(
+            isSingle: false,
+            organizationName: '',
+            organizationSlug: '',
+            adminEmail: 'root@example.com',
+            adminPassword: 'correct horse battery',
+        ));
+
+        self::assertNull($result->organizationId);
+        self::assertFalse($result->organizationCreated);
+        self::assertTrue($result->adminCreated);
+
+        $superadmin = $this->executor->fetchOne('SELECT role, organization_id, status, password_hash FROM users WHERE email = ?', ['root@example.com']);
+        self::assertNotNull($superadmin);
+        self::assertSame('superadmin', (string) $superadmin['role']);
+        self::assertNull($superadmin['organization_id']);
+        self::assertSame('active', (string) $superadmin['status']);
+        self::assertTrue(password_verify('correct horse battery', (string) $superadmin['password_hash']));
+
+        // Multi-tenant install creates no organization or company settings.
+        $orgCount = $this->executor->fetchOne('SELECT COUNT(*) AS c FROM organizations');
+        self::assertNotNull($orgCount);
+        self::assertSame(0, (int) $orgCount['c']);
+
+        $companyCount = $this->executor->fetchOne('SELECT COUNT(*) AS c FROM company_settings');
+        self::assertNotNull($companyCount);
+        self::assertSame(0, (int) $companyCount['c']);
+    }
+}

--- a/tests/Install/InstallApplicationTest.php
+++ b/tests/Install/InstallApplicationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Install;
+
+use NeneInvoice\Auth\Role;
+use NeneInvoice\Install\InstallApplication;
+use NeneInvoice\Install\InstallConfig;
+use NeneInvoice\Install\InstallProvisioningRepositoryInterface;
+use NeneInvoice\Organization\CreateOrganizationInput;
+use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
+use NeneInvoice\Organization\Organization;
+use NeneInvoice\Organization\OrganizationRepositoryInterface;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+use NeneInvoice\User\User;
+use NeneInvoice\User\UserEmailConflictException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The first-run orchestration extracted out of `public_html/install.php` (S3-2).
+ * These prove the two install shapes and their idempotent re-run behaviour
+ * without touching a database — the Pdo insert layer is covered separately by
+ * {@see PdoInstallProvisioningRepositoryTest}.
+ */
+final class InstallApplicationTest extends TestCase
+{
+    public function test_single_tenant_creates_org_admin_then_seeds_company_settings(): void
+    {
+        $createOrganization = $this->createMock(CreateOrganizationUseCaseInterface::class);
+        $createOrganization->expects(self::once())
+            ->method('execute')
+            ->with(
+                null,
+                self::callback(static fn (CreateOrganizationInput $in): bool => $in->name === 'Acme'
+                    && $in->slug === 'acme'
+                    && $in->adminEmail === 'owner@example.com'
+                    && $in->adminPassword === 'password123'),
+            )
+            ->willReturn(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true, id: 42));
+
+        $organizations = $this->createStub(OrganizationRepositoryInterface::class);
+
+        $provisioning = $this->createMock(InstallProvisioningRepositoryInterface::class);
+        $provisioning->expects(self::once())->method('seedCompanySettings')->with(42, 'Acme');
+        $provisioning->expects(self::never())->method('createInitialSuperadmin');
+
+        $result = (new InstallApplication($createOrganization, $organizations, $provisioning))
+            ->install(new InstallConfig(
+                isSingle: true,
+                organizationName: 'Acme',
+                organizationSlug: 'acme',
+                adminEmail: 'owner@example.com',
+                adminPassword: 'password123',
+            ));
+
+        self::assertSame(42, $result->organizationId);
+        self::assertTrue($result->organizationCreated);
+        self::assertTrue($result->adminCreated);
+        self::assertTrue($result->isSingle);
+        self::assertSame('owner@example.com', $result->adminEmail);
+    }
+
+    public function test_single_tenant_slug_conflict_resolves_existing_org_idempotently(): void
+    {
+        $createOrganization = $this->createStub(CreateOrganizationUseCaseInterface::class);
+        $createOrganization->method('execute')
+            ->willThrowException(new OrganizationSlugConflictException('acme'));
+
+        $organizations = $this->createMock(OrganizationRepositoryInterface::class);
+        $organizations->expects(self::once())
+            ->method('findBySlug')
+            ->with('acme')
+            ->willReturn(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true, id: 7));
+
+        $provisioning = $this->createMock(InstallProvisioningRepositoryInterface::class);
+        $provisioning->expects(self::never())->method('seedCompanySettings');
+
+        $result = (new InstallApplication($createOrganization, $organizations, $provisioning))
+            ->install(new InstallConfig(
+                isSingle: true,
+                organizationName: 'Acme',
+                organizationSlug: 'acme',
+                adminEmail: 'owner@example.com',
+                adminPassword: 'password123',
+            ));
+
+        self::assertSame(7, $result->organizationId);
+        self::assertFalse($result->organizationCreated);
+        self::assertFalse($result->adminCreated);
+        self::assertTrue($result->isSingle);
+    }
+
+    public function test_multi_tenant_creates_cross_tenant_superadmin_only(): void
+    {
+        $createOrganization = $this->createMock(CreateOrganizationUseCaseInterface::class);
+        $createOrganization->expects(self::never())->method('execute');
+
+        $organizations = $this->createStub(OrganizationRepositoryInterface::class);
+
+        $provisioning = $this->createMock(InstallProvisioningRepositoryInterface::class);
+        $provisioning->expects(self::once())
+            ->method('createInitialSuperadmin')
+            ->with('root@example.com', self::callback(static fn (string $hash): bool => $hash !== ''))
+            ->willReturn(new User(email: 'root@example.com', passwordHash: 'x', role: Role::Superadmin, organizationId: null, id: 1));
+        $provisioning->expects(self::never())->method('seedCompanySettings');
+
+        $result = (new InstallApplication($createOrganization, $organizations, $provisioning))
+            ->install(new InstallConfig(
+                isSingle: false,
+                organizationName: '',
+                organizationSlug: '',
+                adminEmail: 'root@example.com',
+                adminPassword: 'password123',
+            ));
+
+        self::assertNull($result->organizationId);
+        self::assertFalse($result->organizationCreated);
+        self::assertTrue($result->adminCreated);
+        self::assertFalse($result->isSingle);
+    }
+
+    public function test_multi_tenant_superadmin_email_conflict_is_idempotent(): void
+    {
+        $createOrganization = $this->createStub(CreateOrganizationUseCaseInterface::class);
+        $organizations = $this->createStub(OrganizationRepositoryInterface::class);
+
+        $provisioning = $this->createMock(InstallProvisioningRepositoryInterface::class);
+        $provisioning->expects(self::once())
+            ->method('createInitialSuperadmin')
+            ->willThrowException(new UserEmailConflictException('root@example.com'));
+
+        $result = (new InstallApplication($createOrganization, $organizations, $provisioning))
+            ->install(new InstallConfig(
+                isSingle: false,
+                organizationName: '',
+                organizationSlug: '',
+                adminEmail: 'root@example.com',
+                adminPassword: 'password123',
+            ));
+
+        self::assertFalse($result->adminCreated);
+        self::assertNull($result->organizationId);
+        self::assertFalse($result->isSingle);
+    }
+}

--- a/tests/Install/PdoInstallProvisioningRepositoryTest.php
+++ b/tests/Install/PdoInstallProvisioningRepositoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Install;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneInvoice\Auth\Role;
+use NeneInvoice\Install\PdoInstallProvisioningRepository;
+use NeneInvoice\User\UserEmailConflictException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The installer's cross-tenant bootstrap inserts. Proves the superadmin lands
+ * with organization_id = NULL / the fixed `superadmin` / `active` shape, that the
+ * global email uniqueness surfaces as a clean {@see UserEmailConflictException},
+ * and that company settings are seeded with the given legal name.
+ */
+final class PdoInstallProvisioningRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoInstallProvisioningRepository $repository;
+
+    protected function setUp(): void
+    {
+        $config = new DatabaseConfig(
+            url: null,
+            environment: 'test',
+            adapter: 'sqlite',
+            host: 'localhost',
+            port: 1,
+            name: ':memory:',
+            user: 'sqlite',
+            password: '',
+            charset: 'utf8',
+        );
+        $factory = new PdoConnectionFactory($config);
+        $pdo = $factory->create();
+
+        foreach (['users', 'company_settings'] as $table) {
+            $schema = file_get_contents(dirname(__DIR__, 2) . "/database/schema/{$table}.sql");
+            self::assertIsString($schema);
+            $pdo->exec($schema);
+        }
+
+        $this->executor = new PdoDatabaseQueryExecutor($factory, $pdo);
+        $this->repository = new PdoInstallProvisioningRepository($this->executor);
+    }
+
+    public function test_creates_cross_tenant_superadmin_with_null_org(): void
+    {
+        $user = $this->repository->createInitialSuperadmin('root@example.com', 'hashed');
+
+        self::assertGreaterThan(0, $user->id);
+        self::assertSame(Role::Superadmin, $user->role);
+        self::assertNull($user->organizationId);
+        self::assertSame('active', $user->status);
+
+        $row = $this->executor->fetchOne('SELECT role, organization_id, status FROM users WHERE id = ?', [$user->id]);
+        self::assertNotNull($row);
+        self::assertSame('superadmin', (string) $row['role']);
+        self::assertNull($row['organization_id']);
+        self::assertSame('active', (string) $row['status']);
+    }
+
+    public function test_rejects_duplicate_superadmin_email(): void
+    {
+        $this->repository->createInitialSuperadmin('dup@example.com', 'hashed');
+
+        $this->expectException(UserEmailConflictException::class);
+        $this->repository->createInitialSuperadmin('dup@example.com', 'hashed2');
+    }
+
+    public function test_seeds_company_settings_with_legal_name(): void
+    {
+        $this->repository->seedCompanySettings(42, 'Acme Inc');
+
+        $row = $this->executor->fetchOne('SELECT organization_id, legal_name FROM company_settings WHERE organization_id = ?', [42]);
+        self::assertNotNull($row);
+        self::assertSame(42, (int) $row['organization_id']);
+        self::assertSame('Acme Inc', (string) $row['legal_name']);
+    }
+}


### PR DESCRIPTION
Closes #579
Refs #578 (S3-2)

## 概要

`public_html/install.php` step 2 の**生 SQL による組織/管理者/company_settings 作成**を、テスト可能な `NeneInvoice\Install\InstallApplication` ユースケースへ抽出する（epic #578 のスライス S3-2・records の薄型 installer パターン）。**作成物・カラムは現行と同一、経路のみ整理**。

## 変更点

- **single**: 既存 `CreateOrganizationUseCase`（org＋初期 admin を **1 トランザクション＋監査**で作成）を再利用し、`company_settings`（legal_name）をシード。従来の**非トランザクション生 SQL を廃し、org+admin の原子性と監査記録を獲得**。
- **multi**: superadmin（`organization_id=NULL`）は `CreateUserUseCase` が RoleNotAssignable で弾くため、install 専用の cross-tenant repo `PdoInstallProvisioningRepository` で作成（`InitialAdminRepository` の前例に倣う）。
- **install.php**: `RuntimeContainerFactory` で container を boot し use case を解決（records と同じ）。**生 SQL を install.php から排除**（step 2 は +39/−32）。フィールド検証・再設置ガード・UI（素 HTML のまま）は不変。

## 追加物

- `src/Install/InstallApplication.php` / `InstallConfig.php` / `InstallResult.php`
- `src/Install/InstallProvisioningRepositoryInterface.php` / `PdoInstallProvisioningRepository.php`

## テスト（9 件・82 assertions）

- **orchestration**（mock）: single＝org+admin+company_settings シード / single 冪等（slug 衝突→既存解決）/ multi＝superadmin のみ / multi 冪等（email 衝突）。
- **Pdo repo**（SQLite）: superadmin が org=NULL・superadmin・active で着地 / email 重複→`UserEmailConflictException` / company_settings シード。
- **統合**（SQLite・**実 `CreateOrganizationUseCase` + 実 repo**）: single で organizations＋users(admin)＋company_settings が正しく着地（password_verify 込み）/ multi で cross-tenant superadmin のみ・org/company_settings 0 件。

`composer check` 緑（PHPStan clean・cs-fixer clean・OpenAPI/MCP valid・PHPUnit notice 解消）。用語レジストリ追加なし・会計コンプライアンス影響なし。

## 非スコープ

UI 刷新（S3-1・ClaudeDesign 依頼中／素 HTML 維持）・Feature B の統合（S3-3）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)