### PR TITLE
refactor(demo): グローバル RateLimitStorageInterface 束縛をやめ guard 内 inline 生成に (#638)

### DIFF
--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -17,7 +17,6 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\ClockInterface;
-use Nene2\Middleware\RateLimitStorageInterface;
 use NeneInvoice\Auth\RefreshTokenIssuer;
 use NeneInvoice\Http\RuntimeServiceProvider;
 use NeneInvoice\Organization\CreateOrganizationUseCaseInterface;
@@ -101,22 +100,20 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                 },
             )
             ->set(
-                RateLimitStorageInterface::class,
-                static fn (ContainerInterface $c): RateLimitStorageInterface => new FileRateLimitStorage(
-                    self::projectRoot($c) . '/var',
-                    self::clock($c),
-                ),
-            )
-            ->set(
                 DemoCapacityGuardInterface::class,
                 static function (ContainerInterface $c): DemoCapacityGuardInterface {
                     $config = self::appConfig($c);
                     $query = self::query($c);
-                    $storage = $c->get(RateLimitStorageInterface::class);
 
-                    if (!$storage instanceof RateLimitStorageInterface) {
-                        throw new LogicException('Rate limit storage service is invalid.');
-                    }
+                    // demo 専用の throttle ストレージは guard 内で inline 生成する
+                    // （deal/vault/clear と同形・#638）。グローバルな
+                    // RateLimitStorageInterface::class をこの demo 用 File 実装で
+                    // 束縛すると、将来 login throttle 等の別ミドルウェアが同 ID を
+                    // 解決したときに var/rate-limits/ を巻き添えにするため。
+                    $storage = new FileRateLimitStorage(
+                        self::projectRoot($c) . '/var',
+                        self::clock($c),
+                    );
 
                     return new CountingDemoCapacityGuard(
                         demoOrgCount: static function () use ($query, $config): int {


### PR DESCRIPTION
Closes #638（umbrella #631 の (d)）

## 変更内容

- `src/Demo/DemoServiceProvider.php` — `RateLimitStorageInterface::class` のコンテナ登録を撤去し、`DemoCapacityGuardInterface` ファクトリ内で `new FileRateLimitStorage(...)` を inline 生成（deal 形）。demo 以外の consumer がグローバル ID 経由で demo 用ストレージを掴む経路を排除。

挙動は等価（同じ `var/` 直下・同じ Clock・guard だけが使用）。

## 検収

- `composer check` 全緑（test / analyse / cs / openapi / mcp / conformance）。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（DI 配線のみの等価リファクタ・用語レジストリ影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)