### PR TITLE
fix(db): organizations.custom_domain に unique index を追加 (#646)

### DIFF
--- a/database/migrations/20260711000000_add_unique_index_to_organizations_custom_domain.php
+++ b/database/migrations/20260711000000_add_unique_index_to_organizations_custom_domain.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * organizations.custom_domain に unique index を追加する（#646・監査 #631-(h)）。
+ *
+ * findByCustomDomain() はテナント解決経路（CustomDomainResolutionStrategy）で
+ * 使われるため、重複登録を DB 制約で防ぎ、解決クエリの full scan も解消する。
+ * NULL 許容カラムのため、MySQL / SQLite とも NULL 複数行（custom_domain 未設定の
+ * org 多数）はそのまま許容される。vault の同スキーマ・同名規約に統一。
+ */
+final class AddUniqueIndexToOrganizationsCustomDomain extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('organizations')
+            ->addIndex(['custom_domain'], ['unique' => true, 'name' => 'uniq_organizations_custom_domain'])
+            ->update();
+    }
+}


### PR DESCRIPTION
Closes #646（umbrella #631 の (h)）

## 変更内容

- 増分 migration `20260711000000_add_unique_index_to_organizations_custom_domain.php` — `uniq_organizations_custom_domain` unique index を追加（vault と同名規約・`change()` で可逆）。

## 既存データの重複確認

- ローカル dev DB（sqlite）: non-null `custom_domain` は 0 行・重複なし。
- 本番/既存設置: 重複が存在する場合は migration が unique 制約違反で fail し顕在化する（silent には通らない）。

## 検収

- temp SQLite に全 migration 適用 → NULL 2 行挿入 OK（未設定 org 互換）・同一ドメイン 2 行目は Integrity constraint violation で拒否・`PRAGMA index_list` で unique=1 確認。
- `composer check` 全緑（integration 含め CI で MySQL 経路も確認）。

## セルフレビュー

- チェックリスト: `docs/review/checklist.md` 準拠（migration のみ・API/アプリコード無変更・用語レジストリ影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)