### PR TITLE
docs(daily): 2026-07-11 日報 (#627)

### DIFF
--- a/docs/daily-reports/2026-07-11.md
+++ b/docs/daily-reports/2026-07-11.md
@@ -1,0 +1,49 @@
+# Daily Report — 2026-07-11
+
+**Project:** NeNe Invoice（自己ホスト型 見積・請求・入金管理／日本の適格請求書対応・マルチテナント前提）
+**Branch state at end of day:** `origin/main` @ `cbae73b`（CI 全緑）
+**Author:** Claude Fable 5（施主とペア）／修正実装は統合リナ（並行セッション）
+
+---
+
+## Summary
+
+**本番デモ（`/demo/bldmainte`）の全機能を正常系で打鍵する QA セッション**を実施（約110リクエスト・API 直打鍵）。見積→請求→入金のフルライフサイクル、銀行入金自動消込（CSV 取込→サジェスト→確定→ignore）、定期請求 CRUD、マスタ・CSV 入出力、ユーザー管理、印影、サービス API（token 発行→read/write→void→revoke）、監査ログまで**正常系はほぼ全機能が完走**。
+
+一方で**要対応の障害 2 件＋仕様乖離 1 件**を検出して起票（#620/#621/#622）。3 件とも**統合リナが即日修正・マージ（PR #623/#624/#625）**し、翌日に本番反映まで再打鍵で検証完了。残った UX 論点（デモのメール送信が構造的に必ず失敗する）は #626 として起票した。
+
+## 打鍵で確認できたこと（正常系・完走）
+
+- **認証・セッション**: `/demo/{template}` 払い出し → cookie → `POST /auth/refresh`（CSRF）→ Bearer、logout 後の refresh は 401（フェイルクローズド）。HETEML の Authorization 剥がしは `X-Authorization` ミラー（#596）で仕様どおり回避
+- **閲覧系 27 エンドポイント全 200**（検索・フィルタ・ソート・エクスポート含む）。`/admin/organizations` は 403 ＝ superadmin 専用ガードが正常
+- **見積→請求→入金**: 取引先作成 → 見積（税計算正）→ PDF → sent → accepted → 変換 → 発行（適格・`INV-2026-012` 採番連続）→ PDF → 一部入金 `partially_paid` → 全額 `paid`
+- **銀行入金自動消込（#505）**: シード済み名義ゆれ明細のサジェスト（score 64・amount-exact + name-similar）→ confirm → paid。銀行 CSV 取込（`net_bank_credit_debit`）→ confirm、ignore フローも完走
+- **定期請求・品目・テンプレート・取引先の CRUD**、CSV 取込（テンプレ列準拠。列数不一致は行番号付き 422 — 良い挙動）
+- **サービス API**: `label`+`subject`+`scopes` で token 発行 → `/api/*` read → 入金記録（`paid_at`・`idempotency_key` 必須）→ void → revoke 後 401
+- **決済 GW**: 未設定を正しく報告（`not_configured`）。payment-link 発行/失効は動作
+- **監査ログ**: 上記の全操作が正しく記録
+
+## 検出 → 修正 → 本番反映検証（すべてクローズ）
+
+| 所見 | Issue | PR | 検証 |
+| --- | --- | --- | --- |
+| 公開リンク2種（`/invoices/download/{token}`・`/pay/{token}`）が SPA シェルに先食いされ顧客に届かない（`BasePath::API_PREFIXES` 欠落＋org 解決） | #620 | #623 | 本番で bogus token が SPA HTML でなく実ハンドラの 404 に到達することを確認 |
+| メール送信の搬送層失敗が生の 500 で表面化 | #621 | #624 | 新規デモ組織で実打鍵 → `502 email-delivery-failed` の Problem Details を確認 |
+| OpenAPI `UpdateUserRequest` に実装必須の `status`（active\|invited）が無い | #622 | #625 | スキーマ追記＋SPA 編集フォーム送信をコード確認 |
+
+## Notable / 学び
+
+- **公開導線は「実トークンでの end-to-end」でしか検証できない**: `/invoices/download` も `/pay` もハンドラ・テストは存在しており、ルーティング前段（SPA シェル分岐）で死んでいた。ユニットテストでは出ない種類の欠陥で、本番相当環境での打鍵が捕まえた
+- **打鍵は「API スキーマの実効性テスト」にもなる**: OpenAPI だけを頼りにリクエストを組んだことで、スキーマと実装の乖離（#622）や、テンプレ CSV の `__template,id,...` 列規約・サービス API の必須フィールドなど、ドキュメント外の暗黙仕様が炙り出せた
+- **並行体制が機能した**: 打鍵側（本セッション）が発見・起票・本番検証、統合リナが即日修正という分業で、発見から本番反映まで約半日で完結
+
+## 現状・積み残し
+
+- `origin/main` クリーン @ `cbae73b`。打鍵で検出した 3 件はすべてクローズ・本番反映済み
+- **#626（新規・open）**: デモ組織のメール送信は 502 を正しく返すが構造的に必ず失敗する（シードが `.example` 宛て）。セールス導線としての体験改善案 A/B/C を併記済み・要施主判断
+- デモは使い捨て org 方式のため、打鍵で作成したデータは sweep で自然消滅（後片付け不要）
+- 製品側の次の本命は引き続き #527（一括発行・一括メール）ほか `docs/todo/current.md` 参照
+
+## 品質ゲート
+
+- 本セッションは QA・docs のみ（プロダクトコード変更なし）。修正 3 PR（#623/#624/#625）は統合リナ側で CI 緑マージ済み


### PR DESCRIPTION
Closes #627

本セッション（07-10深夜〜07-11）の日報。本番デモ `/demo/bldmainte` 全機能打鍵（正常系ほぼ完走）→ 検出3所見（#620/#621/#622）の統合リナ即日修正・本番反映検証 → 残 UX 論点 #626 起票。docs のみ（セルフレビュー: docs-policy）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)