### PR TITLE
feat(demo): 税理士リード向け「使い捨て org」デモ（/demo/{template}・使い捨て org 方式）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,14 @@ TENANT_RESOLUTION=single
 ORG_SLUG=
 BASE_DOMAIN=localhost
 
+# --- Disposable-demo mode (税理士リード向けデモ・使い捨て org) ---
+# 1 にすると公開ルート `GET /demo/{template}`（template ∈ kensetsu|bldmainte|seisaku）が
+# 有効になり、都度ランダム slug の使い捨て org を生成・業種シード投入・セッション発行して
+# `/{slug}/dashboard` へ 302 する。**デモ機専用**。本番・通常インストールでは未設定(=無効)のままにする。
+# 前提: `TENANT_RESOLUTION=path`（single だと soleOrgFallback で全員同一 org に落ちる）＋ HTTPS
+# （Cookie は Secure 固定。localhost は secure 扱い）。使い捨て org の掃除は tools/sweep-demo.php を cron で。
+# DEMO_MODE=1
+
 # --- Recurring billing execution (#526) ---
 # 1（既定）: 共用ホスティング(Tier A・cron 不可)向け。認証済み /admin/ リクエスト時に
 #   期日到来の定期請求の「下書き」を自動生成する（組織ごと 1日1回にスロットル）。

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -19,6 +19,7 @@ use NeneInvoice\Company\CompanyRouteRegistrar;
 use NeneInvoice\Company\CompanySettingsNotFoundExceptionHandler;
 use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Dashboard\DashboardRouteRegistrar;
+use NeneInvoice\Demo\DemoRouteRegistrar;
 use NeneInvoice\GatewaySettings\GatewaySettingsRouteRegistrar;
 use NeneInvoice\Invoice\InvoiceEmailExceptionHandler;
 use NeneInvoice\Invoice\InvoiceNotFoundExceptionHandler;
@@ -108,6 +109,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $serviceTokenRoutes = $container->get(ServiceTokenRouteRegistrar::class);
                     $paymentLinkRoutes = $container->get(PaymentLinkRouteRegistrar::class);
                     $gatewaySettingsRoutes = $container->get(GatewaySettingsRouteRegistrar::class);
+                    $demoRoutes = $container->get(DemoRouteRegistrar::class);
+
+                    if (!$demoRoutes instanceof DemoRouteRegistrar) {
+                        throw new LogicException('Demo route registrar service is invalid.');
+                    }
 
                     if (!$dashboardRoutes instanceof DashboardRouteRegistrar) {
                         throw new LogicException('Dashboard route registrar service is invalid.');
@@ -189,7 +195,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Gateway settings route registrar service is invalid.');
                     }
 
