### PR TITLE
feat(http): API レスポンスに Cache-Control: no-store を既定付与 (#601)

### DIFF
--- a/src/Http/CacheControlMiddleware.php
+++ b/src/Http/CacheControlMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Http;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Adds `Cache-Control: no-store` to every API response that does not set the
+ * header itself, so authenticated invoicing data is never stored by shared
+ * caches.
+ *
+ * RFC 9111 §3.5 forbids shared caches from storing responses to requests that
+ * carry an `Authorization` header, but on Tier A shared hosting the SPA
+ * delivers the Bearer token via the `X-Authorization` mirror
+ * ({@see AuthorizationHeaderFallback}, #596), which intermediaries do not
+ * recognize — that safety net does not apply on this path, so the application
+ * must opt out of caching explicitly.
+ *
+ * An explicit `Cache-Control` set by a handler (e.g. the demo 302's
+ * `no-store`, or a future conditional-GET/ETag response) is left untouched.
+ * The SPA shell and static assets are served outside this pipeline and keep
+ * their existing cache behaviour.
+ */
+final readonly class CacheControlMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        if ($response->hasHeader('Cache-Control')) {
+            return $response;
+        }
+
+        return $response->withHeader('Cache-Control', 'no-store');
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -23,6 +23,7 @@ use Nene2\Http\RequestScopedHolder;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
+use Nene2\Middleware\MiddlewareDispatcher;
 use Nene2\Routing\Router;
 use NeneInvoice\ApplicationServiceProvider;
 use NeneInvoice\Audit\AuditServiceProvider;
@@ -309,7 +310,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Runtime application factory service is invalid.');
                     }
 
-                    return $factory->create();
+                    // Wrap the NENE2 pipeline from the outside (alongside the
+                    // framework's security headers) so every API response —
+                    // including error responses — defaults to
+                    // `Cache-Control: no-store` unless a handler set the
+                    // header explicitly (#601).
+                    return new MiddlewareDispatcher([new CacheControlMiddleware()], $factory->create());
                 },
             )
             ->set(ResponseEmitter::class, static fn (ContainerInterface $container): ResponseEmitter => new ResponseEmitter());

--- a/tests/Http/CacheControlMiddlewareTest.php
+++ b/tests/Http/CacheControlMiddlewareTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Http;
+
+use NeneInvoice\Http\CacheControlMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CacheControlMiddlewareTest extends TestCase
+{
+    public function test_adds_no_store_when_response_has_no_cache_control(): void
+    {
+        $response = (new CacheControlMiddleware())->process(
+            new ServerRequest('GET', '/admin/me'),
+            self::handlerReturning((new Psr17Factory())->createResponse(200)),
+        );
+
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+    }
+
+    public function test_keeps_explicit_cache_control_untouched(): void
+    {
+        $inner = (new Psr17Factory())
+            ->createResponse(302)
+            ->withHeader('Cache-Control', 'no-store, no-cache');
+
+        $response = (new CacheControlMiddleware())->process(
+            new ServerRequest('POST', '/demo/tax-accountant'),
+            self::handlerReturning($inner),
+        );
+
+        self::assertSame('no-store, no-cache', $response->getHeaderLine('Cache-Control'));
+    }
+
+    public function test_keeps_explicit_caching_directive_untouched(): void
+    {
+        $inner = (new Psr17Factory())
+            ->createResponse(200)
+            ->withHeader('Cache-Control', 'private, max-age=60');
+
+        $response = (new CacheControlMiddleware())->process(
+            new ServerRequest('GET', '/admin/me'),
+            self::handlerReturning($inner),
+        );
+
+        self::assertSame('private, max-age=60', $response->getHeaderLine('Cache-Control'));
+    }
+
+    private static function handlerReturning(ResponseInterface $response): RequestHandlerInterface
+    {
+        return new class ($response) implements RequestHandlerInterface {
+            public function __construct(private readonly ResponseInterface $response)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+    }
+}

--- a/tests/Http/HealthEndpointTest.php
+++ b/tests/Http/HealthEndpointTest.php
@@ -29,6 +29,10 @@ final class HealthEndpointTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
 
+        // Default cache policy (#601): API responses without an explicit
+        // Cache-Control carry `no-store` through the wrapped pipeline.
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
         $payload = json_decode((string) $response->getBody(), true);
         self::assertIsArray($payload);
         self::assertSame('ok', $payload['status'] ?? null);
@@ -38,5 +42,22 @@ final class HealthEndpointTest extends TestCase
         $checks = $payload['checks'];
         self::assertIsArray($checks);
         self::assertSame('ok', $checks['database'] ?? null);
+    }
+
+    public function test_unauthenticated_api_error_response_carries_no_store(): void
+    {
+        // The `X-Authorization` mirror path (#596) bypasses RFC 9111's
+        // Authorization-based shared-cache protection, so even error
+        // responses on authenticated routes must say `no-store` (#601).
+        $container = (new RuntimeContainerFactory(dirname(__DIR__, 2)))->create();
+
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        $request = (new Psr17Factory())->createServerRequest('GET', '/admin/me');
+        $response = $application->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
     }
 }


