### PR TITLE
docs(readme): Documentation 表に CHANGELOG リンクを追加 (#425)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ In progress / designed: MFA (TOTP), fee write-off & over-payment split (tax-advi
 
 | Topic | Document |
 | --- | --- |
+| **Changelog** | [`CHANGELOG.md`](./CHANGELOG.md) |
 | **Compliance (binding)** | [`docs/explanation/accounting-compliance.md`](./docs/explanation/accounting-compliance.md) |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |


### PR DESCRIPTION
part of #425 Must 3（README 最終確認）。CHANGELOG.md 新設（#686）に伴い Documentation 表から辿れるようにする小改善。Status 節は実態整合で変更不要と確認済（別途 #686）。ドキュメントのみ・外向き公開なし。