### PR TITLE
fix(release): build-release.sh の NENE2 制約を composer.json から読む方式に (#629)

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -7,8 +7,9 @@
 #
 # 設計（nene-records の build-release.sh に倣う・#576 / _work/reports/2026-07-05/）:
 # - 作業ツリーの vendor は一切触らない。配布物は staging で Packagist の
-#   hideyukimori/nene2 ^1.6 を解決した実体 vendor を組む（path repo / symlink を
-#   持ち込まない）。symlink が 1 本でも残ったら fail。
+#   hideyukimori/nene2（制約は composer.json の require から読む・#629）を解決した
+#   実体 vendor を組む（path repo / symlink を持ち込まない）。symlink が 1 本でも
+#   残ったら fail。
 # - 同梱は allowlist 方式（dev 専用物・秘密・巨大物の混入を構造的に防ぐ）。
 # - 出荷物は WordPress 式にトップレベル展開。SHA-256 サイドカーを併せて出力。
 
@@ -19,10 +20,19 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/dist"
 STAGE="$DIST/build/stage"
 ZIP_NAME="nene-invoice-${VERSION}.zip"
-# demo ブランチ（feat/demo-disposable-org）は GuardedJwtSecretResolver 等を含む
-# nene2 ^1.8.2 系を要求する（composer.json の require と一致させる）。旧値 ^1.6 は
-# 当該クラスを含まず、fail-close JWT が壊れるため是正（#576 追補）。
-NENE2_CONSTRAINT="^1.8.2"
+# NENE2 の解決制約は composer.json の require から読む（#629）。ハードコードは
+# ^1.6（fail-close JWT 破壊）→ ^1.8.2（v1.10 系のブランドエラーページ欠落）と
+# 2 度 composer.json とドリフトした前科があるため禁止 — repo とリリース ZIP が
+# 常に同じ制約で NENE2 を解決することを構造的に保証する。
+NENE2_CONSTRAINT="$(php -r '
+$json = json_decode((string) file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+echo $json["require"]["hideyukimori/nene2"] ?? "";
+' "$ROOT/composer.json")"
+
+if [ -z "$NENE2_CONSTRAINT" ]; then
+    echo "✗ composer.json の require に hideyukimori/nene2 がありません。" >&2
+    exit 1
+fi
 
 echo "=== NeNe Invoice Tier A release build: $VERSION ==="
 
@@ -63,7 +73,7 @@ mkdir -p "$STAGE/var"
 touch "$STAGE/var/.gitkeep"
 
 # ----------------------------------------
-# 3. Packagist ^1.6 の本番 vendor（path repo / symlink を持ち込まない）
+# 3. Packagist の本番 vendor（制約は composer.json 由来・path repo / symlink を持ち込まない）
 # ----------------------------------------
 echo "→ composer: resolve hideyukimori/nene2 ${NENE2_CONSTRAINT} from Packagist..."
 php -r '


### PR DESCRIPTION
Closes #629

## 変更内容

- `tools/build-release.sh` のハードコード `NENE2_CONSTRAINT="^1.8.2"` を廃止し、`composer.json` の `require."hideyukimori/nene2"` から `php -r` で抽出する方式に変更（ドリフト再発の構造的防止）。
- 制約が読めない場合はビルドを即 fail。
- ヘッダ・セクションコメントの旧 `^1.6` 記述を現実装に合わせて更新。

## 検収

- `bash tools/build-release.sh dev` 実走 → `nene2 resolved: v1.10.0`（composer.json `^1.10` と一致）を確認。symlink 検査・PayloadInstaller 実体検査も pass。検証用 zip はビルド確認後に削除済み。
- `composer check` 全緑（test / analyse / cs / openapi / mcp / conformance）。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（シェルスクリプトのみの変更・アプリコード無変更・用語レジストリ影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)