### PR TITLE
feat(demo): デモ限定 cookieless 計測（GoatCounter）を env-gate 配線 (#658)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ BASE_DOMAIN=localhost
 # DEMO_TTL_HOURS=3         # 作成から何時間で sweep 対象になるか
 # DEMO_MAX_ORGS=200        # 同時に存在できる demo org の上限（超過分は古い順に sweep・作成は 503）
 # DEMO_SLUG_ATTEMPTS=5     # slug 衝突時のリトライ回数
+#
+# デモ限定 cookieless 計測（GoatCounter 自己ホスト・#658）。**デモ機の .env にのみ**
+# 計測ホストの origin を設定すると、SPAシェルに GoatCounter ビーコンを注入し、その応答の
+# CSP に当該 origin を追加する（script-src / connect-src / img-src）。**未設定なら一切注入せず
+# CSP も既定のまま**＝OSS 本体・通常インストールは計測ゼロ。origin 文字列はこの .env.example や
+# コミット済みフロント（React ビルド）・.htaccess には**焼き込まない**（信頼の柱）。
+# 例: DEMO_ANALYTICS_ENDPOINT=https://stats.example.test （末尾スラッシュ無し・パス無しの origin）
+# DEMO_ANALYTICS_ENDPOINT=
 
 # --- Recurring billing execution (#526) ---
 # 1（既定）: 共用ホスティング(Tier A・cron 不可)向け。認証済み /admin/ リクエスト時に

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -28,7 +28,15 @@ RewriteRule ^ index.php [QSA,L]
     # CSP tuned to the built SPA: external module script only (script-src 'self',
     # no inline script), but a few dynamic inline style attributes need
     # 'unsafe-inline' for styles. frame-ancestors 'self' blocks clickjacking.
-    Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
+    #
+    # The `expr=` guard makes this default yield when the response already carries
+    # a CSP set by PHP. Only the disposable-demo shell does that (env-gated
+    # cookieless analytics, #658): there SpaShell emits a CSP widened for the
+    # analytics origin, and this line must not clobber it into two intersecting
+    # CSPs. Every other response (static assets, JSON API, and the SPA shell on
+    # non-demo installs, none of which set a CSP) is unchanged — the expr is true
+    # and the default CSP below is applied exactly as before.
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" "expr=-z resp('Content-Security-Policy')"
     Header always set X-Frame-Options "SAMEORIGIN"
     Header always set X-Content-Type-Options "nosniff"
     Header always set Referrer-Policy "strict-origin-when-cross-origin"

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -90,7 +90,14 @@ $method = $request->getMethod();
 $response = null;
 
 if (($method === 'GET' || $method === 'HEAD') && !BasePath::isApiPath($spaPlan->spaPath)) {
-    $shell = new SpaShell($projectRoot . '/public_html/admin/index.html', $psr17Factory, $psr17Factory);
+    // Demo-only, env-gated cookieless analytics (#658): the disposable-demo host
+    // sets DEMO_ANALYTICS_ENDPOINT in its .env; every other install leaves it
+    // unset so no beacon and no analytics CSP are ever emitted. The origin
+    // literal lives only in that .env — never in .env.example or the built SPA.
+    $analyticsEndpointRaw = $_ENV['DEMO_ANALYTICS_ENDPOINT'] ?? getenv('DEMO_ANALYTICS_ENDPOINT');
+    $analyticsEndpoint = is_string($analyticsEndpointRaw) && $analyticsEndpointRaw !== '' ? $analyticsEndpointRaw : null;
+
+    $shell = new SpaShell($projectRoot . '/public_html/admin/index.html', $psr17Factory, $psr17Factory, $analyticsEndpoint);
     $response = $shell->serve($spaPlan->assetBase, $spaPlan->appBase);
 }
 

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -30,14 +30,34 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
 {
+    /** @var \Closure(string): void Where entry log lines go; defaults to `error_log`. */
+    private \Closure $logSink;
+
+    /**
+     * @param (\Closure(string): void)|null $logSink Sink for the demo-entry
+     *        attribution line (#658). Defaults to PHP's `error_log`, matching the
+     *        product's existing convention; overridable in tests so the recorded
+     *        line can be asserted without depending on the global `error_log` ini.
+     */
     public function __construct(
         private RefreshTokenIssuer $refreshTokenIssuer,
         private Psr17Factory $responseFactory,
+        ?\Closure $logSink = null,
     ) {
+        $this->logSink = $logSink ?? static function (string $line): void {
+            error_log($line);
+        };
     }
 
     public function seatAndRedirect(ServerRequestInterface $request, ProvisionedDemoOrg $org): ResponseInterface
     {
+        // Attribution layer 1 (#658): record channel/campaign here — the last
+        // moment they exist — because the 302 below drops the query and the
+        // browser's next request to /{slug}/dashboard is same-origin (no UTM, a
+        // self Referer). No PII: only Referer + utm_* + the disposable slug are
+        // logged; never the client IP or any personal field.
+        $this->logDemoEntry($request, $org);
+
         $refreshToken = $this->refreshTokenIssuer->issue($org->adminUserId, $org->orgId);
 
         // Scope the session cookies to the tenant slug so the browser sends them
@@ -52,5 +72,54 @@ final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
             ->withHeader('Cache-Control', 'no-store')
             ->withAddedHeader('Set-Cookie', SessionCookies::setRefresh($refreshToken->rawToken, $refreshToken->expiresAtTimestamp, $slugBase))
             ->withAddedHeader('Set-Cookie', SessionCookies::setCsrf($csrfToken, $refreshToken->expiresAtTimestamp, $slugBase));
+    }
+
+    /**
+     * Emits one `error_log` line per demo entry with the referer and UTM tags,
+     * matching the product's existing `error_log('NeNe Invoice: …')` convention.
+     * Values are sanitised (control chars stripped, length-capped) so a crafted
+     * Referer / query cannot forge log lines, and missing tags render as `-` so
+     * a UTM-less entry still logs cleanly instead of breaking the redirect.
+     */
+    private function logDemoEntry(ServerRequestInterface $request, ProvisionedDemoOrg $org): void
+    {
+        $query = $request->getQueryParams();
+
+        $fields = [
+            'slug' => $org->slug,
+            'utm_source' => $query['utm_source'] ?? null,
+            'utm_medium' => $query['utm_medium'] ?? null,
+            'utm_campaign' => $query['utm_campaign'] ?? null,
+            'referer' => $request->getHeaderLine('Referer'),
+        ];
+
+        $parts = [];
+
+        foreach ($fields as $key => $value) {
+            $parts[] = $key . '=' . self::sanitiseLogValue(is_string($value) ? $value : null);
+        }
+
+        ($this->logSink)('NeNe Invoice: demo-entry ' . implode(' ', $parts));
+    }
+
+    /**
+     * Renders a log field value: `-` when absent/empty, otherwise the value with
+     * CR/LF and other control characters removed (log-injection defence) and
+     * capped at 256 chars so a long crafted URL can't bloat the log.
+     */
+    private static function sanitiseLogValue(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        $clean = preg_replace('/[\x00-\x1F\x7F]+/', ' ', $value) ?? '';
+        $clean = trim($clean);
+
+        if ($clean === '') {
+            return '-';
+        }
+
+        return mb_substr($clean, 0, 256);
     }
 }

--- a/src/Http/SpaShell.php
+++ b/src/Http/SpaShell.php
@@ -28,14 +28,68 @@ use Psr\Http\Message\StreamFactoryInterface;
  *
  * Serving the shell through the front controller (rather than a static file)
  * also fixes SPA deep-links / F5: any non-API GET returns the shell.
+ *
+ * ## Optional demo analytics (env-gated, OSS-clean)
+ *
+ * When — and only when — `$analyticsEndpoint` is a valid origin (wired from the
+ * `DEMO_ANALYTICS_ENDPOINT` env, set on the disposable-demo host alone), a third
+ * `<head>` tag is added: the cookieless GoatCounter beacon
+ * (`<script data-goatcounter="…/count" async src="…/count.js">`). Because that
+ * beacon loads a cross-origin script and posts to a cross-origin collector, this
+ * response also carries its own `Content-Security-Policy` that widens
+ * `script-src` / `connect-src` / `img-src` to the analytics origin.
+ *
+ * The OSS release ships **no** analytics origin anywhere: the endpoint literal
+ * lives only in the demo host's `.env`, never in `.env.example`, the committed
+ * React build, or `.htaccess`. With the env unset the shell is byte-for-byte the
+ * pre-analytics shell and sets no CSP header (Apache's default `.htaccess` CSP
+ * applies, unchanged). See `public_html/.htaccess` for the Apache side of the
+ * hand-off (its default CSP yields to the one this class sets on the shell).
  */
 final readonly class SpaShell
 {
+    /**
+     * Mirror of the default `Content-Security-Policy` in `public_html/.htaccess`.
+     * Only consulted when demo analytics is enabled: this class then emits the
+     * CSP itself (widened for the analytics origin) and `.htaccess` steps aside.
+     * Keep this string in lockstep with the `.htaccess` `Header always set
+     * Content-Security-Policy` value — a drift here only affects the demo shell.
+     */
+    private const string BASE_CSP = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
+
+    /** Normalised analytics origin (e.g. `https://stats.example.test`), or null when disabled. */
+    private ?string $analyticsEndpoint;
+
     public function __construct(
         private string $shellPath,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        ?string $analyticsEndpoint = null,
     ) {
+        $this->analyticsEndpoint = self::normaliseEndpoint($analyticsEndpoint);
+    }
+
+    /**
+     * Accepts an analytics endpoint only when it is a bare `http(s)://host[:port]`
+     * origin — no path, query, fragment, whitespace or control characters. Any
+     * trailing slash is trimmed. Anything else (including empty/unset) disables
+     * analytics (fail-safe), so a fat-fingered env can never inject markup or a
+     * malformed CSP / header. The value is operator-controlled (server `.env`),
+     * but validating it keeps header/attribute construction provably safe.
+     */
+    private static function normaliseEndpoint(?string $endpoint): ?string
+    {
+        if ($endpoint === null) {
+            return null;
+        }
+
+        $endpoint = rtrim(trim($endpoint), '/');
+
+        if ($endpoint === '' || preg_match('#^https?://[A-Za-z0-9.\-]+(:\d+)?$#', $endpoint) !== 1) {
+            return null;
+        }
+
+        return $endpoint;
     }
 
     /**
@@ -61,6 +115,13 @@ final readonly class SpaShell
             ->withHeader('Content-Type', 'text/html; charset=UTF-8')
             ->withBody($this->streamFactory->createStream($this->inject($html, $assetBase, $appBase)));
 
+        // Only when demo analytics is on does this class own the shell's CSP
+        // (widened for the analytics origin); `.htaccess` yields to it. With the
+        // env unset no CSP header is set here and the Apache default applies.
+        if ($this->analyticsEndpoint !== null) {
+            $response = $response->withHeader('Content-Security-Policy', $this->analyticsCsp());
+        }
+
         return $response;
     }
 
@@ -69,10 +130,45 @@ final readonly class SpaShell
         $assetHref = htmlspecialchars($assetBase . '/admin/', ENT_QUOTES);
         $appHref = htmlspecialchars($appBase . '/', ENT_QUOTES);
 
-        $tags = "<head>\n    <base href=\"{$assetHref}\" />\n    <meta name=\"app-base\" content=\"{$appHref}\" />";
+        $tags = "<head>\n    <base href=\"{$assetHref}\" />\n    <meta name=\"app-base\" content=\"{$appHref}\" />" . $this->analyticsTag();
 
         // Inject right after the opening <head> so <base> precedes any relative
         // URL. If the marker is absent (unexpected), serve the shell unchanged.
         return str_replace('<head>', $tags, $html);
+    }
+
+    /**
+     * The cookieless GoatCounter beacon, or an empty string when analytics is
+     * disabled. Both URLs derive from the single validated origin; the origin is
+     * escaped for the HTML attribute context (belt-and-suspenders — the endpoint
+     * is already validated to a bare origin).
+     */
+    private function analyticsTag(): string
+    {
+        if ($this->analyticsEndpoint === null) {
+            return '';
+        }
+
+        $dataAttr = htmlspecialchars($this->analyticsEndpoint . '/count', ENT_QUOTES);
+        $src = htmlspecialchars($this->analyticsEndpoint . '/count.js', ENT_QUOTES);
+
+        return "\n    <script data-goatcounter=\"{$dataAttr}\" async src=\"{$src}\"></script>";
+    }
+
+    /**
+     * The default CSP widened so the beacon may load its cross-origin script and
+     * report to its cross-origin collector. GoatCounter's `count.js` posts via
+     * `navigator.sendBeacon` (connect-src) with an `Image()` fallback (img-src),
+     * so the origin is added to `script-src`, `connect-src` and `img-src`.
+     */
+    private function analyticsCsp(): string
+    {
+        $origin = $this->analyticsEndpoint;
+
+        return str_replace(
+            ["script-src 'self'", "connect-src 'self'", "img-src 'self' data:"],
+            ["script-src 'self' {$origin}", "connect-src 'self' {$origin}", "img-src 'self' data: {$origin}"],
+            self::BASE_CSP,
+        );
     }
 }

--- a/tests/Demo/DemoSessionSeaterTest.php
+++ b/tests/Demo/DemoSessionSeaterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use Nene2\Demo\ProvisionedDemoOrg;
+use NeneInvoice\Auth\RefreshTokenIssuer;
+use NeneInvoice\Demo\DemoSessionSeater;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\InMemoryRefreshTokenRepository;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Attribution layer 1 (#658): the disposable-demo entry logs Referer + UTM tags
+ * before the 302 drops them. The log sink is injected so the recorded line can
+ * be asserted directly — proving a tagged entry is recorded, a UTM-less entry
+ * still logs (and still redirects), and crafted values cannot forge log lines.
+ */
+final class DemoSessionSeaterTest extends TestCase
+{
+    /** @var list<string> */
+    private array $logged = [];
+
+    private function seater(): DemoSessionSeater
+    {
+        $issuer = new RefreshTokenIssuer(new InMemoryRefreshTokenRepository(), new FixedClock());
+
+        return new DemoSessionSeater(
+            $issuer,
+            new Psr17Factory(),
+            function (string $line): void {
+                $this->logged[] = $line;
+            },
+        );
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private function request(string $uri, array $headers = []): ServerRequestInterface
+    {
+        $request = (new Psr17Factory())->createServerRequest('GET', $uri);
+        $query = [];
+        parse_str((string) parse_url($uri, PHP_URL_QUERY), $query);
+        $request = $request->withQueryParams($query);
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
+    }
+
+    private function line(): string
+    {
+        self::assertCount(1, $this->logged, 'exactly one entry line expected');
+
+        return $this->logged[0];
+    }
+
+    public function test_utm_and_referer_are_recorded_before_redirect(): void
+    {
+        $request = $this->request(
+            '/demo/kensetsu?utm_source=facebook&utm_medium=cpc&utm_campaign=tax2026',
+            ['Referer' => 'https://www.facebook.com/'],
+        );
+
+        $response = $this->seater()->seatAndRedirect($request, new ProvisionedDemoOrg(orgId: 7, slug: 'demo-abcd', adminUserId: 3));
+
+        // The redirect itself is unaffected.
+        self::assertSame(302, $response->getStatusCode());
+
+        $line = $this->line();
+        self::assertStringContainsString('NeNe Invoice: demo-entry', $line);
+        self::assertStringContainsString('slug=demo-abcd', $line);
+        self::assertStringContainsString('utm_source=facebook', $line);
+        self::assertStringContainsString('utm_medium=cpc', $line);
+        self::assertStringContainsString('utm_campaign=tax2026', $line);
+        self::assertStringContainsString('referer=https://www.facebook.com/', $line);
+    }
+
+    public function test_entry_without_utm_still_logs_and_redirects(): void
+    {
+        $request = $this->request('/demo/kensetsu');
+
+        $response = $this->seater()->seatAndRedirect($request, new ProvisionedDemoOrg(orgId: 1, slug: 'demo-zzzz', adminUserId: 2));
+
+        self::assertSame(302, $response->getStatusCode());
+
+        $line = $this->line();
+        self::assertStringContainsString('slug=demo-zzzz', $line);
+        // Missing tags render as `-` rather than breaking.
+        self::assertStringContainsString('utm_source=-', $line);
+        self::assertStringContainsString('utm_medium=-', $line);
+        self::assertStringContainsString('utm_campaign=-', $line);
+        self::assertStringContainsString('referer=-', $line);
+    }
+
+    public function test_crafted_values_cannot_forge_log_lines(): void
+    {
+        $request = $this->request(
+            '/demo/kensetsu?utm_source=' . rawurlencode("evil\r\nNeNe Invoice: demo-entry slug=forged"),
+        );
+
+        $this->seater()->seatAndRedirect($request, new ProvisionedDemoOrg(orgId: 5, slug: 'demo-real', adminUserId: 4));
+
+        // Exactly one line is emitted and it carries the real slug; CR/LF in the
+        // crafted value are stripped so no second logical line can be forged.
+        $line = $this->line();
+        self::assertStringContainsString('slug=demo-real', $line);
+        self::assertStringNotContainsString("\n", $line);
+        self::assertStringNotContainsString("\r", $line);
+    }
+}

--- a/tests/Http/SpaShellTest.php
+++ b/tests/Http/SpaShellTest.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Tests\Http;
 
 use NeneInvoice\Http\SpaShell;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SpaShellTest extends TestCase
@@ -27,9 +28,9 @@ final class SpaShellTest extends TestCase
         }
     }
 
-    private function shell(): SpaShell
+    private function shell(?string $analyticsEndpoint = null): SpaShell
     {
-        return new SpaShell($this->shellPath, $this->psr17, $this->psr17);
+        return new SpaShell($this->shellPath, $this->psr17, $this->psr17, $analyticsEndpoint);
     }
 
     public function test_root_install_injects_root_asset_and_app_base(): void
@@ -60,5 +61,77 @@ final class SpaShellTest extends TestCase
         $shell = new SpaShell($this->shellPath . '.absent', $this->psr17, $this->psr17);
 
         self::assertNull($shell->serve('', ''));
+    }
+
+    public function test_analytics_disabled_by_default_injects_no_beacon_and_no_csp(): void
+    {
+        // The OSS default: env unset → the shell is the pre-analytics shell and
+        // sets no CSP header (Apache's .htaccess default applies unchanged).
+        $response = $this->shell()->serve('', '');
+        self::assertNotNull($response);
+
+        $html = (string) $response->getBody();
+        self::assertStringNotContainsString('goatcounter', $html);
+        self::assertStringNotContainsString('<script', $html);
+        self::assertFalse($response->hasHeader('Content-Security-Policy'));
+    }
+
+    public function test_analytics_endpoint_injects_beacon_and_widens_csp(): void
+    {
+        $response = $this->shell('https://stats.example.test')->serve('', '');
+        self::assertNotNull($response);
+
+        $html = (string) $response->getBody();
+        self::assertStringContainsString(
+            '<script data-goatcounter="https://stats.example.test/count" async src="https://stats.example.test/count.js"></script>',
+            $html,
+        );
+        // The base tags still come first (base precedes any relative URL).
+        self::assertStringContainsString('<base href="/admin/" />', $html);
+
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("script-src 'self' https://stats.example.test", $csp);
+        self::assertStringContainsString("connect-src 'self' https://stats.example.test", $csp);
+        self::assertStringContainsString("img-src 'self' data: https://stats.example.test", $csp);
+        // The rest of the hardened default is intact.
+        self::assertStringContainsString("frame-ancestors 'self'", $csp);
+        self::assertStringContainsString("object-src 'none'", $csp);
+    }
+
+    public function test_trailing_slash_is_trimmed_from_endpoint(): void
+    {
+        $response = $this->shell('https://stats.example.test/')->serve('', '');
+        self::assertNotNull($response);
+
+        self::assertStringContainsString('src="https://stats.example.test/count.js"', (string) $response->getBody());
+    }
+
+    /**
+     * A malformed or non-origin endpoint fails safe to disabled — no markup and
+     * no CSP header — so a fat-fingered env can never inject a tag or a broken
+     * header value.
+     */
+    #[DataProvider('invalidEndpoints')]
+    public function test_invalid_endpoint_fails_safe_to_disabled(string $endpoint): void
+    {
+        $response = $this->shell($endpoint)->serve('', '');
+        self::assertNotNull($response);
+
+        self::assertStringNotContainsString('goatcounter', (string) $response->getBody());
+        self::assertFalse($response->hasHeader('Content-Security-Policy'));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function invalidEndpoints(): array
+    {
+        return [
+            'empty' => [''],
+            'whitespace' => ['   '],
+            'has path' => ['https://stats.example.test/count'],
+            'has query' => ['https://stats.example.test?a=1'],
+            'no scheme' => ['stats.example.test'],
+            'crlf injection' => ["https://stats.example.test\r\nX-Evil: 1"],
+            'javascript scheme' => ['javascript:alert(1)'],
+        ];
     }
 }


