### PR TITLE
feat(mcp): local MCP server の runner を nene2 consumer 化する (#678)

### DIFF
--- a/src/Mcp/LocalMcpAuthPlan.php
+++ b/src/Mcp/LocalMcpAuthPlan.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Mcp;
+
+/**
+ * Decides how the local MCP server obtains its bearer token (ADR 0021, option C).
+ *
+ * Pure decision from an environment map — no I/O, no clock — so it is unit
+ * testable. The runner ({@see \tools/local-mcp-server.php}) executes the plan:
+ * a pre-issued token is used verbatim; mint claims are handed to the app's
+ * {@see \Nene2\Auth\TokenIssuerInterface} (which adds `iat`/`exp`), so that the
+ * minted token is signed with the exact secret the running API verifies with.
+ *
+ * Fail-closed order:
+ *   1. `NENE2_LOCAL_MCP_BEARER` set     → use it (no secret-derived privilege).
+ *   2. else `NENE2_ALLOW_DEV_SECRET=1`
+ *      and `NENE2_LOCAL_JWT_SECRET` set → mint `{sub, role, org}`.
+ *   3. else                            → no token (only `getHealth` works).
+ *
+ * The minted role defaults to `admin` (non-superadmin) — the least-privilege role
+ * that satisfies the full read-only tool set, since `getCompanySettings` needs
+ * `manage_company_settings`, which member/viewer lack. Minting a `superadmin`
+ * token is a deliberate dev-only escape hatch reachable ONLY through the triple
+ * opt-in `NENE2_ALLOW_DEV_SECRET=1` + `NENE2_LOCAL_MCP_INCLUDE_ADMIN=1` +
+ * `NENE2_LOCAL_MCP_ROLE=superadmin`; asking for it without enabling admin
+ * exposure is refused loudly rather than silently downgraded.
+ */
+final readonly class LocalMcpAuthPlan
+{
+    private const DEFAULT_ROLE = 'admin';
+    private const DEFAULT_ORG = 1;
+    private const DEFAULT_SUB = 0;
+
+    /**
+     * @param array<string, mixed>|null $mintClaims `{sub, role, org}` to mint, or null
+     */
+    private function __construct(
+        public ?string $preIssuedToken,
+        public ?array $mintClaims,
+    ) {
+    }
+
+    public function hasToken(): bool
+    {
+        return $this->preIssuedToken !== null || $this->mintClaims !== null;
+    }
+
+    /**
+     * @param array<string, string|false|null> $env raw environment (e.g. getenv() map)
+     *
+     * @throws LocalMcpConfigException when a superadmin mint is requested without
+     *                                 the admin-exposure opt-in
+     */
+    public static function fromEnv(array $env): self
+    {
+        $bearer = self::str($env, 'NENE2_LOCAL_MCP_BEARER');
+
+        if ($bearer !== '') {
+            return new self($bearer, null);
+        }
+
+        $allowDevSecret = self::str($env, 'NENE2_ALLOW_DEV_SECRET') === '1';
+        $secret = self::str($env, 'NENE2_LOCAL_JWT_SECRET');
+
+        if (!$allowDevSecret || $secret === '') {
+            return new self(null, null);
+        }
+
+        $role = self::str($env, 'NENE2_LOCAL_MCP_ROLE');
+        $role = $role === '' ? self::DEFAULT_ROLE : $role;
+
+        if ($role === 'superadmin' && self::str($env, 'NENE2_LOCAL_MCP_INCLUDE_ADMIN') !== '1') {
+            throw new LocalMcpConfigException(
+                'Refusing to mint a superadmin MCP token: set NENE2_LOCAL_MCP_INCLUDE_ADMIN=1 to '
+                . 'acknowledge cross-tenant admin exposure, or use a non-superadmin NENE2_LOCAL_MCP_ROLE.',
+            );
+        }
+
+        $orgRaw = self::str($env, 'NENE2_LOCAL_MCP_ORG');
+        $org = ctype_digit($orgRaw) ? (int) $orgRaw : self::DEFAULT_ORG;
+
+        $subRaw = self::str($env, 'NENE2_LOCAL_MCP_SUB');
+        $sub = ctype_digit($subRaw) ? (int) $subRaw : self::DEFAULT_SUB;
+
+        return new self(null, ['sub' => $sub, 'role' => $role, 'org' => $org]);
+    }
+
+    /**
+     * @param array<string, string|false|null> $env
+     */
+    private static function str(array $env, string $key): string
+    {
+        $value = $env[$key] ?? '';
+
+        return is_string($value) ? trim($value) : '';
+    }
+}

--- a/src/Mcp/LocalMcpCatalogFilter.php
+++ b/src/Mcp/LocalMcpCatalogFilter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Mcp;
+
+/**
+ * Selects which catalog tools the local MCP server exposes (ADR 0021).
+ *
+ * Read-only by default: only `safety: read` tools are served. `admin`-safety
+ * tools (cross-tenant / oversight reads) are exposed only when the operator opts
+ * in with `NENE2_LOCAL_MCP_INCLUDE_ADMIN=1`. This narrows *exposure* only — the
+ * real authorization gate stays at the API's OrgGuard + capability boundary, so a
+ * token whose role does not satisfy an endpoint is still rejected there.
+ *
+ * Pure (array in, array out) so it is unit testable against the committed
+ * `docs/mcp/tools.json`. `LocalMcpToolCatalog` reads a file path and offers no
+ * filter hook, so the runner writes the filtered result to a temporary catalog.
+ */
+final class LocalMcpCatalogFilter
+{
+    /**
+     * @param list<array<string, mixed>> $tools
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function apply(array $tools, bool $includeAdmin): array
+    {
+        if ($includeAdmin) {
+            return $tools;
+        }
+
+        return array_values(array_filter(
+            $tools,
+            static fn (array $tool): bool => ($tool['safety'] ?? null) === 'read',
+        ));
+    }
+}

--- a/src/Mcp/LocalMcpConfigException.php
+++ b/src/Mcp/LocalMcpConfigException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Mcp;
+
+/**
+ * Raised when the local MCP server's environment is misconfigured in a way that
+ * must fail loudly rather than fall back to a wider posture (ADR 0021) — e.g.
+ * requesting a superadmin mint without the admin-exposure opt-in.
+ */
+final class LocalMcpConfigException extends \RuntimeException
+{
+}

--- a/tests/Mcp/LocalMcpAuthPlanTest.php
+++ b/tests/Mcp/LocalMcpAuthPlanTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Mcp;
+
+use NeneInvoice\Mcp\LocalMcpAuthPlan;
+use NeneInvoice\Mcp\LocalMcpConfigException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves the ADR 0021 option-C fail-closed auth decision is pure and correct:
+ * pre-issued wins, dev-secret mint is opt-in, neither yields no token, and the
+ * superadmin mint is refused unless the admin-exposure opt-in is also set.
+ */
+final class LocalMcpAuthPlanTest extends TestCase
+{
+    public function test_pre_issued_bearer_is_used_verbatim_and_wins_over_secret(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_LOCAL_MCP_BEARER' => '  header.payload.sig  ',
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+        ]);
+
+        self::assertSame('header.payload.sig', $plan->preIssuedToken);
+        self::assertNull($plan->mintClaims);
+        self::assertTrue($plan->hasToken());
+    }
+
+    public function test_no_credentials_yields_no_token(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([]);
+
+        self::assertNull($plan->preIssuedToken);
+        self::assertNull($plan->mintClaims);
+        self::assertFalse($plan->hasToken());
+    }
+
+    public function test_dev_secret_without_allow_flag_yields_no_token(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+            // NENE2_ALLOW_DEV_SECRET not set
+        ]);
+
+        self::assertFalse($plan->hasToken());
+    }
+
+    public function test_allow_flag_without_secret_yields_no_token(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv(['NENE2_ALLOW_DEV_SECRET' => '1']);
+
+        self::assertFalse($plan->hasToken());
+    }
+
+    public function test_mint_defaults_to_non_superadmin_admin_role_and_org_one(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+        ]);
+
+        self::assertNull($plan->preIssuedToken);
+        self::assertSame(['sub' => 0, 'role' => 'admin', 'org' => 1], $plan->mintClaims);
+    }
+
+    public function test_mint_honours_explicit_org_sub_and_non_superadmin_role(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+            'NENE2_LOCAL_MCP_ORG' => '7',
+            'NENE2_LOCAL_MCP_SUB' => '42',
+            'NENE2_LOCAL_MCP_ROLE' => 'viewer',
+        ]);
+
+        self::assertSame(['sub' => 42, 'role' => 'viewer', 'org' => 7], $plan->mintClaims);
+    }
+
+    public function test_superadmin_mint_is_refused_without_admin_exposure_optin(): void
+    {
+        $this->expectException(LocalMcpConfigException::class);
+        $this->expectExceptionMessage('superadmin');
+
+        LocalMcpAuthPlan::fromEnv([
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+            'NENE2_LOCAL_MCP_ROLE' => 'superadmin',
+            // NENE2_LOCAL_MCP_INCLUDE_ADMIN not set → refused
+        ]);
+    }
+
+    public function test_superadmin_mint_allowed_only_through_triple_optin(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+            'NENE2_LOCAL_MCP_ROLE' => 'superadmin',
+            'NENE2_LOCAL_MCP_INCLUDE_ADMIN' => '1',
+        ]);
+
+        self::assertSame(['sub' => 0, 'role' => 'superadmin', 'org' => 1], $plan->mintClaims);
+    }
+
+    public function test_non_numeric_org_falls_back_to_default(): void
+    {
+        $plan = LocalMcpAuthPlan::fromEnv([
+            'NENE2_ALLOW_DEV_SECRET' => '1',
+            'NENE2_LOCAL_JWT_SECRET' => 'dev-secret',
+            'NENE2_LOCAL_MCP_ORG' => 'not-a-number',
+        ]);
+
+        self::assertIsArray($plan->mintClaims);
+        self::assertSame(1, $plan->mintClaims['org']);
+    }
+}

