### PR TITLE
refactor(frontend): knip の exclude 全域 off を narrow 化する (#669)

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -4,5 +4,8 @@
   "entry": ["e2e/**/*.spec.ts"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
-  "exclude": ["exports", "types"]
+  "ignoreIssues": {
+    "src/shared/api/schema.gen.ts": ["exports", "types"]
+  },
+  "tags": ["-knipignore"]
 }

--- a/frontend/src/entities/auth/api-types.ts
+++ b/frontend/src/entities/auth/api-types.ts
@@ -1,5 +1,4 @@
 import type { components } from '@/shared/api/schema.gen'
 
-export type LoginRequestDto = components['schemas']['LoginRequest']
 export type LoginResponseDto = components['schemas']['LoginResponse']
 export type CurrentUserDto = components['schemas']['CurrentUser']

--- a/frontend/src/entities/company-settings/api-types.ts
+++ b/frontend/src/entities/company-settings/api-types.ts
@@ -1,4 +1,3 @@
 import type { components } from '@/shared/api/schema.gen'
 
 export type CompanySettingsDto = components['schemas']['CompanySettings']
-export type UpdateCompanySettingsDto = components['schemas']['UpdateCompanySettingsRequest']

--- a/frontend/src/entities/organization/api-types.ts
+++ b/frontend/src/entities/organization/api-types.ts
@@ -1,7 +1,6 @@
 import type { components } from '@/shared/api/schema.gen'
 
 export type OrganizationDto = components['schemas']['Organization']
-export type CreateOrganizationRequestDto = components['schemas']['CreateOrganizationRequest']
 
 export interface OrganizationListDto {
   items: OrganizationDto[]

--- a/frontend/src/entities/organization/queries.ts
+++ b/frontend/src/entities/organization/queries.ts
@@ -26,7 +26,17 @@ export function useOrganizationList(
   })
 }
 
