### PR TITLE
検品C Clock sweep: 認証クラスタの現在時刻直書きを ClockInterface 注入へ (#591)

### DIFF
--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -15,6 +15,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RequestScopedHolder;
 use NeneInvoice\ApplicationServiceProvider;
@@ -175,7 +176,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Refresh token repository service is invalid.');
                     }
 
-                    return new RefreshTokenIssuer($repository);
+                    return new RefreshTokenIssuer($repository, self::clock($container));
                 },
             )
             ->set(
@@ -202,7 +203,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Refresh token issuer service is invalid.');
                     }
 
-                    return new LoginUseCase($users, $tokenIssuer, new PdoLoginThrottle($query), $refreshTokenIssuer);
+                    return new LoginUseCase($users, $tokenIssuer, new PdoLoginThrottle($query), $refreshTokenIssuer, self::clock($container));
                 },
             )
             ->set(
@@ -229,7 +230,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Token issuer service is invalid.');
                     }
 
-                    return new RefreshSessionUseCase($repository, $users, $issuer, $tokenIssuer);
+                    return new RefreshSessionUseCase($repository, $users, $issuer, $tokenIssuer, self::clock($container));
                 },
             )
             ->set(
@@ -241,7 +242,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Refresh token repository service is invalid.');
                     }
 
-                    return new LogoutUseCase($repository);
+                    return new LogoutUseCase($repository, self::clock($container));
                 },
             )
             ->set(
@@ -371,6 +372,17 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                     return new AuthRouteRegistrar($loginHandler, $getCurrentUserHandler, $refreshHandler, $logoutHandler);
                 },
             );
+    }
+
+    private static function clock(ContainerInterface $c): ClockInterface
+    {
+        $clock = $c->get(ClockInterface::class);
+
+        if (!$clock instanceof ClockInterface) {
+            throw new LogicException('Clock service is invalid.');
+        }
+
+        return $clock;
     }
 
     /** @return RequestScopedHolder<int> */

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Auth;
 
 use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\ClockInterface;
 use NeneInvoice\User\UserRepositoryInterface;
 
 /**
@@ -27,6 +28,7 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
         private TokenIssuerInterface $tokenIssuer,
         private LoginThrottleInterface $throttle,
         private RefreshTokenIssuer $refreshTokenIssuer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -37,7 +39,7 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
         // Brute-force throttle: once an IP exceeds the failure ceiling within the
         // window, reject further attempts until the window rolls off (429).
         if ($ip !== null) {
-            $since = date('Y-m-d H:i:s', time() - self::THROTTLE_WINDOW_SECONDS);
+            $since = date('Y-m-d H:i:s', $this->clock->now()->getTimestamp() - self::THROTTLE_WINDOW_SECONDS);
             if ($this->throttle->countFailuresSince($ip, $since) >= self::THROTTLE_MAX_FAILURES) {
                 throw new TooManyLoginAttemptsException(self::THROTTLE_WINDOW_SECONDS);
             }
@@ -60,7 +62,7 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
             $this->throttle->clearFailures($ip);
         }
 
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
 
         $token = $this->tokenIssuer->issue([
             'sub' => $user->id,

--- a/src/Auth/LogoutUseCase.php
+++ b/src/Auth/LogoutUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Auth;
 
+use Nene2\Http\ClockInterface;
+
 /**
  * Server-side session revocation (ADR 0014).
  *
@@ -17,6 +19,7 @@ final readonly class LogoutUseCase implements LogoutUseCaseInterface
 {
     public function __construct(
         private RefreshTokenRepositoryInterface $refreshTokens,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -32,6 +35,6 @@ final readonly class LogoutUseCase implements LogoutUseCaseInterface
             return;
         }
 
-        $this->refreshTokens->revokeFamily($record->familyId, date('Y-m-d H:i:s'));
+        $this->refreshTokens->revokeFamily($record->familyId, $this->clock->now()->format('Y-m-d H:i:s'));
     }
 }

--- a/src/Auth/RefreshSessionUseCase.php
+++ b/src/Auth/RefreshSessionUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Auth;
 
 use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\ClockInterface;
 use NeneInvoice\User\UserRepositoryInterface;
 
 /**
@@ -25,12 +26,13 @@ final readonly class RefreshSessionUseCase implements RefreshSessionUseCaseInter
         private UserRepositoryInterface $users,
         private RefreshTokenIssuer $issuer,
         private TokenIssuerInterface $tokenIssuer,
+        private ClockInterface $clock,
     ) {
     }
 
     public function execute(string $rawToken): RefreshedSession
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
         $record = $this->refreshTokens->findByHash(RefreshTokenSecret::hash($rawToken));
 
         if ($record === null) {
@@ -68,7 +70,7 @@ final readonly class RefreshSessionUseCase implements RefreshSessionUseCaseInter
         $this->refreshTokens->markUsed($record->id ?? 0, $now);
         $rotated = $this->issuer->issue($user->id, $user->organizationId, $record->familyId);
 
-        $issuedAt = time();
+        $issuedAt = $this->clock->now()->getTimestamp();
         $accessToken = $this->tokenIssuer->issue([
             'sub' => $user->id,
             'role' => $user->role->value,

--- a/src/Auth/RefreshTokenIssuer.php
+++ b/src/Auth/RefreshTokenIssuer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Auth;
 
+use Nene2\Http\ClockInterface;
+
 /**
  * Mints and persists a new refresh token for a principal (ADR 0014).
  *
@@ -21,6 +23,7 @@ final readonly class RefreshTokenIssuer
 
     public function __construct(
         private RefreshTokenRepositoryInterface $repository,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -30,7 +33,7 @@ final readonly class RefreshTokenIssuer
      */
     public function issue(int $userId, ?int $organizationId, ?string $familyId = null): IssuedRefreshToken
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $expiresAtTs = $now + self::TOKEN_TTL_SECONDS;
 
         $raw = RefreshTokenSecret::generateRaw();