-                    return [$dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $recurringInvoiceRoutes, $invoiceRoutes, $paymentRoutes, $bankTransactionRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes, $serviceTokenRoutes, $paymentLinkRoutes, $gatewaySettingsRoutes];
+                    return [$demoRoutes, $dashboardRoutes, $authRoutes, $auditRoutes, $organizationRoutes, $userRoutes, $clientRoutes, $companyRoutes, $quoteRoutes, $recurringInvoiceRoutes, $invoiceRoutes, $paymentRoutes, $bankTransactionRoutes, $serviceApiRoutes, $downloadTokenRoutes, $lineItemRoutes, $itemRoutes, $templateRoutes, $serviceTokenRoutes, $paymentLinkRoutes, $gatewaySettingsRoutes];
                 },
             )
             ->set(

--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+
+/**
+ * Seeds a freshly created (disposable) demo organization with realistic,
+ * industry-specific business data for the tax-accountant demo (2026-07-07).
+ *
+ * Writes go through the shared {@see DatabaseQueryExecutorInterface} (one
+ * connection per request) — deliberately NOT a second PDO, which under SQLite
+ * would contend with the app's own connection ("database is locked"). Every row
+ * carries an explicit `organization_id` (never a request-scoped holder): the demo
+ * route is org-less at entry and provisions a brand-new tenant, so seeding is a
+ * deliberate cross-tenant write into the org the caller just created — the same
+ * shape as {@see \NeneInvoice\Organization\PdoInitialAdminRepository}.
+ *
+ * All dates are relative to today (T) so the data always looks "current": a few
+ * invoices issued this month, one or two overdue, some paid this month. Amounts,
+ * withholding, and registration numbers follow the seed specification
+ * (`handoff-invoice-demo-seed-2026-07-07.md`). Each template carries exactly one
+ * payer-name-mismatch reconciliation case (`payer_aliases` + `bank_transactions`).
+ */
+final class DemoDataSeeder
+{
+    private int $orgId;
+    private string $now;
+    private DateTimeImmutable $today;
+
+    public function __construct(
+        private readonly DatabaseQueryExecutorInterface $query,
+        private readonly ClockInterface $clock,
+    ) {
+    }
+
+    public function seed(int $orgId, DemoTemplate $template): void
+    {
+        $this->orgId = $orgId;
+        $nowDt = $this->clock->now();
+        $this->now = $nowDt->format('Y-m-d H:i:s');
+        // Midnight of the clock's current date (an explicit date string, not a
+        // wall-clock read), so relative seed dates anchor to a stable "today".
+        $this->today = new DateTimeImmutable($nowDt->format('Y-m-d'));
+
+        match ($template) {
+            DemoTemplate::Kensetsu => $this->seedKensetsu(),
+            DemoTemplate::Bldmainte => $this->seedBldmainte(),
+            DemoTemplate::Seisaku => $this->seedSeisaku(),
+        };
+    }
+
+    // ---------------------------------------------------------------- dates
+    private function dayThisMonth(int $d): string
+    {
+        return $this->today->format('Y-m-') . sprintf('%02d', $d);
+    }
+
+    private function dayPrevMonth(int $d): string
+    {
+        return $this->today->modify('first day of last month')->format('Y-m-') . sprintf('%02d', $d);
+    }
+
+    private function endThisMonth(): string
+    {
+        return $this->today->modify('last day of this month')->format('Y-m-d');
+    }
+
+    private function endPrevMonth(): string
+    {
+        return $this->today->modify('last day of last month')->format('Y-m-d');
+    }
+
+    private function endTwoMonthsAgo(): string
+    {
+        return $this->today->modify('-2 months')->modify('last day of this month')->format('Y-m-d');
+    }
+
+    private function dayTwoMonthsAgo(int $d): string
+    {
+        return $this->today->modify('-2 months')->format('Y-m-') . sprintf('%02d', $d);
+    }
+
+    private function endNextMonth(): string
+    {
+        return $this->today->modify('last day of next month')->format('Y-m-d');
+    }
+
+    private function firstOfNextMonth(): string
+    {
+        return $this->today->modify('first day of next month')->format('Y-m-d');
+    }
+
+    private function year(): int
+    {
+        return (int) $this->today->format('Y');
+    }
+
+    // ------------------------------------------------------------- inserters
+    private function setCompanySettings(
+        string $legalName,
+        string $address,
+        string $phone,
+        string $email,
+        string $registrationNumber,
+        string $bankName,
+        string $bankBranch,
+        string $accountType,
+        string $accountNumber,
+    ): void {
+        $this->query->execute(
+            'INSERT INTO company_settings
+                (organization_id, legal_name, address, phone, email, registration_number,
+                 bank_name, bank_branch, account_type, account_number, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->orgId, $legalName, $address, $phone, $email, $registrationNumber,
+                $bankName, $bankBranch, $accountType, $accountNumber, $this->now, $this->now,
+            ],
+        );
+    }
+
+    private function insertClient(string $name, ?string $kana, ?string $contact, ?string $email, ?string $address, ?string $regnum): int
+    {
+        return $this->query->insert(
+            'INSERT INTO clients
+                (organization_id, name, name_kana, contact_name, email, billing_address, registration_number, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [$this->orgId, $name, $kana, $contact, $email, $address, $regnum, $this->now, $this->now],
+        );
+    }
+
+    private function insertItem(string $description, int $unitCents, int $taxBps = 1000): void
+    {
+        $this->query->execute(
+            'INSERT INTO items
+                (organization_id, description, default_unit_price_cents, default_tax_rate_bps, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 0, ?, ?)',
+            [$this->orgId, $description, $unitCents, $taxBps, $this->now, $this->now],
+        );
+    }
+
+    /**
+     * @param list<array{string,int,int,int}> $lines [description, qty, unit_cents, tax_bps]
+     * @return array{0:int,1:int,2:int}                [subtotal, tax, total] in cents
+     */
+    private function calcTotals(array $lines): array
+    {
+        $subtotal = 0;
+        $taxByRate = [];
+        foreach ($lines as [$desc, $qty, $unit, $taxBps]) {
+            $lineSubtotal = $qty * $unit;
+            $subtotal += $lineSubtotal;
+            $taxByRate[$taxBps] = ($taxByRate[$taxBps] ?? 0) + $lineSubtotal;
+        }
+        $tax = 0;
+        foreach ($taxByRate as $bps => $taxable) {
+            $tax += (int) round($taxable * $bps / 10000);
+        }
+
+        return [$subtotal, $tax, $subtotal + $tax];
+    }
+
+    /** @param list<array{string,int,int,int}> $lines */
+    private function insertLines(string $parentType, int $parentId, array $lines): void
+    {
+        foreach ($lines as $i => [$desc, $qty, $unit, $taxBps]) {
+            $this->query->execute(
+                'INSERT INTO line_items
+                    (parent_type, parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [$parentType, $parentId, $desc, $qty, $unit, $taxBps, $i, $this->now, $this->now],
+            );
+        }
+    }
+
+    /** @param list<array{string,int,int,int}> $lines */
+    private function insertQuote(int $clientId, string $number, string $status, ?string $issuedAt, ?string $validUntil, ?string $notes, array $lines): int
+    {
+        [$sub, $tax, $total] = $this->calcTotals($lines);
+        $id = $this->query->insert(
+            'INSERT INTO quotes
+                (organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [$this->orgId, $clientId, $number, $status, $issuedAt, $validUntil, $sub, $tax, $total, $notes, $this->now, $this->now],
+        );
+        $this->insertLines('quote', $id, $lines);
+
+        return $id;
+    }
+
+    /** @param list<array{string,int,int,int}> $lines */
+    private function insertInvoice(
+        int $clientId,
+        ?string $number,
+        string $status,
+        bool $isQualified,
+        ?string $issuedAt,
+        ?string $dueAt,
+        ?string $notes,
+        array $lines,
+        ?int $quoteId = null,
+    ): int {
+        [$sub, $tax, $total] = $this->calcTotals($lines);
+        $id = $this->query->insert(
+            'INSERT INTO invoices
+                (organization_id, client_id, quote_id, invoice_number, status, is_qualified_invoice, issued_at, due_at, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [
+                $this->orgId, $clientId, $quoteId, $number, $status, $isQualified ? 1 : 0,
+                $issuedAt, $dueAt, $sub, $tax, $total, $notes, $this->now, $this->now,
+            ],
+        );
+        $this->insertLines('invoice', $id, $lines);
+
+        return $id;
+    }
+
+    private function insertPayment(int $invoiceId, int $amountCents, string $paidAt, string $method, ?string $note): int
+    {
+        return $this->query->insert(
+            'INSERT INTO payments
+                (organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
+            [$this->orgId, $invoiceId, $amountCents, $paidAt, $method, $note, $this->now, $this->now],
+        );
+    }
+
+    private function insertPayerAlias(string $normalizedName, int $clientId): void
+    {
+        $this->query->execute(
+            'INSERT INTO payer_aliases (organization_id, normalized_name, client_id, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)',
+            [$this->orgId, $normalizedName, $clientId, $this->now, $this->now],
+        );
+    }
+
+    private function insertBankTransaction(
+        string $valueDate,
+        int $amountCents,
+        string $payerName,
+        string $description,
+        string $status,
+        ?int $matchedInvoiceId = null,
+        ?int $matchedPaymentId = null,
+    ): void {
+        $this->query->execute(
+            'INSERT INTO bank_transactions
+                (organization_id, value_date, direction, amount_cents, payer_name, description, bank_reference, status, matched_invoice_id, matched_payment_id, imported_at, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $this->orgId, $valueDate, 'credit', $amountCents, $payerName, $description, null,
+                $status, $matchedInvoiceId, $matchedPaymentId, $this->now, $this->now, $this->now,
+            ],
+        );
+    }
+
+    /** @param list<array{string,int,int,int}> $lines */
+    private function insertRecurring(int $clientId, string $name, array $lines, string $nextRunOn, ?string $notes): void
+    {
+        [$sub, $tax, $total] = $this->calcTotals($lines);
+        $id = $this->query->insert(
+            'INSERT INTO recurring_invoices
+                (organization_id, client_id, name, frequency, subtotal_cents, tax_cents, total_cents, next_run_on, is_active, notes, is_deleted, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, 0, ?, ?)',
+            [$this->orgId, $clientId, $name, 'monthly', $sub, $tax, $total, $nextRunOn, $notes, $this->now, $this->now],
+        );
+        $this->insertLines('recurring_invoice', $id, $lines);
+    }
+
+    private function upsertSequence(string $docType, int $year, int $lastNumber): void
+    {
+        $this->query->execute(
+            'INSERT INTO document_sequences (organization_id, doc_type, year, last_number) VALUES (?, ?, ?, ?)',
+            [$this->orgId, $docType, $year, $lastNumber],
+        );
+    }
+
+    private function invoiceNumber(int $n): string
+    {
+        return sprintf('INV-%d-%03d', $this->year(), $n);
+    }
+
+    private function quoteNumber(int $n): string
+    {
+        return sprintf('EST-%d-%03d', $this->year(), $n);
+    }
+
+    // ============================================================ templates
+    private function seedKensetsu(): void
+    {
+        $this->setCompanySettings(
+            '株式会社山手建設',
+            '東京都渋谷区神南1-2-3 山手ビル5F',
+            '03-5555-1234',
+            'info@yamate-kensetsu.example',
+            'T1010001011111',
+            'みずほ銀行',
+            '渋谷支店',
+            '普通',
+            '1234567',
+        );
+
+        foreach (['木工事', '基礎工事', '仮設工事', '内装工事', '諸経費'] as $item) {
+            $this->insertItem($item, 100000);
+        }
+
+        $c1 = $this->insertClient('大京建設株式会社', 'ダイキョウケンセツ', '部長 加藤', 'kato@daikyo-kensetsu.example', '東京都新宿区西新宿3-1-1', 'T2020002022222');
+        $c2 = $this->insertClient('有限会社丸和不動産', 'マルワフドウサン', '丸山', 'maruyama@maruwa.example', '東京都杉並区高円寺1-1-1', 'T3030003033333');
+        $c3 = $this->insertClient('株式会社ミナト工務店', 'ミナトコウムテン', '港', 'minato@minato-koumuten.example', '神奈川県横浜市中区港町1-1', 'T4040004044444');
+        $c4 = $this->insertClient('田中 一郎', 'タナカ イチロウ', null, 'tanaka@example.example', '東京都世田谷区成城2-2-2', null);
+        $c5 = $this->insertClient('佐藤 花子', 'サトウ ハナコ', null, 'sato@example.example', '東京都大田区田園調布3-3-3', null);
+        $c6 = $this->insertClient('大和ハウジング株式会社', 'ヤマトハウジング', '大和', 'yamato@yamato-housing.example', '埼玉県さいたま市大宮区1-1-1', 'T5050005055555');
+
+        // 見積（見積→請求の動線）
+        $q1 = $this->insertQuote($c1, $this->quoteNumber(1), 'accepted', $this->dayPrevMonth(15), $this->endThisMonth(), '〇〇邸新築 木工事', [['木工事', 1, 2800000, 1000]]);
+        $this->insertQuote($c4, $this->quoteNumber(2), 'sent', $this->dayThisMonth(3), $this->endNextMonth(), '増築工事一式', [['増築工事一式', 1, 1200000, 1000]]);
+
+        // 請求（10件・ステータス散らし・期限超過1件）
+        $i1 = $this->insertInvoice($c1, $this->invoiceNumber(1), 'paid', true, $this->dayPrevMonth(20), $this->endThisMonth(), '出来高1回目・基礎工事', [['基礎工事', 1, 1500000, 1000]]);
+        $this->insertInvoice($c1, $this->invoiceNumber(2), 'issued', true, $this->dayThisMonth(5), $this->endNextMonth(), '出来高2回目・木工事', [['木工事', 1, 1000000, 1000], ['造作工事', 1, 300000, 1000]], $q1);
+        $this->insertInvoice($c5, $this->invoiceNumber(3), 'issued', true, $this->endTwoMonthsAgo(), $this->endPrevMonth(), '内装工事', [['内装工事', 1, 680000, 1000]]);
+        $i4 = $this->insertInvoice($c2, $this->invoiceNumber(4), 'paid', true, $this->dayPrevMonth(10), $this->dayThisMonth(10), '諸経費精算', [['諸経費', 1, 240000, 1000]]);
+        $this->insertInvoice($c4, $this->invoiceNumber(5), 'issued', true, $this->dayThisMonth(1), $this->endNextMonth(), '増築・出来高1回目', [['木工事', 1, 600000, 1000]]);
+        $this->insertInvoice($c3, null, 'draft', false, null, null, '仮設工事（下書き）', [['仮設工事', 1, 350000, 1000]]);
+        $this->insertInvoice($c1, $this->invoiceNumber(6), 'issued', true, $this->dayPrevMonth(28), $this->endThisMonth(), '追加木工事', [['木工事', 1, 180000, 1000]]);
+        $i8 = $this->insertInvoice($c5, $this->invoiceNumber(7), 'paid', true, $this->dayPrevMonth(15), $this->dayThisMonth(15), '基礎補修', [['基礎工事', 1, 120000, 1000]]);
+        $this->insertInvoice($c6, null, 'draft', false, null, null, '内装工事（下書き）', [['内装工事', 1, 920000, 1000]]);
+        $i10 = $this->insertInvoice($c1, $this->invoiceNumber(8), 'paid', true, $this->dayPrevMonth(5), $this->dayThisMonth(5), '諸経費', [['諸経費', 1, 75000, 1000]]);
+
+        // 入金（paid 4件）
+        $p1 = $this->insertPayment($i1, 1650000, $this->endThisMonth(), 'bank_transfer', null);
+        $p4 = $this->insertPayment($i4, 264000, $this->dayThisMonth(8), 'bank_transfer', null);
+        $this->insertPayment($i8, 132000, $this->dayThisMonth(15), 'bank_transfer', null);
+        $this->insertPayment($i10, 82500, $this->dayThisMonth(5), 'bank_transfer', null);
+
+        // 消込見せ場（名義ズレ1件）: 丸和不動産 → 振込名義「マルワフドウサン」
+        $this->insertPayerAlias('マルワフドウサン', $c2);
+        $this->insertBankTransaction($this->dayThisMonth(8), 264000, 'マルワフドウサン', '振込入金', 'posted', $i4, $p4);
+        // 名義一致の通常消込（参考）
+        $this->insertBankTransaction($this->endThisMonth(), 1650000, 'ダイキヨウケンセツ(カ', '振込入金', 'posted', $i1, $p1);
+
+        $this->upsertSequence('invoice', $this->year(), 8);
+        $this->upsertSequence('quote', $this->year(), 2);
+    }
+
+    private function seedBldmainte(): void
+    {
+        $this->setCompanySettings(
+            '株式会社クリーンサポート東京',
+            '東京都新宿区新宿4-5-6 CSビル2F',
+            '03-6666-2345',
+            'info@cleansupport.example',
+            'T6060006066666',
+            '三井住友銀行',
+            '新宿支店',
+            '普通',
+            '7654321',
+        );
+
+        foreach (['日常清掃', '定期清掃', '設備点検', '貯水槽清掃', '消防設備点検'] as $item) {
+            $this->insertItem($item, 50000);
+        }
+
+        $clients = [
+            $this->insertClient('株式会社渋谷ビルディング', 'シブヤビルディング', '渋谷', 'shibuya@building.example', '東京都渋谷区道玄坂1-1-1', 'T7070007077777'),
+            $this->insertClient('新宿センタービル管理組合', 'シンジュクセンタービル', '管理人', 'kanri@shinjuku-center.example', '東京都新宿区西新宿2-2-2', null),
+            $this->insertClient('株式会社丸の内商事', 'マルノウチショウジ', '丸の内', 'marunouchi@shoji.example', '東京都千代田区丸の内1-1-1', 'T8080008088888'),
+            $this->insertClient('池袋パークタワー管理組合', 'イケブクロパークタワー', '管理人', 'kanri@ikebukuro-park.example', '東京都豊島区東池袋3-3-3', null),
+            $this->insertClient('有限会社原宿不動産', 'ハラジュクフドウサン', '原宿', 'harajuku@fudosan.example', '東京都渋谷区神宮前1-1-1', null),
+            $this->insertClient('株式会社品川エステート', 'シナガワエステート', '品川', 'shinagawa@estate.example', '東京都港区港南2-2-2', null),
+            $this->insertClient('目黒デンタルクリニック', 'メグロデンタルクリニック', '院長', 'meguro@dental.example', '東京都目黒区目黒1-1-1', null),
+            $this->insertClient('株式会社上野リテール', 'ウエノリテール', '上野', 'ueno@retail.example', '東京都台東区上野4-4-4', null),
+            $this->insertClient('中野サンモール商店会', 'ナカノサンモール', '会長', 'nakano@sunmall.example', '東京都中野区中野5-5-5', null),
+            $this->insertClient('株式会社世田谷ハウジング', 'セタガヤハウジング', '世田谷', 'setagaya@housing.example', '東京都世田谷区太子堂1-1-1', null),
+        ];
+
+        // recurring_invoices（毎月定額・次回=翌月01）
+        $recurring = [
+            [0, '日常清掃', 80000], [1, '定期清掃＋設備点検', 60000], [2, '日常清掃', 50000], [3, '定期清掃', 40000],
+            [4, '設備点検', 20000], [5, '日常清掃', 70000], [6, '定期清掃', 30000], [7, '日常清掃＋消防点検', 55000],
+            [8, '定期清掃', 35000], [9, '貯水槽清掃', 45000],
+        ];
+        foreach ($recurring as [$idx, $name, $sub]) {
+            $note = $idx === 9 ? '隔月請求（調整中）' : null;
+            $this->insertRecurring($clients[$idx], $name, [[$name, 1, $sub, 1000]], $this->firstOfNextMonth(), $note);
+        }
+
+        // 当月分（発行=当月01・期限=当月末）— recurring から一括生成された体
+        // status: paid=c1,c3,c5,c6,c7,c8 / issued(送付済)=c2,c4,c9 / draft=c10
+        $monthly = [
+            [0, 80000, 'paid'], [1, 60000, 'issued'], [2, 50000, 'paid'], [3, 40000, 'issued'],
+            [4, 20000, 'paid'], [5, 70000, 'paid'], [6, 30000, 'paid'], [7, 55000, 'paid'],
+            [8, 35000, 'issued'], [9, 45000, 'draft'],
+        ];
+        $seq = 0;
+        $c2Invoice = null;
+        foreach ($monthly as [$idx, $sub, $status]) {
+            $name = $recurring[$idx][1];
+            $isDraft = $status === 'draft';
+            $number = $isDraft ? null : $this->invoiceNumber(++$seq);
+            $issuedAt = $isDraft ? null : $this->dayThisMonth(1);
+            $dueAt = $isDraft ? null : $this->endThisMonth();
+            $invId = $this->insertInvoice($clients[$idx], $number, $status, !$isDraft, $issuedAt, $dueAt, '当月定期清掃料', [[$name, 1, $sub, 1000]]);
+            if ($idx === 1) {
+                $c2Invoice = $invId;
+            }
+            if ($status === 'paid') {
+                $this->insertPayment($invId, (int) round($sub * 1.1), $this->dayThisMonth(10), 'bank_transfer', null);
+            }
+        }
+
+        // 前月繰越（期限超過2件）: c5・c7 の前月分
+        $this->insertInvoice($clients[4], $this->invoiceNumber(++$seq), 'issued', true, $this->dayPrevMonth(1), $this->endPrevMonth(), '前月分・設備点検（未入金）', [['設備点検', 1, 20000, 1000]]);
+        $this->insertInvoice($clients[6], $this->invoiceNumber(++$seq), 'issued', true, $this->dayPrevMonth(1), $this->endPrevMonth(), '前月分・定期清掃（未入金）', [['定期清掃', 1, 30000, 1000]]);
+
+        // 消込見せ場: 新宿センタービル管理組合 → 振込名義「シンジユクセンタ-ビル」（当月請求への入金）
+        $this->insertPayerAlias('シンジユクセンタ-ビル', $clients[1]);
+        $this->insertBankTransaction($this->dayThisMonth(5), 66000, 'シンジユクセンタ-ビル', '振込入金（要消込）', 'unmatched', $c2Invoice);
+
+        $this->upsertSequence('invoice', $this->year(), $seq);
+    }
+
+    private function seedSeisaku(): void
+    {
+        $this->setCompanySettings(
+            '株式会社アトリエノート',
+            '東京都渋谷区恵比寿1-2-3 ノートビル4F',
+            '03-7777-3456',
+            'info@atelier-note.example',
+            'T9090009099999',
+            'GMOあおぞらネット銀行',
+            '法人営業部',
+            '普通',
+            '2468013',
+        );
+
+        foreach (['ディレクション費', '制作費', '月額運用(顧問料)', '撮影費', '追加修正費'] as $item) {
+            $this->insertItem($item, 100000);
+        }
+
+        $c1 = $this->insertClient('株式会社サンライズ広告', 'サンライズコウコク', '宣伝部', 'promo@sunrise-ad.example', '東京都港区赤坂1-1-1', 'T1112223334445');
+        $c2 = $this->insertClient('合同会社ブルームテック', 'ブルームテック', 'CTO', 'cto@bloomtech.example', '東京都渋谷区桜丘町2-2-2', null);
+        $c3 = $this->insertClient('株式会社北斗製作所', 'ホクトセイサクショ', '総務', 'soumu@hokuto.example', '東京都大田区蒲田1-1-1', 'T2223334445556');
+        $c4 = $this->insertClient('一般社団法人みらい教育協会', 'ミライキョウイクキョウカイ', '事務局', 'jimu@mirai-edu.example', '東京都文京区本郷3-3-3', null);
+        $c5 = $this->insertClient('株式会社エヌ・ワークス', 'エヌワークス', '代表', 'ceo@n-works.example', '東京都中野区中野4-4-4', null);
+
+        // 源泉徴収あり：各請求は [報酬 @10%] ＋ [源泉徴収 マイナス行 @0%]。合計＝請求額（＝振込額）。
+        // 番号は draft を除いて発番。[clientId, status, issued, due, 摘要, 報酬, 源泉, paidAmount|null]
+        $rows = [
+            [$c1, 'issued', $this->dayThisMonth(1), $this->endNextMonth(), '月額運用(顧問料)', 100000, 10210, null],
+            [$c3, 'issued', $this->dayThisMonth(1), $this->endNextMonth(), '月額運用(顧問料)', 150000, 15315, null],
+            [$c5, 'paid', $this->dayPrevMonth(1), $this->endThisMonth(), '月額運用(顧問料)', 80000, 8168, 79832],
+            [$c1, 'issued', $this->dayPrevMonth(20), $this->endThisMonth(), 'スポット制作(LP一式)', 500000, 51050, null],
+            [$c2, 'issued', $this->dayTwoMonthsAgo(25), $this->dayPrevMonth(25), 'ディレクション＋制作', 350000, 35735, null],
+            [$c4, 'paid', $this->dayPrevMonth(10), $this->dayThisMonth(10), '撮影費', 220000, 22462, 219538],
+            [$c3, 'draft', null, null, '追加修正費', 60000, 6126, null],
+            [$c2, 'issued', $this->dayThisMonth(1), $this->endNextMonth(), '月額運用(顧問料)', 120000, 12252, null],
+            [$c5, 'paid', $this->dayPrevMonth(28), $this->endThisMonth(), 'スポット(バナー制作)', 90000, 9189, 89811],
+            [$c1, 'paid', $this->dayPrevMonth(5), $this->dayThisMonth(5), '追加ディレクション', 45000, 4594, 44906],
+        ];
+
+        $inv5 = null;
+        $seq = 0;
+        foreach ($rows as [$clientId, $status, $issued, $due, $summary, $reward, $withholding, $paid]) {
+            $isDraft = $status === 'draft';
+            $number = $isDraft ? null : $this->invoiceNumber(++$seq);
+            $lines = [
+                [$summary, 1, $reward, 1000],
+                ['源泉徴収税', 1, -$withholding, 0],
+            ];
+            $invId = $this->insertInvoice($clientId, $number, $status, !$isDraft, $issued, $due, '源泉徴収あり', $lines);
+            if ($summary === 'ディレクション＋制作') {
+                $inv5 = $invId;
+            }
+            if ($paid !== null) {
+                $this->insertPayment($invId, $paid, $due ?? $this->dayThisMonth(10), 'bank_transfer', null);
+            }
+        }
+
+        // 消込見せ場: ブルームテック → 振込名義「ブル-ムテツク(ド」（期限超過 INV-5 への遅延入金）
+        $this->insertPayerAlias('ブル-ムテツク(ド', $c2);
+        $this->insertBankTransaction($this->dayThisMonth(3), 349265, 'ブル-ムテツク(ド', '振込入金（遅延・要消込）', 'unmatched', $inv5);
+
+        $this->upsertSequence('invoice', $this->year(), $seq);
+    }
+}

--- a/src/Demo/DemoRouteRegistrar.php
+++ b/src/Demo/DemoRouteRegistrar.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the disposable-demo route. Invoked with the {@see Router} during
+ * runtime assembly (see {@see \NeneInvoice\ApplicationServiceProvider}).
+ *
+ * `GET /demo/{template}` is public and org-less (it *creates* orgs); it is gated
+ * at runtime by `DEMO_MODE=1` inside the handler and bypasses org resolution
+ * ({@see \NeneInvoice\Organization\Resolution\OrgResolverMiddleware}).
+ */
+final readonly class DemoRouteRegistrar
+{
+    public function __construct(private StartDemoHandler $handler)
+    {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+        $router->get('/demo/{template}', static fn (ServerRequestInterface $r) => $handler->handle($r));
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the disposable-demo domain: the data seeder, the HTTP handler, and its
+ * route registrar. All dependencies (org creation, refresh-token issuance, PDO
+ * connection factory) are reused from existing providers — no auth code is added.
+ */
+final readonly class DemoServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DemoDataSeeder::class,
+                static function (ContainerInterface $c): DemoDataSeeder {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $c->get(ClockInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new DemoDataSeeder($query, $clock);
+                },
+            )
+            ->set(
+                StartDemoHandler::class,
+                static function (ContainerInterface $c): StartDemoHandler {
+                    $createOrg = $c->get(CreateOrganizationUseCaseInterface::class);
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $seeder = $c->get(DemoDataSeeder::class);
+                    $refreshTokenIssuer = $c->get(RefreshTokenIssuer::class);
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+                    $psr17 = $c->get(Psr17Factory::class);
+
+                    if (!$createOrg instanceof CreateOrganizationUseCaseInterface) {
+                        throw new LogicException('Create organization use case service is invalid.');
+                    }
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    if (!$seeder instanceof DemoDataSeeder) {
+                        throw new LogicException('Demo data seeder service is invalid.');
+                    }
+
+                    if (!$refreshTokenIssuer instanceof RefreshTokenIssuer) {
+                        throw new LogicException('Refresh token issuer service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    if (!$psr17 instanceof Psr17Factory) {
+                        throw new LogicException('PSR-17 factory service is invalid.');
+                    }
+
+                    return new StartDemoHandler($createOrg, $query, $seeder, $refreshTokenIssuer, $problemDetails, $psr17);
+                },
+            )
+            ->set(
+                DemoRouteRegistrar::class,
+                static function (ContainerInterface $c): DemoRouteRegistrar {
+                    $handler = $c->get(StartDemoHandler::class);
+
+                    if (!$handler instanceof StartDemoHandler) {
+                        throw new LogicException('Start demo handler service is invalid.');
+                    }
+
+                    return new DemoRouteRegistrar($handler);
+                },
+            );
+    }
+}

--- a/src/Demo/DemoTemplate.php
+++ b/src/Demo/DemoTemplate.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+/**
+ * The industry templates a disposable demo organization can be seeded with.
+ *
+ * The value is the `{template}` segment of `GET /demo/{template}` and the key the
+ * {@see DemoDataSeeder} switches on. Three industries were chosen (2026-07-07) as
+ * the tax-accountant referral set: construction, building maintenance, and
+ * production/consulting (with withholding tax).
+ */
+enum DemoTemplate: string
+{
+    case Kensetsu = 'kensetsu';
+    case Bldmainte = 'bldmainte';
+    case Seisaku = 'seisaku';
+
+    /** Human label (Japanese) for the seeded organization / logging. */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Kensetsu => '建設・工務店',
+            self::Bldmainte => 'ビルメンテ・清掃',
+            self::Seisaku => '制作・コンサル',
+        };
+    }
+}

--- a/src/Demo/StartDemoHandler.php
+++ b/src/Demo/StartDemoHandler.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Auth\RefreshTokenSecret;
+use NeneInvoice\Auth\SessionCookies;
+use NeneInvoice\Http\BasePath;
+use NeneInvoice\Organization\CreateOrganizationInput;
+use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
+use NeneInvoice\Organization\OrganizationSlugConflictException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * `GET /demo/{template}` — public, gated by `DEMO_MODE=1`. Provisions a brand-new
+ * **disposable** organization, seeds it with industry data, seats a session, and
+ * redirects into the freshly minted tenant's SPA (2026-07-07 「使い捨て org」デモ).
+ *
+ * Auth handoff (方式A, path-tenancy): this issues the same `ni_refresh` + `ni_csrf`
+ * cookies a login would, but **scoped to `/{slug}/auth`** so the browser sends
+ * them to the SPA's slug-prefixed `POST /{slug}/auth/refresh` on first load. The
+ * SPA obtains its in-memory access token from that one silent refresh (auth-gate)
+ * — no access token is handed over here, and the authentication core (rotation /
+ * SessionCookies body) is untouched. Reloading the tenant SPA drops to the login
+ * screen (one-shot); the intended path is to re-hit `/demo/{template}` for a
+ * fresh org, which is the "reset to initial state" affordance.
+ */
+final readonly class StartDemoHandler implements RequestHandlerInterface
+{
+    /** How many random slugs to try before giving up on a collision. */
+    private const SLUG_ATTEMPTS = 5;
+
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $createOrganization,
+        private DatabaseQueryExecutorInterface $query,
+        private DemoDataSeeder $seeder,
+        private RefreshTokenIssuer $refreshTokenIssuer,
+        private ProblemDetailsResponseFactory $problemDetails,
+        private Psr17Factory $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if ($this->env('DEMO_MODE', '0') !== '1') {
+            return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, 'Demo mode is not enabled on this instance.');
+        }
+
+        $params = (array) $request->getAttribute(\Nene2\Routing\Router::PARAMETERS_ATTRIBUTE, []);
+        $templateKey = isset($params['template']) && is_string($params['template']) ? $params['template'] : '';
+        $template = DemoTemplate::tryFrom($templateKey);
+
+        if ($template === null) {
+            return $this->problemDetails->create($request, 'not-found', 'Not Found', 404, "Unknown demo template '{$templateKey}'.");
+        }
+
+        $organization = $this->createDisposableOrg($template);
+        $slug = $organization->slug;
+        $orgId = $organization->id ?? 0;
+
+        $this->seeder->seed($orgId, $template);
+
+        // The demo admin was provisioned in the same transaction as the org; look
+        // up its id to seat a refresh-token family for it (cross-tenant read via
+        // the shared executor — no second connection).
+        $adminRow = $this->query->fetchOne(
+            'SELECT id FROM users WHERE organization_id = ? AND role = ? ORDER BY id ASC LIMIT 1',
+            [$orgId, 'admin'],
+        );
+        $adminId = (int) ($adminRow['id'] ?? 0);
+
+        $refreshToken = $this->refreshTokenIssuer->issue($adminId, $orgId);
+
+        // Scope the session cookies to the tenant slug so the browser sends them
+        // to the SPA's slug-prefixed /{slug}/auth/refresh (方式A). The install base
+        // (ADR 0015) is '' at the document root, '/invoice' under a subdirectory.
+        $installBase = BasePath::fromRequest($request);
+        $slugBase = $installBase . '/' . $slug;
+        $csrfToken = RefreshTokenSecret::generateCsrfToken();
+
+        return $this->responseFactory->createResponse(302)
+            ->withHeader('Location', $slugBase . '/dashboard')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($refreshToken->rawToken, $refreshToken->expiresAtTimestamp, $slugBase))
+            ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $refreshToken->expiresAtTimestamp, $slugBase));
+    }
+
+    private function createDisposableOrg(DemoTemplate $template): \NeneInvoice\Organization\Organization
+    {
+        $lastError = null;
+        for ($attempt = 0; $attempt < self::SLUG_ATTEMPTS; $attempt++) {
+            $slug = 'demo-' . bin2hex(random_bytes(4));
+            $input = new CreateOrganizationInput(
+                name: $this->companyName($template),
+                slug: $slug,
+                plan: 'free',
+                adminEmail: 'admin@' . $slug . '.demo.local',
+                adminPassword: bin2hex(random_bytes(16)),
+            );
+
+            try {
+                return $this->createOrganization->execute(null, $input);
+            } catch (OrganizationSlugConflictException $e) {
+                $lastError = $e;
+                continue;
+            }
+        }
+
+        throw $lastError ?? new OrganizationSlugConflictException('demo');
+    }
+
+    private function companyName(DemoTemplate $template): string
+    {
+        return match ($template) {
+            DemoTemplate::Kensetsu => '株式会社山手建設',
+            DemoTemplate::Bldmainte => '株式会社クリーンサポート東京',
+            DemoTemplate::Seisaku => '株式会社アトリエノート',
+        };
+    }
+
+    private function env(string $key, string $default): string
+    {
+        $value = $_ENV[$key] ?? getenv($key);
+
+        return is_string($value) && $value !== '' ? $value : $default;
+    }
+}