### PR DESCRIPTION
## 目的

認証付き API レスポンスが `Cache-Control` 無しで返っており、`X-Authorization` ミラー経路（#596/#597）では RFC 9111 §3.5 の「Authorization 付きリクエストへの応答は共有キャッシュ保存禁止」のセーフティネットが効かない。請求・入金データを扱う API が中間キャッシュに保存される余地を塞ぐため、既定で `Cache-Control: no-store` を付与する。

Closes #601

## 変更点

- `NeneInvoice\Http\CacheControlMiddleware` を追加: レスポンスに `Cache-Control` が**無い場合のみ** `no-store` を付与（ハンドラの明示指定 — デモ 302 の `no-store` や将来の ConditionalGet/ETag — は上書きしない）。
- `RuntimeServiceProvider`: NENE2 `RuntimeApplicationFactory::create()` の戻りを `MiddlewareDispatcher` で包み、パイプラインの**外側**に配線。ErrorHandler より外なのでエラーレスポンス（401/404/500 等）にも付く。
- `index.php` の SPA shell（`SpaShell`）・静的アセットはパイプライン外＝キャッシュ挙動不変（`admin/assets` は Apache 直配信）。
- OpenAPI 契約は変更なし（横断的セキュリティヘッダは契約に記載しない既存流儀。`Retry-After` のような意味論ヘッダのみ記載）。

## 検証結果

- ユニット: 無指定→`no-store` 付与 / 明示 `no-store, no-cache` 不変 / 明示 `private, max-age=60` 不変
- フルパイプライン: `GET /health` 200 に `no-store` / `GET /admin/me` 未認証 401 に `no-store`（`tests/Http/HealthEndpointTest`）
- 実機（php built-in server）: `GET /health` 200・`GET /admin/me` 401・`POST /auth/refresh` 401 いずれも `Cache-Control: no-store`、SPA shell `GET /` は Cache-Control 無し（従来どおり）
- `composer check` 全緑（906 tests / PHPStan / CS / OpenAPI / MCP / conformance）

## 残リスク・備考

- `/health` 等の公開エンドポイントにも `no-store` が付くが、動的 JSON でありキャッシュさせない方が安全側。
- フリート他製品も同構造（NENE2 RuntimeApplicationFactory + Bearer 認証）のため、本ミドルウェアは **NENE2 上流化の候補**（本 PR では実装しない）。
- 公開予定記事 `qiita-authorization-header-stripped.md`（07-10 公開）の「API に no-store を返している」の記述を本対応で真にする。

Self-review: backend-api, middleware-security（NENE2 側チェックリスト準用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