--- a/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
+++ b/src/InvoiceDownloadToken/DownloadInvoicePdfHandler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace NeneInvoice\InvoiceDownloadToken;
 
-use DateTimeImmutable;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\SecureTokenHelper;
 use Nene2\Routing\Router;
@@ -38,6 +38,7 @@ final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterfac
         private Psr17Factory $psr17,
         private ProblemDetailsResponseFactory $problemDetails,
         private RequestScopedHolder $orgId,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -49,7 +50,7 @@ final readonly class DownloadInvoicePdfHandler implements RequestHandlerInterfac
 
         $record = $this->tokens->findByHash($tokenHash);
 
-        $now = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         if ($record === null || $record->isExpired($now)) {
             return $this->problemDetails->create($request, 'invoice-not-found', 'Not Found', 404, 'Download link not found or expired.');

--- a/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
+++ b/src/InvoiceDownloadToken/InvoiceDownloadTokenServiceProvider.php
@@ -65,6 +65,7 @@ final readonly class InvoiceDownloadTokenServiceProvider implements ServiceProvi
                     self::resolve($c, Psr17Factory::class),
                     self::resolve($c, ProblemDetailsResponseFactory::class),
                     self::orgHolder($c),
+                    self::resolve($c, ClockInterface::class),
                 ),
             )
             ->set(

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\Auth;
 
 use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Http\UtcClock;
 use NeneInvoice\Auth\InvalidCredentialsException;
 use NeneInvoice\Auth\LoginInput;
 use NeneInvoice\Auth\LoginUseCase;
@@ -24,7 +25,7 @@ final class LoginUseCaseTest extends TestCase
     public function test_issues_token_with_identity_claims_on_valid_credentials(): void
     {
         $verifier = new LocalBearerTokenVerifier(self::SECRET);
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier, new InMemoryLoginThrottle(), $this->refreshIssuer());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), $verifier, new InMemoryLoginThrottle(), $this->refreshIssuer(), new UtcClock());
 
         $output = $useCase->execute(new LoginInput('admin@example.com', 'correct-horse'));
 
@@ -36,7 +37,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_wrong_password(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer(), new UtcClock());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('admin@example.com', 'wrong'));
@@ -44,7 +45,7 @@ final class LoginUseCaseTest extends TestCase
 
     public function test_rejects_unknown_email(): void
     {
-        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer());
+        $useCase = new LoginUseCase($this->repositoryWithUser('correct-horse'), new LocalBearerTokenVerifier(self::SECRET), new InMemoryLoginThrottle(), $this->refreshIssuer(), new UtcClock());
 
         $this->expectException(InvalidCredentialsException::class);
         $useCase->execute(new LoginInput('nobody@example.com', 'correct-horse'));