--- a/src/Http/BasePath.php
+++ b/src/Http/BasePath.php
@@ -25,7 +25,7 @@ final class BasePath
     public const REQUEST_ATTRIBUTE = 'app.base_path';
 
     /** API path prefixes that must reach the router, never the SPA shell. */
-    private const API_PREFIXES = ['/auth', '/admin', '/api', '/health', '/machine', '/examples'];
+    private const API_PREFIXES = ['/auth', '/admin', '/api', '/health', '/machine', '/examples', '/demo'];
 
     /**
      * @param array<string, mixed> $serverParams PSR-7 server params (or `$_SERVER`)

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -33,6 +33,7 @@ use NeneInvoice\BankTransaction\BankTransactionServiceProvider;
 use NeneInvoice\Client\ClientServiceProvider;
 use NeneInvoice\Company\CompanyServiceProvider;
 use NeneInvoice\Dashboard\DashboardServiceProvider;
+use NeneInvoice\Demo\DemoServiceProvider;
 use NeneInvoice\DocumentSequence\DocumentSequenceServiceProvider;
 use NeneInvoice\GatewaySettings\GatewaySettingsServiceProvider;
 use NeneInvoice\Invoice\InvoiceServiceProvider;
@@ -77,6 +78,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new ApplicationServiceProvider());
         $builder->addProvider(new AuditServiceProvider());
         $builder->addProvider(new DashboardServiceProvider());
+        $builder->addProvider(new DemoServiceProvider());
         $builder->addProvider(new InvoiceDownloadTokenServiceProvider());
         $builder->addProvider(new AuthServiceProvider());
         $builder->addProvider(new OrganizationServiceProvider());

--- a/src/Install/PayloadAcquisition.php
+++ b/src/Install/PayloadAcquisition.php
@@ -45,6 +45,7 @@ final class PayloadAcquisition
         '.env.example',
         'README.md',
         'var',
+        'tools',
     ];
 
     /** Upload ceiling; a host's effective limit (upload_max_filesize) may be smaller. */

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -38,6 +38,10 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         '/api/',
         '/invoices/download/',
         '/admin/organizations',
