### PR TITLE
chore(demo): 入場ログ(層1)を var/ file sink 化（error_log→SSH可視）

### DIFF
--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -84,7 +84,12 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                         throw new LogicException('PSR-17 factory service is invalid.');
                     }
 
-                    return new DemoSessionSeater($refreshTokenIssuer, $psr17);
+                    // Entry log lines go to var/demo-entry.log, SSH-visible on the
+                    // Tier A target, instead of error_log's HETEML-panel-only sink
+                    // (#661). Same var/ path resolution as FileRateLimitStorage below.
+                    $logSink = new FileDemoEntryLogSink(self::projectRoot($c) . '/var');
+
+                    return new DemoSessionSeater($refreshTokenIssuer, $psr17, $logSink(...));
                 },
             )
             ->set(

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -30,14 +30,20 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
 {
-    /** @var \Closure(string): void Where entry log lines go; defaults to `error_log`. */
+    /**
+     * @var \Closure(string): void Where entry log lines go. `DemoServiceProvider`
+     *      wires this to {@see FileDemoEntryLogSink} (`var/demo-entry.log`, #661);
+     *      defaults to `error_log` only when not wired (e.g. tests).
+     */
     private \Closure $logSink;
 
     /**
      * @param (\Closure(string): void)|null $logSink Sink for the demo-entry
-     *        attribution line (#658). Defaults to PHP's `error_log`, matching the
-     *        product's existing convention; overridable in tests so the recorded
-     *        line can be asserted without depending on the global `error_log` ini.
+     *        attribution line (#658). Production wiring passes the `var/`
+     *        file sink (#661); this parameter defaults to PHP's `error_log`
+     *        as a fallback and so tests can inject an in-memory sink to
+     *        assert the recorded line without depending on the global
+     *        `error_log` ini.
      */
     public function __construct(
         private RefreshTokenIssuer $refreshTokenIssuer,

--- a/src/Demo/FileDemoEntryLogSink.php
+++ b/src/Demo/FileDemoEntryLogSink.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Demo;
+
+/**
+ * Appends demo-entry attribution lines (#658) to `<baseDir>/demo-entry.log`
+ * instead of PHP's `error_log` (#661).
+ *
+ * On the Tier A shared-hosting target (HETEML), `error_log` output only lands
+ * in the hosting control panel's log viewer — invisible over SSH, so it can't
+ * be `tail -f`'d or `grep`'d for precise UTM/channel analysis. `var/` is the
+ * only writable runtime directory there, same rationale and same fail-open
+ * convention as {@see FileRateLimitStorage} and
+ * {@see \NeneInvoice\RecurringInvoice\FileRecurringRunThrottle}: a write
+ * failure (missing/unwritable dir, full disk, …) falls back to `error_log`
+ * rather than losing the line or breaking the demo redirect.
+ *
+ * Invokable so it plugs directly into {@see DemoSessionSeater}'s
+ * `(\Closure(string): void)` sink parameter via the `$sink(...)` first-class
+ * callable syntax.
+ */
+final readonly class FileDemoEntryLogSink
+{
+    private const string FILENAME = 'demo-entry.log';
+
+    public function __construct(private string $baseDir)
+    {
+    }
+
+    public function __invoke(string $line): void
+    {
+        if (!is_dir($this->baseDir)) {
+            @mkdir($this->baseDir, 0o775, true);
+        }
+
+        $file = $this->baseDir . '/' . self::FILENAME;
+        $written = @file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+
+        if ($written === false) {
+            error_log(sprintf(
+                'NeNe Invoice: could not persist demo-entry log at %s; falling back to error_log.',
+                $file,
+            ));
+            error_log($line);
+        }
+    }
+}

--- a/tests/Demo/FileDemoEntryLogSinkTest.php
+++ b/tests/Demo/FileDemoEntryLogSinkTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Demo;
+
+use NeneInvoice\Demo\FileDemoEntryLogSink;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The demo-entry attribution line (#658) is appended to `var/demo-entry.log`
+ * rather than `error_log` (#661) so it is `tail -f`/`grep`-able over SSH on
+ * the Tier A shared-hosting target, where `error_log` only reaches the
+ * hosting control panel. Mirrors {@see FileRateLimitStorageTest}'s temp-dir
+ * convention.
+ */
+final class FileDemoEntryLogSinkTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/ni-demo-entry-log-test-' . bin2hex(random_bytes(6));
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->baseDir . '/demo-entry.log');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_appends_a_line_to_the_log_file_under_base_dir(): void
+    {
+        $sink = new FileDemoEntryLogSink($this->baseDir);
+
+        $sink('NeNe Invoice: demo-entry slug=demo-abcd utm_source=facebook');
+
+        $contents = (string) file_get_contents($this->baseDir . '/demo-entry.log');
+        self::assertSame(
+            'NeNe Invoice: demo-entry slug=demo-abcd utm_source=facebook' . PHP_EOL,
+            $contents,
+        );
+    }
+
+    public function test_creates_the_base_dir_when_missing(): void
+    {
+        self::assertDirectoryDoesNotExist($this->baseDir);
+
+        (new FileDemoEntryLogSink($this->baseDir))('NeNe Invoice: demo-entry slug=demo-zzzz');
+
+        self::assertDirectoryExists($this->baseDir);
+        self::assertFileExists($this->baseDir . '/demo-entry.log');
+    }
+
+    public function test_appends_multiple_lines_in_order(): void
+    {
+        $sink = new FileDemoEntryLogSink($this->baseDir);
+
+        $sink('NeNe Invoice: demo-entry slug=demo-one');
+        $sink('NeNe Invoice: demo-entry slug=demo-two');
+
+        $lines = explode(PHP_EOL, trim((string) file_get_contents($this->baseDir . '/demo-entry.log')));
+        self::assertSame(
+            ['NeNe Invoice: demo-entry slug=demo-one', 'NeNe Invoice: demo-entry slug=demo-two'],
+            $lines,
+        );
+    }
+
+    public function test_falls_back_to_error_log_when_the_file_cannot_be_written(): void
+    {
+        // A base dir that is itself an existing *file* can never become a
+        // writable directory: is_dir() is false, @mkdir() fails silently, and
+        // the subsequent file_put_contents() also fails — exercising the
+        // fail-open branch without needing chmod/root tricks.
+        $blockingFile = sys_get_temp_dir() . '/ni-demo-entry-log-blocker-' . bin2hex(random_bytes(6));
+        file_put_contents($blockingFile, 'not a directory');
+
+        try {
+            $sink = new FileDemoEntryLogSink($blockingFile);
+
+            // Must not throw: the fallback path (error_log) absorbs the
+            // failure so a demo-entry redirect is never broken by logging.
+            $sink('NeNe Invoice: demo-entry slug=demo-fallback');
+            self::expectNotToPerformAssertions();
+        } finally {
+            @unlink($blockingFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- デモ入場ログ（attribution 層1・#658）の既定 sink `error_log` を、`var/demo-entry.log` へ append する file sink に切り替え。
- 理由: Tier A 共有ホスティング（HETEML）では `error_log` の出力先がコンパネのログ画面のみで SSH から不可視。精密な UTM/チャネル分析（`tail -f`/`grep`）ができない。
- `FileDemoEntryLogSink`（新設）は `FileRateLimitStorage` と同一の `var/` パス解決・fail-open（書込失敗時は `error_log` へフォールバック）規約を流用。
- `DemoServiceProvider` の `DemoSessionSeater` 配線をこの file sink（`$sink(...)` first-class callable）に差し替え。行フォーマットは不変。
- `.gitignore` は既存の `/var/`（ディレクトリ丸ごと）で `var/demo-entry.log` もカバー済み・変更不要（`git status --ignored` で確認）。

## Test plan

- [x] `vendor/bin/phpunit tests/Demo/` green（既存 `DemoSessionSeaterTest`／`FileRateLimitStorageTest` 無変更で通過・新規 `FileDemoEntryLogSinkTest` 追加）
- [x] `vendor/bin/phpunit` フルスイート green（987 tests, 3596 assertions, 既存の unrelated skip 4件のみ）
- [x] `vendor/bin/phpstan analyse` エラーなし
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` 差分なし

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)