@@ -57,6 +58,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             new InMemoryLoginThrottle(),
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
@@ -70,6 +72,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             new InMemoryLoginThrottle(),
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         $this->expectException(InvalidCredentialsException::class);
@@ -88,6 +91,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         // Even with the correct password, the IP is over the failure ceiling.
@@ -107,6 +111,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         // 9 failures is one below the ceiling of 10: the correct password
@@ -124,6 +129,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         try {
@@ -145,6 +151,7 @@ final class LoginUseCaseTest extends TestCase
             new LocalBearerTokenVerifier(self::SECRET),
             $throttle,
             $this->refreshIssuer(),
+            new UtcClock(),
         );
 
         $useCase->execute(new LoginInput('admin@example.com', 'correct-horse', '203.0.113.9'));
@@ -154,7 +161,7 @@ final class LoginUseCaseTest extends TestCase
 
     private function refreshIssuer(): RefreshTokenIssuer
     {
-        return new RefreshTokenIssuer(new InMemoryRefreshTokenRepository());
+        return new RefreshTokenIssuer(new InMemoryRefreshTokenRepository(), new UtcClock());
     }
 
     private function repositoryWithUser(string $plainPassword, string $status = 'active'): UserRepositoryInterface

--- a/tests/Auth/LogoutUseCaseTest.php
+++ b/tests/Auth/LogoutUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Auth;
 
+use Nene2\Http\UtcClock;
 use NeneInvoice\Auth\LogoutUseCase;
 use NeneInvoice\Auth\RefreshTokenIssuer;
 use NeneInvoice\Auth\RefreshTokenSecret;
@@ -15,9 +16,9 @@ final class LogoutUseCaseTest extends TestCase
     public function test_revokes_the_token_family(): void
     {
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $issued = (new RefreshTokenIssuer($refreshTokens))->issue(42, 1);
+        $issued = (new RefreshTokenIssuer($refreshTokens, new UtcClock()))->issue(42, 1);
 
-        (new LogoutUseCase($refreshTokens))->execute($issued->rawToken);
+        (new LogoutUseCase($refreshTokens, new UtcClock()))->execute($issued->rawToken);
 
         $record = $refreshTokens->findByHash(RefreshTokenSecret::hash($issued->rawToken));
         self::assertNotNull($record);
@@ -27,7 +28,7 @@ final class LogoutUseCaseTest extends TestCase
     public function test_is_a_noop_for_a_missing_or_unknown_token(): void
     {
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $useCase = new LogoutUseCase($refreshTokens);
+        $useCase = new LogoutUseCase($refreshTokens, new UtcClock());
 
         // No exception for null/empty/unknown — logout is idempotent.
         $useCase->execute(null);

--- a/tests/Auth/RefreshSessionUseCaseTest.php
+++ b/tests/Auth/RefreshSessionUseCaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\Auth;
 
 use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Http\UtcClock;
 use NeneInvoice\Auth\InvalidRefreshTokenException;
 use NeneInvoice\Auth\RefreshSessionUseCase;
 use NeneInvoice\Auth\RefreshToken;
@@ -26,9 +27,9 @@ final class RefreshSessionUseCaseTest extends TestCase
         $users = new InMemoryUserRepository();
         $userId = $users->save($this->user(organizationId: 5));
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $issuer = new RefreshTokenIssuer($refreshTokens, new UtcClock());
         $verifier = new LocalBearerTokenVerifier(self::SECRET);
-        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, $verifier);
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, $verifier, new UtcClock());
 
         $issued = $issuer->issue($userId, 5);
 
@@ -50,8 +51,9 @@ final class RefreshSessionUseCaseTest extends TestCase
         $useCase = new RefreshSessionUseCase(
             $refreshTokens,
             new InMemoryUserRepository(),
-            new RefreshTokenIssuer($refreshTokens),
+            new RefreshTokenIssuer($refreshTokens, new UtcClock()),
             new LocalBearerTokenVerifier(self::SECRET),
+            new UtcClock(),
         );
 
         $this->expectException(InvalidRefreshTokenException::class);
