### PR TITLE
feat(demo): エラーページにリデザイン基準テーマ適用＋解除カウントダウン実装 (#614)

### DIFF
--- a/src/Demo/DemoBrowserErrorPage.php
+++ b/src/Demo/DemoBrowserErrorPage.php
@@ -9,20 +9,35 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Content negotiation for the public demo start route (#612).
+ * Content negotiation for the public demo start route (#612, redesign #614).
  *
  * `GET /demo/{template}` is the one route real people open in a browser (the
  * tax-accountant referral link), so its errors must not surface as raw RFC 9457
  * JSON — a non-technical visitor reads that as "the site is broken". When the
  * client prefers `text/html`, the Problem Details error is replaced with a
- * small self-contained Japanese explanation page; API-shaped clients (no
- * `text/html` in Accept) keep the JSON untouched, as does the success redirect.
+ * self-contained error card following the redesign reference theme (deep-green
+ * business SaaS, `NeNe Invoice (24).zip` demo-error mock): brand header strip,
+ * reason callout, and — for 429 — a live countdown that enables the retry
+ * button when the window resets. API-shaped clients (no `text/html` in Accept)
+ * keep the JSON untouched, as does the success redirect.
  *
- * The page never echoes request input (e.g. the template segment) — all copy is
- * fixed text plus numbers computed server-side (`Retry-After` minutes).
+ * The page carries its own `Content-Security-Policy` allowing its inline
+ * style/script ({@see \Nene2\Middleware\SecurityHeadersMiddleware} only adds
+ * the app-wide `default-src 'self'` when the header is absent, which would
+ * block both). That is safe here precisely because the page never echoes
+ * request input (e.g. the template segment) — all copy is fixed text plus
+ * numbers computed server-side.
  */
 final readonly class DemoBrowserErrorPage
 {
+    private const string SELF_HOST_URL = 'https://github.com/hideyukiMORI/nene-invoice';
+
+    /**
+     * Inline style/script must be allowed for this one self-contained page;
+     * everything else stays locked down. No request input is ever echoed.
+     */
+    private const string CSP = "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'";
+
     public function __construct(
         private Psr17Factory $responseFactory,
         private int $throttleLimit,
@@ -40,37 +55,95 @@ final readonly class DemoBrowserErrorPage
             return $response;
         }
 
-        [$title, $message] = $this->copyFor($response);
+        $status = $response->getStatusCode();
+        $retryAfter = (int) $response->getHeaderLine('Retry-After');
 
-        $html = $this->render($title, $message);
-        $page = $this->responseFactory->createResponse($response->getStatusCode())
+        $page = $this->responseFactory->createResponse($status)
             ->withHeader('Content-Type', 'text/html; charset=utf-8')
-            ->withHeader('Cache-Control', 'no-store');
+            ->withHeader('Cache-Control', 'no-store')
+            ->withHeader('Content-Security-Policy', self::CSP);
 
         if ($response->hasHeader('Retry-After')) {
             $page = $page->withHeader('Retry-After', $response->getHeaderLine('Retry-After'));
         }
 
-        $page->getBody()->write($html);
+        $page->getBody()->write($this->render($status, $retryAfter));
 
         return $page;
     }
 
-    /** @return array{0: string, 1: string} [title, message] */
-    private function copyFor(ResponseInterface $response): array
+    private function render(int $status, int $retryAfter): string
     {
-        $windowHours = intdiv($this->throttleWindowSeconds, 3600);
-        $windowLabel = $windowHours >= 1 ? "{$windowHours}時間" : intdiv($this->throttleWindowSeconds, 60) . '分';
+        [$title, $lead] = $this->copyFor($status);
 
-        return match ($response->getStatusCode()) {
+        $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+        $safeLead = htmlspecialchars($lead, ENT_QUOTES, 'UTF-8');
+        $css = $this->css();
+        $reason = $this->reasonBlock($status);
+        $wait = $status === 429 && $retryAfter > 0 ? $this->countdownBlock($retryAfter) : '';
+        $actions = $this->actionsBlock($status, $retryAfter);
+        $refCode = $status . ' · ' . $this->refCode($status);
+        $script = $status === 429 && $retryAfter > 0 ? $this->countdownScript($retryAfter) : '';
+        $selfHostUrl = self::SELF_HOST_URL;
+
+        return <<<HTML
+            <!DOCTYPE html>
+            <html lang="ja" class="theme-light">
+            <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <meta name="robots" content="noindex">
+            <title>{$safeTitle} — NeNe Invoice デモ</title>
+            <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 42 42'%3E%3Crect width='42' height='42' fill='%23275245'/%3E%3Ctext x='-2' y='32' font-family='sans-serif' font-weight='800' font-size='32' fill='%23ffffff' opacity='0.4'%3EN%3C/text%3E%3Ctext x='11' y='32' font-family='sans-serif' font-weight='800' font-size='32' fill='%23ffffff'%3EN%3C/text%3E%3C/svg%3E">
+            <style>{$css}</style>
+            </head>
+            <body>
+            <main class="err" role="alert" aria-live="polite">
+              <div class="err-top">
+                <span class="mono-mark" aria-hidden="true"><svg viewBox="0 0 42 42"><text x="-2" y="31" font-family="sans-serif" font-weight="800" font-size="32" fill="currentColor" opacity="0.4">N</text><text x="11" y="31" font-family="sans-serif" font-weight="800" font-size="32" fill="currentColor">N</text></svg></span>
+                <div class="et-name">
+                  <b>NeNe Invoice</b>
+                  <span>お試しデモ</span>
+                </div>
+              </div>
+              <div class="err-body">
+                <div class="err-ico" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="9"></circle>
+                    <path d="M12 7.5V12l3 2"></path>
+                  </svg>
+                </div>
+                <h1>{$safeTitle}</h1>
+                <p class="lead">{$safeLead}</p>
+            {$reason}{$wait}{$actions}
+                <div class="alt">または</div>
+                <div class="self">
+                  <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="11" rx="1.5"></rect><path d="M8 10V7a4 4 0 0 1 8 0v3"></path></svg>
+                  <div class="st"><b>待たずに、自分の環境で。</b> NeNe Invoice はオープンソース（MIT）。自社サーバに置けば回数制限なくご利用いただけます。<a href="{$selfHostUrl}" rel="noopener">製品情報・セットアップを見る →</a></div>
+                </div>
+              </div>
+              <div class="err-foot">
+                <span>NeNe Invoice — Invoice Management</span>
+                <span class="ref">{$refCode}</span>
+              </div>
+            </main>
+            {$script}
+            </body>
+            </html>
+            HTML;
+    }
+
+    /** @return array{0: string, 1: string} [title, lead] */
+    private function copyFor(int $status): array
+    {
+        return match ($status) {
             429 => [
                 'デモのご利用が集中しています',
-                "同一ネットワーク（IP）からのデモ開始は{$windowLabel}に{$this->throttleLimit}回までに制限しています。"
-                    . $this->retryAdvice($response),
+                '現在、多くの方がデモをお試しいただいています。少し時間をおいてから、もう一度お開きください。',
             ],
             503 => [
                 'ただいまデモが満席です',
-                'お試し用のデモ環境が上限に達しています。古いデモは毎時自動的に整理されますので、しばらくしてからもう一度このリンクを開いてください。',
+                'お試し用のデモ環境が上限に達しています。古いデモは毎時自動的に整理されますので、しばらくしてからもう一度お開きください。',
             ],
             404 => [
                 'このデモは現在ご利用いただけません',
@@ -83,50 +156,255 @@ final readonly class DemoBrowserErrorPage
         };
     }
 
-    private function retryAdvice(ResponseInterface $response): string
+    private function reasonBlock(int $status): string
     {
-        $retryAfter = (int) $response->getHeaderLine('Retry-After');
+        $windowHours = intdiv($this->throttleWindowSeconds, 3600);
+        $windowLabel = $windowHours >= 1 ? "{$windowHours}時間" : intdiv($this->throttleWindowSeconds, 60) . '分';
 
-        if ($retryAfter <= 0) {
-            return 'しばらくしてからもう一度このリンクを開いてください。';
+        $text = match ($status) {
+            429 => "サーバー保護のため、同一ネットワーク（IP）からのデモ開始は <b>{$windowLabel}あたり{$this->throttleLimit}回まで</b> に制限しています。この上限に達すると、一定時間おいて自動的に解除されます。",
+            503 => 'サーバー保護のため、同時に存在できるデモ環境の数に上限を設けています。古いデモ環境が整理されて空きができると、自動的にご利用いただけるようになります。',
+            default => '',
+        };
+
+        if ($text === '') {
+            return '';
         }
 
-        $minutes = max(1, (int) ceil($retryAfter / 60));
+        return <<<HTML
+                <div class="reason">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2l5 2v3.5c0 3-2 5.3-5 6.5-3-1.2-5-3.5-5-6.5V4z"></path></svg>
+                  <div class="rz">{$text}</div>
+                </div>
 
-        return "約{$minutes}分後にもう一度このリンクを開いてください。";
+            HTML;
     }
 
-    private function render(string $title, string $message): string
+    private function countdownBlock(int $retryAfter): string
     {
-        $safeTitle = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-        $safeMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+        $clock = $this->formatClock($retryAfter);
 
         return <<<HTML
-            <!DOCTYPE html>
-            <html lang="ja">
-            <head>
-            <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1">
-            <meta name="robots" content="noindex">
-            <title>{$safeTitle} — NeNe Invoice デモ</title>
-            <style>
-            body { margin: 0; font-family: system-ui, -apple-system, "Hiragino Sans", "Noto Sans JP", sans-serif;
-                   background: #f5f6f8; color: #1f2933; display: grid; min-height: 100vh; place-items: center; }
-            main { background: #fff; border: 1px solid #e0e4e8; border-radius: 12px; padding: 2.5rem 2rem;
-                   max-width: 30rem; margin: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,.06); }
-            h1 { font-size: 1.2rem; margin: 0 0 .75rem; }
-            p { margin: 0; line-height: 1.8; }
-            .brand { margin-top: 1.5rem; font-size: .8rem; color: #6b7684; }
-            </style>
-            </head>
-            <body>
-            <main>
-            <h1>{$safeTitle}</h1>
-            <p>{$safeMessage}</p>
-            <p class="brand">NeNe Invoice — お試しデモ</p>
-            </main>
-            </body>
-            </html>
+                <div class="wait">
+                  <div class="wl">
+                    再度お試しいただける目安
+                    <small>制限時間が経過すると自動で解除されます</small>
+                  </div>
+                  <div class="clock" id="clock">{$clock}</div>
+                </div>
+
             HTML;
+    }
+
+    private function actionsBlock(int $status, int $retryAfter): string
+    {
+        if ($status === 404) {
+            return '';
+        }
+
+        $disabled = $status === 429 && $retryAfter > 0 ? ' disabled' : '';
+
+        return <<<HTML
+                <div class="err-actions">
+                  <button class="btn btn-primary btn-block" id="retry" type="button"{$disabled}>
+                    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path><path d="M3 4v4h4"></path></svg>
+                    もう一度デモを開く
+                  </button>
+                </div>
+
+            HTML;
+    }
+
+    private function countdownScript(int $retryAfter): string
+    {
+        // The reload re-requests /demo/{template}, which mints a fresh org —
+        // exactly the demo's "reset to initial state" affordance.
+        return <<<HTML
+            <script>
+            (function () {
+              var remain = {$retryAfter};
+              var clock = document.getElementById('clock');
+              var retry = document.getElementById('retry');
+              retry.addEventListener('click', function () { location.reload(); });
+              function render() {
+                if (remain <= 0) {
+                  clock.textContent = '00:00';
+                  clock.classList.add('is-done');
+                  retry.disabled = false;
+                  return true;
+                }
+                var m = Math.floor(remain / 60);
+                var s = remain % 60;
+                clock.textContent = (m < 10 ? '0' + m : m) + ':' + (s < 10 ? '0' + s : s);
+                return false;
+              }
+              render();
+              var timer = setInterval(function () {
+                remain -= 1;
+                if (render()) clearInterval(timer);
+              }, 1000);
+            })();
+            </script>
+            HTML;
+    }
+
+    private function formatClock(int $seconds): string
+    {
+        $m = intdiv(max(0, $seconds), 60);
+        $s = max(0, $seconds) % 60;
+
+        return sprintf('%02d:%02d', $m, $s);
+    }
+
+    private function refCode(int $status): string
+    {
+        return match ($status) {
+            429 => 'DEMO_RATE_LIMIT',
+            503 => 'DEMO_CAPACITY',
+            404 => 'DEMO_NOT_FOUND',
+            default => 'DEMO_ERROR',
+        };
+    }
+
+    /**
+     * Resolved subset of the redesign reference theme (light, deep-green,
+     * dense/square direction) — kept inline so the page is fully
+     * self-contained under its strict CSP.
+     */
+    private function css(): string
+    {
+        return <<<'CSS'
+            :root {
+              --bg: oklch(98% 0.0025 175);
+              --surface: oklch(100% 0 0);
+              --surface-2: oklch(97.4% 0.0035 175);
+              --surface-sunk: oklch(96.2% 0.004 175);
+              --border: oklch(90.5% 0.006 172);
+              --fg: oklch(27% 0.011 172);
+              --fg-muted: oklch(50% 0.01 172);
+              --fg-subtle: oklch(62% 0.008 172);
+              --fg-faint: oklch(73% 0.007 172);
+              --brand: oklch(41% 0.046 167);
+              --brand-strong: oklch(34% 0.045 168);
+              --brand-deep: oklch(28% 0.036 170);
+              --brand-soft: oklch(93.5% 0.018 167);
+              --brand-softer: oklch(97% 0.01 167);
+              --on-brand: oklch(98.5% 0.006 165);
+              --link: oklch(46% 0.055 215);
+              --ok: oklch(47% 0.07 155);
+              --warn: oklch(55% 0.075 75);
+              --warn-soft: oklch(95% 0.035 80);
+              --side-brand: oklch(93% 0.025 158);
+              --shadow-pop: 0 8px 28px oklch(28% 0.03 165 / 0.16), 0 2px 6px oklch(28% 0.03 165 / 0.08);
+              --font-sans: "Noto Sans JP", system-ui, -apple-system, "Hiragino Sans", sans-serif;
+              --font-num: "Roboto Mono", ui-monospace, "Noto Sans JP", monospace;
+            }
+            *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+            html { font-size: 13px; }
+            body {
+              font-family: var(--font-sans); color: var(--fg); line-height: 1.5;
+              -webkit-font-smoothing: antialiased; font-feature-settings: "palt" 1;
+              min-height: 100vh; display: grid; place-items: center;
+              padding: 28px 20px;
+              background:
+                radial-gradient(120% 90% at 50% -10%, var(--brand-softer) 0%, transparent 55%),
+                var(--bg);
+            }
+            a { color: var(--link); text-decoration: none; }
+            a:hover { text-decoration: underline; }
+            .err {
+              width: 100%; max-width: 480px;
+              background: var(--surface);
+              border: 1px solid var(--border);
+              box-shadow: var(--shadow-pop);
+              overflow: hidden;
+            }
+            .err-top {
+              position: relative; overflow: hidden;
+              display: flex; align-items: center; gap: 12px;
+              padding: 18px 26px;
+              background: linear-gradient(150deg, var(--brand-strong) 0%, var(--brand-deep) 100%);
+              color: #fff;
+            }
+            .err-top::before {
+              content: ""; position: absolute; inset: 0; pointer-events: none;
+              background-image:
+                linear-gradient(oklch(100% 0 0 / 0.06) 1px, transparent 1px),
+                linear-gradient(90deg, oklch(100% 0 0 / 0.06) 1px, transparent 1px);
+              background-size: 34px 34px;
+              mask-image: linear-gradient(150deg, #000 10%, transparent 82%);
+              -webkit-mask-image: linear-gradient(150deg, #000 10%, transparent 82%);
+            }
+            .mono-mark { width: 32px; height: 30px; flex: none; display: block; color: var(--side-brand); position: relative; z-index: 1; }
+            .mono-mark svg { width: 100%; height: 100%; display: block; }
+            .et-name { position: relative; z-index: 1; }
+            .et-name b { display: block; font-size: 14.5px; font-weight: 700; letter-spacing: .01em; }
+            .et-name span { display: block; font-size: 10px; letter-spacing: .18em; text-transform: uppercase; color: oklch(82% 0.02 160); margin-top: 2px; }
+            .err-body { padding: 30px 30px 26px; }
+            .err-ico {
+              width: 46px; height: 46px; display: grid; place-items: center;
+              background: var(--warn-soft); color: var(--warn);
+              border: 1px solid color-mix(in oklch, var(--warn) 30%, transparent);
+              margin-bottom: 18px;
+            }
+            .err-ico svg { width: 24px; height: 24px; }
+            .err-body h1 { font-size: 20px; font-weight: 700; letter-spacing: -.01em; line-height: 1.45; }
+            .err-body .lead { font-size: 13px; color: var(--fg-muted); line-height: 1.85; margin-top: 10px; }
+            .reason {
+              display: flex; gap: 11px; align-items: flex-start; margin-top: 20px;
+              padding: 13px 15px;
+              background: var(--brand-soft);
+              border: 1px solid color-mix(in oklch, var(--brand) 18%, transparent);
+              border-left: 3px solid var(--brand);
+            }
+            .reason svg { width: 16px; height: 16px; flex: none; margin-top: 1px; color: var(--brand-strong); }
+            .reason .rz { font-size: 12px; line-height: 1.7; color: var(--fg); }
+            .reason .rz b { font-weight: 700; color: var(--brand-strong); }
+            .wait {
+              display: flex; align-items: center; justify-content: space-between; gap: 14px;
+              margin-top: 18px; padding: 14px 16px;
+              background: var(--surface-sunk);
+              border: 1px solid var(--border);
+            }
+            .wait .wl { font-size: 11.5px; color: var(--fg-muted); font-weight: 600; }
+            .wait .wl small { display: block; font-size: 10.5px; font-weight: 500; color: var(--fg-faint); margin-top: 3px; }
+            .wait .clock {
+              font-family: var(--font-num); font-variant-numeric: tabular-nums;
+              font-size: 27px; font-weight: 700; letter-spacing: .02em; color: var(--brand-strong);
+              line-height: 1;
+            }
+            .wait .clock.is-done { color: var(--ok); }
+            .err-actions { display: flex; flex-direction: column; gap: 9px; margin-top: 22px; }
+            .btn {
+              display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+              font-family: inherit; font-size: 12.5px; font-weight: 600;
+              cursor: pointer; padding: 10px 15px; border: 1px solid transparent; line-height: 1;
+              transition: background .12s, box-shadow .12s; white-space: nowrap;
+            }
+            .btn svg { width: 15px; height: 15px; pointer-events: none; }
+            .btn-primary { background: var(--brand); color: var(--on-brand); }
+            .btn-primary:hover { background: var(--brand-strong); }
+            .btn[disabled] { opacity: .5; cursor: not-allowed; }
+            .btn-block { width: 100%; }
+            .alt { display: flex; align-items: center; gap: 14px; margin: 22px 0 4px; color: var(--fg-faint); font-size: 11px; }
+            .alt::before, .alt::after { content: ""; height: 1px; background: var(--border); flex: 1; }
+            .self { display: flex; align-items: flex-start; gap: 11px; padding: 4px 2px; }
+            .self svg { width: 17px; height: 17px; flex: none; margin-top: 2px; color: var(--brand-strong); }
+            .self .st { font-size: 12.5px; line-height: 1.7; color: var(--fg-muted); }
+            .self .st b { color: var(--fg); font-weight: 600; }
+            .self .st a { font-weight: 600; }
+            .err-foot {
+              padding: 13px 30px; border-top: 1px solid var(--border);
+              background: var(--surface-2);
+              font-size: 11px; color: var(--fg-subtle);
+              display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+            }
+            .err-foot .ref { font-family: var(--font-num); color: var(--fg-faint); }
+            @media (max-width: 480px) {
+              .err-body { padding: 24px 20px 22px; }
+              .err-foot { padding: 12px 20px; }
+              .wait .clock { font-size: 23px; }
+            }
+            CSS;
     }
 }

--- a/tests/Demo/DemoBrowserErrorPageTest.php
+++ b/tests/Demo/DemoBrowserErrorPageTest.php
@@ -12,8 +12,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * The public demo link is opened by non-technical visitors in a browser, so its
- * errors must render as an explanation page, not raw Problem Details JSON —
- * while API-shaped clients and the success redirect stay byte-identical (#612).
+ * errors must render as a designed explanation page (redesign reference theme,
+ * #614) with its own CSP — not raw Problem Details JSON — while API-shaped
+ * clients and the success redirect stay byte-identical (#612).
  */
 final class DemoBrowserErrorPageTest extends TestCase
 {
@@ -42,7 +43,7 @@ final class DemoBrowserErrorPageTest extends TestCase
         return $response;
     }
 
-    public function test_browser_429_becomes_html_with_limit_and_retry_minutes(): void
+    public function test_browser_429_renders_limit_countdown_and_disabled_retry(): void
     {
         $result = $this->page->apply(
             $this->request('text/html,application/xhtml+xml;q=0.9,*/*;q=0.8'),
@@ -55,19 +56,36 @@ final class DemoBrowserErrorPageTest extends TestCase
         self::assertSame('no-store', $result->getHeaderLine('Cache-Control'));
 
         $body = (string) $result->getBody();
-        self::assertStringContainsString('1時間に30回まで', $body);
-        self::assertStringContainsString('約59分後', $body);
+        self::assertStringContainsString('1時間あたり30回まで', $body);
+        self::assertStringContainsString('id="clock">58:39<', $body, 'initial clock is server-rendered (works without JS)');
+        self::assertStringContainsString('var remain = 3519;', $body, 'countdown script seeds from Retry-After');
+        self::assertStringContainsString('id="retry" type="button" disabled', $body, 'retry stays disabled until the window resets');
+        self::assertStringContainsString('429 · DEMO_RATE_LIMIT', $body);
     }
 
-    public function test_browser_503_becomes_capacity_page(): void
+    public function test_html_page_carries_its_own_csp_allowing_inline_assets(): void
+    {
+        $result = $this->page->apply($this->request('text/html'), $this->problem(429)->withHeader('Retry-After', '60'));
+
+        $csp = $result->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("style-src 'unsafe-inline'", $csp);
+        self::assertStringContainsString("script-src 'unsafe-inline'", $csp);
+        self::assertStringContainsString("default-src 'none'", $csp, 'app-wide default-src self would block the inline design');
+    }
+
+    public function test_browser_503_renders_capacity_page_with_enabled_retry_and_no_countdown(): void
     {
         $result = $this->page->apply($this->request('text/html'), $this->problem(503));
 
+        $body = (string) $result->getBody();
         self::assertSame(503, $result->getStatusCode());
-        self::assertStringContainsString('満席', (string) $result->getBody());
+        self::assertStringContainsString('満席', $body);
+        self::assertStringContainsString('id="retry" type="button">', $body, 'capacity clears on its own — retry starts enabled');
+        self::assertStringNotContainsString('id="clock"', $body);
+        self::assertStringContainsString('503 · DEMO_CAPACITY', $body);
     }
 
-    public function test_browser_404_becomes_unavailable_page_without_echoing_input(): void
+    public function test_browser_404_renders_unavailable_page_without_echoing_input(): void
     {
         $result = $this->page->apply($this->request('text/html'), $this->problem(404));
 
@@ -75,6 +93,8 @@ final class DemoBrowserErrorPageTest extends TestCase
         self::assertSame(404, $result->getStatusCode());
         self::assertStringContainsString('ご利用いただけません', $body);
         self::assertStringNotContainsString('kensetsu', $body, 'fixed copy only — never echo the template segment');
+        self::assertStringNotContainsString('id="retry"', $body, 'reloading a dead link would just 404 again');
+        self::assertStringContainsString('404 · DEMO_NOT_FOUND', $body);
     }
 
     public function test_api_clients_keep_problem_details_untouched(): void


### PR DESCRIPTION
Closes #614

## 概要

#612 の暫定エラーページを、施主提供のリデザイン基準テーマ（deep-green business SaaS・`NeNe Invoice (24).zip` demo-error モック）準拠に置換し、制限解除カウントダウンを実装する。

## 変更

- **デザイン（モック準拠・self-contained）**: ブランドヘッダー（深緑グラデ＋グリッドテクスチャ＋NN モノグラム＋「お試しデモ」）／warn 時計アイコン／reason 左アクセントブロック（「1時間あたり30回まで」は `DemoServiceProvider` 定数から供給）／「または」区切り＋セルフホスト誘導（OSS/MIT → GitHub リポジトリ）／フッター参照コード（`429 · DEMO_RATE_LIMIT` 等）。テーマトークン（oklch）はライトテーマの解決値をページ内に内蔵・外部資産ゼロ
- **カウントダウン**: サーバが Retry-After 秒を `var remain = N` に埋め込み。初期 mm:ss は**サーバレンダリング**（JS 無効でも目安が見える）。1秒刻みで減り、0 で時計が ok 色＋「もう一度デモを開く」活性化（reload = 新しい使い捨て org＝デモのリセット動線と一致）
- **CSP バグ修正（重要）**: `SecurityHeadersMiddleware` の `default-src 'self'` はインライン CSS/JS をブロックするため、**#612 の暫定ページは実は素の HTML 表示だった**。middleware は「無ければ付与」の実装なので、このページ専用 CSP（`style-src/script-src 'unsafe-inline'`・他は `'none'`/`data:` で施錠）を応答に持たせて解決。入力エコーは一切ないため inline 許可は安全（テストで担保）
- ステータス別出し分け: 503=再試行ボタン活性（満席は自然に空く）／404=ボタン非表示（踏み直しても 404）

## 検証（実出力）

- `composer check` 全緑（**921 tests, 3403 assertions** / PHPStan / cs / OpenAPI / MCP / conformance）
- テスト 7 本: 429（上限文言・サーバレンダ初期時計 58:39・`var remain = 3519`・disabled ボタン・参照コード）／CSP ヘッダ内容／503（満席・活性ボタン・時計なし）／404（入力非エコー・ボタンなし）／API Accept 不変／302 不変
- ローカル実機: 404 ページで **CSP が本ページ専用値のまま素通り**（middleware に上書きされない）を確認。429 実発動で `id="clock">46:00<`・`var remain = 2760`・disabled・Retry-After 2760 を確認

## 残課題（本 PR 外）

- merge 後 本番反映 → throttle を armed にして施主がブラウザで目視（カウントダウン動作込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)