### PR TITLE
fix: サインアウト後URLクリーン化(#654)＋PDFへの会社ロゴ描画(#510)

### DIFF
--- a/docs/security/2026-06-08-assessment-round3.md
+++ b/docs/security/2026-06-08-assessment-round3.md
@@ -71,7 +71,7 @@
 | 権限昇格 | superadmin は API で割当不可、他組織へのユーザー作成不可。 |
 | 暗号 | bcrypt、CSPRNG トークン、SHA-256 ハッシュ保存、`hash_equals`。 |
 | 公開 DL トークン | 256bit・ハッシュ保存・期限・org スコープ・ファイル名サニタイズ。 |
-| PDF 生成 | 全ユーザー入力エスケープ。`logo_url` は描画せず **SSRF/HTML インジェクションなし**。 |
+| PDF 生成 | 全ユーザー入力エスケープ。`logo_url` は **base64 の `data:` 画像 URI のみ埋め込み**（`PdfLogo`・Issue #510）。http/https・ローカルパス・その他スキームは描画しない＝**サーバ側フェッチなし → SSRF なし**、src は属性エスケープ済で **HTML インジェクションなし**。 |
 | CSV エクスポート | 数式インジェクション無害化済み。 |
 | メール送信 | PHPMailer API 経由でヘッダインジェクション対策済み。 |
 | 危険シンク | `eval`/`exec`/`system`/`unserialize`/動的 `include` **なし**。 |

--- a/frontend/src/features/account-menu/hooks/use-account-menu.test.ts
+++ b/frontend/src/features/account-menu/hooks/use-account-menu.test.ts
@@ -1,8 +1,14 @@
 import { act, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { hasAuthToken, setAuthToken } from '@/shared/api/client'
 import { renderHookWithProviders } from '@tests/render/render-with-providers'
 import { useAccountMenu } from './use-account-menu'
+
+const navigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => navigate }
+})
 
 describe('useAccountMenu', () => {
   it('exposes the current user email and role and signs out', async () => {
@@ -19,5 +25,8 @@ describe('useAccountMenu', () => {
     })
 
     expect(hasAuthToken()).toBe(false)
+    // #654: sign-out cleans the URL back to the root so the deep admin path is
+    // not left in the address bar behind the login screen.
+    expect(navigate).toHaveBeenCalledWith('/', { replace: true })
   })
 })

