### PR TITLE
fix(demo): bldmainte / seisaku のデモシードに見積2件を追加 (#651)

### DIFF
--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -406,6 +406,10 @@ final class DemoDataSeeder implements DemoDataSeederInterface
             $this->insertClient('株式会社世田谷ハウジング', 'セタガヤハウジング', '世田谷', 'setagaya@housing.example', '東京都世田谷区太子堂1-1-1', null),
         ];
 
+        // 見積（見積→請求の動線）
+        $this->insertQuote($clients[7], $this->quoteNumber(1), 'accepted', $this->dayPrevMonth(15), $this->endThisMonth(), '定期清掃契約（年間）', [['定期清掃契約（年間）', 1, 396000, 1000]]);
+        $this->insertQuote($clients[3], $this->quoteNumber(2), 'sent', $this->dayThisMonth(3), $this->endNextMonth(), '消防設備点検・貯水槽清掃 一式', [['消防設備点検', 1, 90000, 1000], ['貯水槽清掃', 1, 60000, 1000]]);
+
         // recurring_invoices（毎月定額・次回=翌月01）
         $recurring = [
             [0, '日常清掃', 80000], [1, '定期清掃＋設備点検', 60000], [2, '日常清掃', 50000], [3, '定期清掃', 40000],
@@ -450,6 +454,7 @@ final class DemoDataSeeder implements DemoDataSeederInterface
         $this->insertBankTransaction($this->dayThisMonth(5), 66000, 'シンジユクセンタ-ビル', '振込入金（要消込）', 'unmatched', $c2Invoice);
 
         $this->upsertSequence('invoice', $this->year(), $seq);
+        $this->upsertSequence('quote', $this->year(), 2);
     }
 
     private function seedSeisaku(): void
@@ -475,6 +480,10 @@ final class DemoDataSeeder implements DemoDataSeederInterface
         $c3 = $this->insertClient('株式会社北斗製作所', 'ホクトセイサクショ', '総務', 'soumu@hokuto.example', '東京都大田区蒲田1-1-1', 'T2223334445556');
         $c4 = $this->insertClient('一般社団法人みらい教育協会', 'ミライキョウイクキョウカイ', '事務局', 'jimu@mirai-edu.example', '東京都文京区本郷3-3-3', null);
         $c5 = $this->insertClient('株式会社エヌ・ワークス', 'エヌワークス', '代表', 'ceo@n-works.example', '東京都中野区中野4-4-4', null);
+
+        // 見積（見積→請求の動線）
+        $this->insertQuote($c2, $this->quoteNumber(1), 'accepted', $this->dayPrevMonth(15), $this->endThisMonth(), 'コーポレートサイト リニューアル一式', [['ディレクション費', 1, 200000, 1000], ['制作費', 1, 800000, 1000]]);
+        $this->insertQuote($c4, $this->quoteNumber(2), 'sent', $this->dayThisMonth(3), $this->endNextMonth(), '採用動画 撮影・編集一式', [['撮影費', 1, 300000, 1000], ['追加修正費', 1, 50000, 1000]]);
 
         // 源泉徴収あり：各請求は [報酬 @10%] ＋ [源泉徴収 マイナス行 @0%]。合計＝請求額（＝振込額）。
         // 番号は draft を除いて発番。[clientId, status, issued, due, 摘要, 報酬, 源泉, paidAmount|null]
@@ -514,5 +523,6 @@ final class DemoDataSeeder implements DemoDataSeederInterface
         $this->insertBankTransaction($this->dayThisMonth(3), 349265, 'ブル-ムテツク(ド', '振込入金（遅延・要消込）', 'unmatched', $inv5);
 
         $this->upsertSequence('invoice', $this->year(), $seq);
+        $this->upsertSequence('quote', $this->year(), 2);
     }
 }

--- a/tests/Demo/DemoDataSeederDateTest.php
+++ b/tests/Demo/DemoDataSeederDateTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Demo;
 
-use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneInvoice\Demo\DemoDataSeeder;
 use NeneInvoice\Demo\DemoTemplate;
 use NeneInvoice\Tests\Support\FixedClock;
@@ -68,90 +67,5 @@ final class DemoDataSeederDateTest extends TestCase
         );
 
         self::assertNotEmpty($futureDue);
