### PR TITLE
fix(demo): シードの履歴イベント日付を today にクランプし未来日付を根絶する (#605)

### DIFF
--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -21,7 +21,11 @@ use Nene2\Http\ClockInterface;
  * shape as {@see \NeneInvoice\Organization\PdoInitialAdminRepository}.
  *
  * All dates are relative to today (T) so the data always looks "current": a few
- * invoices issued this month, one or two overdue, some paid this month. Amounts,
+ * invoices issued this month, one or two overdue, some paid this month. Dates of
+ * *historical* events (issue dates, payments, bank transactions) are clamped to
+ * today at the inserters — day-of-month anchors like "the 15th" must never
+ * produce a future receipt when the demo is opened early in the month. Due
+ * dates are deliberately NOT clamped (a future due date is normal). Amounts,
  * withholding, and registration numbers follow the seed specification
  * (`handoff-invoice-demo-seed-2026-07-07.md`). Each template carries exactly one
  * payer-name-mismatch reconciliation case (`payer_aliases` + `bank_transactions`).
@@ -98,6 +102,22 @@ final class DemoDataSeeder
     private function year(): int
     {
         return (int) $this->today->format('Y');
+    }
+
+    /**
+     * Clamps a historical event date (issue / payment / bank transaction) to
+     * today. Day-of-month anchors ("the 15th", "end of this month") land in the
+     * future when the demo is opened early in the month, and a future-dated
+     * receipt is exactly the kind of wart the target audience (accountants)
+     * notices first. `Y-m-d` strings compare correctly as strings.
+     */
+    private function noLaterThanToday(?string $date): ?string
+    {
+        if ($date === null) {
+            return null;
+        }
+
+        return min($date, $this->today->format('Y-m-d'));
     }
 
     // ------------------------------------------------------------- inserters
@@ -186,7 +206,7 @@ final class DemoDataSeeder
             'INSERT INTO quotes
                 (organization_id, client_id, quote_number, status, issued_at, valid_until, subtotal_cents, tax_cents, total_cents, notes, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
-            [$this->orgId, $clientId, $number, $status, $issuedAt, $validUntil, $sub, $tax, $total, $notes, $this->now, $this->now],
+            [$this->orgId, $clientId, $number, $status, $this->noLaterThanToday($issuedAt), $validUntil, $sub, $tax, $total, $notes, $this->now, $this->now],
         );
         $this->insertLines('quote', $id, $lines);
 
@@ -212,7 +232,7 @@ final class DemoDataSeeder
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)',
             [
                 $this->orgId, $clientId, $quoteId, $number, $status, $isQualified ? 1 : 0,
-                $issuedAt, $dueAt, $sub, $tax, $total, $notes, $this->now, $this->now,
+                $this->noLaterThanToday($issuedAt), $dueAt, $sub, $tax, $total, $notes, $this->now, $this->now,
             ],
         );
         $this->insertLines('invoice', $id, $lines);
@@ -226,7 +246,7 @@ final class DemoDataSeeder
             'INSERT INTO payments
                 (organization_id, invoice_id, amount_cents, paid_at, method, note, is_deleted, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)',
-            [$this->orgId, $invoiceId, $amountCents, $paidAt, $method, $note, $this->now, $this->now],
+            [$this->orgId, $invoiceId, $amountCents, (string) $this->noLaterThanToday($paidAt), $method, $note, $this->now, $this->now],
         );
     }
 
@@ -253,7 +273,7 @@ final class DemoDataSeeder
                 (organization_id, value_date, direction, amount_cents, payer_name, description, bank_reference, status, matched_invoice_id, matched_payment_id, imported_at, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
-                $this->orgId, $valueDate, 'credit', $amountCents, $payerName, $description, null,
+                $this->orgId, (string) $this->noLaterThanToday($valueDate), 'credit', $amountCents, $payerName, $description, null,
                 $status, $matchedInvoiceId, $matchedPaymentId, $this->now, $this->now, $this->now,
             ],
         );

