### PR TITLE
fix(frontend): codegen 出力の drift を解消し、鮮度を機械で守る (#668)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3595,6 +3595,7 @@ components:
       properties:
         preview:
           type: boolean
+          const: true
           description: Always true; marks the response as a non-sent demo preview.
         recipient:
           type: string

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "e2e/**/*.ts"],
   "entry": ["e2e/**/*.spec.ts"],
-  "ignore": ["src/shared/api/schema.gen.ts"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "exclude": ["exports", "types"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "jsdom": "^27.2.0",
         "knip": "^5.70.2",
         "msw": "^2.12.3",
-        "openapi-typescript": "^7.13.0",
+        "openapi-typescript": "7.13.0",
         "prettier": "^3.6.2",
         "storybook": "^9.1.5",
         "tailwindcss": "^4.1.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,10 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
+    "codegen:check": "node scripts/check-codegen.mjs",
     "gen:icons": "node scripts/gen-icons.mjs",
     "knip": "knip",
-    "check": "npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run build-storybook"
+    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run build-storybook"
   },
   "dependencies": {
     "@fontsource/noto-sans-jp": "^5.2.9",
@@ -61,7 +62,7 @@
     "jsdom": "^27.2.0",
     "knip": "^5.70.2",
     "msw": "^2.12.3",
-    "openapi-typescript": "^7.13.0",
+    "openapi-typescript": "7.13.0",
     "prettier": "^3.6.2",
     "storybook": "^9.1.5",
     "tailwindcss": "^4.1.17",

--- a/frontend/scripts/check-codegen.mjs
+++ b/frontend/scripts/check-codegen.mjs
@@ -1,0 +1,35 @@
+// Freshness gate for the generated OpenAPI types (Issue #668).
+// Regenerates schema.gen.ts into a temp file and fails if it differs from the
+// committed one — i.e. someone edited docs/openapi/openapi.yaml without running:
+//   npm run codegen
+// A-5 ("generated types are actually imported") only proves the file is wired
+// up, not that it is current; #626 drifted for a month under a green CI because
+// nothing compared the output. Mirrors the regen-diff the standards apply to
+// themegen (03:575): deterministic regeneration, compared, mismatch = FAIL.
+// Local and hermetic — no network, so it is safe to run per-PR in `check`.
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+const SPEC = path.resolve(dirname, '../../docs/openapi/openapi.yaml')
+const COMMITTED = path.resolve(dirname, '../src/shared/api/schema.gen.ts')
+
+const tmp = mkdtempSync(path.join(tmpdir(), 'nene-invoice-codegen-'))
+const fresh = path.join(tmp, 'schema.gen.ts')
+
+try {
+  execFileSync('openapi-typescript', [SPEC, '-o', fresh], { stdio: 'pipe' })
+
+  if (readFileSync(fresh, 'utf8') !== readFileSync(COMMITTED, 'utf8')) {
+    console.error(
+      'schema.gen.ts is stale: docs/openapi/openapi.yaml has changed since it was generated.\n' +
+        'Run `npm run codegen` and commit the result.',
+    )
+    process.exit(1)
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}

--- a/frontend/src/entities/invoice/api-types.ts
+++ b/frontend/src/entities/invoice/api-types.ts
@@ -4,6 +4,7 @@ import type { components } from '@/shared/api/schema.gen'
 export type InvoiceDto = components['schemas']['Invoice']
 export type LineItemDto = components['schemas']['LineItem']
 export type InvoiceWithLinesDto = components['schemas']['InvoiceWithLines']
+export type SendInvoiceEmailPreviewDto = components['schemas']['SendInvoiceEmailPreview']
 
 /**
  * List envelope. The OpenAPI `InvoiceList` is the generic page envelope, so the

--- a/frontend/src/entities/invoice/mutations.ts
+++ b/frontend/src/entities/invoice/mutations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query'
 import { apiClient } from '@/shared/api/client'
 import type { AppError } from '@/shared/api/errors'
-import type { InvoiceWithLinesDto } from './api-types'
+import type { InvoiceWithLinesDto, SendInvoiceEmailPreviewDto } from './api-types'
 import { toInvoiceWithLines } from './mapper'
 import type { CreateInvoiceInput, InvoiceWithLines, IssueInvoiceInput } from './model'
 import { invoiceKeys } from './query-keys'
@@ -85,12 +85,7 @@ export function useGenerateDownloadToken(): UseMutationResult<
  * API answers 200 with the message it would have sent (never delivering it,
  * because demo clients use undeliverable `.example` addresses).
  */
-export interface SendInvoiceEmailPreview {
-  preview: true
-  recipient: string
-  subject: string
-  body_html: string
-}
+export type SendInvoiceEmailPreview = SendInvoiceEmailPreviewDto
 
 /**
  * POST /admin/invoices/{id}/send-email — sends the invoice PDF to the client.

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -1121,6 +1121,8 @@ export interface paths {
         /**
          * Send invoice by email
          * @description Generates the invoice PDF and sends it to the client's email address. Requires the invoice to be in issued, partially_paid, or paid status and the client to have an email address. Requires ManageBilling capability.
+         *
+         *     Demo organizations (slug prefixed by the configured demo slug prefix) do not send: their seeded clients use fictitious `.example` addresses that cannot be delivered. Instead the endpoint returns 200 with a preview of the message that would have been sent, for display in the UI (#626).
          */
         post: operations["sendInvoiceEmail"];
         delete?: never;
@@ -1892,6 +1894,20 @@ export interface components {
              */
             qualified: boolean;
             due_at?: string | null;
+        };
+        /** @description Preview of the email a demo organization would have sent (#626). Returned with status 200 instead of actually delivering the message. */
+        SendInvoiceEmailPreview: {
+            /**
+             * @description Always true; marks the response as a non-sent demo preview.
+             * @constant
+             */
+            preview: true;
+            /** @description Client email address the message would have been sent to. */
+            recipient: string;
+            /** @description Subject line of the message. */
+            subject: string;
+            /** @description HTML body of the message (server-generated, escaped). */
+            body_html: string;
         };
         Payment: {
             id: number;
@@ -4343,7 +4359,16 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Email sent */
+            /** @description Demo organization — email not sent; preview of the message returned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SendInvoiceEmailPreview"];
+                };
+            };
+            /** @description Email sent (non-demo organization) */
             204: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## 概要

closes #668

横断§4（統合リナの持ち球）の invoice 分。**統合リナ了承 07-16**（§4 は知見の台帳＋規約側の穴の管轄で、実装は各リポが正）。

`schema.gen.ts` が **origin/main で 28行 stale** だった。PR #657（#626 デモのメール送信プレビュー化・07-12 merged）が `openapi.yaml` を編集したが codegen を再実行しておらず、その空白を FE が**同名 interface の手書き**で埋めていて、型の正本が2つある状態だった（payout の `tokens.ts` / `api-types.ts` と同型）。

**ライブのバグではない**（手書き型の方が narrow なので画面は動く）。壊れていたのは正本の一意性と、それを守る機構の不在。

## なぜ1か月気づかれなかったか

| 機構 | 実測 |
| --- | --- |
| `codegen` script | 存在するが **`check` に無い** |
| CI | **無い**（`frontend-ci.yml` は `npm run check` と `npm run e2e` のみ） |
| knip | 出力を `ignore` して**沈黙** |
| 規約 `05:716` A-5 | **import されているかしか見ず、鮮度を守らない** |

## 変更

**① 契約に「always true」を表現させた**

用語レジストリ `terminology.md:134` は `preview` (always `true`) と登録し、backend も `SendInvoiceEmailHandler.php:53` で `'preview' => true` とリテラルを返すのに、契約は `type: boolean` としか書いていなかった。**手書き型の `preview: true` の方が意味論を正確に写していた**ので、契約側を OAS 3.1 の `const: true` で直した。これで生成型が `preview: true` になり、**型を弱めずに**手書き型を捨てられる。

```diff
         preview:
           type: boolean
+          const: true
           description: Always true; marks the response as a non-sent demo preview.
```

**② 手書き型 → 生成型からの導出**（既存 idiom の `api-types.ts` に寄せた）

```diff
-export interface SendInvoiceEmailPreview {
-  preview: true
-  recipient: string
-  subject: string
-  body_html: string
-}
+export type SendInvoiceEmailPreview = SendInvoiceEmailPreviewDto
```

**③ regen-diff を `check` に先行導入**（統合リナ了承）

`scripts/check-codegen.mjs` — 決定的に再生成して committed と比較・不一致は FAIL。規約 `03:575` が themegen に発明した形を codegen にも当てる。**ローカル再生成→diff はネット不要＝hermetic** なので per-PR で回せる（AM-12 相1 に非抵触）。決定性のため **`openapi-typescript` を exact pin**（`^` を外す）。

**④ knip の `ignore` を削除**

## 実測ログ

**drift の再現（修正前・origin/main）**

```
$ diff -u <(git show origin/main:frontend/src/shared/api/schema.gen.ts) <fresh>
→ 28行差分: SendInvoiceEmailPreview スキーマ(11行) と 200 プレビュー応答(10行) が不在
```

**ゲートが実際に落ちることを変異で確認**（「導入≠実行」を避ける）

```
① 同期済み            → npm run codegen:check  exit=0
② openapi.yaml に probe フィールドを注入 → exit=1
   "schema.gen.ts is stale: docs/openapi/openapi.yaml has changed since it was generated.
    Run `npm run codegen` and commit the result."
③ 復旧                → exit=0
```

**knip の `ignore` が不要であることを変異で確認**

```
① ignore 削除・現状          → exit=0（誤検知ゼロ）
② 未接続ファイルを1本置く変異 → exit=1 "Unused files (1) src/__knip_probe.ts"
→ 検出器は生きている。ignore は外すだけでよく、vault#218 の ignoreIssues は invoice には不要
```

**check（両面）**

```
frontend: npm run check   exit=0（codegen:check / tsc -b / eslint / prettier / vitest 85 files 316 tests / knip / storybook）
backend : composer check  exit=0（OK 981 tests, 3604 assertions / OpenAPI contracts are valid (2 documents) / MCP valid / Conformance OK）
```

## 本 PR は必要条件であって十分条件ではない

- 規約 `05:716` A-5 の**条文化**（鮮度を守る形へ強化）は**統合リナの standards patch レーン**が引き取り済み。フリート標準形が決まったら追随する。
- **他リポ展開は未着手**（codegen script を持つ10リポ中 check に入っているのは、本PR前は0リポ）。
- `knip.json` の `exclude: ["exports","types"]` の narrow 化は**本PR外**。実測で **12件を沈黙**させており、うち **3件が生成型の定型出力（`paths` / `webhooks` / `$defs`）＝§4 が「黙らせるしかなかった可能性」と書いていたその現物**、残り9件は実プロダクトコードの未使用 export/type で triage が要る。→ 別 Issue #669。

## セルフレビュー

- `docs/review/frontend.md`
- `docs/review/openapi-contract.md`

会計・税務コンプライアンスへの影響: **無し**（デモ org のメールプレビュー表示の型のみ。請求・税・採番・PDF・保存に触れない）。