-    }
-}
-
-/**
- * Records every INSERT and exposes values by (table, column), resolved from the
- * statement's own column list — no hard-coded parameter indexes.
- */
-final class RecordingQueryExecutor implements DatabaseQueryExecutorInterface
-{
-    /** @var list<array{sql: string, parameters: array<int|string, mixed>}> */
-    private array $inserts = [];
-
-    private int $nextId = 1;
-
-    public function execute(string $sql, array $parameters = []): int
-    {
-        $this->record($sql, $parameters);
-
-        return 1;
-    }
-
-    public function insert(string $sql, array $parameters = []): int
-    {
-        $this->record($sql, $parameters);
-
-        return $this->nextId++;
-    }
-
-    public function lastInsertId(): int
-    {
-        return $this->nextId - 1;
-    }
-
-    public function fetchOne(string $sql, array $parameters = []): ?array
-    {
-        return null;
-    }
-
-    public function fetchAll(string $sql, array $parameters = []): array
-    {
-        return [];
-    }
-
-    /** @return list<mixed> Values bound to $column across all INSERTs into $table. */
-    public function columnValues(string $table, string $column): array
-    {
-        $values = [];
-
-        foreach ($this->inserts as $insert) {
-            if (preg_match('/INSERT INTO ' . $table . '\s*\(([^)]+)\)/i', $insert['sql'], $m) !== 1) {
-                continue;
-            }
-            $columns = array_map('trim', explode(',', $m[1]));
-            $index   = array_search($column, $columns, true);
-            if ($index === false) {
-                continue;
-            }
-            // Positional parameters line up with the column list only when every
-            // VALUES entry is a placeholder; the seeder embeds literals (e.g.
-            // is_deleted 0), so count placeholders up to the column's position.
-            if (preg_match('/VALUES\s*\((.+)\)/is', $insert['sql'], $vm) !== 1) {
-                continue;
-            }
-            $slots       = array_map('trim', explode(',', $vm[1]));
-            $paramIndex  = 0;
-            foreach ($slots as $slotPosition => $slot) {
-                if ($slotPosition === $index) {
-                    $values[] = $slot === '?' ? ($insert['parameters'][$paramIndex] ?? null) : $slot;
-                    break;
-                }
-                if ($slot === '?') {
-                    $paramIndex++;
-                }
-            }
-        }
-
-        return $values;
-    }
-
-    /** @param array<int|string, mixed> $parameters */
-    private function record(string $sql, array $parameters): void
-    {
-        if (stripos(ltrim($sql), 'INSERT') === 0) {
-            $this->inserts[] = ['sql' => $sql, 'parameters' => $parameters];
-        }
     }
 }

