### PR TITLE
feat(invoice): デモorgのメール送信をプレビューモーダル化（実送しない） (#626)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -131,6 +131,7 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Dashboard read model | `unpaid_count`, `overdue_count`, `outstanding_total_cents`, `recent_unpaid`, `received_this_month_cents`, `received_last_month_cents`, `billed_this_month_cents`, `billed_last_month_cents`, `monthly_billed` (→ `month`, `billed_cents`, `count`), `billed_prev_year_month_cents`, `billed_daily_current` / `billed_daily_prev_month` (→ `day`, `cumulative_cents`) | `monthly_received_cents`, `received_this_month`, `mtd_cents`, `issued_this_month_cents`, `invoiced_cents`, `yoy_cents`, `daily_billed` |
 | Receivable aging buckets | `aging` → `current`, `overdue_1_30`, `overdue_31_plus` | `aging_buckets`, `bucket_*`, `over_30` |
 | Line-item suggestion read model | `items` → `description`, `unit_price_cents`, `tax_rate_bps`, `usage_count`, `source` (`master`/`history`) | `count`, `times_used`, `frequency`, `default_price_cents`, `origin`, `kind` |
+| Invoice-email preview read model (demo orgs, #626) | `preview` (always `true`), `recipient`, `subject`, `body_html` | `to`, `email`, `title`, `body`, `html`, `is_preview` |
 
 Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
 the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2080,12 +2080,25 @@ paths:
         Generates the invoice PDF and sends it to the client's email address.
         Requires the invoice to be in issued, partially_paid, or paid status
         and the client to have an email address. Requires ManageBilling capability.
+
+
+        Demo organizations (slug prefixed by the configured demo slug prefix) do
+        not send: their seeded clients use fictitious `.example` addresses that
+        cannot be delivered. Instead the endpoint returns 200 with a preview of
+        the message that would have been sent, for display in the UI (#626).
       operationId: sendInvoiceEmail
       security:
         - bearerAuth: []
       responses:
+        '200':
+          description: >
+            Demo organization — email not sent; preview of the message returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendInvoiceEmailPreview'
         '204':
-          description: Email sent
+          description: Email sent (non-demo organization)
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3574,6 +3587,25 @@ components:
           description: Whether to issue as a qualified invoice (適格請求書).
         due_at:
           type: [string, 'null']
+    SendInvoiceEmailPreview:
+      type: object
+      description: >
+        Preview of the email a demo organization would have sent (#626). Returned
+        with status 200 instead of actually delivering the message.
+      properties:
+        preview:
+          type: boolean
+          description: Always true; marks the response as a non-sent demo preview.
+        recipient:
+          type: string
+          description: Client email address the message would have been sent to.
+        subject:
+          type: string
+          description: Subject line of the message.
+        body_html:
+          type: string
+          description: HTML body of the message (server-generated, escaped).
+      required: [preview, recipient, subject, body_html]
     Payment:
       type: object
       properties:

--- a/frontend/src/entities/invoice/index.ts
+++ b/frontend/src/entities/invoice/index.ts
@@ -22,6 +22,6 @@ export {
   useGenerateDownloadToken,
   useSendInvoiceEmail,
 } from './mutations'
-export type { DownloadTokenResult } from './mutations'
+export type { DownloadTokenResult, SendInvoiceEmailPreview } from './mutations'
 export { useDownloadInvoicePdf } from './download'
 export { useExportInvoicesCsv, useExportPaymentsCsv } from './export'

--- a/frontend/src/entities/invoice/mutations.ts
+++ b/frontend/src/entities/invoice/mutations.ts
@@ -80,12 +80,36 @@ export function useGenerateDownloadToken(): UseMutationResult<
   })
 }
 
-/** POST /admin/invoices/{id}/send-email — sends the invoice PDF to the client. */
-export function useSendInvoiceEmail(): UseMutationResult<number, AppError, number> {
-  return useMutation<number, AppError, number>({
+/**
+ * Preview returned instead of a real send for demo organizations (#626): the
+ * API answers 200 with the message it would have sent (never delivering it,
+ * because demo clients use undeliverable `.example` addresses).
+ */
+export interface SendInvoiceEmailPreview {
+  preview: true
+  recipient: string
+  subject: string
+  body_html: string
+}
+
+/**
+ * POST /admin/invoices/{id}/send-email — sends the invoice PDF to the client.
+ *
+ * Non-demo orgs deliver for real and answer 204 (resolves to `null` here).
+ * Demo orgs do not send and answer 200 with a {@link SendInvoiceEmailPreview}
+ * so the UI can show what would have gone out (#626).
+ */
+export function useSendInvoiceEmail(): UseMutationResult<
+  SendInvoiceEmailPreview | null,
+  AppError,
+  number
+> {
+  return useMutation<SendInvoiceEmailPreview | null, AppError, number>({
     mutationFn: async (id) => {
-      await apiClient.post(`/admin/invoices/${String(id)}/send-email`)
-      return id
+      const result = await apiClient.post<SendInvoiceEmailPreview | undefined>(
+        `/admin/invoices/${String(id)}/send-email`,
+      )
+      return result ?? null
     },
   })
 }

--- a/frontend/src/features/view-invoice/ui/EmailPreviewModal.tsx
+++ b/frontend/src/features/view-invoice/ui/EmailPreviewModal.tsx
@@ -1,0 +1,81 @@
+import { useId } from 'react'
+import type { SendInvoiceEmailPreview } from '@/entities/invoice'
+import { useTranslation } from '@/shared/i18n'
+import { Button, InlineAlert, Stack, Text } from '@/shared/ui'
+
+export interface EmailPreviewModalProps {
+  preview: SendInvoiceEmailPreview
+  onClose: () => void
+}
+
+/**
+ * Shows the email a demo organization *would* have sent, instead of delivering
+ * it (#626): demo clients use fictitious `.example` addresses that always bounce,
+ * which would surface as a 502 and read like a product failure in a sales demo.
+ * The notice makes clear no message was actually sent.
+ *
+ * `body_html` is rendered with `dangerouslySetInnerHTML`. This is safe here: the
+ * markup is a fixed server-side template (SendInvoiceEmailUseCase) whose only
+ * tags are literal `<p>` / `<br>`, and every interpolated value (client name,
+ * company name, invoice number) is `htmlspecialchars`-escaped before it reaches
+ * the client — there is no path for untrusted HTML to enter the string.
+ */
+export function EmailPreviewModal({ preview, onClose }: EmailPreviewModalProps) {
+  const { t } = useTranslation()
+  const titleId = useId()
+
+  return (
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-surface-overlay/70 px-inline-md">
+      <button
+        type="button"
+        aria-label={t('common.actions.close')}
+        className="absolute inset-0 size-full cursor-default"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative w-full max-w-lg rounded-md border border-border bg-surface-raised px-inline-lg py-stack-lg shadow-md"
+      >
+        <Stack gap="md">
+          <Text as="h2" id={titleId} variant="heading-sm">
+            {t('admin.invoices.detail.emailPreviewTitle')}
+          </Text>
+
+          <InlineAlert tone="info" message={t('admin.invoices.detail.emailPreviewNotice')} />
+
+          <Stack gap="sm">
+            <div>
+              <Text variant="muted" className="text-caption">
+                {t('admin.invoices.detail.emailPreviewRecipient')}
+              </Text>
+              <Text className="break-all">{preview.recipient}</Text>
+            </div>
+            <div>
+              <Text variant="muted" className="text-caption">
+                {t('admin.invoices.detail.emailPreviewSubject')}
+              </Text>
+              <Text>{preview.subject}</Text>
+            </div>
+            <div>
+              <Text variant="muted" className="text-caption">
+                {t('admin.invoices.detail.emailPreviewBody')}
+              </Text>
+              <div
+                className="rounded-md border border-border bg-surface px-inline-md py-stack-sm"
+                dangerouslySetInnerHTML={{ __html: preview.body_html }}
+              />
+            </div>
+          </Stack>
+
+          <Stack direction="row" gap="sm" className="justify-end">
+            <Button variant="primary" size="sm" onClick={onClose}>
+              {t('common.actions.close')}
+            </Button>
+          </Stack>
+        </Stack>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
@@ -66,3 +66,52 @@ describe('ViewInvoice — send-email failure banner (#650)', () => {
     expect(alert).not.toHaveTextContent("We couldn't reach the mail server")
   })
 })
+
+describe('ViewInvoice — demo email preview (#626)', () => {
+  it('opens the preview modal (recipient / subject / body + "not sent" notice) on a preview response', async () => {
+    server.use(
+      http.get('/admin/invoices/:id', () => HttpResponse.json(buildInvoiceWithLinesDto())),
+      http.get('/admin/clients/:id', () => HttpResponse.json(buildClientDto())),
+      http.post('/admin/invoices/:id/send-email', () =>
+        HttpResponse.json({
+          preview: true,
+          recipient: 'buyer@example.com',
+          subject: '請求書 INV-2026-001 — テスト商会',
+          body_html: '<p>株式会社サンプル 様</p><p>添付の PDF をご確認ください。</p>',
+        }),
+      ),
+    )
+
+    const user = userEvent.setup()
+    const { findByRole } = renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
+
+    await user.click(await findByRole('button', { name: 'Send by email' }))
+
+    const dialog = await findByRole('dialog')
+    expect(dialog).toHaveTextContent('Email preview')
+    // The "no email was actually sent" demo notice must be shown.
+    expect(dialog).toHaveTextContent('No email was actually sent')
+    expect(dialog).toHaveTextContent('buyer@example.com')
+    expect(dialog).toHaveTextContent('請求書 INV-2026-001 — テスト商会')
+    expect(dialog).toHaveTextContent('株式会社サンプル 様')
+  })
+
+  it('shows the success toast (not the modal) on a 204 real send', async () => {
+    server.use(
+      http.get('/admin/invoices/:id', () => HttpResponse.json(buildInvoiceWithLinesDto())),
+      http.get('/admin/clients/:id', () => HttpResponse.json(buildClientDto())),
+      http.post('/admin/invoices/:id/send-email', () => new HttpResponse(null, { status: 204 })),
+    )
+
+    const user = userEvent.setup()
+    const { findByRole, findByText, queryByRole } = renderWithProviders(
+      <ViewInvoice invoiceId={toInvoiceId(1)} />,
+    )
+
+    await user.click(await findByRole('button', { name: 'Send by email' }))
+
+    // Success toast (role="status") appears; no preview dialog is opened.
+    expect(await findByText('Email sent')).toBeInTheDocument()
+    expect(queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { toClientId, useClient } from '@/entities/client'
 import { useCompanySettings } from '@/entities/company-settings'
@@ -8,6 +9,7 @@ import {
   type CreateInvoiceInput,
   type InvoiceId,
   type InvoiceWithLines,
+  type SendInvoiceEmailPreview,
 } from '@/entities/invoice'
 import { useTranslation } from '@/shared/i18n'
 import { formatCalendarDate, formatJstDate } from '@/shared/lib/format-date'
@@ -26,6 +28,7 @@ import {
 } from '@/shared/ui'
 import { useGenerateDownloadLink } from '../hooks/use-generate-download-link'
 import { useViewInvoice } from '../hooks/use-view-invoice'
+import { EmailPreviewModal } from './EmailPreviewModal'
 
 export interface ViewInvoiceProps {
   invoiceId: InvoiceId
@@ -73,6 +76,8 @@ function InvoiceDocument({
   const isIssued = invoice.status !== 'draft'
   const pdf = useDownloadInvoicePdf(invoiceId, invoice.invoice_number)
   const sendEmail = useSendInvoiceEmail()
+  // Set when a demo org's send returns a preview instead of delivering (#626).
+  const [emailPreview, setEmailPreview] = useState<SendInvoiceEmailPreview | null>(null)
   const link = useGenerateDownloadLink(invoiceId, isIssued)
   const client = useClient(toClientId(invoice.client_id))
   const company = useCompanySettings()
@@ -93,10 +98,16 @@ function InvoiceDocument({
     void navigate('/invoices/new', { state: { duplicate: snapshot } })
   }
 
-  // 型3 success toast on send; reused by the 型2 "resend" recovery action.
+  // On send: a demo org returns a preview (no real delivery) → open the preview
+  // modal (#626); a real org returns null (204) → 型3 success toast. Reused by
+  // the 型2 "resend" recovery action.
   const sendInvoiceEmail = () => {
     sendEmail.mutate(invoiceId, {
-      onSuccess: () => {
+      onSuccess: (result) => {
+        if (result?.preview === true) {
+          setEmailPreview(result)
+          return
+        }
         showToast({
           tone: 'ok',
           title: t('admin.invoices.detail.emailSentTitle'),
@@ -326,6 +337,15 @@ function InvoiceDocument({
           </div>
         </div>
       </div>
+
+      {emailPreview !== null && (
+        <EmailPreviewModal
+          preview={emailPreview}
+          onClose={() => {
+            setEmailPreview(null)
+          }}
+        />
+      )}
     </Stack>
   )
 }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -533,6 +533,12 @@ export const enMessages: MessageCatalog = {
     'We couldn\'t reach the mail server, so the email wasn\'t sent. Try "Resend" again in a moment; if it keeps failing, contact your system administrator.',
   'admin.invoices.detail.emailRetry': 'Resend',
   'admin.invoices.detail.emailCheckClient': 'Check client',
+  'admin.invoices.detail.emailPreviewTitle': 'Email preview',
+  'admin.invoices.detail.emailPreviewNotice':
+    'This is a demo environment. No email was actually sent — below is a preview of what would be sent in production.',
+  'admin.invoices.detail.emailPreviewRecipient': 'To',
+  'admin.invoices.detail.emailPreviewSubject': 'Subject',
+  'admin.invoices.detail.emailPreviewBody': 'Body',
   'admin.invoices.detail.generateLink': 'Generate client link',
   'admin.invoices.detail.generatingLink': 'Generating link…',
   'admin.invoices.detail.generateLinkError': 'Could not generate link.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -542,6 +542,12 @@ export const jaMessages = {
     'メールサーバーに接続できず、送信に失敗しました。しばらくしてから「再送信する」をお試しください。解消しない場合はシステム管理者にご連絡ください。',
   'admin.invoices.detail.emailRetry': '再送信する',
   'admin.invoices.detail.emailCheckClient': '取引先を確認',
+  'admin.invoices.detail.emailPreviewTitle': 'メール送信のプレビュー',
+  'admin.invoices.detail.emailPreviewNotice':
+    'これはデモ環境です。実際にはメールを送信していません。以下は、本番環境で送信される内容のプレビューです。',
+  'admin.invoices.detail.emailPreviewRecipient': '宛先',
+  'admin.invoices.detail.emailPreviewSubject': '件名',
+  'admin.invoices.detail.emailPreviewBody': '本文',
   'admin.invoices.detail.generateLink': 'クライアント向けリンクを生成',
   'admin.invoices.detail.generatingLink': 'リンクを生成中…',
   'admin.invoices.detail.generateLinkError': 'リンクの生成に失敗しました。',

--- a/src/Invoice/InvoiceServiceProvider.php
+++ b/src/Invoice/InvoiceServiceProvider.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Invoice;
 
 use LogicException;
 use Nene2\Audit\AuditRecorderInterface;
+use Nene2\Config\AppConfig;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
@@ -219,10 +220,20 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 SendInvoiceEmailHandler::class,
-                static fn (ContainerInterface $c): SendInvoiceEmailHandler => new SendInvoiceEmailHandler(
-                    self::resolve($c, SendInvoiceEmailUseCaseInterface::class),
-                    self::resolve($c, Psr17Factory::class),
-                ),
+                static function (ContainerInterface $c): SendInvoiceEmailHandler {
+                    // Demo orgs (slug prefixed by demo.slugPrefix) never send for
+                    // real — their `.example` clients bounce (#626). Detection is
+                    // gated on demoMode so a plain install always sends: the empty
+                    // prefix disables interception (safe default, breaks nothing).
+                    $demo = self::appConfig($c)->demo;
+                    $demoSlugPrefix = $demo->demoMode ? $demo->slugPrefix : '';
+
+                    return new SendInvoiceEmailHandler(
+                        self::resolve($c, SendInvoiceEmailUseCaseInterface::class),
+                        self::json($c),
+                        $demoSlugPrefix,
+                    );
+                },
             )
             ->set(
                 InvoiceEmailExceptionHandler::class,
@@ -273,6 +284,11 @@ final readonly class InvoiceServiceProvider implements ServiceProviderInterface
     private static function problemDetails(ContainerInterface $c): ProblemDetailsResponseFactory
     {
         return self::resolve($c, ProblemDetailsResponseFactory::class);
+    }
+
+    private static function appConfig(ContainerInterface $c): AppConfig
+    {
+        return self::resolve($c, AppConfig::class);
     }
 
     /** @return RequestScopedHolder<int> */

--- a/src/Invoice/PreparedInvoiceEmail.php
+++ b/src/Invoice/PreparedInvoiceEmail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Invoice;
 
 use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
 use NeneInvoice\LineItem\LineItem;
 
 /**
@@ -24,6 +25,7 @@ final readonly class PreparedInvoiceEmail
         public Invoice $invoice,
         public array $lines,
         public Client $client,
+        public CompanySettings $company,
         public string $invoiceNumber,
         public string $subject,
         public string $bodyHtml,

--- a/src/Invoice/PreparedInvoiceEmail.php
+++ b/src/Invoice/PreparedInvoiceEmail.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+use NeneInvoice\Client\Client;
+use NeneInvoice\LineItem\LineItem;
+
+/**
+ * Internal value object holding everything needed to either send an invoice
+ * email or render its preview (#626). Built once by
+ * {@see SendInvoiceEmailUseCase::prepare()} after the sendability / client-email
+ * guards pass, so `execute()` and `preview()` share the exact same subject /
+ * body / recipient. Not exposed over HTTP — the preview response uses
+ * {@see SendInvoiceEmailPreview}.
+ */
+final readonly class PreparedInvoiceEmail
+{
+    /**
+     * @param list<LineItem> $lines
+     */
+    public function __construct(
+        public Invoice $invoice,
+        public array $lines,
+        public Client $client,
+        public string $invoiceNumber,
+        public string $subject,
+        public string $bodyHtml,
+    ) {
+    }
+}

--- a/src/Invoice/SendInvoiceEmailHandler.php
+++ b/src/Invoice/SendInvoiceEmailHandler.php
@@ -4,23 +4,40 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneInvoice\Auth\AuthContext;
-use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * `POST /admin/invoices/{id}/send-email` — sends the invoice PDF to the client.
- * Returns 204 No Content on success.
- * MailerException and InvoiceEmailException bubble up to domain exception handlers.
+ *
+ * Non-demo organizations send for real and get `204 No Content` on success.
+ *
+ * Demo organizations (identified by the `demo.slugPrefix` on the resolved org
+ * slug, set by OrgResolverMiddleware as `nene2.org.slug`) must NOT send: their
+ * seeded clients use fictitious `.example` addresses that always bounce with a
+ * 502, which reads like a product failure in a sales demo (#626). Instead the
+ * handler returns `200` with a JSON preview `{ preview, recipient, subject,
+ * body_html }` so the UI can show what *would* be sent, clearly labelled as a
+ * demo that did not actually deliver.
+ *
+ * MailerException and InvoiceEmailException bubble up to domain exception
+ * handlers.
  */
 final readonly class SendInvoiceEmailHandler implements RequestHandlerInterface
 {
+    /**
+     * @param string $demoSlugPrefix organization-slug prefix that marks a demo
+     *                                org; empty disables demo detection so every
+     *                                org sends for real (safe default)
+     */
     public function __construct(
         private SendInvoiceEmailUseCaseInterface $useCase,
-        private Psr17Factory $psr17,
+        private JsonResponseFactory $json,
+        private string $demoSlugPrefix,
     ) {
     }
 
@@ -29,8 +46,30 @@ final readonly class SendInvoiceEmailHandler implements RequestHandlerInterface
         $params = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id     = is_array($params) && isset($params['id']) ? (int) $params['id'] : 0;
 
+        if ($this->isDemoOrg($request)) {
+            $preview = $this->useCase->preview($id);
+
+            return $this->json->create([
+                'preview'   => true,
+                'recipient' => $preview->recipient,
+                'subject'   => $preview->subject,
+                'body_html' => $preview->bodyHtml,
+            ]);
+        }
+
         $this->useCase->execute(AuthContext::userId($request), $id);
 
-        return $this->psr17->createResponse(204);
+        return $this->json->createEmpty(204);
+    }
+
+    private function isDemoOrg(ServerRequestInterface $request): bool
+    {
+        if ($this->demoSlugPrefix === '') {
+            return false;
+        }
+
+        $slug = $request->getAttribute('nene2.org.slug');
+
+        return is_string($slug) && str_starts_with($slug, $this->demoSlugPrefix);
     }
 }

--- a/src/Invoice/SendInvoiceEmailPreview.php
+++ b/src/Invoice/SendInvoiceEmailPreview.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Invoice;
+
+/**
+ * Preview of the email that would be sent for an invoice, without actually
+ * sending it. Used by demo organizations (whose fictitious `.example` clients
+ * are undeliverable): the send action returns this content for display in a
+ * modal instead of dispatching a message. See #626.
+ *
+ * `recipient` / `subject` / `bodyHtml` map to the JSON fields `recipient`,
+ * `subject`, `body_html` (用語レジストリ登録済み). No PDF is attached to a
+ * preview; the body text already notes that a PDF would be enclosed.
+ */
+final readonly class SendInvoiceEmailPreview
+{
+    public function __construct(
+        public string $recipient,
+        public string $subject,
+        public string $bodyHtml,
+    ) {
+    }
+}

--- a/src/Invoice/SendInvoiceEmailUseCase.php
+++ b/src/Invoice/SendInvoiceEmailUseCase.php
@@ -53,11 +53,8 @@ final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseI
 
         $prepared = $this->prepare($invoiceId);
 
-        $company = $this->companySettings->find()
-            ?? new CompanySettings(organizationId: $organizationId, legalName: $this->fromName);
-
         $withLines = new InvoiceWithLines($prepared->invoice, $prepared->lines, 0);
-        $pdfData   = new Pdf\InvoicePdfData($withLines, $company, $prepared->client);
+        $pdfData   = new Pdf\InvoicePdfData($withLines, $prepared->company, $prepared->client);
         $pdfBytes  = $this->pdfGenerator->generate($pdfData);
 
         $this->mailer->send(new MailMessage(
@@ -161,6 +158,7 @@ final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseI
             invoice: $invoice,
             lines: $lines,
             client: $client,
+            company: $company,
             invoiceNumber: $invoiceNumber,
             subject: "請求書 {$invoiceNumber} — {$companyName}",
             bodyHtml: $bodyHtml,

--- a/src/Invoice/SendInvoiceEmailUseCase.php
+++ b/src/Invoice/SendInvoiceEmailUseCase.php
@@ -51,6 +51,75 @@ final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseI
     {
         $organizationId = $this->orgId->get();
 
+        $prepared = $this->prepare($invoiceId);
+
+        $company = $this->companySettings->find()
+            ?? new CompanySettings(organizationId: $organizationId, legalName: $this->fromName);
+
+        $withLines = new InvoiceWithLines($prepared->invoice, $prepared->lines, 0);
+        $pdfData   = new Pdf\InvoicePdfData($withLines, $company, $prepared->client);
+        $pdfBytes  = $this->pdfGenerator->generate($pdfData);
+
+        $this->mailer->send(new MailMessage(
+            toAddress: (string) $prepared->client->email,
+            toName: $prepared->client->name,
+            subject: $prepared->subject,
+            bodyHtml: $prepared->bodyHtml,
+            attachmentBytes: $pdfBytes,
+            attachmentName: preg_replace('/[^A-Za-z0-9\-_]/', '_', $prepared->invoiceNumber) . '.pdf',
+            attachmentMime: 'application/pdf',
+        ));
+
+        // Audit (ADR 0008): record the send as an auditable event. `after` is the
+        // sanitized snapshot of the invoice content that was sent (proof of what
+        // went out); `before` is null because no entity state changed.
+        $this->audit->record(new AuditEvent(
+            action: 'invoice.sent',
+            entityType: 'invoice',
+            entityId: $invoiceId,
+            actorId: $actorUserId,
+            organizationId: $organizationId,
+            before: null,
+            after: InvoiceResponse::toArray($prepared->invoice, $prepared->lines),
+        ));
+    }
+
+    /**
+     * Builds the email content (recipient / subject / body) without sending it or
+     * recording an audit event (#626). Used by demo organizations, whose
+     * fictitious `.example` clients are undeliverable; the send action shows this
+     * in a modal instead of dispatching a message. No PDF is generated — the body
+     * already notes that a PDF would be attached.
+     *
+     * The same sendability / client-email guards as {@see execute()} apply, so a
+     * draft invoice or an emailless client is rejected identically.
+     *
+     * @throws InvoiceNotFoundException
+     * @throws InvoiceEmailException
+     */
+    public function preview(int $invoiceId): SendInvoiceEmailPreview
+    {
+        $prepared = $this->prepare($invoiceId);
+
+        return new SendInvoiceEmailPreview(
+            recipient: (string) $prepared->client->email,
+            subject: $prepared->subject,
+            bodyHtml: $prepared->bodyHtml,
+        );
+    }
+
+    /**
+     * Runs the shared guards and assembles the recipient / subject / body that
+     * both {@see execute()} and {@see preview()} rely on, so real sends and demo
+     * previews never diverge.
+     *
+     * @throws InvoiceNotFoundException
+     * @throws InvoiceEmailException
+     */
+    private function prepare(int $invoiceId): PreparedInvoiceEmail
+    {
+        $organizationId = $this->orgId->get();
+
         $invoice = $this->invoices->findById($invoiceId);
 
         if ($invoice === null) {
@@ -72,14 +141,10 @@ final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseI
             throw InvoiceEmailException::noClientEmail($invoiceId);
         }
 
-        $lines     = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
-        $withLines = new InvoiceWithLines($invoice, $lines, 0);
+        $lines = $this->lineItems->findByParent(LineItemParent::Invoice, $invoiceId);
 
         $company = $this->companySettings->find()
             ?? new CompanySettings(organizationId: $organizationId, legalName: $this->fromName);
-
-        $pdfData = new Pdf\InvoicePdfData($withLines, $company, $client);
-        $pdfBytes = $this->pdfGenerator->generate($pdfData);
 
         $invoiceNumber = $invoice->invoiceNumber ?? "INV-{$invoiceId}";
         $companyName   = $company->legalName;
@@ -92,27 +157,13 @@ final readonly class SendInvoiceEmailUseCase implements SendInvoiceEmailUseCaseI
             htmlspecialchars($companyName, ENT_QUOTES, 'UTF-8'),
         );
 
-        $this->mailer->send(new MailMessage(
-            toAddress: $client->email,
-            toName: $client->name,
+        return new PreparedInvoiceEmail(
+            invoice: $invoice,
+            lines: $lines,
+            client: $client,
+            invoiceNumber: $invoiceNumber,
             subject: "請求書 {$invoiceNumber} — {$companyName}",
             bodyHtml: $bodyHtml,
-            attachmentBytes: $pdfBytes,
-            attachmentName: preg_replace('/[^A-Za-z0-9\-_]/', '_', $invoiceNumber) . '.pdf',
-            attachmentMime: 'application/pdf',
-        ));
-
-        // Audit (ADR 0008): record the send as an auditable event. `after` is the
-        // sanitized snapshot of the invoice content that was sent (proof of what
-        // went out); `before` is null because no entity state changed.
-        $this->audit->record(new AuditEvent(
-            action: 'invoice.sent',
-            entityType: 'invoice',
-            entityId: $invoiceId,
-            actorId: $actorUserId,
-            organizationId: $organizationId,
-            before: null,
-            after: InvoiceResponse::toArray($invoice, $lines),
-        ));
+        );
     }
 }

--- a/src/Invoice/SendInvoiceEmailUseCaseInterface.php
+++ b/src/Invoice/SendInvoiceEmailUseCaseInterface.php
@@ -7,4 +7,11 @@ namespace NeneInvoice\Invoice;
 interface SendInvoiceEmailUseCaseInterface
 {
     public function execute(?int $actorUserId, int $invoiceId): void;
+
+    /**
+     * Builds the email preview (recipient / subject / body) without sending or
+     * auditing. Used by demo organizations (#626). Applies the same sendability
+     * / client-email guards as {@see execute()}.
+     */
+    public function preview(int $invoiceId): SendInvoiceEmailPreview;
 }

--- a/tests/Invoice/SendInvoiceEmailHandlerTest.php
+++ b/tests/Invoice/SendInvoiceEmailHandlerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Routing\Router;
+use NeneInvoice\Client\Client;
+use NeneInvoice\Company\CompanySettings;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Invoice\Pdf\InvoicePdfData;
+use NeneInvoice\Invoice\Pdf\InvoicePdfGeneratorInterface;
+use NeneInvoice\Invoice\SendInvoiceEmailHandler;
+use NeneInvoice\Invoice\SendInvoiceEmailUseCase;
+use NeneInvoice\Tests\Support\InMemoryClientRepository;
+use NeneInvoice\Tests\Support\InMemoryCompanySettingsRepository;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use NeneInvoice\Tests\Support\InMemoryLineItemRepository;
+use NeneInvoice\Tests\Support\RecordingAuditRecorder;
+use NeneInvoice\Tests\Support\RecordingMailer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers #626: demo orgs get a 200 preview (no send); real orgs get 204 (send).
+ */
+final class SendInvoiceEmailHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private RecordingMailer $mailer;
+    private RecordingAuditRecorder $audit;
+    private int $invoiceId;
+    private SendInvoiceEmailUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set(1);
+
+        $invoices        = new InMemoryInvoiceRepository($holder);
+        $clients         = new InMemoryClientRepository($holder);
+        $companySettings = new InMemoryCompanySettingsRepository();
+        $lineItems       = new InMemoryLineItemRepository();
+        $this->mailer    = new RecordingMailer();
+        $this->audit     = new RecordingAuditRecorder();
+
+        $companySettings->save(new CompanySettings(organizationId: 1, legalName: 'テスト商会'));
+        $clientId = $clients->save(new Client(
+            organizationId: 1,
+            name: '株式会社サンプル',
+            email: 'buyer@example.com',
+        ));
+        $this->invoiceId = $invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: $clientId,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 10000,
+            taxCents: 1000,
+            totalCents: 11000,
+            invoiceNumber: 'INV-2026-001',
+            issuedAt: '2026-05-01 00:00:00',
+        ));
+
+        $pdfGenerator = new class () implements InvoicePdfGeneratorInterface {
+            public function generate(InvoicePdfData $data): string
+            {
+                return '%PDF-1.4 fake';
+            }
+        };
+
+        $this->useCase = new SendInvoiceEmailUseCase(
+            $invoices,
+            $lineItems,
+            $clients,
+            $companySettings,
+            $pdfGenerator,
+            $this->mailer,
+            $this->audit,
+            $holder,
+            'NeNe Invoice',
+        );
+    }
+
+    private function handler(string $demoSlugPrefix): SendInvoiceEmailHandler
+    {
+        return new SendInvoiceEmailHandler(
+            $this->useCase,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            $demoSlugPrefix,
+        );
+    }
+
+    public function test_demo_org_returns_preview_json_and_does_not_send(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/send-email")
+            ->withAttribute('nene2.org.slug', 'demo-abc123')
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
+
+        $response = $this->handler('demo-')->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertTrue($body['preview']);
+        self::assertSame('buyer@example.com', $body['recipient']);
+        self::assertStringContainsString('INV-2026-001', (string) $body['subject']);
+        self::assertStringContainsString('株式会社サンプル', (string) $body['body_html']);
+
+        // No real send, no audit event.
+        self::assertCount(0, $this->mailer->sent);
+        self::assertCount(0, $this->audit->records);
+    }
+
+    public function test_non_demo_org_sends_and_returns_204(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/send-email")
+            ->withAttribute('nene2.org.slug', 'acme')
+            ->withAttribute('nene2.auth.claims', ['sub' => 7, 'role' => 'admin', 'org' => 1])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
+
+        $response = $this->handler('demo-')->handle($request);
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertCount(1, $this->mailer->sent);
+        self::assertSame('buyer@example.com', $this->mailer->sent[0]->toAddress);
+        self::assertCount(1, $this->audit->records);
+    }
+
+    public function test_empty_prefix_disables_demo_detection_and_sends(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', "/admin/invoices/{$this->invoiceId}/send-email")
+            ->withAttribute('nene2.org.slug', 'demo-abc123')
+            ->withAttribute('nene2.auth.claims', ['sub' => 7, 'role' => 'admin', 'org' => 1])
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, ['id' => (string) $this->invoiceId]);
+
+        $response = $this->handler('')->handle($request);
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertCount(1, $this->mailer->sent);
+    }
+}

--- a/tests/Invoice/SendInvoiceEmailUseCaseTest.php
+++ b/tests/Invoice/SendInvoiceEmailUseCaseTest.php
@@ -179,6 +179,70 @@ final class SendInvoiceEmailUseCaseTest extends TestCase
         $this->useCase->execute(7, $invoiceId);
     }
 
+    public function test_preview_returns_recipient_subject_and_body_without_sending(): void
+    {
+        $this->companySettings->save(new CompanySettings(
+            organizationId: 1,
+            legalName: 'テスト商会',
+        ));
+        $clientId  = $this->clients->save(new Client(
+            organizationId: 1,
+            name: '株式会社サンプル',
+            email: 'buyer@example.com',
+        ));
+        $invoiceId = $this->issuedInvoice($clientId);
+
+        $preview = $this->useCase->preview($invoiceId);
+
+        self::assertSame('buyer@example.com', $preview->recipient);
+        self::assertStringContainsString('INV-2026-001', $preview->subject);
+        self::assertStringContainsString('テスト商会', $preview->subject);
+        self::assertStringContainsString('株式会社サンプル', $preview->bodyHtml);
+        self::assertStringContainsString('INV-2026-001', $preview->bodyHtml);
+
+        // Preview must not send a message nor record an audit event.
+        self::assertCount(0, $this->mailer->sent);
+        self::assertCount(0, $this->audit->records);
+    }
+
+    public function test_preview_throws_not_found_for_unknown_invoice(): void
+    {
+        $this->expectException(InvoiceNotFoundException::class);
+        $this->useCase->preview(999);
+    }
+
+    public function test_preview_throws_when_invoice_is_draft(): void
+    {
+        $clientId  = $this->clients->save(new Client(
+            organizationId: 1,
+            name: 'Buyer',
+            email: 'buyer@example.com',
+        ));
+        $invoiceId = $this->invoices->save(new Invoice(
+            organizationId: 1,
+            clientId: $clientId,
+            status: InvoiceStatus::Draft,
+            subtotalCents: 1000,
+            taxCents: 100,
+            totalCents: 1100,
+        ));
+
+        $this->expectException(InvoiceEmailException::class);
+        $this->useCase->preview($invoiceId);
+    }
+
+    public function test_preview_throws_when_client_has_no_email(): void
+    {
+        $clientId  = $this->clients->save(new Client(
+            organizationId: 1,
+            name: 'No Email Corp',
+        ));
+        $invoiceId = $this->issuedInvoice($clientId);
+
+        $this->expectException(InvoiceEmailException::class);
+        $this->useCase->preview($invoiceId);
+    }
+
     public function test_uses_company_name_from_settings(): void
     {
         $this->companySettings->save(new CompanySettings(


### PR DESCRIPTION
Closes #626

## 背景
デモ組織の取引先は `.example` ドメインで配信不能なため、請求書「メール送信」が構造的に必ず 502 になる。デモは税理士・見込み客向けセールス導線なので、最初の一押しがエラーだと製品障害に見える。**施主裁定 = 案C**: デモorgでは実送信せず、送信内容をプレビューモーダルで見せ「デモのため実送しません」と明示する。非デモorgは従来どおり実送信（変更なし）。

## 実装（レスポンス駆動＝FE側で demo 判定不要）
### バックエンド
- `SendInvoiceEmailUseCase::preview()` を追加。`execute()` と件名/本文/宛先の組み立て・ガード（not-issued / client-email-missing）を private `prepare()` で共有。preview は **mailer 未呼び・監査 `invoice.sent` 未記録・PDF 未生成**（本文に添付 PDF の旨は含む）。
- `SendInvoiceEmailHandler` を demo 対応化。request 属性 `nene2.org.slug` と `demo.slugPrefix`（**demoMode 有効時のみ**、無効なら空prefix＝検出無効で従来どおり実送）を `str_starts_with` で突合。demo なら `preview()` → **200 JSON** `{ preview, recipient, subject, body_html }`、非demo なら `execute()` → **204**。
- slugPrefix は `InvoiceServiceProvider` の handler 配線で `AppConfig->demo` から注入。
- **用語レジストリ**（`terminology.md §3`）に Invoice-email preview read model（`preview`/`recipient`/`subject`/`body_html`）を追加。**OpenAPI** に send-email の 200 preview レスポンス＋`SendInvoiceEmailPreview` schema を 204 と併記。

### フロントエンド
- `useSendInvoiceEmail` が `SendInvoiceEmailPreview | null`（204→null）を返すよう変更。
- `ViewInvoice`: `preview === true` でプレビューモーダル（`EmailPreviewModal`）を開く。204 は従来トースト。502 等のエラー分岐は不変。
- i18n ja/en に見出し・「デモのため実送しません」注記・宛先/件名/本文ラベルを追加。

## 安全性（body_html の描画）
`body_html` は `SendInvoiceEmailUseCase` の**固定テンプレ**（`<p>`/`<br>` のみ）で、動的値（取引先名/会社名/請求書番号）は**サーバ側で htmlspecialchars 済み**。untrusted HTML の混入経路が無いことを確認のうえ `dangerouslySetInnerHTML` を使用（コンポーネント JSDoc に根拠明記）。

## テスト
- backend: demo slug → preview 200 + JSON 形（mailer/audit 未呼び）、非demo → 204 で mailer 呼び出し＋audit 記録、空prefix→実送、preview でも not-issued/no-email ガードが効く。
- frontend: preview:true でモーダルが開き宛先/件名/本文＋「No email was actually sent」注記が出る、204 で従来トースト・モーダル非表示。

## 品質ゲート
- `composer check`: **緑**（951 tests / PHPStan / CS / OpenAPI / MCP / conformance）。
- `npm run check --prefix frontend`: **緑**（type-check / lint / format / test / knip / build-storybook）。

## セルフレビュー
- コンプライアンス: 送信・採番・PDF・保存ロジックは不変（preview は読み取りのみ・非破壊）。
- 命名: 新規 JSON フィールドは snake_case・用語レジストリ登録済み。
- 既存挙動: 非demo（demoMode 無効含む）は完全に従来どおり（安全側）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)