### PR TITLE
fix(demo): sweep が recurring 実行スタンプの残骸を掃除するようにする (#603)

### DIFF
--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -47,6 +47,22 @@ $overflow = array_slice($allDemo, $maxOrgs);
 
 $targets = array_values(array_unique(array_merge($expired, $overflow)));
 
+// RECURRING_INLINE の実行スタンプ（FileRecurringRunThrottle・var/recurring-runs/org-{id}.txt）は
+// ファイルなので DB 掃除では消えず、demo org の回転数だけ無限蓄積する。organizations に
+// 存在しない org の残骸だけ自己修復で消す（実在 org — 本番含む — のスタンプには触れない）。
+// 掃除対象ゼロの回でも走らせる（過去の取りこぼし回収のため、早期 return より前に置く）。
+$existsStmt = $pdo->prepare('SELECT 1 FROM organizations WHERE id = ?');
+foreach (glob($root . '/var/recurring-runs/org-*.txt') ?: [] as $marker) {
+    if (preg_match('/org-(\d+)\.txt$/', $marker, $m) !== 1) {
+        continue;
+    }
+    $existsStmt->execute([(int) $m[1]]);
+    if ($existsStmt->fetchColumn() === false) {
+        @unlink($marker);
+        echo "残骸スタンプ掃除: " . basename($marker) . PHP_EOL;
+    }
+}
+
 if ($targets === []) {
     echo "掃除対象なし（demo org・TTL {$ttlHours}h・上限 {$maxOrgs}）。" . PHP_EOL;
 
@@ -88,6 +104,9 @@ foreach ($targets as $orgId) {
     } catch (OrganizationNotFoundException) {
         // すでに消えている（並行実行など）— 無視。
     }
+
+    // 実行スタンプは org と一緒に片付ける（上の自己修復パスの当日分）。
+    @unlink($root . '/var/recurring-runs/org-' . $orgId . '.txt');
 }
 
 echo "{$swept} 件の demo org を掃除しました（TTL {$ttlHours}h・上限 {$maxOrgs}）。" . PHP_EOL;


### PR DESCRIPTION
Closes #603

## 変更
- sweep の org 削除ループで該当 `var/recurring-runs/org-{id}.txt` を unlink
- 自己修復パス: `organizations` に存在しない id の残骸スタンプを回収（実在 org — 本番含む — は不触）。掃除対象ゼロの回でも走るよう早期 return より前に配置

## 検証
- ローカル実走: 偽残骸（org-1/org-2/org-999999）だけ削除・実在 org-5 のスタンプ温存を確認
- マージ後 HETEML で実走し、削除済み demo org の残骸（org-9〜16）が回収されることを確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)