### PR DESCRIPTION
## 目的
税理士リード向けデモのアトリビューション取得のため、cookieless 自己ホスト計測（GoatCounter・ConoHa `https://stats.ayane.co.jp`）を **env駆動・デモ限定・OSSリリース無汚染**でデモ機に配線する。正本: `_work/handoff-analytics-setup-2026-07-12-work-order.md` ②③。

`Closes #658`

## 変更点
### ② SPAシェル env-gate 注入 ＋ デモCSP（`src/Http/SpaShell.php`, `public_html/index.php`, `public_html/.htaccess`, `.env.example`）
- `DEMO_ANALYTICS_ENDPOINT` に**値がある時だけ** SpaShell が `<head>` に GoatCounter ビーコン `<script data-goatcounter=".../count" async src=".../count.js">` を注入する。**未設定なら一切注入せず、CSPヘッダも出さない**（Apache 既定 CSP がそのまま適用）。
- env はサーバ側 SpaShell にコンストラクタ注入（`index.php` が `$_ENV`/`getenv` から読む・既存 `APP_BASE_PATH`/`TENANT_RESOLUTION` と同型）。
- endpoint は `http(s)://host[:port]` の bare origin のみ許可（パス・クエリ・制御文字は fail-safe で無効化）＝ヘッダ/属性生成を安全化。
- **CSP拡張**: env 有効時のみ SpaShell が応答に CSP を出し、`script-src`/`connect-src`/`img-src` に計測 origin を追加。GoatCounter は sendBeacon（connect-src）＋Image フォールバック（img-src）のため 3 ディレクティブに付与。
- **.htaccess 正本との整合**: 本アプリの CSP は `public_html/.htaccess` の `Header always set Content-Security-Policy` が正本（SPAシェルは front-controller 経由だが CSP は Apache 層）。PHP が独自 CSP を出した時だけ .htaccess が譲るよう `expr=-z resp('Content-Security-Policy')` を最小追加。**非デモ機（env 未設定＝PHP が CSP を出さない）は expr が真で既定 CSP をそのまま適用＝挙動不変**。