+        // Disposable-demo provisioning (`GET /demo/{template}`) is org-less: it
+        // *creates* a new tenant, so there is no slug in the URL to resolve. Gated
+        // by DEMO_MODE in the handler. Kept out of path-tenancy resolution here.
+        '/demo/',
         // Self-service identity: `/admin/me` returns the caller's own record from
         // token claims (user lookup is by id, not org-scoped), so it needs no org
         // context. Bypassing lets a cross-tenant superadmin (organization_id NULL)

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -19,7 +19,10 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/dist"
 STAGE="$DIST/build/stage"
 ZIP_NAME="nene-invoice-${VERSION}.zip"
-NENE2_CONSTRAINT="^1.6"
+# demo ブランチ（feat/demo-disposable-org）は GuardedJwtSecretResolver 等を含む
+# nene2 ^1.8.2 系を要求する（composer.json の require と一致させる）。旧値 ^1.6 は
+# 当該クラスを含まず、fail-close JWT が壊れるため是正（#576 追補）。
+NENE2_CONSTRAINT="^1.8.2"
 
 echo "=== NeNe Invoice Tier A release build: $VERSION ==="
 
@@ -46,6 +49,12 @@ cp -r "$ROOT/public_html" "$STAGE/public_html"
 cp -r "$ROOT/resources" "$STAGE/resources"
 cp "$ROOT/.env.example" "$STAGE/.env.example"
 cp "$ROOT/phinx.php" "$STAGE/phinx.php"
