### PR TITLE
fix(demo): demo org カウント/sweep の LIKE に ESCAPE を明示 (#636)

### DIFF
--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -22,6 +22,7 @@ use NeneInvoice\Auth\RefreshTokenIssuer;
 use NeneInvoice\Http\RuntimeServiceProvider;
 use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
 use NeneInvoice\Organization\DeleteOrganizationUseCaseInterface;
+use NeneInvoice\Support\SqlLike;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 
@@ -119,9 +120,11 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
 
                     return new CountingDemoCapacityGuard(
                         demoOrgCount: static function () use ($query, $config): int {
+                            // ESCAPE 明示＋prefix のワイルドカードエスケープ（clear #277 還流・#636）。
+                            // エスケープ文字は invoice 業務クエリと同じ SqlLike の '!'（#396）。
                             $row = $query->fetchOne(
-                                'SELECT COUNT(*) AS cnt FROM organizations WHERE slug LIKE ?',
-                                [$config->demo->slugPrefix . '%'],
+                                "SELECT COUNT(*) AS cnt FROM organizations WHERE slug LIKE ? ESCAPE '!'",
+                                [SqlLike::escape($config->demo->slugPrefix) . '%'],
                             );
 
                             return $row !== null ? (int) $row['cnt'] : 0;

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -23,6 +23,7 @@ use Nene2\Demo\DisposableDemoSweeper;
 use Nene2\Demo\DisposableOrgReaperInterface;
 use Nene2\Http\ClockInterface;
 use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Support\SqlLike;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -64,9 +65,11 @@ foreach (glob($root . '/var/rate-limits/*.json') ?: [] as $window) {
     }
 }
 
+// ESCAPE 明示＋prefix のワイルドカードエスケープ（clear #277 還流・#636）。
+// エスケープ文字は invoice 業務クエリと同じ SqlLike の '!'（#396）。
 $rows = $query->fetchAll(
-    'SELECT id, created_at FROM organizations WHERE slug LIKE ?',
-    [$demo->slugPrefix . '%'],
+    "SELECT id, created_at FROM organizations WHERE slug LIKE ? ESCAPE '!'",
+    [SqlLike::escape($demo->slugPrefix) . '%'],
 );
 
 $records = array_map(


### PR DESCRIPTION
Closes #636（umbrella #631 の (c)）

## 変更内容

- `src/Demo/DemoServiceProvider.php` — demo org カウントの `slug LIKE ?` を `LIKE ? ESCAPE '!'` ＋ `SqlLike::escape($prefix)` に。
- `tools/sweep-demo.php` — sweep の demo org 一覧 SELECT も同形に。

clear #277 で入った LIKE 可搬性修正の還流。エスケープ文字は clear/deal/vault の `'|'` ではなく、invoice 業務クエリ（#396・`src/Support/SqlLike.php`）と同じ `'!'` に統一（形は同じ・製品内一貫性を優先）。

## 検収

- `composer check` 全緑（test / analyse / cs / openapi / mcp / conformance）。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（挙動等価な防御的修正・用語レジストリ影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)