@@ -63,8 +65,8 @@ final class RefreshSessionUseCaseTest extends TestCase
         $users = new InMemoryUserRepository();
         $userId = $users->save($this->user(organizationId: 1));
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $issuer = new RefreshTokenIssuer($refreshTokens);
-        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+        $issuer = new RefreshTokenIssuer($refreshTokens, new UtcClock());
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET), new UtcClock());
 
         $issued = $issuer->issue($userId, 1);
         $rotated = $useCase->execute($issued->rawToken); // spend the first token
@@ -97,7 +99,7 @@ final class RefreshSessionUseCaseTest extends TestCase
             issuedAt: '2020-01-01 00:00:00',
             expiresAt: '2020-01-08 00:00:00',
         ));
-        $useCase = new RefreshSessionUseCase($refreshTokens, $users, new RefreshTokenIssuer($refreshTokens), new LocalBearerTokenVerifier(self::SECRET));
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, new RefreshTokenIssuer($refreshTokens, new UtcClock()), new LocalBearerTokenVerifier(self::SECRET), new UtcClock());
 
         $this->expectException(InvalidRefreshTokenException::class);
         $useCase->execute($raw);
@@ -108,9 +110,9 @@ final class RefreshSessionUseCaseTest extends TestCase
         $users = new InMemoryUserRepository();
         $userId = $users->save($this->user(organizationId: 1, status: 'disabled'));
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $issuer = new RefreshTokenIssuer($refreshTokens, new UtcClock());
         $issued = $issuer->issue($userId, 1);
-        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET), new UtcClock());
 
         $this->expectException(InvalidRefreshTokenException::class);
         $useCase->execute($issued->rawToken);
@@ -122,9 +124,9 @@ final class RefreshSessionUseCaseTest extends TestCase
         // User now lives in org 9, but the token was minted for org 1.
         $userId = $users->save($this->user(organizationId: 9));
         $refreshTokens = new InMemoryRefreshTokenRepository();
-        $issuer = new RefreshTokenIssuer($refreshTokens);
+        $issuer = new RefreshTokenIssuer($refreshTokens, new UtcClock());
         $issued = $issuer->issue($userId, 1);
-        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET));
+        $useCase = new RefreshSessionUseCase($refreshTokens, $users, $issuer, new LocalBearerTokenVerifier(self::SECRET), new UtcClock());
 
         $this->expectException(InvalidRefreshTokenException::class);
         $useCase->execute($issued->rawToken);

--- a/tests/Auth/RefreshTokenIssuerTest.php
+++ b/tests/Auth/RefreshTokenIssuerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Auth\RefreshTokenSecret;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\InMemoryRefreshTokenRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves the Clock sweep: with an injected {@see FixedClock} the minted
+ * issued-at / expires-at instants are fully deterministic (no real-time drift),
+ * so refresh-token lifetime math can be asserted to the second.
+ */
+final class RefreshTokenIssuerTest extends TestCase
+{
+    public function test_fixed_clock_makes_issued_and_expiry_instants_deterministic(): void
+    {
+        $repository = new InMemoryRefreshTokenRepository();
+        // Fixed UTC instant 2026-06-06 03:00:00 (default of FixedClock).
+        $issuer = new RefreshTokenIssuer($repository, new FixedClock());
+
+        $issued = $issuer->issue(userId: 42, organizationId: 7);
+
+        // expiry = fixed now + 14d, computed from the clock, not wall time.
+        self::assertSame('2026-06-20 03:00:00', $issued->expiresAt);
+        self::assertSame(1781924400, $issued->expiresAtTimestamp);
+
+        // The persisted record's issued-at is the fixed instant.
+        $record = $repository->findByHash(RefreshTokenSecret::hash($issued->rawToken));
+        self::assertNotNull($record);
+        self::assertSame('2026-06-06 03:00:00', $record->issuedAt);
+        self::assertSame('2026-06-20 03:00:00', $record->expiresAt);
+
+        // Re-issuing under the same fixed clock yields identical timestamps:
+        // the determinism the sweep buys (previously time()-dependent).
+        $again = $issuer->issue(userId: 42, organizationId: 7);
+        self::assertSame($issued->expiresAt, $again->expiresAt);
+        self::assertSame($issued->expiresAtTimestamp, $again->expiresAtTimestamp);
+    }
+}