+# 本番 cron ツール（vendor/autoload.php をプロジェクト直下から require する）。
+# sweep-demo.php = 使い捨てデモ org の掃除、run-recurring.php = 定期請求の実行。
+# dev/ビルド専用ツール（build-release.sh / seed-dev.php 等）は同梱しない。
+mkdir -p "$STAGE/tools"
+cp "$ROOT/tools/sweep-demo.php" "$STAGE/tools/sweep-demo.php"
+cp "$ROOT/tools/run-recurring.php" "$STAGE/tools/run-recurring.php"
 cp "$ROOT/composer.json" "$STAGE/composer.json"
 cp "$ROOT/README.md" "$STAGE/README.md"
 

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * 使い捨てデモ org の掃除スクリプト（税理士リード向けデモ／`DEMO_MODE`）。
+ * 使い方: php tools/sweep-demo.php   （cron 例: 毎時 0 分）
+ *
+ * - slug prefix `demo-` の org を対象に、作成から DEMO_TTL_HOURS（既定 3）を過ぎたものを削除。
+ * - さらに容量上限 DEMO_MAX_ORGS（既定 200）を超える分は、古いものから削除（暴走・DoS 保険）。
+ * - org 本体の削除は監査つきの DeleteOrganizationUseCase 経由。子テーブルは使い捨てデータなので
+ *   best-effort で organization_id / 親経由に一括 DELETE（"消えていい" のが強み＝掃除は雑でよい）。
+ *
+ * 本番 org（`demo-` 以外の slug）には一切触れない。
+ */
+
+declare(strict_types=1);
+
+use Nene2\Config\AppConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Organization\DeleteOrganizationUseCaseInterface;
+use NeneInvoice\Organization\OrganizationNotFoundException;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+$container = (new RuntimeContainerFactory($root))->create();
+$container->get(AppConfig::class);
+
+$connectionFactory = $container->get(DatabaseConnectionFactoryInterface::class);
+assert($connectionFactory instanceof DatabaseConnectionFactoryInterface);
+$pdo = $connectionFactory->create();
+
+$ttlEnv   = getenv('DEMO_TTL_HOURS');
+$maxEnv   = getenv('DEMO_MAX_ORGS');
+$ttlHours = is_string($ttlEnv) && $ttlEnv !== '' ? (int) $ttlEnv : 3;
+$maxOrgs  = is_string($maxEnv) && $maxEnv !== '' ? (int) $maxEnv : 200;
+$cutoff   = date('Y-m-d H:i:s', time() - ($ttlHours * 3600));
+
+// 1) TTL 超過。SELECT は fetchAll で完全に読み切る（カーソルを開いたまま削除しないため）。
+$expiredStmt = $pdo->prepare("SELECT id FROM organizations WHERE slug LIKE 'demo-%' AND created_at < ? ORDER BY id ASC");
+$expiredStmt->execute([$cutoff]);
+$expired = array_map('intval', $expiredStmt->fetchAll(PDO::FETCH_COLUMN));
+
+// 2) 容量上限。新しい方から $maxOrgs 件を残し、あふれた古い分を対象に加える。
+$allDemo  = array_map('intval', $pdo->query("SELECT id FROM organizations WHERE slug LIKE 'demo-%' ORDER BY created_at DESC, id DESC")->fetchAll(PDO::FETCH_COLUMN));
+$overflow = array_slice($allDemo, $maxOrgs);
+
+$targets = array_values(array_unique(array_merge($expired, $overflow)));
+
+if ($targets === []) {
+    echo "掃除対象なし（demo org・TTL {$ttlHours}h・上限 {$maxOrgs}）。" . PHP_EOL;
+
+    return;
+}
+
+$delete = $container->get(DeleteOrganizationUseCaseInterface::class);
+assert($delete instanceof DeleteOrganizationUseCaseInterface);
+
+// organization_id を直接持つ子テーブル（line_items は親経由なので別処理）。
+$childTables = [
+    'clients', 'items', 'quotes', 'invoices', 'payments', 'bank_transactions',
+    'payer_aliases', 'recurring_invoices', 'company_settings', 'document_sequences',
+    'users', 'refresh_tokens', 'login_attempts', 'service_tokens',
+    'payment_links', 'invoice_download_tokens', 'templates', 'company_seal_images',
+];
+
+$swept = 0;
+foreach ($targets as $orgId) {
+    // line_items は organization_id を持たない（parent 経由）。親削除前に片付ける。
+    foreach (['invoice', 'quote', 'recurring_invoice'] as $parentType) {
+        $pdo->prepare(
+            "DELETE FROM line_items WHERE parent_type = ? AND parent_id IN
+                (SELECT id FROM {$parentType}s WHERE organization_id = ?)",
+        )->execute([$parentType, $orgId]);
+    }
+    foreach ($childTables as $table) {
+        try {
+            $pdo->prepare("DELETE FROM {$table} WHERE organization_id = ?")->execute([$orgId]);
+        } catch (\PDOException) {
+            // テーブルが無い環境（軽量構成）でも掃除は続行する。
+        }
+    }
+
+    try {
+        $delete->execute(null, $orgId);
+        $swept++;
+        echo "掃除: org {$orgId}" . PHP_EOL;
+    } catch (OrganizationNotFoundException) {
+        // すでに消えている（並行実行など）— 無視。
+    }
+}
+
+echo "{$swept} 件の demo org を掃除しました（TTL {$ttlHours}h・上限 {$maxOrgs}）。" . PHP_EOL;


