### PR TITLE
fix(routing): 公開リンク2種（/invoices/download・/pay）を SPA シェル先食いと org 解決から救出 (#620)

### DIFF
--- a/src/Http/BasePath.php
+++ b/src/Http/BasePath.php
@@ -24,8 +24,16 @@ final class BasePath
     /** Request attribute under which the front controller stores the detected base. */
     public const REQUEST_ATTRIBUTE = 'app.base_path';
 
-    /** API path prefixes that must reach the router, never the SPA shell. */
-    private const API_PREFIXES = ['/auth', '/admin', '/api', '/health', '/machine', '/examples', '/demo'];
+    /**
+     * API path prefixes that must reach the router, never the SPA shell.
+     *
+     * `/invoices/download` (public PDF share link) and `/pay` (hosted card
+     * payment page) are public GET routes handled by the router (#620). The
+     * download prefix is deliberately deep: bare `/invoices` would swallow the
+     * SPA screens `/invoices`, `/invoices/new`, `/invoices/:id`
+     * (frontend/src/app/router.tsx).
+     */
+    private const API_PREFIXES = ['/auth', '/admin', '/api', '/health', '/machine', '/examples', '/demo', '/invoices/download', '/pay'];
 
     /**
      * @param array<string, mixed> $serverParams PSR-7 server params (or `$_SERVER`)

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -37,6 +37,10 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         '/auth/',
         '/api/',
         '/invoices/download/',
+        // Public hosted-payment routes (`/pay/{token}`, `/pay/{token}/charge`)
+        // are token-authenticated and resolve their organization from the
+        // payment-link record itself, so there is no slug in the URL (#620).
+        '/pay/',
         '/admin/organizations',
         // Disposable-demo provisioning (`GET /demo/{template}`) is org-less: it
         // *creates* a new tenant, so there is no slug in the URL to resolve. Gated

--- a/src/Organization/Resolution/PathPrefixResolutionStrategy.php
+++ b/src/Organization/Resolution/PathPrefixResolutionStrategy.php
@@ -25,6 +25,9 @@ final readonly class PathPrefixResolutionStrategy implements PathScopedResolutio
         '/auth/',
         '/api/',
         '/invoices/download/',
+        // Public hosted-payment routes carry no slug; the handler resolves the
+        // organization from the payment-link token (#620).
+        '/pay/',
         '/admin/organizations',
     ];
 

--- a/tests/Http/BasePathTest.php
+++ b/tests/Http/BasePathTest.php
@@ -69,6 +69,15 @@ final class BasePathTest extends TestCase
         yield 'root is spa' => ['/', false];
         yield 'dashboard is spa' => ['/dashboard', false];
         yield 'admin-ish but not boundary' => ['/administration', false];
+        // Public share/payment links must reach the router, never the SPA shell (#620).
+        yield 'public pdf download' => ['/invoices/download/tok_abc123', true];
+        yield 'public pay page' => ['/pay/tok_abc123', true];
+        // ...but the SPA's own /invoices screens keep getting the shell (#620).
+        yield 'invoices list is spa' => ['/invoices', false];
+        yield 'invoice create is spa' => ['/invoices/new', false];
+        yield 'invoice detail is spa' => ['/invoices/818', false];
+        yield 'invoices-ish but not boundary' => ['/invoicesdownload', false];
+        yield 'pay-ish but not boundary' => ['/payments', false];
     }
 
     #[DataProvider('apiPaths')]

--- a/tests/Http/PathTenancyRoutingTest.php
+++ b/tests/Http/PathTenancyRoutingTest.php
@@ -49,6 +49,21 @@ final class PathTenancyRoutingTest extends TestCase
 
             return $response;
         });
+
+        // Public token routes, registered exactly as the app registers them
+        // (InvoiceDownloadTokenRouteRegistrar / PaymentLinkRouteRegistrar).
+        $this->router->get('/invoices/download/{token}', function (): ResponseInterface {
+            $response = $this->psr17->createResponse(200);
+            $response->getBody()->write('pdf-handler-reached');
+
+            return $response;
+        });
+        $this->router->get('/pay/{token}', function (): ResponseInterface {
+            $response = $this->psr17->createResponse(200);
+            $response->getBody()->write('pay-handler-reached');
+
+            return $response;
+        });
     }
 
     private function dispatch(string $path): ResponseInterface
@@ -104,5 +119,30 @@ final class PathTenancyRoutingTest extends TestCase
 
         self::assertSame(404, $response->getStatusCode());
         self::assertStringContainsString('organization-not-found', (string) $response->getBody());
+    }
+
+    /**
+     * Public PDF share link (#620): the slug-less `/invoices/download/{token}`
+     * URL that "リンクをコピー" hands to customers must bypass org resolution
+     * (the handler resolves the org from the token record) and reach the route.
+     */
+    public function test_public_pdf_download_link_bypasses_org_resolution(): void
+    {
+        $response = $this->dispatch('/invoices/download/tok_abc123');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('pdf-handler-reached', (string) $response->getBody());
+    }
+
+    /**
+     * Public hosted-payment page (#620): the slug-less `/pay/{token}` URL must
+     * not be mistaken for a `pay` tenant slug in path mode.
+     */
+    public function test_public_pay_link_bypasses_org_resolution(): void
+    {
+        $response = $this->dispatch('/pay/tok_abc123');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('pay-handler-reached', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
Closes #620

## 変更

- `BasePath::API_PREFIXES` に `/invoices/download`・`/pay` を追加 — 公開PDF共有リンクと支払ページが SPA シェルに先食いされず router に届く。
  - `/invoices` 丸ごとは追加しない: SPA 画面ルート `/invoices`・`/invoices/new`・`/invoices/:id`（`frontend/src/app/router.tsx`）を壊すため、深いプレフィックスで限定（コメントに明記）。
- `OrgResolverMiddleware` / `PathPrefixResolutionStrategy` の `BYPASS_PREFIXES` に `/pay/` を追加 — path テナンシー（本番設定）で `pay` が slug 誤解釈され 404 になるのを防止。`PayPageHandler` / charge はトークンから org を自己解決する設計（`findByHash` は org 非スコープ・`orgId->set()` をハンドラ側で実施）。

## 回帰テスト

- `BasePathTest`: 公開2ルート=API 扱い／`/invoices`・`/invoices/new`・`/invoices/818` は従来どおり SPA／`/invoicesdownload`・`/payments` の境界誤爆なし。
- `PathTenancyRoutingTest`: 実 `OrgResolverMiddleware`＋実 Router で slug 無し `/invoices/download/{token}`・`/pay/{token}` がハンドラに到達することを固定。
- 公開PDF の `application/pdf` は既存 `DownloadInvoicePdfHandlerTest` が固定済み。

## 検証

`composer check` 全緑（933 tests / PHPStan max / CS / OpenAPI / MCP / Conformance）。

## セルフレビューチェックリスト

- [x] 用語レジストリ準拠（新規識別子なし）
- [x] テナントスコープ影響なし（公開トークンルートの org 自己解決を確認）
- [x] 回帰テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)