--- a/tests/Demo/DemoDataSeederQuoteTest.php
+++ b/tests/Demo/DemoDataSeederQuoteTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use NeneInvoice\Demo\DemoDataSeeder;
+use NeneInvoice\Demo\DemoTemplate;
+use NeneInvoice\Tests\Support\FixedClock;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every demo template must seed at least one quote so the 見積一覧 screen
+ * shows the 見積→請求 lifecycle instead of an empty state (#651). `kensetsu`
+ * already had quotes; `bldmainte` and `seisaku` did not.
+ */
+final class DemoDataSeederQuoteTest extends TestCase
+{
+    /** @return iterable<string, array{0: DemoTemplate}> */
+    public static function templates(): iterable
+    {
+        foreach (DemoTemplate::cases() as $template) {
+            yield $template->value => [$template];
+        }
+    }
+
+    #[DataProvider('templates')]
+    public function test_seeds_at_least_one_quote(DemoTemplate $template): void
+    {
+        $recorder = new RecordingQueryExecutor();
+        $seeder   = new DemoDataSeeder($recorder, new FixedClock('2026-08-01T09:00:00Z'));
+        $seeder->seed(1, $template);
+
+        self::assertGreaterThanOrEqual(
+            1,
+            $recorder->insertCount('quotes'),
+            "expected at least one seeded quote for {$template->value}",
+        );
+    }
+
+    #[DataProvider('templates')]
+    public function test_quote_document_sequence_matches_seeded_quote_count(DemoTemplate $template): void
+    {
+        $recorder = new RecordingQueryExecutor();
+        $seeder   = new DemoDataSeeder($recorder, new FixedClock('2026-08-01T09:00:00Z'));
+        $seeder->seed(1, $template);
+
+        $sequenceRows = $recorder->columnValues('document_sequences', 'doc_type');
+        $quoteRowCount = count(array_filter($sequenceRows, static fn (mixed $docType): bool => $docType === 'quote'));
+
+        self::assertSame(1, $quoteRowCount, "expected exactly one quote document_sequences row for {$template->value}");
+    }
+}

--- a/tests/Demo/RecordingQueryExecutor.php
+++ b/tests/Demo/RecordingQueryExecutor.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Records every INSERT and exposes values by (table, column), resolved from the
+ * statement's own column list — no hard-coded parameter indexes. Shared by the
+ * demo-seed tests so every INSERT of every template can be inspected without a
+ * database.
+ */
+final class RecordingQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    /** @var list<array{sql: string, parameters: array<int|string, mixed>}> */
+    private array $inserts = [];
+
+    private int $nextId = 1;
+
+    public function execute(string $sql, array $parameters = []): int
+    {
+        $this->record($sql, $parameters);
+
+        return 1;
+    }
+
+    public function insert(string $sql, array $parameters = []): int
+    {
+        $this->record($sql, $parameters);
+
+        return $this->nextId++;
+    }
+
+    public function lastInsertId(): int
+    {
+        return $this->nextId - 1;
+    }
+
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        return null;
+    }
+
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        return [];
+    }
+
+    /** @return list<mixed> Values bound to $column across all INSERTs into $table. */
+    public function columnValues(string $table, string $column): array
+    {
+        $values = [];
+
+        foreach ($this->inserts as $insert) {
+            if (preg_match('/INSERT INTO ' . $table . '\s*\(([^)]+)\)/i', $insert['sql'], $m) !== 1) {
+                continue;
+            }
+            $columns = array_map('trim', explode(',', $m[1]));
+            $index   = array_search($column, $columns, true);
+            if ($index === false) {
+                continue;
+            }
+            // Positional parameters line up with the column list only when every
+            // VALUES entry is a placeholder; the seeder embeds literals (e.g.
+            // is_deleted 0), so count placeholders up to the column's position.
+            if (preg_match('/VALUES\s*\((.+)\)/is', $insert['sql'], $vm) !== 1) {
+                continue;
+            }
+            $slots       = array_map('trim', explode(',', $vm[1]));
+            $paramIndex  = 0;
+            foreach ($slots as $slotPosition => $slot) {
+                if ($slotPosition === $index) {
+                    $values[] = $slot === '?' ? ($insert['parameters'][$paramIndex] ?? null) : $slot;
+                    break;
+                }
+                if ($slot === '?') {
+                    $paramIndex++;
+                }
+            }
+        }
+
+        return $values;
+    }
+
+    /** @return int Number of INSERTs recorded into $table. */
+    public function insertCount(string $table): int
+    {
+        $count = 0;
+        foreach ($this->inserts as $insert) {
+            if (preg_match('/INSERT INTO ' . $table . '\s*\(/i', $insert['sql']) === 1) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /** @param array<int|string, mixed> $parameters */
+    private function record(string $sql, array $parameters): void
+    {
+        if (stripos(ltrim($sql), 'INSERT') === 0) {
+            $this->inserts[] = ['sql' => $sql, 'parameters' => $parameters];
+        }
+    }
+}


### PR DESCRIPTION
Closes #651

## 変更内容

`src/Demo/DemoDataSeeder.php` の `seedBldmainte()` / `seedSeisaku()` に、`seedKensetsu()` と同じ構造（`insertQuote()` ×2・`accepted`/`sent`・`upsertSequence('quote', ...)`）で見積サンプルを追加。品目文言は各テンプレの既存 items に沿わせた:

- bldmainte（ビルメンテ・清掃）: 「定期清掃契約（年間）」(accepted・上野リテール) / 「消防設備点検・貯水槽清掃 一式」(sent・池袋パークタワー管理組合)
- seisaku（制作・コンサル）: 「コーポレートサイト リニューアル一式」(accepted・ブルームテック) / 「採用動画 撮影・編集一式」(sent・みらい教育協会)

日付は既存の相対日付ヘルパ（`dayPrevMonth` / `endThisMonth` / `dayThisMonth` / `endNextMonth`）をそのまま使用し、`insertQuote()` 内部の `noLaterThanToday` clamp 規約（#605）に自動的に従う。

## テスト用リファクタ（付随）

`tests/Demo/DemoDataSeederDateTest.php` に同居していた `RecordingQueryExecutor`（recording テストダブル）を `tests/Demo/RecordingQueryExecutor.php` へ独立（PSR-4 準拠・複数テストファイルで安全に共有できるように）。併せて `insertCount(string $table): int` を追加。

`tests/Demo/DemoDataSeederQuoteTest.php`（新規）:
- 全テンプレ（`DemoTemplate::cases()`）で見積が1件以上シードされることを検証（bldmainte / seisaku の回帰防止）
- `document_sequences` の `quote` 行が各テンプレでちょうど1件であることを検証

## 検証

- `vendor/bin/phpunit tests/Demo/`: 全緑（新規6テスト含む）
- `composer check`（test 944件・phpstan・cs・openapi・mcp・conformance）全緑

Self-review: 該当する専用チェックリストなし（seed データのみ・API/DB スキーマ/認可の変更なし）。`docs/workflow.md` の標準フロー通り確認。

## 影響範囲・注意

- 本番デプロイはしない。既存の使い捨てデモ組織には遡って反映されない（TTL 消滅を待つか、次回の org 払い出しから有効）。

## 関連

- 実ブラウザ全機能打鍵レポート `_work/reports/2026-07-11/invoice-demo-browser-dakan-report.md`（🟡2）
