### PR TITLE
fix(invoice): メール送信の搬送層失敗を 502 email-delivery-failed の Problem Details 化 (#621)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -179,6 +179,7 @@ Base URL: `https://nene-invoice.dev/problems/`. Slug is **kebab-case**.
 | `bank-transaction-not-found` | Bank transaction id not found in the caller's org (404; #505) |
 | `invalid-webhook-token` | PAY.JP webhook `X-Payjp-Webhook-Token` missing or incorrect (401; public webhook) |
 | `demo-capacity-exceeded` | Disposable-demo organization ceiling reached — demo start refused before provisioning (503; NENE2 `Nene2\Demo`, #608) |
+| `email-delivery-failed` | Mail transport (SMTP) failed while sending an email — the request was valid, the upstream hop failed (502; #621) |
 
 Add new slugs here before using them. Validation `errors[].field` uses
 snake_case paths (e.g. `body.registration_number`); `errors[].code` is

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2094,6 +2094,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+        '502':
+          $ref: '#/components/responses/EmailDeliveryFailed'
   /admin/invoices/{id}/payments:
     parameters:
       - $ref: '#/components/parameters/IdPathParam'
@@ -2409,6 +2411,12 @@ components:
             $ref: '#/components/schemas/ProblemDetails'
     ValidationFailed:
       description: Request body or field validation error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+    EmailDeliveryFailed:
+      description: The mail transport (SMTP) failed; the email was not delivered.
       content:
         application/problem+json:
           schema:

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -30,6 +30,7 @@ use NeneInvoice\InvoiceDownloadToken\InvoiceDownloadTokenRouteRegistrar;
 use NeneInvoice\Item\ItemNotFoundExceptionHandler;
 use NeneInvoice\Item\ItemRouteRegistrar;
 use NeneInvoice\LineItem\LineItemRouteRegistrar;
+use NeneInvoice\Mailer\MailerExceptionHandler;
 use NeneInvoice\Organization\OrganizationNotFoundExceptionHandler;
 use NeneInvoice\Organization\OrganizationRouteRegistrar;
 use NeneInvoice\Organization\OrganizationSlugConflictExceptionHandler;
@@ -222,6 +223,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $invoiceValidation = $container->get(InvoiceValidationExceptionHandler::class);
                     $qualifiedIncomplete = $container->get(QualifiedInvoiceIncompleteExceptionHandler::class);
                     $invoiceEmail = $container->get(InvoiceEmailExceptionHandler::class);
+                    $mailerFailure = $container->get(MailerExceptionHandler::class);
                     $paymentValidation = $container->get(PaymentValidationExceptionHandler::class);
                     $paymentExceeds = $container->get(PaymentExceedsOutstandingExceptionHandler::class);
                     $paymentNotFound = $container->get(PaymentNotFoundExceptionHandler::class);
@@ -313,6 +315,10 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Invoice email exception handler service is invalid.');
                     }
 
+                    if (!$mailerFailure instanceof MailerExceptionHandler) {
+                        throw new LogicException('Mailer exception handler service is invalid.');
+                    }
+
                     if (!$paymentValidation instanceof PaymentValidationExceptionHandler) {
                         throw new LogicException('Payment validation exception handler service is invalid.');
                     }
@@ -337,7 +343,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Service token not-found exception handler service is invalid.');
                     }
 
-                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $itemNotFound, $templateNotFound, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $recurringInvoiceNotFound, $recurringInvoiceValidation, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $invoiceEmail, $paymentValidation, $paymentExceeds, $paymentNotFound, $bankTransactionNotFound, $bankTransactionValidation, $serviceTokenNotFound];
+                    return [$orgNotFound, $orgSlugConflict, $userNotFound, $userEmailConflict, $roleNotAssignable, $cannotDeleteSelf, $clientNotFound, $invalidRegNumber, $itemNotFound, $templateNotFound, $companySettingsNotFound, $companyInvalidRegNumber, $quoteNotFound, $quoteValidation, $quoteInvalidTransition, $recurringInvoiceNotFound, $recurringInvoiceValidation, $invoiceNotFound, $invoiceValidation, $qualifiedIncomplete, $invoiceEmail, $mailerFailure, $paymentValidation, $paymentExceeds, $paymentNotFound, $bankTransactionNotFound, $bankTransactionValidation, $serviceTokenNotFound];
                 },
             );
     }

--- a/src/Mailer/MailerExceptionHandler.php
+++ b/src/Mailer/MailerExceptionHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Mailer;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Maps a mail-transport failure ({@see MailerException}) to a `502 Bad Gateway`
+ * `email-delivery-failed` Problem Details response instead of a generic 500
+ * (#621): the upstream SMTP hop failed, the request itself was valid.
+ *
+ * The transport error (which may name SMTP hosts) goes to `error_log` for ops;
+ * the response detail stays generic so nothing about the mail infrastructure
+ * leaks to API clients.
+ */
+final readonly class MailerExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private ProblemDetailsResponseFactory $problemDetails)
+    {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof MailerException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        assert($exception instanceof MailerException);
+
+        error_log('NeNe Invoice: email delivery failed: ' . $exception->getMessage());
+
+        return $this->problemDetails->create(
+            $request,
+            'email-delivery-failed',
+            'Email Delivery Failed',
+            502,
+            'The email could not be delivered because the mail transport failed. Check the MAIL_* configuration or try again later.',
+        );
+    }
+}

