### PR TITLE
feat(installer): Feature B の取得ロジックを PayloadAcquisition へ抽出＋allowlist 修正 (#581)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -28,6 +28,7 @@ use Nene2\Install\TenantConfigurationValidator;
 use NeneInvoice\Http\RuntimeContainerFactory;
 use NeneInvoice\Install\InstallApplication;
 use NeneInvoice\Install\InstallConfig;
+use NeneInvoice\Install\PayloadAcquisition;
 use NeneInvoice\Install\PdoInstallProvisioningRepository;
 use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
 use NeneInvoice\Organization\PdoOrganizationRepository;
@@ -36,19 +37,6 @@ use Phinx\Config\Config;
 define('ROOT', dirname(__DIR__));
 define('INSTALLED_MARKER', ROOT . '/var/.installed');
 define('ENV_FILE', ROOT . '/.env');
-
-// -------------------------------------------------------------------
-// Feature B（手動アップロードによるアプリ取得）用の定数。
-//
-// このラウンドは「配布元の SHA-256 照合のみ」。ADR 0018 の署名検証は
-// updater / 自動取得ラウンドで同時導入する（本 install は署名検証を行わない）。
-// -------------------------------------------------------------------
-// 配布 ZIP のトップレベル・エントリはこの集合の部分集合でなければならない。
-// （build-release.sh が同梱するもの＝無関係／悪意ある ZIP を弾くためのガード）
-const ACQUIRE_ALLOWED_TOP = ['src', 'vendor', 'database', 'public_html', 'composer.json', 'phinx.php', '.env.example', 'var'];
-// アップロード上限（.zip のみ受け付ける）。共有ホスティングの実効値
-// （upload_max_filesize / post_max_size）がこれより小さいこともある。
-const ACQUIRE_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 // -------------------------------------------------------------------
 // Guard: すでにインストール済みならブロック
@@ -243,124 +231,6 @@ function acquireRequirementChecks(): array
 }
 
 /**
- * ZIP エントリ名が展開先 ROOT の外へ書き込もうとしていないか（zip-slip）を判定する。
- * 絶対パス・ドライブレター・`..` セグメントを含むものはすべて「脱出」とみなす（厳格）。
- */
-function acquireEntryEscapesRoot(string $entry): bool
-{
-    $norm = str_replace('\\', '/', $entry);
-
-    if ($norm === '' || $norm === '/') {
-        return false;
-    }
-
-    // 絶対パス（/foo）または Windows ドライブレター（C:\）は拒否。
-    if ($norm[0] === '/' || preg_match('#^[A-Za-z]:#', $norm) === 1) {
-        return true;
-    }
-
-    foreach (explode('/', $norm) as $seg) {
-        if ($seg === '..') {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
- * ZIP のトップレベル・エントリ名（第 1 セグメント）を返す。
- */
-function acquireTopSegment(string $entry): string
-{
-    $norm = ltrim(str_replace('\\', '/', $entry), '/');
-    $slash = strpos($norm, '/');
-
-    return $slash === false ? $norm : substr($norm, 0, $slash);
-}
-
-/**
- * ZIP を厳格に検証してから ROOT へ展開する。
- *
- * ガード:
- *  - すべてのエントリについて zip-slip（`..` / 絶対パス）を拒否。
- *  - トップレベル・エントリが ACQUIRE_ALLOWED_TOP の部分集合でなければ拒否。
- *  - 検証を全通過してから初めて extractTo() する（部分展開を避ける）。
- */
-function extractPayloadZip(string $zipPath, string $root): void
-{
-    if (!class_exists('ZipArchive')) {
-        throw new RuntimeException('zip 拡張（ZipArchive）が有効ではありません。');
-    }
-
-    $zip = new ZipArchive();
-
-    if ($zip->open($zipPath) !== true) {
-        throw new RuntimeException('アップロードされた ZIP を開けませんでした。ファイルが壊れていないか確認してください。');
-    }
-
-    try {
-        if ($zip->numFiles === 0) {
-            throw new RuntimeException('ZIP が空です。公式配布元の ZIP をアップロードしてください。');
-        }
-
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $entry = $zip->getNameIndex($i);
-
-            if ($entry === false) {
-                throw new RuntimeException('ZIP のエントリを読み取れませんでした。');
-            }
-
-            if (acquireEntryEscapesRoot($entry)) {
-                throw new RuntimeException('ZIP に不正なパス（zip-slip の疑い）が含まれています。展開を中止しました。');
-            }
-
-            $top = acquireTopSegment($entry);
-
-            if ($top !== '' && !in_array($top, ACQUIRE_ALLOWED_TOP, true)) {
-                throw new RuntimeException('想定外のエントリ「' . $top . '」が ZIP に含まれています。NeNe Invoice の配布 ZIP をアップロードしてください。');
-            }
-        }
-
-        if ($zip->extractTo($root) !== true) {
-            throw new RuntimeException('ZIP の展開に失敗しました。書き込み権限とディスク容量を確認してください。');
-        }
-    } finally {
-        $zip->close();
-    }
-}
-
-/**
- * SHA-256 を照合してから ZIP を展開する（Feature B の中核・単体テスト可能）。
- * ハッシュ不一致・書式不正・空欄はいずれも拒否（展開しない）。
- */
-function verifyAndExtractPayload(string $zipPath, string $expectedHash, string $root): void
-{
-    $expected = strtolower(trim($expectedHash));
-
-    if ($expected === '') {
-        throw new RuntimeException('公式配布元のリリースページに記載された SHA-256 を入力してください。');
-    }
-
-    if (preg_match('/^[0-9a-f]{64}$/', $expected) !== 1) {
-        throw new RuntimeException('SHA-256 の形式が正しくありません（64 桁の 16 進数を入力してください）。');
-    }
-
-    $actual = hash_file('sha256', $zipPath);
-
-    if ($actual === false) {
-        throw new RuntimeException('アップロードされたファイルのハッシュを計算できませんでした。');
-    }
-
-    // タイミング攻撃対策として hash_equals を使う（照合は展開の前に必ず行う）。
-    if (!hash_equals($expected, strtolower($actual))) {
-        throw new RuntimeException('SHA-256 が一致しません。公式配布元からダウンロードした ZIP と、そのページに記載のハッシュを確認してください。');
-    }
-
-    extractPayloadZip($zipPath, $root);
-}
-
-/**
  * Web アップロード（multipart POST）を検証し、一時ファイル経由で展開する。
  * 一時 ZIP は成功・失敗いずれの場合も必ず削除する。
  */
@@ -387,8 +257,8 @@ function handleAcquireUpload(): void
         throw new RuntimeException('アップロードされたファイルが空です。');
     }
 
-    if ($size > ACQUIRE_MAX_UPLOAD_BYTES) {
-        throw new RuntimeException('ファイルサイズが上限（' . (int) (ACQUIRE_MAX_UPLOAD_BYTES / 1024 / 1024) . 'MB）を超えています。');
+    if ($size > PayloadAcquisition::MAX_UPLOAD_BYTES) {
+        throw new RuntimeException('ファイルサイズが上限（' . (int) (PayloadAcquisition::MAX_UPLOAD_BYTES / 1024 / 1024) . 'MB）を超えています。');
     }
 
     $origName = (string) ($_FILES['payload']['name'] ?? '');
@@ -411,7 +281,7 @@ function handleAcquireUpload(): void
 
     try {
         // SHA-256 照合 → zip-slip / トップレベル検証 → 展開（すべて展開前に検証）。
-        verifyAndExtractPayload($dest, (string) ($_POST['expected_sha256'] ?? ''), ROOT);
+        PayloadAcquisition::verifyAndExtract($dest, (string) ($_POST['expected_sha256'] ?? ''), ROOT);
     } finally {
         // 一致・不一致・例外いずれでも一時 ZIP を削除する。
         @unlink($dest);
@@ -465,6 +335,10 @@ $isMultiInstall = $installedMode !== 'single';
 
 if (!$payloadPresent) {
     // ================= Feature B: アプリ取得（アップロード）フロー =================
+    // vendor 不在＝Composer autoloader も無いため、取得ロジックを持つ依存ゼロの
+    // クラスを直接 require する（toolkit には依存できない）。
+    require_once ROOT . '/src/Install/PayloadAcquisition.php';
+
     $view      = 'acquire';
     $checks    = acquireRequirementChecks();
     $reqErrors = array_values(array_filter($checks, static fn (array $c): bool => !$c['ok']));

--- a/src/Install/PayloadAcquisition.php
+++ b/src/Install/PayloadAcquisition.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Install;
+
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * The web installer's "Feature B" — acquiring the application payload from a
+ * manually uploaded release ZIP when `vendor/` is absent (a host that only
+ * extracted `public_html/`, or a partial upload).
+ *
+ * ⚠️ Runs BEFORE `vendor/` exists, so this class must stay dependency-free: no
+ * NENE2 toolkit, no other `src/` classes, only the global `ZipArchive` and
+ * `RuntimeException`. `public_html/install.php` loads it with a direct
+ * `require_once` (not the Composer autoloader, which isn't available yet).
+ *
+ * Security invariants (validated before any extraction):
+ *  - every entry is rejected if it escapes the root (`..`, absolute path, drive letter) — zip-slip;
+ *  - every top-level entry must be in {@see self::ALLOWED_TOP} — rejects unrelated / hostile ZIPs;
+ *  - the SHA-256 the operator pastes from the release page must match — integrity.
+ *
+ * This round verifies the distributor SHA-256 only; ADR 0018 signature
+ * verification lands with the updater / auto-fetch round.
+ */
+final class PayloadAcquisition
+{
+    /**
+     * The only top-level entries a NeNe Invoice release ZIP may contain. Kept in
+     * sync with what `tools/build-release.sh` ships (guarded by
+     * {@see \NeneInvoice\Tests\Install\PayloadAcquisitionTest}) — a mismatch here
+     * would reject the official ZIP.
+     */
+    public const array ALLOWED_TOP = [
+        'src',
+        'vendor',
+        'database',
+        'public_html',
+        'resources',
+        'composer.json',
+        'composer.lock',
+        'phinx.php',
+        '.env.example',
+        'README.md',
+        'var',
+    ];
+
+    /** Upload ceiling; a host's effective limit (upload_max_filesize) may be smaller. */
+    public const int MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+    /**
+     * Whether a ZIP entry name tries to write outside the extraction root
+     * (zip-slip). Absolute paths, Windows drive letters and any `..` segment all
+     * count as an escape (strict).
+     */
+    public static function entryEscapesRoot(string $entry): bool
+    {
+        $norm = str_replace('\\', '/', $entry);
+
+        if ($norm === '' || $norm === '/') {
+            return false;
+        }
+
+        // Absolute path (/foo) or Windows drive letter (C:\).
+        if ($norm[0] === '/' || preg_match('#^[A-Za-z]:#', $norm) === 1) {
+            return true;
+        }
+
+        foreach (explode('/', $norm) as $seg) {
+            if ($seg === '..') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** The top-level (first) segment of a ZIP entry name. */
+    public static function topSegment(string $entry): string
+    {
+        $norm  = ltrim(str_replace('\\', '/', $entry), '/');
+        $slash = strpos($norm, '/');
+
+        return $slash === false ? $norm : substr($norm, 0, $slash);
+    }
+
+    /**
+     * Verify the SHA-256, then extract. The hash is checked with a constant-time
+     * comparison BEFORE anything is unzipped; a blank, malformed or mismatched
+     * hash all refuse extraction.
+     */
+    public static function verifyAndExtract(string $zipPath, string $expectedHash, string $root): void
+    {
+        $expected = strtolower(trim($expectedHash));
+
+        if ($expected === '') {
+            throw new RuntimeException('公式配布元のリリースページに記載された SHA-256 を入力してください。');
+        }
+
+        if (preg_match('/^[0-9a-f]{64}$/', $expected) !== 1) {
+            throw new RuntimeException('SHA-256 の形式が正しくありません（64 桁の 16 進数を入力してください）。');
+        }
+
+        $actual = hash_file('sha256', $zipPath);
+
+        if ($actual === false) {
+            throw new RuntimeException('アップロードされたファイルのハッシュを計算できませんでした。');
+        }
+
+        // Constant-time compare; verification always precedes extraction.
+        if (!hash_equals($expected, strtolower($actual))) {
+            throw new RuntimeException('SHA-256 が一致しません。公式配布元からダウンロードした ZIP と、そのページに記載のハッシュを確認してください。');
+        }
+
+        self::extract($zipPath, $root);
+    }
+
+    /**
+     * Validate every entry (zip-slip + top-level allowlist) and only then extract
+     * to $root — a full pass first so a hostile ZIP never partially extracts.
+     */
+    public static function extract(string $zipPath, string $root): void
+    {
+        if (!class_exists('ZipArchive')) {
+            throw new RuntimeException('zip 拡張（ZipArchive）が有効ではありません。');
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($zipPath) !== true) {
+            throw new RuntimeException('アップロードされた ZIP を開けませんでした。ファイルが壊れていないか確認してください。');
+        }
+
+        try {
+            if ($zip->numFiles === 0) {
+                throw new RuntimeException('ZIP が空です。公式配布元の ZIP をアップロードしてください。');
+            }
+
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entry = $zip->getNameIndex($i);
+
+                if ($entry === false) {
+                    throw new RuntimeException('ZIP のエントリを読み取れませんでした。');
+                }
+
+                if (self::entryEscapesRoot($entry)) {
+                    throw new RuntimeException('ZIP に不正なパス（zip-slip の疑い）が含まれています。展開を中止しました。');
+                }
+
+                $top = self::topSegment($entry);
+
+                if ($top !== '' && !in_array($top, self::ALLOWED_TOP, true)) {
+                    throw new RuntimeException('想定外のエントリ「' . $top . '」が ZIP に含まれています。NeNe Invoice の配布 ZIP をアップロードしてください。');
+                }
+            }
+
+            if ($zip->extractTo($root) !== true) {
+                throw new RuntimeException('ZIP の展開に失敗しました。書き込み権限とディスク容量を確認してください。');
+            }
+        } finally {
+            $zip->close();
+        }
+    }
+}

--- a/tests/Install/PayloadAcquisitionTest.php
+++ b/tests/Install/PayloadAcquisitionTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Install;
+
+use NeneInvoice\Install\PayloadAcquisition;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * The installer's "Feature B" payload acquisition — the security-critical part
+ * (zip-slip guard, top-level allowlist, SHA-256 verification) extracted out of
+ * `public_html/install.php` so it can actually be unit tested.
+ */
+final class PayloadAcquisitionTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } elseif (is_file($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function entryProvider(): iterable
+    {
+        yield 'normal file'      => ['src/Foo.php', false];
+        yield 'top-level file'   => ['composer.json', false];
+        yield 'empty'            => ['', false];
+        yield 'bare slash'       => ['/', false];
+        yield 'parent traversal' => ['../etc/passwd', true];
+        yield 'nested traversal' => ['src/../../evil', true];
+        yield 'absolute path'    => ['/etc/passwd', true];
+        yield 'drive letter'     => ['C:\\Windows\\evil', true];
+        yield 'backslash parent' => ['..\\evil', true];
+    }
+
+    #[DataProvider('entryProvider')]
+    public function test_entry_escapes_root(string $entry, bool $expected): void
+    {
+        self::assertSame($expected, PayloadAcquisition::entryEscapesRoot($entry));
+    }
+
+    public function test_top_segment(): void
+    {
+        self::assertSame('src', PayloadAcquisition::topSegment('src/Foo.php'));
+        self::assertSame('composer.json', PayloadAcquisition::topSegment('composer.json'));
+        self::assertSame('src', PayloadAcquisition::topSegment('/src/Foo.php'));
+        self::assertSame('public_html', PayloadAcquisition::topSegment('public_html\\admin\\index.php'));
+    }
+
+    public function test_verify_and_extract_rejects_blank_hash(): void
+    {
+        $zip = $this->makeZip(['composer.json' => '{}']);
+        $this->expectException(RuntimeException::class);
+        PayloadAcquisition::verifyAndExtract($zip, '', $this->makeDir());
+    }
+
+    public function test_verify_and_extract_rejects_malformed_hash(): void
+    {
+        $zip = $this->makeZip(['composer.json' => '{}']);
+        $this->expectException(RuntimeException::class);
+        PayloadAcquisition::verifyAndExtract($zip, 'not-a-sha', $this->makeDir());
+    }
+
+    public function test_verify_and_extract_rejects_mismatched_hash(): void
+    {
+        $zip = $this->makeZip(['composer.json' => '{}']);
+        $wrong = str_repeat('0', 64);
+        $this->expectException(RuntimeException::class);
+        PayloadAcquisition::verifyAndExtract($zip, $wrong, $this->makeDir());
+    }
+
+    public function test_verify_and_extract_accepts_matching_hash_and_extracts(): void
+    {
+        $zip = $this->makeZip(['src/Foo.php' => '<?php', 'composer.json' => '{}']);
+        $hash = hash_file('sha256', $zip);
+        self::assertIsString($hash);
+        $dest = $this->makeDir();
+
+        PayloadAcquisition::verifyAndExtract($zip, $hash, $dest);
+
+        self::assertFileExists($dest . '/src/Foo.php');
+        self::assertFileExists($dest . '/composer.json');
+    }
+
+    public function test_extract_rejects_unexpected_top_level_entry(): void
+    {
+        $zip = $this->makeZip(['src/Foo.php' => '<?php', 'evil/malware.sh' => 'rm -rf /']);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/想定外のエントリ/');
+        PayloadAcquisition::extract($zip, $this->makeDir());
+    }
+
+    public function test_extract_rejects_empty_zip(): void
+    {
+        $zip = $this->makeZip([]);
+        $this->expectException(RuntimeException::class);
+        PayloadAcquisition::extract($zip, $this->makeDir());
+    }
+
+    public function test_extract_accepts_all_allowed_top_level_entries(): void
+    {
+        $entries = [];
+        foreach (PayloadAcquisition::ALLOWED_TOP as $top) {
+            // Directories get a child file; plain files are added directly.
+            $entries[str_contains($top, '.') ? $top : $top . '/keep'] = 'x';
+        }
+        $zip = $this->makeZip($entries);
+        $dest = $this->makeDir();
+
+        PayloadAcquisition::extract($zip, $dest);
+
+        self::assertFileExists($dest . '/src/keep');
+        self::assertFileExists($dest . '/composer.json');
+        self::assertFileExists($dest . '/README.md');
+    }
+
+    /**
+     * Drift guard: every top-level entry `tools/build-release.sh` ships must be in
+     * the allowlist, otherwise Feature B would reject the official release ZIP —
+     * exactly the bug that motivated this class (resources / README.md /
+     * composer.lock were missing).
+     */
+    public function test_allowlist_covers_everything_build_release_ships(): void
+    {
+        $script = (string) file_get_contents(dirname(__DIR__, 2) . '/tools/build-release.sh');
+
+        // Single-segment staging destinations: "$STAGE/<name>".
+        preg_match_all('#"\$STAGE/([^/"]+)"#', $script, $matches);
+        $shipped = array_unique($matches[1]);
+
+        // vendor/ and composer.lock are produced by `composer update`, not copied.
+        $shipped[] = 'vendor';
+        $shipped[] = 'composer.lock';
+
+        self::assertNotEmpty($shipped, 'Expected to parse staged entries from build-release.sh.');
+
+        foreach ($shipped as $top) {
+            self::assertContains(
+                $top,
+                PayloadAcquisition::ALLOWED_TOP,
+                "build-release.sh ships '{$top}' but PayloadAcquisition::ALLOWED_TOP omits it — Feature B would reject the release ZIP.",
+            );
+        }
+    }
+
+    /**
+     * @param array<string, string> $entries entry name => contents
+     */
+    private function makeZip(array $entries): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nene_pa_') . '.zip';
+        $this->tempPaths[] = $path;
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true);
+        foreach ($entries as $name => $contents) {
+            $zip->addFromString($name, $contents);
+        }
+        $zip->close();
+
+        return $path;
+    }
+
+    private function makeDir(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nene_pa_dir_');
+        self::assertIsString($path);
+        unlink($path);
+        mkdir($path, 0755, true);
+        $this->tempPaths[] = $path;
+
+        return $path;
+    }
+
+    private function removeDir(string $dir): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
Closes #581
Refs #578 (S3-3)

## 概要

`public_html/install.php` の **Feature B（vendor 不在時の手動アップロード取得）** のセキュリティ中核（zip-slip ガード・トップレベル allowlist・SHA-256 照合・展開）を、テスト可能な `NeneInvoice\Install\PayloadAcquisition` へ抽出（epic #578 の S3-3）。install.php は **−126 行**。UI は素 HTML のまま不変。

## 併せて修正したバグ（既存・重要）

`ACQUIRE_ALLOWED_TOP` が**実配布 ZIP のトップレベルと乖離**しており、`resources`（#550 で追加）・`README.md` / `composer.lock`（#576 で追加）を含む**公式リリース ZIP を Feature B が「想定外のエントリ」で拒否**していた。`ALLOWED_TOP` を `build-release.sh` の実出力に合わせて修正し、**再発防止のドリフトガードテスト**（allowlist ⊇ build-release.sh の同梱トップレベル）を追加。

## 設計上の制約

Feature B は **vendor 不在時に走る＝toolkit（vendor 内）に依存できない**。抽出先クラスは依存ゼロ（global の `ZipArchive` / `RuntimeException` のみ）にし、install.php は Composer autoloader ではなく `require_once` で直接読み込む（該当分岐は pre-vendor）。

## テスト（18 件・51 assertions）

- `entryEscapesRoot`: `..` / 絶対パス / ドライブレター / backslash / 正常/空 をデータプロバイダで網羅
- `topSegment`: 通常/トップ/先頭スラッシュ/backslash
- `verifyAndExtract`: 空ハッシュ・書式不正・不一致 → 拒否 / 一致 → 展開
- `extract`: 想定外トップレベル拒否・空 ZIP 拒否・全 `ALLOWED_TOP` 展開
- **ドリフトガード**: `build-release.sh` の同梱物を allowlist が網羅

`composer check` 緑（PHPStan clean・cs-fixer clean・OpenAPI/MCP valid）。用語追加なし・会計コンプライアンス影響なし。

## 非スコープ
UI 刷新（S3-1・ClaudeDesign 依頼中）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)