### PR TITLE
docs(daily): 2026-07-16 日報 (#676)

### DIFF
--- a/docs/daily-reports/2026-07-16.md
+++ b/docs/daily-reports/2026-07-16.md
@@ -1,0 +1,138 @@
+# Daily Report — 2026-07-16
+
+**Project:** NeNe Invoice（自己ホスト型 見積・請求・入金管理／日本の適格請求書対応・マルチテナント前提）
+**Branch state at end of day:** `origin/main` @ `59f0b2d`（CI 全緑）
+**Author:** Claude Fable 5（Invoice リナ）／指揮は統合リナ（施主指示・本日から）
+
+---
+
+## Summary
+
+施主指示により **統合リナの指揮下**に入った初日（依頼があれば対応／疑問は理由付きで統合リナへ／施主判断は統合リナが仕分けた分だけ）。着任時点で invoice は **仕掛かりゼロ・CI 全緑**だったため、統合リナの横断レーン §4（「残り6リポは未測」）の **invoice 分を実測**したところ、**codegen 出力の drift** を発見。統合リナの GO を得て是正まで完了した。
+
+**本日 main 入り 4本**（すべて統合リナがマージ）:
+
+| PR | Issue | 中身 |
+| --- | --- | --- |
+| **#670** | #668 | codegen 出力の drift 解消＋鮮度を機械で守る（regen-diff・exact pin・knip `ignore` 削除） |
+| **#672** | #671 | `current.md` へ 07-11 以降の merge を反映＋**「導入≠実行」の教訓**を記録 |
+| **#673** | #669 | knip の `exclude` 全域 off を narrow 化（`ignoreIssues` ＋ `tags`） |
+| **#675** | #674 | 日報の置き場を `CLAUDE.md` に明記し**口伝をやめる** |
+
+---
+
+## 発見: codegen 出力が 28行 stale だった（#668）
+
+PR #657（#626 デモのメール送信プレビュー化・07-12 merged）が `openapi.yaml` を編集したが **codegen を再実行しておらず**、`schema.gen.ts` に `SendInvoiceEmailPreview` スキーマ（11行）と 200 プレビュー応答（10行）が**不在**。その空白を FE が**同名 interface の手書き**で埋めており、**型の正本が2つある**状態だった（payout の `tokens.ts` / `api-types.ts` と同型）。
+
+**ライブのバグではない**（手書き型の方が narrow なので画面は動く。#626 は実機確認済み）。壊れていたのは正本の一意性と、それを守る機構の不在。
+
+### なぜ1か月気づかれなかったか
+
+| 機構 | 実測 |
+| --- | --- |
+| `codegen` script | 存在するが **`check` に無い** |
+| CI | **無い**（`frontend-ci.yml` は `npm run check` と `npm run e2e` のみ） |
+| knip | 出力を `ignore` して**沈黙** |
+| 規約 `05:716` A-5 | **import されているかしか見ず、鮮度を守らない** |
+
+### 是正の勘所: 契約が意味論を表現していなかった
+
+素直に生成型へ寄せると `preview: true` → `boolean` と**型が弱まる**ことが判明。調べると **用語レジストリ `terminology.md:134` は `preview` (always `true`) と登録**し、backend も `SendInvoiceEmailHandler.php:53` で `'preview' => true` を返すのに、**契約だけが `type: boolean` としか書いていなかった**。つまり**手書き型の方が意味論を正確に写していた**。
+
+OAS 3.1 の `const: true` を契約に足す → 生成型が `preview: true` になる → **型を弱めずに**手書き型を捨てられた。`composer openapi` の validator も通過（`OpenAPI contracts are valid (2 documents)`）。
+
+---
+
+## 発見: 真の沈黙装置は `ignore` ではなく `exclude` だった（#669）
+
+統合リナ §4 が「繋いでも定型出力（`paths`/`webhooks`/`$defs`）で red になるので**黙らせるしかなかった可能性**」と書いていたものの、**invoice における現物**を確認（vault に続き**2件目の裏付け**）。ただし場所が違った:
+
+- `ignore: [schema.gen.ts]` … **実測で不要だった**（外しても exit=0）→ #668 で削除
+- `exclude: ["exports","types"]` … **12件を沈黙**させていた（定型3件＋実プロダクトコード9件）→ #669 で `ignoreIssues` により **`schema.gen.ts` だけに narrow 化**
+
+> **他リポを測る時の注意**: `ignore` だけ見ると「黙らせていない」と誤読する。`exclude` / `ignoreIssues` / `tags` / `ignoreExportsUsedInFile` を併せて見ないと**沈黙の総量が出ない**。
+
+### 出所判定（9件・統合リナのガードレール「削除は真に未使用と実測できたものだけ」）
+
+| 対象 | 実測 | 判断 |
+| --- | --- | --- |
+| DTO 7本 | 全部 `components['schemas'][...]` **派生**・参照0件 | 削除（未使用エイリアス） |
+| `TotalRow` | #207 の共通化で抽出 → **リデザイン(#209/#212–#242)で消費者が書き換えられた遺物** | 削除 |
+| `useOrganization` | detail hook は**全 entity の慣習**で `useInvoice`(3)/`useClient`(3)/`useQuote`(1)/`useUser`(1) は使用中。0 なのは **#560 の停止/更新 FE 導線が未実装**だから | **残す**（消費者待ちの足場・`@knipignore` に根拠明記） |
+
+---
+
+## 🔴 教訓: 「導入≠実行」を本日3回見た
+
+| | 道具は在った | しかし |
+| --- | --- | --- |
+| **#663/#664** | `type-check` script | `tsc --noEmit` がプロジェクト無指定で **0ファイル検査・常に成功** |
+| **#668** | `codegen` script | **`check` にも CI にも無く**、出力が 28行 stale のまま1か月 |
+| **#673** | CI（stacked PR） | **base が main でない PR には1本も走らない**（`branches: [main]` フィルタ） |
+
+**在ることを、実行されていると数えると偽の緑になる。** 規約 `05:716` A-5 の「import されているかしか見ない」も同型の穴。
+
+→ **ゲートを足したら、変異を入れて実際に落ちることを assert する。** 本日の実践:
+
+```
+codegen:check  … openapi.yaml に probe 注入 → exit=1（修復手順を提示）→ 復旧 → exit=0
+knip(ignore外) … 未接続ファイルを1本置く   → exit=1 "Unused files (1)"
+knip(exclude外)… 未使用 export を1本足す   → exit=1 "Unused exported types (1)"
+```
+
+**#664 の価値が即日で回収された**: `TotalRow` を削除したら `tsc -b` が `TS6133: 'Text' is declared but its value is never read` を検出。`tsc --noEmit` のままなら0ファイル検査で見逃していた。
+
+---
+
+## 🔴 CI 罠の3段実測（stacked PR・統合リナ issues #54 へ台帳化済み）
+
+`#669` は `#670` と同じ `knip.json` を触るため stacked（base = `fix/668-codegen-drift`）にしたところ、**CI が1本も走らなかった**。緑にするまでに要した手順は**3段**:
+
+```
+① rebase → force-push     → 起動せず（PR の base がまだ fix/668。branches:[main] は PR の base を見るので
+                             synchronize は発火しても対象外として捨てられる）
+② gh pr edit --base main  → 起動せず（base_changed は既定 activity type に無い）
+③ close → reopen          → 起動（reopened は既定 activity type）
+```
+
+**「base ブランチをマージすれば base が自動で main に移る」も成立しなかった**（GitHub の自動 retarget は **base ブランチ削除時**の挙動）。②は事前に予告できたが**①は予告できず踏んだ**。
+
+---
+
+## 自己申告（3件）
+
+フリートの規範（相互検証・担当リナが統合リナを 33回止めた 07-15 の教訓）に従い、自分の誤りを記録する。
+
+1. **ローカル checkout を origin/main だと思い込んだ** — frontend の type-check を `tsc --noEmit` と読んだが、それは **#664 未取り込みのローカル**で、origin/main は `tsc -b` だった。以降は全部 `git show origin/main:` から測り直した。指示書 §0 の筆頭の型。
+2. **ローカル vendor を lock だと思い込んだ** — `composer check` がローカルで6件 error（`Unknown named parameter $enableAuthorizationHeaderFallback`）。一瞬「自分の変更か」と疑ったが、実測すると **`composer.lock` = v1.11.0 / ローカル `vendor/` = v1.10.0** の腐り。#667 が要求する named parameter が v1.10.0 に無いだけで、CI は lock から install するので緑。`composer install` で **OK (981 tests, 3604 assertions)**。**指示書 §0 の表にある vault の事例と版まで完全に同一**（同じ晩に2リポが同じ版で踏んだ＝個人の不注意ではなく**フリート共通の環境の罠**）→ 統合リナが issues #53 に台帳化。
+3. **実測前の推測を、疑いとして渡した** — #669 起票時に `api-types.ts` を開かず、ファイル名と #668 の記憶から「手書き DTO 7本＝第二の正本だろう」と推測して本文に書いた。統合リナはそれを信じて GO に載せた。**着手時に現物を開いたら7本とも契約からの派生で、手書きではなかった**（＝「寄せる」作業は存在しない）。**あたしの未実測が統合リナの指示を汚染した**。相互検証が効いたのは着手時に現物を確かめたからで、確かめなければそのまま通っていた。
+
+---
+
+## 統合リナの裁定（本日）
+
+- **#425 v1.0.0** = **AYANE 公開直後スロットで着手**（施主裁定）。board に行を追加済み（due 07-22）。**着手合図は統合リナから** → 待機。
+- **日報** = **リポごとの慣習が正**（14リポの移行はしない）。invoice は `docs/daily-reports/` 継続 → **#674 / PR #675 で CLAUDE.md に明記**（本日の口伝解消）。
+- **W3 invoice**（`index.css` 3782行/209クラスの legacy マニフェスト凍結・due 08-21）= **board:60 の施主再考が live な間、着手しない**。
+- **W2b invoice transport 移行**（due 08-08）= **nene2-js の recoverAuth seam が先行依存**。seam が入ったら統合リナから合図。
+
+---
+
+## Next
+
+- **#425**（統合リナの合図待ち・AYANE 公開直後スロット）
+- **W3 / W2b**（上記のとおり待機）
+- 横断§4 の残: 規約 `05:716` A-5 の**条文化**（鮮度を守る形へ強化）は**統合リナの standards patch レーン**。invoice の regen-diff は先行導入であり、**フリート標準形が決まったら追随する**。
+- 他リポ展開（codegen script を持つ10リポ中、`check` に入っているのは本日まで **0リポ**だった）は統合リナの管轄。
+
+## 実測メモ（規模）
+
+| 項目 | 値 |
+| --- | --- |
+| src | 32,502行 / 595 PHP |
+| テスト | backend 981（3,604 assertions）／frontend 85 files・316 tests |
+| OpenAPI 操作 / MCP ツール | 84 / 15 |
+| migration | 26 |
+| frontend | 134 tsx・ts+tsx 計 32,492行 |
+| NENE2 | `^1.10`（lock 実体 **v1.11.0**） |


### PR DESCRIPTION
## 概要

closes #676

**統合リナ GO 07-16**（「日報は書いて GO — #675 で明文化した規律の1本目、まさに今日から始めるのが筋」）。

`CLAUDE.md` ワークフロー 7 を**本日 #674 / PR #675 で明文化**したので、**その1本目**を出す。前回の日報は 2026-07-11（`docs/daily-reports/` に3本目→4本目）。

## 内容

統合リナの指揮下に入った初日の記録。

- **本日 main 入り4本**: #670（codegen drift 解消＋regen-diff）／#672（current.md 棚卸し）／#673（knip exclude narrow 化）／#675（日報の口伝解消）
- **🔴 教訓「導入≠実行」を3回見た日**として記録
  - #663/#664: `type-check` が 0ファイル検査・常に成功
  - #668: `codegen` が `check` にも CI にも無く 28行 stale が1か月
  - #673: **stacked PR には CI が1本も走らない**
- **CI 罠の3段実測**（統合リナ issues #54 に台帳化済み）
- **自己申告3件**: ①ローカル checkout を origin/main と誤読 ②ローカル vendor を lock と誤読（**vault と版まで同一** → issues #53）③**実測前の推測を疑いとして渡し、統合リナの GO を汚染した**
- 統合リナの裁定（#425 = AYANE 公開直後スロット／日報 = リポごと慣習が正／W3・W2b は待機）

## 書式

既存の日報（`2026-07-11.md` / `2026-07-03.md`）の慣習に合わせた（`# Daily Report — YYYY-MM-DD` ＋ Project / Branch state at end of day / Author ＋ Summary）。Issue 先行も既存慣習どおり（`docs(daily): 2026-07-11 日報 (#627) (#628)`）。

## セルフレビュー

- `docs/review/docs-policy.md`

ドキュメントのみ。コード変更なし。