### PR TITLE
chore(standards): active-theme-pointer exemplar アンカーを植栽

### DIFF
--- a/frontend/src/shared/ui/theme/active.css
+++ b/frontend/src/shared/ui/theme/active.css
@@ -1,2 +1,3 @@
 /* Active theme pointer. To restyle the entire app, change ONLY this import. */
+/* [nene2-exemplar:active-theme-pointer] — fleet frontend-standards TH-02 exemplar (check:exemplars). */
 @import './themes/default.css';


### PR DESCRIPTION
## 目的

フリート・フロント統一規約（`nene2-fleet-tooling`）の `check:exemplars`（RAT-3(a)）を green 化するための **exemplar アンカー植栽**。規約文書 03-styling-theming TH-02 が指す

`[X:nene-invoice/frontend/src/shared/ui/theme/active.css#nene2-exemplar:active-theme-pointer]`

を実ファイル側のアンカーコメントと突合させる。

## 変更

- `frontend/src/shared/ui/theme/active.css` に `/* [nene2-exemplar:active-theme-pointer] ... */` の**コメント1行のみ**を追加。CSS の挙動・`@import` は不変。

## 検品（exemplar 実体確認）

- TH-02 は「active.css は `@import` 1行のみ・全デザインの入替＝この1行の変更」。本ファイルはコメント除き `@import './themes/default.css';` の1行のみで、規約が invoice を単独指定した exemplar（records の active.css は7行束で exemplar ではない）に**一致**。

## マージ方針

- **マージ禁止**（施主承認待ち）。fleet-tooling 側の批准 wave とあわせて扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)