### PR DESCRIPTION
## 概要
Rooters 土居さん経由の税理士リード向けデモ。`/demo/{template}` を踏むと使い捨て org を生成して業種シードを流し込み、`/{slug}/dashboard` へ 302 する。**2026-07-08 に `https://invoice.ayane.co.jp` で本番稼働・動作確認済み**。

## 方式（handoff-invoice-demo-2026-07-07.md）
- 使い捨て SQLite ではなく**使い捨て org**: 既存の org 論理分離（OrgResolverMiddleware + RequestScopedHolder、545テスト担保）に乗る。認証コードは新規ゼロ（LoginHandler の出力を模倣して JWT + refresh/csrf Cookie 発行）。
- `TENANT_RESOLUTION=path-scoped(multi)`・ブートストラップ Cookie は slug スコープ（案A・リロード非対応は受容）。
- 業種テンプレ3本: 建設（kensetsu）／ビルメンテ（bldmainte・recurring）／制作（seisaku・源泉）。
- 破棄: `tools/sweep-demo.php`（TTL スイープ・HETEML cron 毎時・実機稼働中）。

## 本コミット追加分
- `tools/build-release.sh`: NENE2_CONSTRAINT ^1.6 → ^1.8.2 是正（GuardedJwtSecretResolver 必須）＋ 本番 cron ツール（sweep-demo.php / run-recurring.php）の ZIP 同梱漏れ修正。いずれも HETEML 実デプロイで発覚。

## テスト
- デモ ZIP（nene-invoice-1.0.0-demo.zip）ビルド → HETEML staging → 本番配置で health 全 PASS・`/demo/{kensetsu|bldmainte|seisaku}` → 302 → dashboard 表示・MySQL シード成功を実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)