### PR TITLE
fix(auth): 前段プロキシが Authorization を剥ぐ共有ホストで Bearer 認証を回復する (#596)

### DIFF
--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -149,10 +149,22 @@ async function shouldRetryAfterRefresh(
 
 type Json = Record<string, unknown>
 
+/**
+ * Attaches the Bearer token to both `Authorization` and `X-Authorization`.
+ * Some shared-hosting front proxies (Tier A; observed on HETEML) strip the
+ * standard `Authorization` header before it reaches PHP, so the backend falls
+ * back to the mirror when the standard header is missing.
+ */
+function attachBearer(headers: Record<string, string>): void {
+  if (authToken === null) return
+  headers['Authorization'] = `Bearer ${authToken}`
+  headers['X-Authorization'] = `Bearer ${authToken}`
+}
+
 async function request<T>(method: string, path: string, body?: Json, isRetry = false): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (body !== undefined) headers['Content-Type'] = 'application/json'
-  if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
+  attachBearer(headers)
 
   let response: Response
   try {
@@ -195,7 +207,7 @@ function safeJsonParse(text: string): unknown {
 /** Fetches a binary resource and returns it as a Blob. Sends the Bearer token. */
 async function requestBlob(path: string, isRetry = false): Promise<Blob> {
   const headers: Record<string, string> = {}
-  if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
+  attachBearer(headers)
 
   let response: Response
   try {
@@ -223,7 +235,7 @@ async function requestBlob(path: string, isRetry = false): Promise<Blob> {
  */
 async function postCsv<T>(path: string, csv: string, isRetry = false): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json', 'Content-Type': 'text/csv' }
-  if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
+  attachBearer(headers)
 
   let response: Response
   try {
@@ -256,7 +268,7 @@ async function postCsv<T>(path: string, csv: string, isRetry = false): Promise<T
  */
 async function postBytes<T>(path: string, body: Blob, isRetry = false): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json', 'Content-Type': 'text/csv' }
-  if (authToken !== null) headers['Authorization'] = `Bearer ${authToken}`
+  attachBearer(headers)
 
   let response: Response
   try {

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,5 +1,11 @@
 RewriteEngine On
 
+# Some CGI/FastCGI shared hosts have Apache itself drop the Authorization
+# header; re-deliver it as an env var so PHP still sees it. Hosts whose *front
+# proxy* strips the header (e.g. HETEML) are covered separately by the SPA's
+# X-Authorization mirror + AuthorizationHeaderFallback.
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Nene2\Config\AppConfig;
 use Nene2\Http\ResponseEmitter;
+use NeneInvoice\Http\AuthorizationHeaderFallback;
 use NeneInvoice\Http\BasePath;
 use NeneInvoice\Http\RuntimeContainerFactory;
 use NeneInvoice\Http\SpaBasePlan;
@@ -46,6 +47,10 @@ $serverRequestCreator = new ServerRequestCreator(
 );
 
 $request = $serverRequestCreator->fromGlobals();
+
+// Tier A: some shared-hosting front proxies strip the standard Authorization
+// header before it reaches PHP; adopt the SPA's X-Authorization mirror instead.
+$request = AuthorizationHeaderFallback::apply($request);
 
 // --- Location-independent install (ADR 0015) ---------------------------------
 // Detect the URL base the app is installed under (document root / subdomain /

--- a/src/Http/AuthorizationHeaderFallback.php
+++ b/src/Http/AuthorizationHeaderFallback.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Recovers the Bearer token on shared hosting whose front proxy strips the
+ * standard `Authorization` header before it reaches PHP (Tier A concern,
+ * observed on HETEML — custom headers pass through, `Authorization` does not,
+ * so neither `.htaccess` tricks nor `CGIPassAuth` can help). The admin SPA
+ * mirrors the token into `X-Authorization`; that value is adopted only when
+ * `Authorization` is absent, so environments that deliver the standard header
+ * are unaffected.
+ */
+final class AuthorizationHeaderFallback
+{
+    public const string FALLBACK_HEADER = 'X-Authorization';
+
+    public static function apply(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if ($request->getHeaderLine('Authorization') !== '') {
+            return $request;
+        }
+
+        $fallback = $request->getHeaderLine(self::FALLBACK_HEADER);
+
+        if ($fallback === '') {
+            return $request;
+        }
+
+        return $request->withHeader('Authorization', $fallback);
+    }
+}

--- a/tests/Http/AuthorizationHeaderFallbackTest.php
+++ b/tests/Http/AuthorizationHeaderFallbackTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use NeneInvoice\Http\AuthorizationHeaderFallback;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+final class AuthorizationHeaderFallbackTest extends TestCase
+{
+    public function test_adopts_x_authorization_when_authorization_is_absent(): void
+    {
+        $request = (new ServerRequest('GET', '/admin/me'))
+            ->withHeader('X-Authorization', 'Bearer token-via-fallback');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertSame('Bearer token-via-fallback', $result->getHeaderLine('Authorization'));
+    }
+
+    public function test_keeps_standard_authorization_when_both_are_present(): void
+    {
+        $request = (new ServerRequest('GET', '/admin/me'))
+            ->withHeader('Authorization', 'Bearer standard')
+            ->withHeader('X-Authorization', 'Bearer mirrored');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertSame('Bearer standard', $result->getHeaderLine('Authorization'));
+    }
+
+    public function test_no_op_when_neither_header_is_present(): void
+    {
+        $request = new ServerRequest('GET', '/admin/me');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertFalse($result->hasHeader('Authorization'));
+        self::assertSame($request, $result);
+    }
+
+    public function test_no_op_when_fallback_header_is_empty(): void
+    {
+        $request = (new ServerRequest('GET', '/admin/me'))
+            ->withHeader('X-Authorization', '');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertFalse($result->hasHeader('Authorization'));
+    }
+}


### PR DESCRIPTION
Closes #596

## 根因（HETEML 実測）
前段リバースプロキシが `Authorization` ヘッダをバックエンド到達前に剥ぎ取る（カスタムヘッダは通過・`.htaccess` の E= トリックでも回収不能＝Apache 自体に届いていない）。demo の「認証遷移でセッション切れ→ログイン画面」の正体。

## 対処（3層）
1. SPA `client.ts`: `attachBearer()` に集約し `Authorization` + `X-Authorization` の両方に Bearer を載せる
2. BE `AuthorizationHeaderFallback`: `Authorization` 不在時のみ `X-Authorization` を採用（標準ヘッダが届く環境は完全に無影響・単体テスト4本）
3. `.htaccess`: Apache 自体が剥ぐタイプの共有ホスト向け `E=HTTP_AUTHORIZATION` 行

## テスト
- `composer check` 緑（phpunit 902 / cs / stan / openapi / conformance）
- frontend `npm run check` 緑（型・lint・format・vitest・build）
- 実機（HETEML）検証は本 PR のアーティファクト反映後に実施

## 備考
- クロスオリジン API 消費者が `X-Authorization` を使う場合は CORS の allow-headers 追加が要るが、admin SPA は same-origin なので本 PR では対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)