--- a/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
+++ b/tests/InvoiceDownloadToken/DownloadInvoicePdfHandlerTest.php
@@ -16,6 +16,7 @@ use NeneInvoice\InvoiceDownloadToken\DownloadInvoicePdfHandler;
 use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadToken;
 use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Pdf\MpdfFactory;
+use NeneInvoice\Tests\Support\FixedClock;
 use NeneInvoice\Tests\Support\InMemoryClientRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySealRepository;
 use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
@@ -66,6 +67,7 @@ final class DownloadInvoicePdfHandlerTest extends TestCase
             $this->psr17,
             new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
             $holder,
+            new FixedClock(),
         );
     }
 


### PR DESCRIPTION
Closes #591

## 概要

検品C「準拠 sweep」の **Clock レーン**。設計: `_work/reports/2026-07-06/upstream-design/06-clock-v-config-sweep.md`（Recipe A）。invoice は既に多数の UseCase が NENE2 `ClockInterface`/`UtcClock` を採用済み（audit ◎採用）だが、**認証まわりの現在時刻直書き**が残っていた。実 grep で全網羅し、DI 経路がクリーンな認証クラスタを ClockInterface 注入へ置換した。

## 置換サイト（生 time() は audit 計測=4 → 0 に）

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `Auth/RefreshTokenIssuer.php` | `time()` | `$this->clock->now()->getTimestamp()` |
| `Auth/LoginUseCase.php` | `time()` ×2（スロットル窓・iat/exp） | 同上 |
| `Auth/RefreshSessionUseCase.php` | `date('Y-m-d H:i:s')` / `time()` | `$this->clock->now()->format(...)` / `->getTimestamp()` |
| `Auth/LogoutUseCase.php` | `date('Y-m-d H:i:s')`（revokedAt） | `$this->clock->now()->format(...)` |
| `InvoiceDownloadToken/DownloadInvoicePdfHandler.php` | `new DateTimeImmutable()`（失効判定 now） | `$this->clock->now()->format(...)` |

## DI 配線

- `AuthServiceProvider`: `clock()` ヘルパを追加し、RefreshTokenIssuer / Login / RefreshSession / Logout の各ファクトリへ `ClockInterface` を注入。
- `InvoiceDownloadTokenServiceProvider`: DownloadInvoicePdfHandler ファクトリへ `ClockInterface` を注入。
- 既定 `UtcClock` は `RuntimeServiceProvider` で束縛済み（新規束縛なし）。独自 Clock は作らない。

## 本番不変の担保

`UtcClock->now()->getTimestamp()` は `time()` と同値（Unix 秒・UTC）、`->format('Y-m-d H:i:s')` は プロセス TZ=UTC 下（`src/bootstrap.php`）で `date('Y-m-d H:i:s')` と同一文字列。**本番挙動は完全に不変**。

## テスト（FixedClock で決定論化）

- 既存の Auth/download テストは注入引数を追加（トークンを実時刻 verifier が検証する経路は `UtcClock`、それ以外は `FixedClock`）。
- **`tests/Auth/RefreshTokenIssuerTest.php`（新規）**: 固定時計で issued-at=`2026-06-06 03:00:00` / expires-at=`2026-06-20 03:00:00` / expiresTs=`1781924400` を秒単位で断定し、再発行しても同値 = 決定論を実証。
- `composer test` 緑（898 tests / 3152 assertions）、`analyse` OK、`cs` 0。

## スコープ外（設計 06 準拠・別レイヤー）

- CRUD `Pdo*Repository` の `created_at`/`updated_at` 用 `date('Y-m-d H:i:s')` — 永続層の監査スタンプ。テストは InMemory ダブルを使い決定論価値が低く、参照製品 contact/serve も据え置き。
- `Support/Jst::today()` / `Jst::nowString()` と呼出側（CSV ファイル名・overdue 判定・list filter 既定）— 設計 06 の「中」難度（静的/VO へ clock を貫通させる要）。別 issue 候補。
- Validation V / ConfigLoader — 設計 06 に従い defer。

## セルフレビュー

- 会計・採番・PDF ロジックは不変（時刻源のみ差し替え）。
- 命名レジストリへの影響なし。非破壊（optional でなく必須注入だが全構築サイトを同一 PR で更新）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
