### PR TITLE
fix(release): dist/ の旧世代 demo zip を一掃し配布前ルールを README 化 (#630)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !/public_html/admin/.htaccess
 /storage/
 /build/
-/dist/
+/dist/*
+!/dist/README.md
 /frontend/node_modules/
 /frontend/apps/*/dist/

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,29 @@
+# dist/ — リリース ZIP の出力先（ビルド成果物・untracked）
+
+ここに置かれる `nene-invoice-<version>.zip`（＋ `.sha256` サイドカー）は
+`tools/build-release.sh` の**その時点のローカルビルド成果物**であり、リポジトリには
+含まれない（`.gitignore`）。**このフォルダの zip を「最新」と信用しないこと。**
+
+## 配布前の鉄則（#630 の再発防止）
+
+2026-07-11 の構造統一性監査で、`Nene2\Demo` consumer 化（#610/#616）**前**の旧世代
+zip がファイル名だけ最新に見える状態で残置され、誤配布リスクになっていた（#630）。
+
+1. **配布する zip は、必ず配布直前に現 `main` から焼き直す**:
+
+   ```bash
+   git checkout main && git pull
+   bash tools/build-release.sh <version>
+   ```
+
+2. ビルドログの `nene2 resolved: vX.Y.Z` が `composer.json` の
+   `require."hideyukimori/nene2"` と整合していることを確認する
+   （制約は composer.json から自動で読まれる — #629）。
+
+3. 古い zip は残さない。用済みの zip・サイドカーは削除する
+   （`rm -f dist/nene-invoice-*.zip*`）。zip の鮮度はファイル日付でしか判定できず、
+   ファイル名のバージョンは中身の世代を保証しない。
+
+## 検証
+
+展開物の設置検証は `compose.installer.yaml`（インストーラ検証用 Docker 環境）を使う。


### PR DESCRIPTION
Closes #630

## 変更内容

- **旧世代 zip 3本＋sha256 サイドカーを削除**（untracked のため rm のみ・コミット対象外）: `nene-invoice-1.0.0-demo.zip`（07-08・`Nene2\Demo` consumer 化前の旧デモ世代）/ `1.0.0-rc1.zip`（07-05）/ `s2-562.zip`（07-04）。
- **再発防止**: `dist/README.md` を追加 — 配布 zip は配布直前に現 main から焼き直す・`nene2 resolved` の整合確認（#629 で制約は composer.json 由来に）・用済み zip は残さない、を明文化。
- `.gitignore` を `/dist/` → `/dist/*` + `!/dist/README.md` に変更（README のみ track）。

## 検収

- `dist/` に旧 zip が残っていないことを確認。
- #629 是正後の `tools/build-release.sh 1.0.0-demo` を現コードで再実走し、新しい正世代 zip（nene2 v1.10.0）を焼き直し（ローカル成果物・営業導線用）。
- `composer check` 全緑。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（ビルド成果物運用と .gitignore のみ・アプリコード無変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)