--- a/tests/Demo/DemoDataSeederDateTest.php
+++ b/tests/Demo/DemoDataSeederDateTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneInvoice\Demo\DemoDataSeeder;
+use NeneInvoice\Demo\DemoTemplate;
+use NeneInvoice\Tests\Support\FixedClock;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Seeded *historical* events (invoice/quote issue dates, payments, bank
+ * transactions) must never post-date "today" — day-of-month anchors like
+ * "the 15th" would otherwise produce future-dated receipts when the demo is
+ * opened early in the month (#605). Due dates are deliberately not clamped.
+ *
+ * Runs the real seeder for every template against a recording executor, so
+ * every INSERT of every template is inspected without a database.
+ */
+final class DemoDataSeederDateTest extends TestCase
+{
+    /** @return iterable<string, array{0: string, 1: string}> */
+    public static function clockDates(): iterable
+    {
+        yield 'first of month (worst case)' => ['2026-08-01T09:00:00Z', '2026-08-01'];
+        yield 'mid month' => ['2026-08-20T09:00:00Z', '2026-08-20'];
+    }
+
+    #[DataProvider('clockDates')]
+    public function test_historical_dates_never_exceed_today(string $clockNow, string $today): void
+    {
+        foreach (DemoTemplate::cases() as $template) {
+            $recorder = new RecordingQueryExecutor();
+            $seeder   = new DemoDataSeeder($recorder, new FixedClock($clockNow));
+            $seeder->seed(1, $template);
+
+            foreach ($recorder->columnValues('payments', 'paid_at') as $paidAt) {
+                self::assertLessThanOrEqual($today, $paidAt, "future paid_at in {$template->value}");
+            }
+            foreach ($recorder->columnValues('bank_transactions', 'value_date') as $valueDate) {
+                self::assertLessThanOrEqual($today, $valueDate, "future value_date in {$template->value}");
+            }
+            foreach (['invoices', 'quotes'] as $table) {
+                foreach ($recorder->columnValues($table, 'issued_at') as $issuedAt) {
+                    if ($issuedAt === null) {
+                        continue; // drafts
+                    }
+                    self::assertLessThanOrEqual($today, $issuedAt, "future issued_at in {$table} ({$template->value})");
+                }
+            }
+        }
+    }
+
+    public function test_due_dates_are_not_clamped(): void
+    {
+        // Early in the month, at least one seeded due date must still lie in the
+        // future — the "due later this month" showcase must survive the clamp.
+        $recorder = new RecordingQueryExecutor();
+        $seeder   = new DemoDataSeeder($recorder, new FixedClock('2026-08-01T09:00:00Z'));
+        $seeder->seed(1, DemoTemplate::Kensetsu);
+
+        $futureDue = array_filter(
+            $recorder->columnValues('invoices', 'due_at'),
+            static fn (?string $due): bool => $due !== null && $due > '2026-08-01',
+        );
+
+        self::assertNotEmpty($futureDue);
+    }
+}
+
+/**
+ * Records every INSERT and exposes values by (table, column), resolved from the
+ * statement's own column list — no hard-coded parameter indexes.
+ */
+final class RecordingQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    /** @var list<array{sql: string, parameters: array<int|string, mixed>}> */
+    private array $inserts = [];
+
+    private int $nextId = 1;
+
+    public function execute(string $sql, array $parameters = []): int
+    {
+        $this->record($sql, $parameters);
+
+        return 1;
+    }
+
+    public function insert(string $sql, array $parameters = []): int
+    {
+        $this->record($sql, $parameters);
+
+        return $this->nextId++;
+    }
+
+    public function lastInsertId(): int
+    {
+        return $this->nextId - 1;
+    }
+
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        return null;
+    }
+
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        return [];
+    }
+
+    /** @return list<mixed> Values bound to $column across all INSERTs into $table. */
+    public function columnValues(string $table, string $column): array
+    {
+        $values = [];
+
+        foreach ($this->inserts as $insert) {
+            if (preg_match('/INSERT INTO ' . $table . '\s*\(([^)]+)\)/i', $insert['sql'], $m) !== 1) {
+                continue;
+            }
+            $columns = array_map('trim', explode(',', $m[1]));
+            $index   = array_search($column, $columns, true);
+            if ($index === false) {
+                continue;
+            }
+            // Positional parameters line up with the column list only when every
+            // VALUES entry is a placeholder; the seeder embeds literals (e.g.
+            // is_deleted 0), so count placeholders up to the column's position.
+            if (preg_match('/VALUES\s*\((.+)\)/is', $insert['sql'], $vm) !== 1) {
+                continue;
+            }
+            $slots       = array_map('trim', explode(',', $vm[1]));
+            $paramIndex  = 0;
+            foreach ($slots as $slotPosition => $slot) {
+                if ($slotPosition === $index) {
+                    $values[] = $slot === '?' ? ($insert['parameters'][$paramIndex] ?? null) : $slot;
+                    break;
+                }
+                if ($slot === '?') {
+                    $paramIndex++;
+                }
+            }
+        }
+
+        return $values;
+    }
+
+    /** @param array<int|string, mixed> $parameters */
+    private function record(string $sql, array $parameters): void
+    {
+        if (stripos(ltrim($sql), 'INSERT') === 0) {
+            $this->inserts[] = ['sql' => $sql, 'parameters' => $parameters];
+        }
+    }
+}


### PR DESCRIPTION
Closes #605

## 問題
シードの日付が「今月の固定日」方式のため、月前半にデモを開くと入金・振込・発行日が未来になる（7/9 アクセスで 7/15・7/31 付の「入金済み」）。閲覧者=税理士が最も気づく粗で、docblock・公開記事の「日付は today 相対」とも乖離していた。

## 対応
- 履歴イベント（paid_at / value_date / issued_at）をインサーター内で `min(date, today)` にクランプ — 全テンプレ・全呼び出しを構造的に網羅
- 期日（due_at / valid_until）は意図的に不変（未来が正常・期限の見せ場を維持）
- テスト: 記録型フェイク executor で実シーダーを全テンプレ実走し、月初（最悪ケース）と月中の2クロックで日付検査（3 tests / 193 assertions）。**修正前コードで fail することを確認済み**（negative check）

## 検証
- `composer check` 全緑
- マージ後 HETEML に反映し、実 API で新規 demo org の paid_at ≦ today を確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)