-/** GET /admin/organizations/{id} — one organization. */
+/**
+ * GET /admin/organizations/{id} — one organization.
+ *
+ * Every other entity pairs `useXList` with `useX` and both are consumed; this
+ * one has no consumer yet because the suspend/update FE for `PATCH
+ * /admin/organizations/{id}` (#560) is still open — see docs/todo/current.md
+ * 「残（任意）: 停止/更新の FE 導線」. Kept as the entity-layer half of that
+ * pending slice rather than deleted and re-added verbatim.
+ *
+ * @knipignore
+ */
 export function useOrganization(id: OrganizationId): UseQueryResult<Organization, AppError> {
   return useQuery<Organization, AppError>({
     queryKey: organizationKeys.detail(id),

--- a/frontend/src/entities/quote/api-types.ts
+++ b/frontend/src/entities/quote/api-types.ts
@@ -2,7 +2,6 @@ import type { components } from '@/shared/api/schema.gen'
 
 export type QuoteDto = components['schemas']['Quote']
 export type QuoteWithLinesDto = components['schemas']['QuoteWithLines']
-export type CreateQuoteRequestDto = components['schemas']['CreateQuoteRequest']
 
 export interface QuoteListDto {
   items: QuoteDto[]

--- a/frontend/src/entities/service-token/api-types.ts
+++ b/frontend/src/entities/service-token/api-types.ts
@@ -2,7 +2,6 @@ import type { components } from '@/shared/api/schema.gen'
 
 export type ServiceTokenDto = components['schemas']['ServiceToken']
 export type CreatedServiceTokenDto = components['schemas']['CreatedServiceToken']
-export type IssueServiceTokenRequestDto = components['schemas']['IssueServiceTokenRequest']
 
 export interface ServiceTokenListDto {
   items: ServiceTokenDto[]

--- a/frontend/src/entities/user/api-types.ts
+++ b/frontend/src/entities/user/api-types.ts
@@ -1,8 +1,6 @@
 import type { components } from '@/shared/api/schema.gen'
 
 export type UserDto = components['schemas']['User']
-export type CreateUserRequestDto = components['schemas']['CreateUserRequest']
-export type UpdateUserRequestDto = components['schemas']['UpdateUserRequest']
 
 export interface UserListDto {
   items: UserDto[]

--- a/frontend/src/shared/ui/components/LineItemsTable.tsx
+++ b/frontend/src/shared/ui/components/LineItemsTable.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from '@/shared/i18n'
 import { formatTaxRate, formatYen } from '@/shared/lib/format-money'
-import { Text } from '../primitives/Text'
 
 /**
  * Minimal row shape a document line must provide. Kept local so the shared UI
@@ -49,16 +48,6 @@ export function LineItemsTable({ items }: { items: LineItemRow[] }) {
           ))}
         </tbody>
       </table>
-    </div>
-  )
-}
-
-/** Label / value row for the totals summary at the bottom of a document. */
-export function TotalRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex justify-between">
-      <Text variant="muted">{label}</Text>
-      <Text className="num">{value}</Text>
     </div>
   )
 }

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -43,7 +43,7 @@ export {
   type InlineAlertTone,
   type InlineAlertRecover,
 } from './components/InlineAlert'
-export { LineItemsTable, TotalRow } from './components/LineItemsTable'
+export { LineItemsTable } from './components/LineItemsTable'
 export { SortableTh, type SortableThProps } from './components/SortableTh'
 export { ToastProvider } from './toast/ToastProvider'
 export { useToast } from './toast/context'


### PR DESCRIPTION
## 概要

closes #669

**統合リナ GO 07-16（ガードレール付き）**: 定型3件は vault#218 の `ignoreIssues` 形で narrow に／実プロダクト9件は**削除前に出所判定**／削除は真に未使用と実測できたものだけ。

## 🔴 マージ手順（重要・CI が走りません）

**stacked PR**: base は `fix/668-codegen-drift`（PR #670）。同じ `knip.json` を触るため衝突回避。

**⚠️ この PR には CI が走っていません。** 両ワークフローとも `pull_request: branches: [main]` に限定されており、base が main でない PR は trigger 対象外（実測）。**base 付け替えだけでは CI は起動しません**（`pull_request` の既定 activity types は opened/synchronize/reopened で、`base_changed` は含まれない）。

**したがって順序は:**
1. **#670 を先にマージ**
2. 本 PR の base が main へ自動で移る
3. **`refactor/669-knip-exclude-narrow` を main に rebase して force-push**（＝`synchronize` で CI 起動）
4. **CI 緑を確認してからマージ**

3 は私が実施します。合図をください。**CI 未実行のままマージしないでください。**

ローカル検証は済んでいます: `npm run check` **exit=0**（85 test files / 316 tests・codegen:check / tsc -b / eslint / prettier / knip / storybook）。

---

`exclude: ["exports","types"]` は issue 種別ごと**全域 off** で、外すと**12件**出る。**これが invoice における真の沈黙装置**だった（#668 で外した `ignore` は実測で不要だった）。

## 🔴 統合リナへ: GO の前提を1つ訂正します（実測で否定されました）

GO に「**手書き request DTO 7本は #668 と同型の『第二の正本』疑いなので、契約/レジストリ突合→生成型へ寄せるを先に**」とありましたが、**この疑いは私が #669 の本文に書いたもので、実測すると誤りでした**。

```ts
// entities/*/api-types.ts — 7本とも既に契約から派生していた（手書きではない）
export type LoginRequestDto = components['schemas']['LoginRequest']
export type CreateUserRequestDto = components['schemas']['CreateUserRequest']
```

**二重定義ではないので「寄せる」作業は存在しません。** 単に**参照0件の未使用エイリアス**でした（→ 削除）。#668 の `SendInvoiceEmailPreview`（本当に手書き）とは別物です。私の推測を裏取りせず本文に書いたのが原因です。

## 出所判定（9件）

| 対象 | 実測 | 判断 |
| --- | --- | --- |
| **DTO 7本** | 全部 `components['schemas'][...]` 派生・**参照0件** | **削除**（未使用エイリアス） |
| **`TotalRow`** | #207 の共通化で抽出 → **リデザイン(#209/#212–#242)で消費者が書き換えられた遺物**。ファイル内でも未使用・story も無し | **削除**（待っている実装が無い） |
| **`useOrganization`** | detail hook は**全 entity の慣習**で、`useInvoice`(3) `useClient`(3) `useQuote`(1) `useUser`(1) は**実際に使われている**。0 なのは **#560 の停止/更新 FE 導線が未実装**だから（current.md「残（任意）」） | **残す**（消費者待ちの足場・`@knipignore` に根拠を明記） |

`useOrganization` を削っても、その FE が入る時に逐語的に書き直すだけなので churn にしかならないと判断しました。異論あれば1行で消せます。

## 変更

```diff
-  "exclude": ["exports", "types"]
+  "ignoreIssues": {
+    "src/shared/api/schema.gen.ts": ["exports", "types"]
+  },
+  "tags": ["-knipignore"]
```

`tags` は symbol 単位の除外。`ignoreIssues` はファイル単位なので、`useOrganization` 1本のために `queries.ts` 全体を黙らせるのは粗すぎる。

## 実測ログ

**沈黙していた12件の内訳**

```
Unused exports (2)        useOrganization / TotalRow
Unused exported types (10) DTO 7本 + paths / webhooks / $defs  ← 後者3件が生成型の定型出力
```

**narrow 化後**

```
① npm run knip                    → exit=0
② 変異: 未使用 export を1本追加   → exit=1 "Unused exported types (1) MutationProbeDto"
   ＝ exports/types の検出が本当に戻った（全域 off の間は何を足しても緑だった）
③ npm run check                   → exit=0（85 test files / 316 tests）
```

**ゲートが仕事をした実例**: `TotalRow` を消したら `tsc -b` が `TS6133: 'Text' is declared but its value is never read` を検出（#664 で `tsc -b` に直っていなければ0ファイル検査で見逃していた）。道連れの import も削除。

## セルフレビュー

- `docs/review/frontend.md`

会計・税務コンプライアンスへの影響: **無し**（未使用の型エイリアスと未使用の表示コンポーネントの削除のみ）。