--- a/src/Mailer/MailerServiceProvider.php
+++ b/src/Mailer/MailerServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Mailer;
 
+use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -30,6 +32,19 @@ final readonly class MailerServiceProvider implements ServiceProviderInterface
                 $encryption = (string) (getenv('MAIL_ENCRYPTION') ?: '');
 
                 return new SmtpMailer($host, $port, $fromAddr, $fromName, $username, $password, $encryption);
+            },
+        );
+
+        $builder->set(
+            MailerExceptionHandler::class,
+            static function (ContainerInterface $c): MailerExceptionHandler {
+                $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                    throw new LogicException('ProblemDetailsResponseFactory service is invalid.');
+                }
+
+                return new MailerExceptionHandler($problemDetails);
             },
         );
     }

--- a/tests/Mailer/MailerExceptionHandlerTest.php
+++ b/tests/Mailer/MailerExceptionHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Mailer;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneInvoice\Mailer\MailerException;
+use NeneInvoice\Mailer\MailerExceptionHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * A mail-transport failure must surface as a 502 `email-delivery-failed`
+ * Problem Details response — never a generic 500 (#621): a prospect clicking
+ * 送信 in the demo should see a graceful "could not deliver", not an outage.
+ */
+final class MailerExceptionHandlerTest extends TestCase
+{
+    private MailerExceptionHandler $handler;
+    private Psr17Factory $psr17;
+    private string $previousErrorLog;
+
+    protected function setUp(): void
+    {
+        $this->psr17   = new Psr17Factory();
+        $this->handler = new MailerExceptionHandler(
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        // The handler error_log()s the transport error for ops; keep it out of
+        // the test runner's output.
+        $this->previousErrorLog = (string) ini_set('error_log', '/dev/null');
+    }
+
+    protected function tearDown(): void
+    {
+        ini_set('error_log', $this->previousErrorLog);
+    }
+
+    public function test_supports_mailer_exception_only(): void
+    {
+        self::assertTrue($this->handler->supports(new MailerException('SMTP send failed')));
+        self::assertFalse($this->handler->supports(new RuntimeException('anything else')));
+    }
+
+    public function test_maps_transport_failure_to_502_problem_details(): void
+    {
+        $request  = $this->psr17->createServerRequest('POST', 'https://host.example/admin/invoices/818/send-email');
+        $response = $this->handler->handle(new MailerException('SMTP send failed: getaddrinfo for mailpit failed'), $request);
+
+        self::assertSame(502, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertSame('https://nene-invoice.dev/problems/email-delivery-failed', $payload['type']);
+        self::assertSame(502, $payload['status']);
+    }
+
+    public function test_response_does_not_leak_transport_internals(): void
+    {
+        $request  = $this->psr17->createServerRequest('POST', 'https://host.example/admin/invoices/818/send-email');
+        $response = $this->handler->handle(new MailerException('SMTP send failed: connect to smtp.internal.example:465'), $request);
+
+        self::assertStringNotContainsString('smtp.internal.example', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
Closes #621

## 変更

- `MailerExceptionHandler`（新規・`src/Mailer/`）: `MailerException` を **502** `email-delivery-failed` の Problem Details に変換。実搬送エラー（SMTP ホスト名等を含み得る）は `error_log` に残し、レスポンス detail は汎用文言（内部情報を漏らさない）。
- `MailerServiceProvider` に DI 登録・`ApplicationServiceProvider` の EXCEPTION_HANDLERS に追加。
- 用語レジストリに slug `email-delivery-failed` を登録（同一 PR ルール）。
- OpenAPI: `sendInvoiceEmail` に `502` 応答（`EmailDeliveryFailed` response component）を追記。

## 真因（本番実証済み・issue 参照）

本番 `.env` に `MAIL_*` 無し → デフォルト `mailpit:1025` へ接続 → HETEML で `getaddrinfo for mailpit failed` を実測 → `MailerException` → ハンドラ未登録で汎用 500。demo seed の `.example` 宛先は意図的仕様のまま（変更なし）。SPA は既存の ActionError バナーが isError で出るため、この 502 化だけで「配信できませんでした」が上品に表示される。

## テスト

`MailerExceptionHandlerTest`: supports 判定／502＋`application/problem+json`＋slug／搬送内部情報の非漏洩。

## 検証

`composer check` 全緑（927 tests / PHPStan max / CS / OpenAPI / MCP / Conformance）。

## セルフレビューチェックリスト

- [x] 用語レジストリ更新（`email-delivery-failed`・同一 PR）
- [x] Problem Details 慣習準拠（kebab-case slug・base URL）
- [x] OpenAPI 追随・回帰テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)