### PR TITLE
fix(demo): /demo のエラーをブラウザには日本語説明ページで返し throttle を30回/時へ (#612)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,9 @@ BASE_DOMAIN=localhost
 # `/{slug}/dashboard` へ 302 する。**デモ機専用**。本番・通常インストールでは未設定(=無効)のままにする。
 # 前提: `TENANT_RESOLUTION=path`（single だと soleOrgFallback で全員同一 org に落ちる）＋ HTTPS
 # （Cookie は Secure 固定。localhost は secure 扱い）。使い捨て org の掃除は tools/sweep-demo.php を cron で。
-# 乱用対策（#608）: 作成前に per-IP スロットル（10回/時・429）と org 数上限（503）をチェックする。
+# 乱用対策（#608/#612）: 作成前に per-IP スロットル（30回/時・429）と org 数上限（503）をチェックする。
 # 判定状態は var/rate-limits/ のファイル（共有ホスティングでもプロセス跨ぎで効く）。
+# ブラウザ（Accept: text/html）には裸の JSON でなく日本語の説明ページを返す（#612）。
 # 値は NENE2 ConfigLoader が厳格にパースする（DEMO_MODE は 1/true/yes のみ有効＝fail-close）。
 # DEMO_MODE=1
 # DEMO_SLUG_PREFIX=demo-   # 使い捨て org の slug 接頭辞。sweep と上限カウントの境界

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NeneInvoice;
 
 use LogicException;
-use Nene2\Demo\DemoRouteRegistrar;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneInvoice\Audit\AuditRouteRegistrar;
@@ -20,6 +19,7 @@ use NeneInvoice\Company\CompanyRouteRegistrar;
 use NeneInvoice\Company\CompanySettingsNotFoundExceptionHandler;
 use NeneInvoice\Company\InvalidRegistrationNumberExceptionHandler as CompanyInvalidRegistrationNumberExceptionHandler;
 use NeneInvoice\Dashboard\DashboardRouteRegistrar;
+use NeneInvoice\Demo\DemoRouteRegistrar;
 use NeneInvoice\GatewaySettings\GatewaySettingsRouteRegistrar;
 use NeneInvoice\Invoice\InvoiceEmailExceptionHandler;
 use NeneInvoice\Invoice\InvoiceNotFoundExceptionHandler;

--- a/src/Demo/DemoBrowserErrorPage.php
+++ b/src/Demo/DemoBrowserErrorPage.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Content negotiation for the public demo start route (#612).
+ *
+ * `GET /demo/{template}` is the one route real people open in a browser (the
+ * tax-accountant referral link), so its errors must not surface as raw RFC 9457
+ * JSON — a non-technical visitor reads that as "the site is broken". When the
+ * client prefers `text/html`, the Problem Details error is replaced with a
+ * small self-contained Japanese explanation page; API-shaped clients (no
+ * `text/html` in Accept) keep the JSON untouched, as does the success redirect.
+ *
+ * The page never echoes request input (e.g. the template segment) — all copy is
+ * fixed text plus numbers computed server-side (`Retry-After` minutes).
+ */
+final readonly class DemoBrowserErrorPage
+{
+    public function __construct(
+        private Psr17Factory $responseFactory,
+        private int $throttleLimit,
+        private int $throttleWindowSeconds,
+    ) {
+    }
+
+    public function apply(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if ($response->getStatusCode() < 400) {
+            return $response;
+        }
+
+        if (!str_contains($request->getHeaderLine('Accept'), 'text/html')) {
+            return $response;
+        }
+
+        [$title, $message] = $this->copyFor($response);
+
+        $html = $this->render($title, $message);
+        $page = $this->responseFactory->createResponse($response->getStatusCode())
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withHeader('Cache-Control', 'no-store');
+
+        if ($response->hasHeader('Retry-After')) {
+            $page = $page->withHeader('Retry-After', $response->getHeaderLine('Retry-After'));
+        }
+
+        $page->getBody()->write($html);
+
+        return $page;
+    }
+
+    /** @return array{0: string, 1: string} [title, message] */
+    private function copyFor(ResponseInterface $response): array
+    {
+        $windowHours = intdiv($this->throttleWindowSeconds, 3600);
+        $windowLabel = $windowHours >= 1 ? "{$windowHours}時間" : intdiv($this->throttleWindowSeconds, 60) . '分';
+
+        return match ($response->getStatusCode()) {
+            429 => [
+                'デモのご利用が集中しています',
+                "同一ネットワーク（IP）からのデモ開始は{$windowLabel}に{$this->throttleLimit}回までに制限しています。"
+                    . $this->retryAdvice($response),
+            ],
+            503 => [
+                'ただいまデモが満席です',
+                'お試し用のデモ環境が上限に達しています。古いデモは毎時自動的に整理されますので、しばらくしてからもう一度このリンクを開いてください。',
+            ],
+            404 => [
+                'このデモは現在ご利用いただけません',
+                'リンクの綴りが変わったか、この環境ではデモが無効になっています。お手数ですが、案内元のリンクをもう一度ご確認ください。',
+            ],
+            default => [
+                'デモを開始できませんでした',
+                '一時的な問題が発生しました。しばらくしてからもう一度このリンクを開いてください。',
+            ],
+        };
+    }
+
+    private function retryAdvice(ResponseInterface $response): string
+    {
+        $retryAfter = (int) $response->getHeaderLine('Retry-After');
+
+        if ($retryAfter <= 0) {
+            return 'しばらくしてからもう一度このリンクを開いてください。';
+        }
+
+        $minutes = max(1, (int) ceil($retryAfter / 60));
+
+        return "約{$minutes}分後にもう一度このリンクを開いてください。";
+    }
+
+    private function render(string $title, string $message): string
+    {
+        $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+        $safeMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+
+        return <<<HTML
+            <!DOCTYPE html>
+            <html lang="ja">
+            <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta name="robots" content="noindex">
+            <title>{$safeTitle} — NeNe Invoice デモ</title>
+            <style>
+            body { margin: 0; font-family: system-ui, -apple-system, "Hiragino Sans", "Noto Sans JP", sans-serif;
+                   background: #f5f6f8; color: #1f2933; display: grid; min-height: 100vh; place-items: center; }
+            main { background: #fff; border: 1px solid #e0e4e8; border-radius: 12px; padding: 2.5rem 2rem;
+                   max-width: 30rem; margin: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,.06); }
+            h1 { font-size: 1.2rem; margin: 0 0 .75rem; }
+            p { margin: 0; line-height: 1.8; }
+            .brand { margin-top: 1.5rem; font-size: .8rem; color: #6b7684; }
+            </style>
+            </head>
+            <body>
+            <main>
+            <h1>{$safeTitle}</h1>
+            <p>{$safeMessage}</p>
+            <p class="brand">NeNe Invoice — お試しデモ</p>
+            </main>
+            </body>
+            </html>
+            HTML;
+    }
+}

--- a/src/Demo/DemoRouteRegistrar.php
+++ b/src/Demo/DemoRouteRegistrar.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+use Nene2\Demo\StartDisposableDemoHandler;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Registers the disposable-demo route, wrapping the framework handler with
+ * browser content negotiation ({@see DemoBrowserErrorPage}, #612). The
+ * framework's own {@see \Nene2\Demo\DemoRouteRegistrar} is not used because it
+ * is typed to the bare handler; everything else (gate, throttle, capacity,
+ * provisioning) stays in {@see StartDisposableDemoHandler}.
+ *
+ * `GET /demo/{template}` is public and org-less (it *creates* orgs); it is gated
+ * at runtime by `DEMO_MODE` inside the handler and bypasses org resolution
+ * ({@see \NeneInvoice\Organization\Resolution\OrgResolverMiddleware}).
+ */
+final readonly class DemoRouteRegistrar
+{
+    public function __construct(
+        private StartDisposableDemoHandler $handler,
+        private DemoBrowserErrorPage $errorPage,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $handler = $this->handler;
+        $errorPage = $this->errorPage;
+
+        $router->get(
+            '/demo/{' . StartDisposableDemoHandler::TEMPLATE_PARAMETER . '}',
+            static fn (ServerRequestInterface $request) => $errorPage->apply($request, $handler->handle($request)),
+        );
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -9,7 +9,6 @@ use Nene2\Config\AppConfig;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Demo\CountingDemoCapacityGuard;
 use Nene2\Demo\DemoCapacityGuardInterface;
-use Nene2\Demo\DemoRouteRegistrar;
 use Nene2\Demo\DisposableOrgReaperInterface;
 use Nene2\Demo\StartDisposableDemoHandler;
 use Nene2\DependencyInjection\ContainerBuilder;
@@ -33,6 +32,15 @@ use Psr\Container\ContainerInterface;
  */
 final readonly class DemoServiceProvider implements ServiceProviderInterface
 {
+    /**
+     * Demo starts allowed per client network per window (#612). Deliberately
+     * generous: the one-shot cookie design makes legitimate re-clicks normal,
+     * and "one IP" is really one office NAT / carrier NAT — while runaway
+     * abuse stays bounded by the instance-wide org ceiling plus hourly sweep.
+     */
+    public const int THROTTLE_LIMIT = 30;
+    public const int THROTTLE_WINDOW_SECONDS = 3600;
+
     public function register(ContainerBuilder $builder): void
     {
         $builder
@@ -113,6 +121,8 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                         },
                         config: $config->demo,
                         throttleStorage: $storage,
+                        throttleLimit: self::THROTTLE_LIMIT,
+                        throttleWindowSeconds: self::THROTTLE_WINDOW_SECONDS,
                         clock: self::clock($c),
                     );
                 },
@@ -158,15 +168,32 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
+                DemoBrowserErrorPage::class,
+                static function (ContainerInterface $c): DemoBrowserErrorPage {
+                    $psr17 = $c->get(Psr17Factory::class);
+
+                    if (!$psr17 instanceof Psr17Factory) {
+                        throw new LogicException('PSR-17 factory service is invalid.');
+                    }
+
+                    return new DemoBrowserErrorPage($psr17, self::THROTTLE_LIMIT, self::THROTTLE_WINDOW_SECONDS);
+                },
+            )
+            ->set(
                 DemoRouteRegistrar::class,
                 static function (ContainerInterface $c): DemoRouteRegistrar {
                     $handler = $c->get(StartDisposableDemoHandler::class);
+                    $errorPage = $c->get(DemoBrowserErrorPage::class);
 
                     if (!$handler instanceof StartDisposableDemoHandler) {
                         throw new LogicException('Start disposable demo handler service is invalid.');
                     }
 
-                    return new DemoRouteRegistrar($handler);
+                    if (!$errorPage instanceof DemoBrowserErrorPage) {
+                        throw new LogicException('Demo browser error page service is invalid.');
+                    }
+
+                    return new DemoRouteRegistrar($handler, $errorPage);
                 },
             );
     }

--- a/tests/Demo/DemoBrowserErrorPageTest.php
+++ b/tests/Demo/DemoBrowserErrorPageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use NeneInvoice\Demo\DemoBrowserErrorPage;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The public demo link is opened by non-technical visitors in a browser, so its
+ * errors must render as an explanation page, not raw Problem Details JSON —
+ * while API-shaped clients and the success redirect stay byte-identical (#612).
+ */
+final class DemoBrowserErrorPageTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private DemoBrowserErrorPage $page;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->page = new DemoBrowserErrorPage($this->psr17, 30, 3600);
+    }
+
+    private function request(string $accept): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest('GET', '/demo/kensetsu');
+
+        return $accept === '' ? $request : $request->withHeader('Accept', $accept);
+    }
+
+    private function problem(int $status): ResponseInterface
+    {
+        $response = $this->psr17->createResponse($status)
+            ->withHeader('Content-Type', 'application/problem+json');
+        $response->getBody()->write('{"type":"problem"}');
+
+        return $response;
+    }
+
+    public function test_browser_429_becomes_html_with_limit_and_retry_minutes(): void
+    {
+        $result = $this->page->apply(
+            $this->request('text/html,application/xhtml+xml;q=0.9,*/*;q=0.8'),
+            $this->problem(429)->withHeader('Retry-After', '3519'),
+        );
+
+        self::assertSame(429, $result->getStatusCode());
+        self::assertStringStartsWith('text/html', $result->getHeaderLine('Content-Type'));
+        self::assertSame('3519', $result->getHeaderLine('Retry-After'), 'Retry-After must survive negotiation');
+        self::assertSame('no-store', $result->getHeaderLine('Cache-Control'));
+
+        $body = (string) $result->getBody();
+        self::assertStringContainsString('1時間に30回まで', $body);
+        self::assertStringContainsString('約59分後', $body);
+    }
+
+    public function test_browser_503_becomes_capacity_page(): void
+    {
+        $result = $this->page->apply($this->request('text/html'), $this->problem(503));
+
+        self::assertSame(503, $result->getStatusCode());
+        self::assertStringContainsString('満席', (string) $result->getBody());
+    }
+
+    public function test_browser_404_becomes_unavailable_page_without_echoing_input(): void
+    {
+        $result = $this->page->apply($this->request('text/html'), $this->problem(404));
+
+        $body = (string) $result->getBody();
+        self::assertSame(404, $result->getStatusCode());
+        self::assertStringContainsString('ご利用いただけません', $body);
+        self::assertStringNotContainsString('kensetsu', $body, 'fixed copy only — never echo the template segment');
+    }
+
+    public function test_api_clients_keep_problem_details_untouched(): void
+    {
+        $problem = $this->problem(429)->withHeader('Retry-After', '60');
+
+        self::assertSame($problem, $this->page->apply($this->request('application/json'), $problem));
+        self::assertSame($problem, $this->page->apply($this->request('*/*'), $problem));
+        self::assertSame($problem, $this->page->apply($this->request(''), $problem));
+    }
+
+    public function test_success_redirect_is_untouched_even_for_browsers(): void
+    {
+        $redirect = $this->psr17->createResponse(302)->withHeader('Location', '/demo-abc/dashboard');
+
+        self::assertSame($redirect, $this->page->apply($this->request('text/html'), $redirect));
+    }
+}


### PR DESCRIPTION
Closes #612

## 背景

公開デモリンク `GET /demo/{template}` は税理士リードがブラウザで踏む唯一の動線だが、429/503/404 が RFC 9457 の裸 JSON で表示され「壊れた」と受け取られる（2026-07-10 実発生）。また throttle 10回/時は one-shot 再クリック前提のデモ設計＋事務所/キャリア NAT を考えると正規利用で枯れる（施主判断で 30回/時へ）。

## 変更

- **`DemoBrowserErrorPage`**: `Accept: text/html` のとき 4xx/5xx を自己完結の日本語 HTML に置換。429 は「同一ネットワークから1時間に30回まで＋約N分後に再試行」（Retry-After から分数計算・ヘッダも保持）、503 は満席案内、404 は固定文言（**入力エコーなし** — template セグメントは絶対に出力しない）。`noindex`・インライン CSS のみ・外部資産なし。API クライアント（Accept に text/html を含まない＝curl の `*/*` 含む）と成功 302 は**バイト不変**。
- **自前 `DemoRouteRegistrar` 再導入**: framework 版は素の `StartDisposableDemoHandler` に型付けされているため、negotiation ラップだけ invoice 側で被せる（gate/throttle/容量/provision は framework のまま）。
- **throttle 30回/時**: `DemoServiceProvider::THROTTLE_LIMIT/WINDOW` 定数で guard と説明ページ文言に単一供給（数字のドリフト防止）。

## 検証

- `composer check` 全緑（920 tests・PHPStan・cs・OpenAPI・MCP・conformance）。新規 5 テスト（429 HTML の上限・分数・Retry-After 保持／503・404 文言／API Accept 不変／302 不変／入力非エコー）
- ローカル実機: ブラウザ Accept で `/demo/unknown` → 日本語 HTML、API Accept → 従来 JSON、`/demo/kensetsu` → 302 不変
- OpenAPI 対象外（demo 経路は spec 非掲載の公開ルート）

## 残課題（本 PR 外）

- merge 後、本番（invoice.ayane.co.jp）へ反映し 429 を実発動させて HTML 表示を確認（施主 GO は取得済みの流れ）
- framework 上流化（既定 HTML テンプレ＋差し替えフック）は NENE2 への提案として別送 — clear/deal/vault が同じ問題を踏むため

🤖 Generated with [Claude Code](https://claude.com/claude-code)