### PR TITLE
fix(invoice): メール送信失敗バナーの文言を実因（Problem Details slug）に整合 (#650)

### DIFF
--- a/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
@@ -1,0 +1,68 @@
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { toInvoiceId } from '@/entities/invoice'
+import { server } from '@tests/msw/server'
+import { buildClientDto } from '@tests/factories/client'
+import { buildInvoiceWithLinesDto } from '@tests/factories/invoice'
+import { renderWithProviders } from '@tests/render/render-with-providers'
+import { ViewInvoice } from './ViewInvoice'
+
+function problem(slug: string, status: number) {
+  return new HttpResponse(
+    JSON.stringify({
+      type: `https://nene-invoice.dev/problems/${slug}`,
+      title: 'error',
+      status,
+    }),
+    { status, headers: { 'Content-Type': 'application/problem+json' } },
+  )
+}
+
+// jsdom navigator.language defaults to en-US, so the component renders the en
+// catalog (see SignInForm.test.tsx). The default invoice/client factories
+// (status "issued", client id 5) make "Send by email" available and satisfy
+// the client detail fetch the document view always makes.
+describe('ViewInvoice — send-email failure banner (#650)', () => {
+  it('shows the mail-transport copy for a 502 email-delivery-failed response, not the client-address copy', async () => {
+    server.use(
+      http.get('/admin/invoices/:id', () => HttpResponse.json(buildInvoiceWithLinesDto())),
+      http.get('/admin/clients/:id', () => HttpResponse.json(buildClientDto())),
+      http.post('/admin/invoices/:id/send-email', () => problem('email-delivery-failed', 502)),
+    )
+
+    const user = userEvent.setup()
+    const { findByRole, getByRole } = renderWithProviders(
+      <ViewInvoice invoiceId={toInvoiceId(1)} />,
+    )
+
+    await user.click(await findByRole('button', { name: 'Send by email' }))
+
+    const alert = await findByRole('alert')
+    expect(alert).toHaveTextContent(
+      'We couldn\'t reach the mail server, so the email wasn\'t sent. Try "Resend" again in a moment; if it keeps failing, contact your system administrator.',
+    )
+    // Not the client-address message — that would misdirect the user (#650).
+    expect(alert).not.toHaveTextContent("The client's email address")
+    expect(getByRole('button', { name: 'Check client' })).toBeInTheDocument()
+  })
+
+  it('shows the client-address copy for a 422 client-email-missing response', async () => {
+    server.use(
+      http.get('/admin/invoices/:id', () => HttpResponse.json(buildInvoiceWithLinesDto())),
+      http.get('/admin/clients/:id', () => HttpResponse.json(buildClientDto())),
+      http.post('/admin/invoices/:id/send-email', () => problem('client-email-missing', 422)),
+    )
+
+    const user = userEvent.setup()
+    const { findByRole } = renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
+
+    await user.click(await findByRole('button', { name: 'Send by email' }))
+
+    const alert = await findByRole('alert')
+    expect(alert).toHaveTextContent(
+      "The client's email address may be missing or malformed. Please check the address and try again.",
+    )
+    expect(alert).not.toHaveTextContent("We couldn't reach the mail server")
+  })
+})

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -115,6 +115,15 @@ function InvoiceDocument({
   const outstanding = invoice.outstanding_cents
   const showOutstanding = outstanding !== null && outstanding > 0
 
+  // 422 `client-email-missing` (src/Invoice/InvoiceEmailException) is the
+  // client's data problem; anything else — most commonly 502
+  // `email-delivery-failed` (mail transport/SMTP failure, #621) — is not, so
+  // it gets its own copy instead of the client-address message (#650).
+  const emailErrorBodyKey =
+    sendEmail.error?.slug === 'client-email-missing'
+      ? 'admin.invoices.detail.emailErrorBodyClientMissing'
+      : 'admin.invoices.detail.emailErrorBodyDeliveryFailed'
+
   return (
     <Stack gap="md">
       <Link to="/invoices" className="nav-back">
@@ -189,7 +198,7 @@ function InvoiceDocument({
         <div className="ar-banner">
           <ActionError
             title={t('admin.invoices.detail.emailErrorTitle')}
-            description={t('admin.invoices.detail.emailErrorBody')}
+            description={t(emailErrorBodyKey)}
             actions={[
               {
                 label: t('admin.invoices.detail.emailRetry'),

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -527,8 +527,10 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.detail.emailSentBody': 'The invoice was sent to {{client}}.',
   'admin.invoices.detail.emailSentBodyNoClient': 'The invoice was sent.',
   'admin.invoices.detail.emailErrorTitle': "Couldn't send the email",
-  'admin.invoices.detail.emailErrorBody':
+  'admin.invoices.detail.emailErrorBodyClientMissing':
     "The client's email address may be missing or malformed. Please check the address and try again.",
+  'admin.invoices.detail.emailErrorBodyDeliveryFailed':
+    'We couldn\'t reach the mail server, so the email wasn\'t sent. Try "Resend" again in a moment; if it keeps failing, contact your system administrator.',
   'admin.invoices.detail.emailRetry': 'Resend',
   'admin.invoices.detail.emailCheckClient': 'Check client',
   'admin.invoices.detail.generateLink': 'Generate client link',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -536,8 +536,10 @@ export const jaMessages = {
   'admin.invoices.detail.emailSentBody': '{{client}} 宛に請求書を送付しました。',
   'admin.invoices.detail.emailSentBodyNoClient': '請求書を送付しました。',
   'admin.invoices.detail.emailErrorTitle': 'メールを送信できませんでした',
-  'admin.invoices.detail.emailErrorBody':
+  'admin.invoices.detail.emailErrorBodyClientMissing':
     '取引先のメールアドレスが未登録、または形式に誤りがある可能性があります。アドレスをご確認のうえ、再度お試しください。',
+  'admin.invoices.detail.emailErrorBodyDeliveryFailed':
+    'メールサーバーに接続できず、送信に失敗しました。しばらくしてから「再送信する」をお試しください。解消しない場合はシステム管理者にご連絡ください。',
   'admin.invoices.detail.emailRetry': '再送信する',
   'admin.invoices.detail.emailCheckClient': '取引先を確認',
   'admin.invoices.detail.generateLink': 'クライアント向けリンクを生成',


### PR DESCRIPTION
Closes #650

## 変更内容

請求書の「メールで送信」失敗時のバナー文言を、実際に返る Problem Details の `slug` に応じて出し分ける。

- 422 `client-email-missing`（取引先メールアドレス不備）→ 従来通り「取引先のメールアドレスが未登録、または形式に誤りがある可能性があります…」
- それ以外（最も一般的には 502 `email-delivery-failed`＝メール配信基盤／SMTP transport の失敗、#621）→ 新規「メールサーバーに接続できず、送信に失敗しました…」

`ja.ts` / `en.ts` 両カタログを更新（`emailErrorBody` → `emailErrorBodyClientMissing` / `emailErrorBodyDeliveryFailed`）。`frontend/src/features/view-invoice/ui/ViewInvoice.tsx` は `sendEmail.error?.slug` で分岐するのみ（ボタン構成は変更なし）。

## 検証

- `frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx`（新規）: 502/422 それぞれで正しいバナー文言が出ること・誤った文言が出ないことを MSW 経由で検証。
- `npm run check`（type-check / lint / format / test 314件 / knip / build-storybook）全緑。
- `composer check` 全緑（バックエンド変更なし・念のため実行）。

Self-review: frontend

## 関連

- #621（500 → 502 Problem Details 化）
- #626（デモ組織ではメール送信が構造的に必ず 502 になる問題。本 PR はバナー文言の整合のみを扱い、#626 の対応方針とは独立）