--- a/tests/Mcp/LocalMcpCatalogFilterTest.php
+++ b/tests/Mcp/LocalMcpCatalogFilterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Mcp;
+
+use NeneInvoice\Mcp\LocalMcpCatalogFilter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves the read-only-by-default exposure of ADR 0021, asserted against the
+ * committed docs/mcp/tools.json so the guarantee tracks the real catalog: with
+ * the admin opt-in off, only `safety: read` tools are served.
+ */
+final class LocalMcpCatalogFilterTest extends TestCase
+{
+    /** @return list<array<string, mixed>> */
+    private function committedTools(): array
+    {
+        $catalog = json_decode(
+            (string) file_get_contents(dirname(__DIR__, 2) . '/docs/mcp/tools.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        self::assertIsArray($catalog);
+        self::assertIsArray($catalog['tools'] ?? null);
+
+        return array_values(array_filter($catalog['tools'], 'is_array'));
+    }
+
+    public function test_default_exposes_only_read_tools(): void
+    {
+        $filtered = LocalMcpCatalogFilter::apply($this->committedTools(), includeAdmin: false);
+
+        self::assertNotEmpty($filtered);
+
+        foreach ($filtered as $tool) {
+            self::assertSame('read', $tool['safety'], sprintf('tool "%s" leaked into the read-only set', $tool['name']));
+        }
+    }
+
+    public function test_default_drops_the_admin_tools_present_in_the_catalog(): void
+    {
+        $all = $this->committedTools();
+        $filtered = LocalMcpCatalogFilter::apply($all, includeAdmin: false);
+
+        $adminCount = count(array_filter($all, static fn (array $t): bool => ($t['safety'] ?? null) === 'admin'));
+
+        // The catalog genuinely contains admin tools (otherwise this test proves nothing).
+        self::assertGreaterThan(0, $adminCount);
+        self::assertCount(count($all) - $adminCount, $filtered);
+    }
+
+    public function test_optin_exposes_every_catalog_tool(): void
+    {
+        $all = $this->committedTools();
+        $filtered = LocalMcpCatalogFilter::apply($all, includeAdmin: true);
+
+        self::assertCount(count($all), $filtered);
+    }
+}

--- a/tools/local-mcp-server.php
+++ b/tools/local-mcp-server.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Local, dev-only MCP server for NeNe Invoice (ADR 0021).
+ *
+ * Consumes NENE2's Nene2\Mcp\LocalMcpServer: reads the committed catalog
+ * (docs/mcp/tools.json), proxies each tool call to the local HTTP API, and
+ * speaks newline-delimited JSON-RPC 2.0 (initialize / tools/list / tools/call)
+ * over stdio. It binds NO network port; the only reachable target is the local
+ * API base URL. Do NOT ship this in a release artifact and do NOT auto-start it —
+ * it is a development convenience, not a production backdoor.
+ *
+ * Usage (host-run, app on :8510):
+ *   php tools/local-mcp-server.php
+ *   NENE2_LOCAL_API_BASE_URL=http://app php tools/local-mcp-server.php   # inside Compose
+ *
+ * Authentication (ADR 0021 option C — fail-closed):
+ *   1. NENE2_LOCAL_MCP_BEARER set                        → used verbatim.
+ *   2. else NENE2_ALLOW_DEV_SECRET=1 + NENE2_LOCAL_JWT_SECRET set
+ *                                                        → mint {sub, role, org}.
+ *   3. else no token → only getHealth works; /admin/* return 401.
+ *
+ * Exposure: read-only by default; set NENE2_LOCAL_MCP_INCLUDE_ADMIN=1 to also
+ * expose the cross-tenant / oversight admin reads (still gated by the API).
+ *
+ * See docs/development/local-mcp-server.md and .env.example for the full env list.
+ */
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Mcp\LocalMcpException;
+use Nene2\Mcp\LocalMcpServer;
+use Nene2\Mcp\LocalMcpToolCatalog;
+use Nene2\Mcp\NativeLocalMcpHttpClient;
+use NeneInvoice\Http\RuntimeContainerFactory;
+use NeneInvoice\Mcp\LocalMcpAuthPlan;
+use NeneInvoice\Mcp\LocalMcpCatalogFilter;
+use NeneInvoice\Mcp\LocalMcpConfigException;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$root = dirname(__DIR__);
+
+$apiBaseUrl = getenv('NENE2_LOCAL_API_BASE_URL');
+if (!is_string($apiBaseUrl) || $apiBaseUrl === '') {
+    $apiBaseUrl = 'http://localhost:8510';
+}
+
+// STDERR carries diagnostics + the state-changing-call audit trail. STDOUT is
+// reserved for the JSON-RPC protocol and must never be polluted.
+$auditHandler = new StreamHandler('php://stderr', Level::Info);
+$auditHandler->setFormatter(new JsonFormatter());
+$logger = new Logger('invoice-local-mcp', [$auditHandler]);
+
+$includeAdmin = getenv('NENE2_LOCAL_MCP_INCLUDE_ADMIN') === '1';
+
+try {
+    $plan = LocalMcpAuthPlan::fromEnv(getenv());
+} catch (LocalMcpConfigException $exception) {
+    fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+$bearerToken = $plan->preIssuedToken;
+
+if ($bearerToken === null && $plan->mintClaims !== null) {
+    // Mint through the app's own issuer so the token is signed with the exact
+    // secret the running API verifies with (GuardedJwtSecretResolver), not a
+    // hand-rolled verifier that could drift from it.
+    $container = (new RuntimeContainerFactory($root))->create();
+    $issuer = $container->get(TokenIssuerInterface::class);
+
+    if (!$issuer instanceof TokenIssuerInterface) {
+        fwrite(STDERR, "Token issuer is unavailable; cannot mint a dev MCP token.\n");
+        exit(1);
+    }
+
+    $now = time();
+    $bearerToken = $issuer->issue($plan->mintClaims + ['iat' => $now, 'exp' => $now + 86400]);
+}
+
+// Read-only by default: write the filtered catalog to a temp file, since
+// LocalMcpToolCatalog reads a path and offers no filter hook.
+$catalog = json_decode((string) file_get_contents($root . '/docs/mcp/tools.json'), true, 512, JSON_THROW_ON_ERROR);
+$allTools = is_array($catalog) && is_array($catalog['tools'] ?? null) ? $catalog['tools'] : [];
+$exposedTools = LocalMcpCatalogFilter::apply(array_values(array_filter($allTools, 'is_array')), $includeAdmin);
+
+$catalogPath = tempnam(sys_get_temp_dir(), 'invoice-mcp-catalog-');
+file_put_contents(
+    $catalogPath,
+    json_encode(
+        ['version' => 1, 'source' => 'docs/openapi/openapi.yaml', 'tools' => $exposedTools],
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+    ) . "\n",
+);
+register_shutdown_function(static fn () => @unlink($catalogPath));
+
+$logger->info('Local MCP server starting.', [
+    'api_base_url' => $apiBaseUrl,
+    'exposure' => $includeAdmin ? 'read+admin' : 'read-only',
+    'tool_count' => count($exposedTools),
+    'auth' => $plan->preIssuedToken !== null ? 'pre-issued' : ($plan->mintClaims !== null ? 'minted' : 'none'),
+]);
+
+$server = new LocalMcpServer(
+    new LocalMcpToolCatalog($catalogPath),
+    new NativeLocalMcpHttpClient($bearerToken),
+    $apiBaseUrl,
+    $logger,
+);
+
+while (($line = fgets(STDIN)) !== false) {
+    $line = trim($line);
+
+    if ($line === '') {
+        continue;
+    }
+
+    try {
+        $message = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($message)) {
+            throw new LocalMcpException('JSON-RPC message must be an object.');
+        }
+
+        $response = $server->handle($message);
+
+        if ($response === null) {
+            continue;
+        }
+    } catch (Throwable $exception) {
+        $response = [
+            'jsonrpc' => '2.0',
+            'id' => null,
+            'error' => [
+                'code' => -32700,
+                'message' => $exception->getMessage(),
+            ],
+        ];
+    }
+
+    fwrite(STDOUT, json_encode($response, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+}


### PR DESCRIPTION
## 概要

part of #678 ／ ADR 0021 の実装 **①runner**（統合リナ実装 GO 07-16）。

nene2 の `Nene2\Mcp\LocalMcpServer` を **dev-only・read-only 既定**で consumer 化し、stdio JSON-RPC（initialize / tools/list / tools/call）で serve する。

## 設計をテスト可能な純粋クラスに切り出した

| クラス | 役割 |
| --- | --- |
| `src/Mcp/LocalMcpAuthPlan` | env → 認証プラン（ADR 0021 (C)・fail-closed）。純粋・時刻非依存（iat/exp は runner が付与） |
| `src/Mcp/LocalMcpCatalogFilter` | read 既定 / admin opt-in の露出決定。純粋（committed カタログで検証） |
| `src/Mcp/LocalMcpConfigException` | fail-closed にすべき誤設定（superadmin×opt-in無し 等） |
| `tools/local-mcp-server.php` | 薄い glue（プラン実行＋カタログ temp 書き出し＋stdio ループ） |

## 認証（(C)・統合リナと合意）

1. `NENE2_LOCAL_MCP_BEARER` → そのまま使う（secret 由来の特権を作らない）
2. else `NENE2_ALLOW_DEV_SECRET=1` ＋ `NENE2_LOCAL_JWT_SECRET` → `{sub, role, org}` を mint
3. else token 無し → `getHealth` 以外 401（fail-closed）

- **mint 既定ロール = `admin`**（非 superadmin）。read 10本は `view_billing` ＋ `getCompanySettings` の `manage_company_settings` を要し、両方を持つ最小ロールが admin（member/viewer は company-settings で 403）。実測: `Role::hasCapability`。
- **superadmin mint は三重 opt-in** でしか到達しない（`ALLOW_DEV_SECRET=1` ＋ `INCLUDE_ADMIN=1` ＋ `role=superadmin`）。opt-in 無しの要求は **loud に拒否**（統合リナ申し送り）。
- フォールバック mint は **app の `TokenIssuerInterface` 経由**＝app と同じ secret 解決（`GuardedJwtSecretResolver`）で署名するので、app が受理するトークンになる（hand-rolled verifier のドリフトを避ける）。

## 露出（read 既定・admin opt-in）

`NENE2_LOCAL_MCP_INCLUDE_ADMIN=1` で admin 5本（クロステナント/監査）も露出。**exposure だけ広げ authorization は広げない** — 真のゲートは API の OrgGuard + capability（role が endpoint を満たさなければ通らない）。

## 実測（API 不要の initialize/tools/list を変異で assert・「導入≠実行」対策）

```
既定(env なし)         → read 10本・readOnlyHint 全 true・admin 混入 0・STDERR exposure=read-only
NENE2_LOCAL_MCP_INCLUDE_ADMIN=1 → 15本
superadmin × opt-in 無し → exit 1 "Refusing to mint a superadmin MCP token…"
未知メソッド           → JSON-RPC -32601
composer check         → exit 0（OK 993 tests, 3640 assertions / phpstan lv8 / cs / openapi valid / mcp valid / conformance OK）
```

ユニットテスト13本（`tests/Mcp/`）green。`tools/call`（HTTP を叩く）の実 API 相手の smoke は **③（別 PR）**で app 起動込みで検証する。

## 段取り

- ①（本 PR）runner ＋ 純粋クラス ＋ ユニット
- ②`.env.example` キー ＋ operator docs（次 PR・独立・main から）
- ③ `tools/mcp-smoke.sh` ＋ 実 API smoke（①マージ後）

## セルフレビュー

- `docs/review/backend-api.md`

会計・税務コンプラ: **射程外**（read-only・mutation 0・dev-only）。ADR 0021 参照。