### ③ 層1: サーバ側 入場ログ（`src/Demo/DemoSessionSeater.php`）
- `/demo/{template}` の **302 直前**に `Referer`＋`utm_source/utm_medium/utm_campaign` を 1 行記録（既定 `error_log`・製品の `NeNe Invoice: …` 慣習に整合）。302 で query が消える前に捕捉。
- **PII 非保存**（Referer＋utm＋使い捨て slug のみ・IP や個人情報なし）。値は制御文字除去＋256字上限でログインジェクション防止。欠損タグは `-`。utm 無しでも壊れず 302 する。
- ログ sink を注入可能化（既定 error_log）＝テストで記録行を直接検証。

## リリース無汚染の担保
- `.env.example` は空キー＋`example.test` の例示のみ（実 origin は焼かない）。
- `git grep stats.ayane` = **0 件**（実 origin は committed 物のどこにも無い）。
- committed React ビルド（`public_html/admin/`）・`frontend/src` に計測コード無し（grep 済み）。
- 注入はサーバ側 SpaShell のみ。実 origin はデモ機 `.env` にのみ存在。

## テスト（新規）
- ②`tests/Http/SpaShellTest.php`: env 未設定→無注入・CSPヘッダ無し／設定時→ビーコン注入・CSP 3ディレクティブ拡張・既定 CSP 保持／末尾スラッシュ trim／不正 endpoint は fail-safe（空・パス・クエリ・スキーム無し・CRLF・javascript: の 7 例）。
- ③`tests/Demo/DemoSessionSeaterTest.php`: utm＋referer 記録／utm 無しでも記録＆302／crafted 値で行偽造不可。

## 検証結果
- `composer check` 緑（**964 tests / 3575 assertions**・PHPStan L8 781 files no errors・CS Fixer clean・OpenAPI/MCP/conformance OK）。
- `npm run check --prefix frontend` 緑（exit 0）。

## 要判断（統合リナへ）
- **.htaccess の CSP 手渡し（expr ガード）は Apache 実機での確認が必要**: `expr=-z resp('Content-Security-Policy')` は Apache 2.4 標準だが CI では検証不可。デモ機（HETEML）で「デモシェルに計測 origin 入りの CSP が 1 本だけ載る／非デモ応答は既定 CSP のまま」を実機確認したい。非デモ機は PHP が CSP を出さない＝挙動不変。
- **本番デプロイは別 GO**（本 PR はマージ可否のレビューまで）。

Self-review: view-rendering, middleware-security, backend-api, frontend