--- a/frontend/src/features/account-menu/hooks/use-account-menu.ts
+++ b/frontend/src/features/account-menu/hooks/use-account-menu.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { signOut, useCurrentUser, type Role } from '@/entities/auth'
 
 export interface UseAccountMenu {
@@ -10,12 +11,20 @@ export interface UseAccountMenu {
 /** Current-user summary plus sign-out (clears the session and query cache). */
 export function useAccountMenu(): UseAccountMenu {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
   const me = useCurrentUser(true)
 
   return {
     email: me.data?.email ?? null,
     role: me.data?.role ?? null,
     onSignOut: () => {
+      // Reset the URL to the app root before clearing the session (#654). The
+      // fail-closed AuthGate renders the login screen in place on token loss
+      // (ADR 0014 / vault #168) — great for an unexpected 401, but on an
+      // explicit sign-out it would leave the deep admin path (e.g.
+      // /audit-logs) in the address bar. Navigating to '/' first cleans the URL
+      // and lands the next login on the dashboard, matching clear/vault.
+      void navigate('/', { replace: true })
       signOut()
       queryClient.clear()
     },

--- a/src/Invoice/Pdf/InvoicePdfGenerator.php
+++ b/src/Invoice/Pdf/InvoicePdfGenerator.php
@@ -8,6 +8,7 @@ use Mpdf\MpdfException;
 use NeneInvoice\LineItem\TaxBreakdownLine;
 use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Pdf\MpdfFactory;
+use NeneInvoice\Pdf\PdfLogo;
 use NeneInvoice\Pdf\PdfStyle;
 use NeneInvoice\Support\Jst;
 use RuntimeException;
@@ -41,6 +42,7 @@ final readonly class InvoicePdfGenerator implements InvoicePdfGeneratorInterface
 
         $html = $this->buildHtml(
             styleBlock: $style->stylesheet(),
+            logoHtml: PdfLogo::html($company->logoUrl),
             sealHtml: self::sealHtml($data->sealImageBase64),
             invoiceNumber: $invoice->invoiceNumber ?? '（下書き）',
             issuedAt: $invoice->issuedAt ? Jst::date($invoice->issuedAt) : '—',
@@ -76,6 +78,7 @@ final readonly class InvoicePdfGenerator implements InvoicePdfGeneratorInterface
      */
     private function buildHtml(
         string $styleBlock,
+        string $logoHtml,
         string $sealHtml,
         string $invoiceNumber,
         string $issuedAt,
@@ -170,6 +173,7 @@ final readonly class InvoicePdfGenerator implements InvoicePdfGeneratorInterface
     <td width="5%"></td>
     <td class="seller">
       <table>
+        {$logoHtml}
         <tr><td colspan="2"><strong>{$esc($companyName)}</strong></td></tr>
         <tr><td colspan="2" style="font-size:8pt;">{$esc($companyAddress)}</td></tr>
         {$registrationRow}

--- a/src/Pdf/PdfLogo.php
+++ b/src/Pdf/PdfLogo.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Pdf;
+
+/**
+ * Renders the issuer logo (`logo_url`) as a self-contained seller-block row for
+ * the 見積書 / 請求書 PDF (Issue #510). Shared by the invoice and quote generators.
+ *
+ * Security: only base64 `data:` image URIs are embedded. Remote URLs
+ * (http/https), local file paths and any other scheme are deliberately NOT
+ * rendered — mPDF would perform a server-side fetch, which is (a) an SSRF surface
+ * that a prior security assessment relied on being absent (see
+ * docs/security/2026-06-08-assessment-round3.md) and (b) unreliable on
+ * network-restricted shared hosting such as HETEML. Embedding only self-contained
+ * data URIs keeps the "no server-side fetch" property intact while still letting a
+ * stored logo appear on the document. The src is attribute-escaped.
+ *
+ * Compliance: the logo is decorative — it adds no 適格請求書 required field and
+ * removes none — so it is compliance-neutral (docs/explanation/accounting-compliance.md;
+ * see the PdfStyle presentation note).
+ */
+final class PdfLogo
+{
+    /** A single-line base64 raster data URI (png / jpeg / gif / webp). */
+    private const DATA_URI = '#^data:image/(?:png|jpe?g|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$#';
+
+    /**
+     * Seller-block table row (`<tr>`) with the embedded logo, or '' when the
+     * stored value is null or not a safe base64 image data URI.
+     */
+    public static function html(?string $logoUrl): string
+    {
+        if ($logoUrl === null || preg_match(self::DATA_URI, $logoUrl) !== 1) {
+            return '';
+        }
+
+        $src = htmlspecialchars($logoUrl, ENT_QUOTES, 'UTF-8');
+
+        return '<tr><td colspan="2" class="logo-cell">'
+            . '<img class="company-logo" src="' . $src . '"></td></tr>';
+    }
+}

--- a/src/Pdf/PdfStyle.php
+++ b/src/Pdf/PdfStyle.php
@@ -118,6 +118,8 @@ h1 { font-family: {$headingFamily}; font-size: 22pt; text-align: center; margin:
 .seller { width: 40%; vertical-align: top; font-size: 9pt; }
 .seller table { width: 100%; border-collapse: collapse; }
 .seller td { padding: {$sellerPad}; }
+.logo-cell { padding-bottom: 1.5mm; }
+.company-logo { max-width: 45mm; max-height: 16mm; }
 .seal-cell { text-align: right; padding-top: 1mm; }
 .seal { width: 20mm; height: 20mm; }
 .greeting { margin-bottom: {$greetingMb}; }

--- a/src/Quote/Pdf/QuotePdfGenerator.php
+++ b/src/Quote/Pdf/QuotePdfGenerator.php
@@ -8,6 +8,7 @@ use Mpdf\MpdfException;
 use NeneInvoice\LineItem\TaxBreakdownLine;
 use NeneInvoice\LineItem\TaxCalculator;
 use NeneInvoice\Pdf\MpdfFactory;
+use NeneInvoice\Pdf\PdfLogo;
 use NeneInvoice\Pdf\PdfStyle;
 use NeneInvoice\Support\Jst;
 use RuntimeException;
@@ -40,6 +41,7 @@ final readonly class QuotePdfGenerator
 
         $html = $this->buildHtml(
             styleBlock: $style->stylesheet(),
+            logoHtml: PdfLogo::html($company->logoUrl),
             sealHtml: self::sealHtml($data->sealImageBase64),
             quoteNumber: $quote->quoteNumber,
             issuedAt: $quote->issuedAt ? Jst::date($quote->issuedAt) : '—',
@@ -74,6 +76,7 @@ final readonly class QuotePdfGenerator
      */
     private function buildHtml(
         string $styleBlock,
+        string $logoHtml,
         string $sealHtml,
         string $quoteNumber,
         string $issuedAt,
@@ -166,6 +169,7 @@ final readonly class QuotePdfGenerator
     <td width="5%"></td>
     <td class="seller">
       <table>
+        {$logoHtml}
         <tr><td colspan="2"><strong>{$esc($companyName)}</strong></td></tr>
         <tr><td colspan="2" style="font-size:8pt;">{$esc($companyAddress)}</td></tr>
         {$registrationRow}

--- a/tests/Invoice/Pdf/InvoicePdfGeneratorTest.php
+++ b/tests/Invoice/Pdf/InvoicePdfGeneratorTest.php
@@ -49,4 +49,34 @@ final class InvoicePdfGeneratorTest extends TestCase
         self::assertStringContainsString('Sun-ExtA', $pdf);
         self::assertStringNotContainsString('DejaVu', $pdf);
     }
+
+    public function test_renders_a_valid_pdf_with_a_base64_logo(): void
+    {
+        // 1x1 transparent PNG stored in company_settings.logo_url (Issue #510).
+        $logo = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+        $invoice = new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 300000,
+            taxCents: 30000,
+            totalCents: 330000,
+            invoiceNumber: 'INV-2026-002',
+            issuedAt: '2026-05-01',
+            dueAt: '2026-05-31',
+        );
+        $lines = [
+            new LineItem(LineItemParent::Invoice, 1, 'コンサルティング', 1, 300000, 1000),
+        ];
+        $data = new InvoicePdfData(
+            new InvoiceWithLines($invoice, $lines, 330000),
+            new CompanySettings(organizationId: 1, legalName: '株式会社ネネ商会', logoUrl: $logo),
+            new Client(organizationId: 1, name: '株式会社サンプル製作所'),
+        );
+
+        $pdf = (new InvoicePdfGenerator(new TaxCalculator(), new MpdfFactory()))->generate($data);
+
+        self::assertStringStartsWith('%PDF', $pdf);
+    }
 }

--- a/tests/Pdf/PdfLogoTest.php
+++ b/tests/Pdf/PdfLogoTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Pdf;
+
+use NeneInvoice\Pdf\PdfLogo;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PdfLogoTest extends TestCase
+{
+    public function test_embeds_a_base64_image_data_uri(): void
+    {
+        // 1x1 transparent PNG.
+        $dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+        $html = PdfLogo::html($dataUri);
+
+        self::assertStringContainsString('<img class="company-logo"', $html);
+        self::assertStringContainsString('src="' . $dataUri . '"', $html);
+    }
+
+    /**
+     * Remote URLs, local paths and other schemes must never be rendered: mPDF
+     * would fetch them server-side (SSRF surface / HETEML network restriction).
+     */
+    #[DataProvider('unsafeValueProvider')]
+    public function test_ignores_values_that_are_not_base64_image_data_uris(?string $logoUrl): void
+    {
+        self::assertSame('', PdfLogo::html($logoUrl));
+    }
+
+    /** @return iterable<string, array{?string}> */
+    public static function unsafeValueProvider(): iterable
+    {
+        yield 'null'          => [null];
+        yield 'empty'        => [''];
+        yield 'https url'    => ['https://example.com/logo.png'];
+        yield 'http url'     => ['http://example.com/logo.png'];
+        yield 'file path'    => ['/var/www/logo.png'];
+        yield 'file scheme'  => ['file:///etc/passwd'];
+        yield 'relative'     => ['assets/logo.png'];
+        yield 'data non-image' => ['data:text/html;base64,PHNjcmlwdD4='];
+        yield 'data svg'     => ['data:image/svg+xml;base64,PHN2Zz48L3N2Zz4='];
+        yield 'not base64'   => ['data:image/png,notbase64'];
+    }
+}

--- a/tests/Quote/Pdf/QuotePdfGeneratorTest.php
+++ b/tests/Quote/Pdf/QuotePdfGeneratorTest.php
@@ -49,4 +49,34 @@ final class QuotePdfGeneratorTest extends TestCase
         self::assertStringContainsString('Sun-ExtA', $pdf);
         self::assertStringNotContainsString('DejaVu', $pdf);
     }
+
+    public function test_renders_a_valid_pdf_with_a_base64_logo(): void
+    {
+        // 1x1 transparent PNG stored in company_settings.logo_url (Issue #510).
+        $logo = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+        $quote = new Quote(
+            organizationId: 1,
+            clientId: 1,
+            quoteNumber: 'EST-2026-002',
+            status: QuoteStatus::Sent,
+            subtotalCents: 450000,
+            taxCents: 45000,
+            totalCents: 495000,
+            issuedAt: '2026-05-01',
+            validUntil: '2026-06-30',
+        );
+        $lines = [
+            new LineItem(LineItemParent::Quote, 1, '保守費用（月額）', 3, 50000, 1000),
+        ];
+        $data = new QuotePdfData(
+            new QuoteWithLines($quote, $lines),
+            new CompanySettings(organizationId: 1, legalName: '株式会社ネネ商会', logoUrl: $logo),
+            new Client(organizationId: 1, name: '株式会社サンプル製作所'),
+        );
+
+        $pdf = (new QuotePdfGenerator(new TaxCalculator(), new MpdfFactory()))->generate($data);
+
+        self::assertStringStartsWith('%PDF', $pdf);
+    }
 }


### PR DESCRIPTION
2件の打鍵残 issue をまとめて片付ける。**マージは統合リナのレビュー後**（このPRはマージしない）。

## #654 — サインアウト後もURLが管理画面パスのまま残る（polish）
判定: **設計意図ではなく取りこぼし → 修正**。
- fail-closed な `AuthGate` が 401 でその場ログイン表示する挙動は vault #168 と同型で意図的（SPA状態保持）だが、それは**予期せぬ401**の話。**明示的なユーザー操作のサインアウト**では sibling も URL をクリーン化している（clear=`navigate('/admin',{replace})`、vault=`clearSession()`＋`navigate('/login',{replace})`）。invoice の `useAccountMenu` だけ navigate が無かった＝取りこぼし。
- 修正: `useAccountMenu.onSignOut` で `navigate('/', { replace: true })` してからセッション破棄。次回ログインは HomeRedirect でダッシュボード（superadmin は組織管理）に着地。

## #510 — 会社ロゴ(logo_url)が請求書/見積PDFに描画されない（確認済みバグ）
スコープ判定: **描画側だけ実装して片付け＋残りは feature 級として報告**。
- 実態: `logo_url` は保存されるが PdfGenerator が一切参照せず未描画（デッド設定）。加えて**フロントの設定フォームに logo 入力欄が無い**（model/mapper/EditCompanySettings いずれにも無し）。値は API 直叩きでしか入らない。
- 実装: 新設 `src/Pdf/PdfLogo.php` が seller ブロックにロゴ行を描画。両ジェネレータ（Invoice/Quote）で使用。CSS は `.company-logo`（max 45mm×16mm）を PdfStyle に追加。
- **セキュリティ判断（重要）**: R3 診断メモが「`logo_url` は描画せず SSRF/HTMLインジェクションなし」を安全性の前提にしていた。任意URLを mPDF に渡すとサーバ側フェッチ＝SSRF、かつ HETEML のネットワーク制約で失敗する。→ **base64 の `data:` 画像URIのみ埋め込み**、http/https・ローカルパス・その他スキームは描画しない方針にして「サーバ側フェッチなし」を維持。診断メモも実態に更新。
- **コンプラ**: ロゴは装飾で適格請求書の必須項目を増減しない（PdfStyle 注記・accounting-compliance.md）＝中立。

### #510 の残スコープ（feature 級・別issue推奨）
- ロゴを**アップロード/保存する UI＋経路**（seal と同様に base64 を専用テーブル/data URI で持たせる案）。現状 UI 無し＝ユーザーは実質ロゴをセットできない。
- 外部URLロゴを許容するか（SSRF許可リスト＋施主判断が要る／HETEMLでは無意味）。**現状は非対応が安全**として実装。
- ライブプレビュー・ブランドカラー/フォント（ロードマップ P2）。

## テスト / CI
- backend `composer check`: 緑（977 tests・PHPStan・CS Fixer・OpenAPI・conformance）。新規 `PdfLogoTest`（data URI 埋め込み／remote・file・非画像 data URI などを無視）＋ Invoice/Quote ジェネレータに data URI ロゴで valid PDF になるテスト。
- frontend `npm run check`: 緑（316 tests・lint・typecheck・build）。`use-account-menu.test.ts` に navigate('/',{replace:true}) の検証を追加。

Closes #654
Closes #510