### PR TITLE
test(mcp): local MCP server の smoke ＋ release 除外ガード (#678)

### DIFF
--- a/tests/Mcp/LocalMcpServerReleaseExclusionTest.php
+++ b/tests/Mcp/LocalMcpServerReleaseExclusionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Mcp;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Enforces the ADR 0021 invariant that the dev-only local MCP server is **never
+ * shipped in a release artifact**. `tools/build-release.sh` copies `tools/` via
+ * an explicit allow-list (only the scripts an operator runs in production), so
+ * the runner is excluded today — but "excluded because nobody added it" is an
+ * implicit truth. This test makes it a declared, gated invariant: if someone
+ * switches to a wholesale `cp -r tools` or adds the runner to the allow-list, CI
+ * turns red instead of silently shipping a dev backdoor into the release ZIP.
+ */
+final class LocalMcpServerReleaseExclusionTest extends TestCase
+{
+    private function buildScript(): string
+    {
+        $path = dirname(__DIR__, 2) . '/tools/build-release.sh';
+        self::assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
+
+    public function test_release_build_does_not_ship_the_local_mcp_runner(): void
+    {
+        self::assertStringNotContainsString(
+            'local-mcp-server.php',
+            $this->buildScript(),
+            'The dev-only MCP runner must not be copied into the release artifact (ADR 0021).',
+        );
+    }
+
+    public function test_release_build_uses_a_tools_allow_list_not_a_wholesale_copy(): void
+    {
+        $script = $this->buildScript();
+
+        // A recursive copy of tools/ would sweep the dev-only runner into the ZIP.
+        self::assertDoesNotMatchRegularExpression(
+            '/cp\s+-r\s+"?\$\{?ROOT\}?\/tools/',
+            $script,
+            'tools/ must be shipped via an explicit allow-list, never `cp -r tools` (ADR 0021).',
+        );
+    }
+}

--- a/tests/Mcp/LocalMcpServerScriptTest.php
+++ b/tests/Mcp/LocalMcpServerScriptTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Mcp;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the real `tools/local-mcp-server.php` as a subprocess and pins its
+ * behaviour end-to-end over stdio JSON-RPC (ADR 0021) — the "does it actually
+ * run" gate, not just the pure units.
+ *
+ * `initialize` and `tools/list` never touch the HTTP API, so these assertions
+ * need no running app and are deterministic in CI: the read-only default exposes
+ * exactly the `safety: read` tools, the admin opt-in widens the set, and a
+ * superadmin mint without the admin opt-in fails closed at startup.
+ * `tools/call` (which proxies to the API) is exercised by tools/mcp-smoke.sh
+ * against a running app, not here.
+ */
+final class LocalMcpServerScriptTest extends TestCase
+{
+    /**
+     * @param array<string, string> $extraEnv
+     * @param list<array<string, mixed>> $messages
+     *
+     * @return array{int, string, string}
+     */
+    private function runServer(array $messages, array $extraEnv = []): array
+    {
+        $env = ['PATH' => (string) getenv('PATH')] + $extraEnv;
+
+        $process = proc_open(
+            ['php', self::root() . '/tools/local-mcp-server.php'],
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            self::root(),
+            $env,
+        );
+
+        self::assertIsResource($process);
+
+        foreach ($messages as $message) {
+            fwrite($pipes[0], json_encode($message, JSON_THROW_ON_ERROR) . "\n");
+        }
+        fclose($pipes[0]);
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [proc_close($process), $stdout, $stderr];
+    }
+
+    /**
+     * @param string $stdout newline-delimited JSON-RPC responses
+     *
+     * @return array<int, array<string, mixed>> responses keyed by their id
+     */
+    private function responsesById(string $stdout): array
+    {
+        $byId = [];
+
+        foreach (explode("\n", trim($stdout)) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($decoded);
+            $byId[$decoded['id']] = $decoded;
+        }
+
+        return $byId;
+    }
+
+    public function test_read_only_default_exposes_only_read_tools(): void
+    {
+        [$exit, $stdout] = $this->runServer([
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list', 'params' => []],
+        ]);
+
+        self::assertSame(0, $exit);
+        $tools = $this->responsesById($stdout)[2]['result']['tools'];
+
+        self::assertNotEmpty($tools);
+        foreach ($tools as $tool) {
+            self::assertTrue(
+                $tool['annotations']['readOnlyHint'],
+                sprintf('tool "%s" leaked into the read-only default', $tool['name']),
+            );
+        }
+
+        $names = array_column($tools, 'name');
+        self::assertNotContains('listOrganizations', $names);
+        self::assertNotContains('listUsers', $names);
+        self::assertNotContains('listAuditLogs', $names);
+    }
+
+    public function test_admin_optin_exposes_more_tools_than_the_default(): void
+    {
+        [, $defaultOut] = $this->runServer([
+            ['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list', 'params' => []],
+        ]);
+        [$exit, $adminOut] = $this->runServer(
+            [['jsonrpc' => '2.0', 'id' => 2, 'method' => 'tools/list', 'params' => []]],
+            ['NENE2_LOCAL_MCP_INCLUDE_ADMIN' => '1'],
+        );
+
+        self::assertSame(0, $exit);
+
+        $defaultCount = count($this->responsesById($defaultOut)[2]['result']['tools']);
+        $adminNames = array_column($this->responsesById($adminOut)[2]['result']['tools'], 'name');
+
+        self::assertGreaterThan($defaultCount, count($adminNames));
+        self::assertContains('listOrganizations', $adminNames);
+    }
+
+    public function test_superadmin_mint_without_admin_optin_fails_closed_at_startup(): void
+    {
+        [$exit, $stdout, $stderr] = $this->runServer(
+            [['jsonrpc' => '2.0', 'id' => 1, 'method' => 'initialize', 'params' => []]],
+            ['NENE2_ALLOW_DEV_SECRET' => '1', 'NENE2_LOCAL_JWT_SECRET' => 'dev', 'NENE2_LOCAL_MCP_ROLE' => 'superadmin'],
+        );
+
+        self::assertSame(1, $exit, 'server must refuse a superadmin mint without the admin opt-in');
+        self::assertStringContainsString('superadmin', $stderr);
+        self::assertSame('', trim($stdout), 'no JSON-RPC response should be emitted on a fail-closed startup');
+    }
+
+    public function test_unknown_method_returns_json_rpc_method_not_found(): void
+    {
+        [$exit, $stdout] = $this->runServer([
+            ['jsonrpc' => '2.0', 'id' => 9, 'method' => 'bogus', 'params' => []],
+        ]);
+
+        self::assertSame(0, $exit);
+        self::assertSame(-32601, $this->responsesById($stdout)[9]['error']['code']);
+    }
+
+    private static function root(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+}

--- a/tools/mcp-smoke.sh
+++ b/tools/mcp-smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Local MCP smoke helper for NeNe Invoice (ADR 0021 / dev-only).
+# Pipes JSON-RPC messages at tools/local-mcp-server.php and prints the responses.
+#
+# `initialize` / `tools/list` need no running API. `tools/call` needs the app up
+# (and MySQL + migrations for anything that reads the DB):
+#   docker compose up -d app
+#   docker compose up -d mysql && docker compose run --rm app composer migrations:migrate
+#
+# Usage:
+#   bash tools/mcp-smoke.sh                          # initialize + tools/list
+#   bash tools/mcp-smoke.sh getHealth '{}'           # + a read-tool call
+#   bash tools/mcp-smoke.sh listInvoices '{"limit":5}'
+#
+# Environment:
+#   NENE2_LOCAL_API_BASE_URL       API base URL (default: http://localhost:8510)
+#   NENE2_LOCAL_MCP_BEARER         pre-issued bearer (needed for /admin/* tools)
+#   NENE2_LOCAL_MCP_INCLUDE_ADMIN  set to 1 to also expose the admin tools
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOL="${1:-}"
+ARGS="${2:-{}}"
+
+MESSAGES=(
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-smoke","version":"0.0.0"}}}'
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+)
+
+if [[ -n "${TOOL}" ]]; then
+    MESSAGES+=("{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"${TOOL}\",\"arguments\":${ARGS}}}")
+fi
+
+printf '%s\n' "${MESSAGES[@]}" | php "${ROOT}/tools/local-mcp-server.php"


### PR DESCRIPTION
## 概要

Closes #678 ／ ADR 0021 の実装 **③smoke+test**（統合リナ GO 07-16）。runner（#680・merged）を締める最後のピース。main から clean（#680 マージ済み）。

## 変更

- **`tools/mcp-smoke.sh`**: dev 用 smoke。`initialize`/`tools/list` は API 不要、`tools/call` は app 起動が前提。nene2 の `mcp-smoke.sh` 相当を invoice port(8510)で。
- **`tests/Mcp/LocalMcpServerScriptTest.php`**: 実 runner をサブプロセスで叩き stdio JSON-RPC を end-to-end にピン留め（`SweepDemoScriptTest` と同じ `proc_open` 型に STDIN を追加）。`initialize`/`tools/list` は HTTP 非依存なので **CI で決定的**。
- **`tests/Mcp/LocalMcpServerReleaseExclusionTest.php`**: 「dev-only runner は release ZIP に載らない」を**機械的不変条件**に（統合リナ指示）。

## 統合リナ指示の反映: 暗黙の真 → 宣言してゲート

「build-release.sh が allow-list で構造的に除外しているのは事実だが『偶然そうなってる』状態。ガードテストで機械強制された不変条件にする」を実装。今日フリートでやっている「不変条件は宣言してゲートする」そのもの。

**変異で実際に落ちることを確認**（緑だけでは不変条件の証明にならない・「導入≠実行」対策）:

```
変異A: runner を allow-list に cp 追加   → 赤（"must not be copied into the release artifact"）
変異B: cp -r "$ROOT/tools" に変更        → 赤（"never `cp -r tools`"）
復旧                                     → 緑（2 tests, 4 assertions）
```

## 実測

```
smoke script 群（19 tests: unit 13 + script 4 + guard 2）→ 緑
composer check → exit 0（OK 999 tests, 3676 assertions / phpstan lv8 / cs / openapi valid / mcp valid / conformance OK）
```

`tools/call` の実 API 相手の smoke は `tools/mcp-smoke.sh` を app 起動で手動実行（DB 読みは MySQL＋migrations 前提）。CI では HTTP 非依存の経路のみ決定的に検証。

## これで ADR 0021 の reference 完成

① runner（#680）＋ ② env+docs（#681）＋ ③ smoke+guard（本 PR）で invoice の local MCP server が閉じた。統合リナの template 化（records/clear へ）は「invoice が緑で回ってから」で合意どおり。

## セルフレビュー

- `docs/review/backend-api.md`

会計・税務コンプラ: 射程外（read-only・dev-only）。ADR 0021 参照。