### PR TITLE
docs: 日報の置き場（docs/daily-reports/）を CLAUDE.md に明記する (#674)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Ops / MCP         ──→         │
 4. 実装 → 品質チェック → commit。
 5. PR 作成：`Closes #N` + セルフレビューチェックリスト名を本文に記載。
 6. CI green → merge → ローカル `main` sync。
+7. 作業した日は日報を **`docs/daily-reports/YYYY-MM-DD.md`** に残す（1日1ファイル・追記）。置き場はリポごとの慣習が正で、**invoice は `docs/daily-reports/`**（施主裁定 2026-07-16。フリートで統一しない — 例: vault は `docs/journal/`・英文）。
 
 **コミット形式:**
 ```


### PR DESCRIPTION
## 概要

closes #674

**統合リナ裁定 07-16 の同乗分**（「CLAUDE.md に置き場を明記する1行だけ、次の docs PR に同乗させて」）。#672 が既にマージ済みのため単独 PR にした。

日報の慣習はフリート14リポにあるのに、**`CLAUDE.md` / `AGENTS.md` に規律を持つリポは 0件＝完全な口伝**だった（統合リナのフリート横断実測）。施主の言葉:「**たしかに毎回僕が書いてって言ってたので、ルールにはなってなかったかもね**」。

**施主裁定（07-16）: 置き場はリポごとの慣習が正**（14リポの移行はしない）。invoice は `docs/daily-reports/` 継続 → 口伝をやめて1行明記する。

## 変更

```diff
 6. CI green → merge → ローカル `main` sync。
+7. 作業した日は日報を **`docs/daily-reports/YYYY-MM-DD.md`** に残す（1日1ファイル・追記）。置き場はリポごとの慣習が正で、**invoice は `docs/daily-reports/`**（施主裁定 2026-07-16。フリートで統一しない — 例: vault は `docs/journal/`・英文）。
```

「フリートで統一しない」と理由まで書いたのは、**統一しなかったこと自体が裁定**であり、書いておかないと次に読む人が「揃っていない＝直すべき」と誤読するため（vault は `AGENTS.md:48` ADR 0008「Repository docs: English only」があるので単純統一はリポ固有の事情と衝突する）。

## 実測（invoice の現況）

- 日報は **`docs/daily-reports/` に3本のみ**（2026-05-30 / 07-03 / 07-11）
- 施主の推測「**Invoice とか Clear とかはたくさん日報が溜まってると思うよ**」は **事実ではない**。invoice リナが独立に実測し、統合リナ §3b の実測（invoice 3）と一致した
- `CLAUDE.md` の日報の記述は **0件**（＝口伝の裏付け）

## セルフレビュー

- `docs/review/docs-policy.md`

ドキュメント1行のみ。コード変更なし。