### PR TITLE
fix(installer): 完了時に install.php を自己削除する (#644)

### DIFF
--- a/compose.installer.yaml
+++ b/compose.installer.yaml
@@ -9,7 +9,7 @@
 #   3) docker compose -p nene-installer -f compose.installer.yaml up -d --build
 #   4) ブラウザで http://localhost:8595/install.php
 #        DB: host=mysql / port=3306 / name=nene_invoice / user=nene_invoice / pass=nene_invoice
-#        管理者: 任意のメール・8文字以上のパスワード・会社名
+#        管理者: 任意のメール・12文字以上のパスワード・会社名
 #   5) 完了後 http://localhost:8595/ でログイン
 #   後始末:
 #     docker compose -p nene-installer -f compose.installer.yaml down -v

--- a/docker/installer-demo/setup.sh
+++ b/docker/installer-demo/setup.sh
@@ -25,7 +25,10 @@ rm -f "$DEST/.env" "$DEST/var/.installed"
 
 # 共有ホスティング相当: Apache(www-data) が .env と var/.installed を書けるよう、
 # ルートと var/ を書き込み可能にする（install.php の要件チェックが見るのはここ）。
-chmod 777 "$DEST" "$DEST/var"
+# public_html も書き込み可能にする — 共有ホスティングでは PHP がファイル所有者
+# として走り、完了時の install.php 自己削除（#644・@unlink(__FILE__)）ができる。
+# bind mount ではディレクトリ権限が無いと unlink できず、実態と乖離するため。
+chmod 777 "$DEST" "$DEST/var" "$DEST/public_html"
 
 if [ ! -f "$DEST/public_html/admin/index.html" ]; then
   echo "⚠ public_html/admin/index.html が無い。先に 'npm run build --prefix frontend' を実行してください。" >&2

--- a/public_html/install.php
+++ b/public_html/install.php
@@ -8,10 +8,13 @@ declare(strict_types=1);
  * 使い方:
  *   1. このファイルにブラウザでアクセス: https://your-domain.example/install.php
  *   2. 画面の指示に従い DB 接続情報・管理者アカウントを入力
- *   3. インストール完了後は install.php を削除またはリネームしてください
+ *   3. インストール完了時に install.php は自動的に自己削除されます
+ *      （FS 権限等で残った場合のみ、手動で削除またはリネームしてください）
  *
  * セキュリティ: インストール完了後に .installed ファイルが生成されます。
  * 既存の .installed が存在する場合はこのスクリプトを拒否します。
+ * 完了時はこのファイル自体を @unlink(__FILE__) で自己削除します（#644・
+ * deal/vault と同形。marker ＋ DB probe の再設置ガードは残る）。
  *
  * 画面デザインは ClaudeDesign 提供のセットアップウィザード（deep-green SaaS
  * テーマ）に準拠。React プロトタイプを自己完結 PHP + バニラ JS に移植している。
@@ -321,6 +324,7 @@ $step        = (int) ($_GET['step'] ?? 0);   // 0=要件チェック(landing) / 
 $errors      = [];                            // バナー用
 $fieldErrors = [];                            // フィールド単位（管理者ステップ）
 $success     = false;
+$selfDeleted = false;                         // 完了時の install.php 自己削除（#644）
 
 // Feature B: アプリ本体（vendor/）が展開されていなければ、要件チェックで
 // ハードに失敗させる代わりに「アプリの取得（アップロード）」ビューを先に出す。
@@ -591,6 +595,12 @@ if (!$payloadPresent) {
                         $reinstallGuard->markInstalled(date('c'));
 
                         $success = true;
+
+                        // 自己削除（#644・deal/vault と同形）: 完了した設置に
+                        // インストーラを残さない。失敗（FS 権限等）した場合は
+                        // 完了画面で従来どおり手動削除を案内する。再設置は
+                        // marker（var/.installed）＋ DB probe が引き続き拒否する。
+                        $selfDeleted = @unlink(__FILE__);
                     } catch (PDOException $e) {
                         $errors[] = 'データベースエラー: ' . $e->getMessage();
                     } catch (\Throwable $e) {
@@ -1208,19 +1218,34 @@ code{font-family:var(--font-num)}
         <div class="done-title">インストール完了</div>
         <div class="done-sub">NeNe Invoice のセットアップが完了しました。管理画面にログインして、最初の請求書を作成しましょう。</div>
 
+        <?php if ($selfDeleted): ?>
+        <div class="sec-warn">
+          <span class="sw-ico"><?= ico('trash') ?></span>
+          <div>
+            <div class="sw-t">install.php は自動的に削除されました</div>
+            <div class="sw-d">このページを離れると再表示できません。もしファイルが残っている場合は、FTP またはファイルマネージャから<b>手動で削除</b>してください。</div>
+          </div>
+        </div>
+        <?php else: ?>
         <div class="sec-warn">
           <span class="sw-ico"><?= ico('trash') ?></span>
           <div>
             <div class="sw-t">セキュリティ: 必ず install.php を削除してください</div>
-            <div class="sw-d">放置すると第三者に再セットアップされる恐れがあります。FTP またはファイルマネージャから <code>install.php</code> を<b>削除（またはリネーム）</b>してください。</div>
+            <div class="sw-d">自動削除に失敗しました（ファイル権限をご確認ください）。放置すると第三者に再セットアップされる恐れがあります。FTP またはファイルマネージャから <code>install.php</code> を<b>削除（またはリネーム）</b>してください。</div>
           </div>
         </div>
+        <?php endif; ?>
 
         <div class="next-h">次のステップ</div>
         <ol class="next-list">
+          <?php if (!$selfDeleted): ?>
           <li><span class="nl-n">1</span><div><b><code>install.php</code> を削除する</b><div class="nl-d">最優先。サーバーからこのファイルを消します。</div></div></li>
           <li><span class="nl-n">2</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>
           <li><span class="nl-n">3</span><div><b>会社情報・登録番号・銀行口座を設定</b><div class="nl-d">最初の見積書・請求書を作成できます。</div></div></li>
+          <?php else: ?>
+          <li><span class="nl-n">1</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>
+          <li><span class="nl-n">2</span><div><b>会社情報・登録番号・銀行口座を設定</b><div class="nl-d">最初の見積書・請求書を作成できます。</div></div></li>
+          <?php endif; ?>
         </ol>
 
         <a class="btn btn-primary btn-block btn-lg" href="./"><?= ico('login') ?>管理画面にログイン</a>


### PR DESCRIPTION
Closes #644（umbrella #631 の (g)）

## 変更内容

- `public_html/install.php` — インストール成功時（`markInstalled` 直後）に `@unlink(__FILE__)` で自己削除（deal/vault 形）。完了画面は `$selfDeleted` で分岐: 成功→「install.php は自動的に削除されました（残っていたら手動削除）」／失敗→従来の手動削除案内＋権限確認の注意。「次のステップ」リストも分岐。ヘッダ docblock 更新。
- `docker/installer-demo/setup.sh` — `public_html` も chmod 777 に（共有ホスティングでは PHP がファイル所有者として走り自己削除できる、という実態の再現。bind mount のディレクトリ権限不足で unlink 不可となり検証が実態と乖離していた）。
- `compose.installer.yaml` — コメントの PW 例を 12 文字に追従（#642 のフォロー）。

再設置ガード（marker `var/.installed` ＋ DB probe）は不変。

## 検収（compose.installer.yaml 実機回帰）

1. `setup.sh` → `docker compose -p nene-installer up -d` で新規展開を起動。
2. 要件→DB（single/path）→管理者の全ステップを HTTP で実走。
3. 8 文字 PW → サーバ側 422 相当のフィールドエラー「パスワードは 12 文字以上にしてください」（#642 の実機確認）。
4. 12+ 文字 PW → インストール完了・完了画面に「install.php は自動的に削除されました」・ファイル実消滅を確認。
5. 削除後 `POST /auth/login` → JWT 発行成功。`GET /install.php` は SPA フォールバック（インストーラ復活なし）。
6. 後片付け（`down -v`＋`rm -rf /tmp/nene-installer-demo`）済み。
- `php -l` OK・`composer check` 全緑。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（インストーラ後始末のみ・アプリ本体/API 無変更・用語レジストリ影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)