### PR TITLE
fix(user): OpenAPI UpdateUserRequest に必須 status を追記し SPA 編集フォームも送信 (#622)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2545,6 +2545,10 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/Role'
+        status:
+          type: string
+          enum: [active, invited]
+      required: [role, status]
     Organization:
       type: object
       properties:

--- a/frontend/src/entities/user/model.ts
+++ b/frontend/src/entities/user/model.ts
@@ -27,9 +27,12 @@ export interface CreateUserInput {
   role: UserRole
 }
 
+// PATCH /admin/users/{id} requires role and status (UpdateUserRequest); the
+// edit form resends the user's current status so it stays unchanged (#622).
 export interface UpdateUserInput {
   id: UserId
   email?: string
   password?: string
-  role?: UserRole
+  role: UserRole
+  status: UserStatus
 }

--- a/frontend/src/entities/user/mutations.test.ts
+++ b/frontend/src/entities/user/mutations.test.ts
@@ -61,20 +61,26 @@ describe('useCreateUser', () => {
 })
 
 describe('useUpdateUser', () => {
-  it('patches and returns the updated user', async () => {
+  it('patches with the required role and status and returns the updated user', async () => {
+    let sentBody: unknown
     server.use(
-      http.patch('/admin/users/:id', () => HttpResponse.json({ ...USER_DTO, role: 'admin' })),
+      http.patch('/admin/users/:id', async ({ request }) => {
+        sentBody = await request.json()
+        return HttpResponse.json({ ...USER_DTO, role: 'admin' })
+      }),
     )
 
     const { result } = renderHookWithProviders(() => useUpdateUser())
     act(() => {
-      result.current.mutate({ id: toUserId(7), role: 'admin' })
+      result.current.mutate({ id: toUserId(7), role: 'admin', status: 'active' })
     })
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
     expect(result.current.data?.role).toBe('admin')
+    // The API requires both fields (UpdateUserRequest, #622).
+    expect(sentBody).toMatchObject({ role: 'admin', status: 'active' })
   })
 })
 

--- a/frontend/src/entities/user/mutations.ts
+++ b/frontend/src/entities/user/mutations.ts
@@ -32,10 +32,10 @@ export function useUpdateUser(): UseMutationResult<User, AppError, UpdateUserInp
 
   return useMutation<User, AppError, UpdateUserInput>({
     mutationFn: async (input) => {
-      const body: Record<string, unknown> = {}
+      // role and status are required by the API (UpdateUserRequest, #622).
+      const body: Record<string, unknown> = { role: input.role, status: input.status }
       if (input.email !== undefined) body['email'] = input.email
       if (input.password !== undefined && input.password !== '') body['password'] = input.password
-      if (input.role !== undefined) body['role'] = input.role
       const dto = await apiClient.patch<UserDto>(`/admin/users/${String(input.id)}`, body)
       return toUser(dto)
     },

--- a/frontend/src/features/edit-user/hooks/use-edit-user.ts
+++ b/frontend/src/features/edit-user/hooks/use-edit-user.ts
@@ -58,12 +58,18 @@ export function useEditUser(userId: UserId): EditUserState {
   }
 
   const submit = form.handleSubmit((values) => {
+    if (user === undefined) {
+      return
+    }
     update.mutate(
       {
         id: userId,
         email: values.email,
         password: values.password !== '' ? values.password : undefined,
         role: values.role,
+        // The API requires status; the edit screen has no status control, so
+        // resend the current value unchanged (#622).
+        status: user.status,
       },
       {
         onSuccess: () => {

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -220,7 +220,11 @@ export interface paths {
         delete: operations["deleteOrganization"];
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update organization
+         * @description Partial update (superadmin). Only the provided fields change; is_active suspends (false) or reactivates (true) the tenant. slug and external_id are immutable here.
+         */
+        patch: operations["updateOrganization"];
         trace?: never;
     };
     "/admin/users": {
@@ -1323,7 +1327,9 @@ export interface components {
             /** Format: email */
             email?: string;
             password?: string;
-            role?: components["schemas"]["Role"];
+            role: components["schemas"]["Role"];
+            /** @enum {string} */
+            status: "active" | "invited";
         };
         Organization: {
             id: number;
@@ -1353,6 +1359,14 @@ export interface components {
              * @description Plaintext password for the tenant's initial admin (hashed server-side). Requires admin_email.
              */
             admin_password?: string;
+        };
+        /** @description Partial update of a tenant (superadmin only). Every field is optional; at least one must be present (else 422). is_active suspends (false) or reactivates (true) the tenant. slug and external_id are immutable here. */
+        UpdateOrganizationRequest: {
+            name?: string;
+            /** @description Billing plan slug. */
+            plan?: string;
+            /** @description false suspends the tenant (its users are locked out); true reactivates it. */
+            is_active?: boolean;
         };
         DownloadTokenResponse: {
             /** @description Public PDF download URL (relative path, no auth required). */
@@ -2022,6 +2036,15 @@ export interface components {
                 "application/problem+json": components["schemas"]["ProblemDetails"];
             };
         };
+        /** @description The mail transport (SMTP) failed; the email was not delivered. */
+        EmailDeliveryFailed: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/problem+json": components["schemas"]["ProblemDetails"];
+            };
+        };
         /** @description Registration number is not `T` followed by 13 digits. */
         InvalidRegistrationNumber: {
             headers: {
@@ -2424,6 +2447,42 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["InsufficientCapability"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    updateOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Resource identifier. */
+                id: components["parameters"]["IdPathParam"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                /**
+                 * @example {
+                 *       "is_active": false
+                 *     }
+                 */
+                "application/json": components["schemas"]["UpdateOrganizationRequest"];
+            };
+        };
+        responses: {
+            /** @description Organization updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Organization"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["InsufficientCapability"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationFailed"];
         };
     };
     listUsers: {
@@ -4295,6 +4354,7 @@ export interface operations {
             403: components["responses"]["InsufficientCapability"];
             404: components["responses"]["NotFound"];
             422: components["responses"]["ValidationFailed"];
+            502: components["responses"]["EmailDeliveryFailed"];
         };
     };
     listPayments: {


### PR DESCRIPTION
Closes #622

## 変更（実装が正・スキーマ追随）

- OpenAPI `UpdateUserRequest`: `status`（enum `active|invited`）を追加し、実装（`UpdateUserHandler` は role/status 必須）どおり `required: [role, status]` を明記。
- `npm run codegen` で `schema.gen.ts` 再生成（#624 の sendInvoiceEmail 502 追記分も同時に反映）。
- **SPA も同じ乖離を踏んでいた**: `useUpdateUser` が status を送らず、ユーザー編集が必ず 422 になっていた。`UpdateUserInput` を API 契約どおり `role`/`status` 必須にし、編集フォームは現在の status をそのまま再送（画面挙動・UI は不変）。
- `mutations.test`: PATCH 送信 body に `role`・`status` が含まれることを固定。

## 検証

- `composer check` 全緑（936 tests / PHPStan max / CS / OpenAPI / MCP / Conformance）。
- `npm run check` 全緑（type-check / lint / prettier / vitest 312 / knip / storybook build）。

## セルフレビューチェックリスト

- [x] 用語レジストリ準拠（`status` 値 `active`/`invited` は登録済み・新規識別子なし）
- [x] OpenAPI＝実装の単一真実（codegen 再生成込み）
- [x] 回帰テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)