### PR TITLE
fix(auth): path テナンシーで cookie を slug スコープ Path で発行する（#38 根治） (#693)

### DIFF
--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -55,7 +55,7 @@ final readonly class LoginHandler implements RequestHandlerInterface
             return $this->problemDetails->create($request, 'invalid-credentials', 'Invalid Credentials', 401, $e->getMessage());
         }
 
-        $base = BasePath::fromRequest($request);
+        $base = BasePath::appBaseFromRequest($request);
 
         return $this->withSessionCookies($this->json->create(['token' => $output->token]), $output->refreshToken, $base);
     }

--- a/src/Auth/LogoutHandler.php
+++ b/src/Auth/LogoutHandler.php
@@ -35,7 +35,7 @@ final readonly class LogoutHandler implements RequestHandlerInterface
         }
 
         $this->useCase->execute(SessionCookies::refreshToken($request));
-        $base = BasePath::fromRequest($request);
+        $base = BasePath::appBaseFromRequest($request);
 
         return $this->json->createEmpty(204)
             ->withAddedHeader('Set-Cookie', SessionCookies::clearRefresh($base))

--- a/src/Auth/RefreshHandler.php
+++ b/src/Auth/RefreshHandler.php
@@ -47,7 +47,7 @@ final readonly class RefreshHandler implements RequestHandlerInterface
             return $this->failClosed($request);
         }
 
-        $base = BasePath::fromRequest($request);
+        $base = BasePath::appBaseFromRequest($request);
         $csrfToken = RefreshTokenSecret::generateCsrfToken();
 
         return $this->json->create(['token' => $session->accessToken])
@@ -57,7 +57,7 @@ final readonly class RefreshHandler implements RequestHandlerInterface
 
     private function failClosed(ServerRequestInterface $request): ResponseInterface
     {
-        $base = BasePath::fromRequest($request);
+        $base = BasePath::appBaseFromRequest($request);
 
         return $this->problemDetails
             ->create($request, 'invalid-refresh-token', 'Unauthorized', 401, 'The session could not be refreshed.')

--- a/src/Http/BasePath.php
+++ b/src/Http/BasePath.php
@@ -25,6 +25,15 @@ final class BasePath
     public const REQUEST_ATTRIBUTE = 'app.base_path';
 
     /**
+     * Request attribute holding the **app base** — the install base plus the
+     * tenant slug (`/invoice/acme`) under path tenancy, set by
+     * {@see \NeneInvoice\Organization\Resolution\OrgResolverMiddleware} before it
+     * strips the slug. It is the URL prefix the browser actually uses, so session
+     * cookies must be scoped to it (#38). Absent outside path mode.
+     */
+    public const APP_BASE_ATTRIBUTE = 'app.app_base';
+
+    /**
      * API path prefixes that must reach the router, never the SPA shell.
      *
      * `/invoices/download` (public PDF share link) and `/pay` (hosted card
@@ -71,6 +80,18 @@ final class BasePath
         $base = $request->getAttribute(self::REQUEST_ATTRIBUTE);
 
         return is_string($base) ? $base : '';
+    }
+
+    /**
+     * The base session cookies must be scoped to: the app base (install base plus
+     * the tenant slug) under path tenancy, else the install base (#38). Falls back
+     * to {@see self::fromRequest()} when no slug axis is present.
+     */
+    public static function appBaseFromRequest(ServerRequestInterface $request): string
+    {
+        $appBase = $request->getAttribute(self::APP_BASE_ATTRIBUTE);
+
+        return is_string($appBase) ? $appBase : self::fromRequest($request);
     }
 
     /** `''` for the document root; otherwise `/segment` (leading slash, no trailing). */

--- a/src/Organization/Resolution/OrgResolverMiddleware.php
+++ b/src/Organization/Resolution/OrgResolverMiddleware.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Organization\Resolution;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Http\BasePath;
 use NeneInvoice\Organization\OrganizationRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -103,6 +104,16 @@ final readonly class OrgResolverMiddleware implements MiddlewareInterface
         // canonical `/admin/...` path. This is the first middleware, so the
         // rewrite propagates to the whole downstream pipeline.
         if ($this->strategy instanceof PathScopedResolutionStrategyInterface) {
+            // Record the slug-scoped app base for cookie issuance (#38) BEFORE the
+            // slug is stripped from the path, so a rotated refresh cookie is
+            // reissued at the same `/{base}/{slug}` Path the browser sends it to —
+            // otherwise the reissue lands slug-less and the next refresh presents
+            // the rotated-away cookie → reuse defense burns the family.
+            $request = $request->withAttribute(
+                BasePath::APP_BASE_ATTRIBUTE,
+                BasePath::fromRequest($request) . '/' . $org->slug,
+            );
+
             $uri     = $request->getUri();
             $request = $request->withUri($uri->withPath($this->strategy->stripPrefix($uri->getPath())));
         }

--- a/tests/Http/BasePathTest.php
+++ b/tests/Http/BasePathTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneInvoice\Tests\Http;
 
 use NeneInvoice\Http\BasePath;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -84,5 +85,24 @@ final class BasePathTest extends TestCase
     public function test_classifies_api_vs_spa(string $path, bool $isApi): void
     {
         self::assertSame($isApi, BasePath::isApiPath($path));
+    }
+
+    public function test_app_base_falls_back_to_install_base_when_no_slug_axis(): void
+    {
+        // No app-base attribute (single/subdomain mode) → the install base (#38).
+        $request = (new Psr17Factory())->createServerRequest('GET', 'https://app.example.com/auth/refresh')
+            ->withAttribute(BasePath::REQUEST_ATTRIBUTE, '/invoice');
+
+        self::assertSame('/invoice', BasePath::appBaseFromRequest($request));
+    }
+
+    public function test_app_base_uses_the_slug_scoped_attribute_when_present(): void
+    {
+        // Path tenancy: OrgResolverMiddleware set the slug-scoped app base (#38).
+        $request = (new Psr17Factory())->createServerRequest('GET', 'https://app.example.com/auth/refresh')
+            ->withAttribute(BasePath::REQUEST_ATTRIBUTE, '/invoice')
+            ->withAttribute(BasePath::APP_BASE_ATTRIBUTE, '/invoice/acme');
+
+        self::assertSame('/invoice/acme', BasePath::appBaseFromRequest($request));
     }
 }

--- a/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
+++ b/tests/Organization/Resolution/OrgResolverMiddlewareTest.php
@@ -6,6 +6,7 @@ namespace NeneInvoice\Tests\Organization\Resolution;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\RequestScopedHolder;
+use NeneInvoice\Http\BasePath;
 use NeneInvoice\Organization\Organization;
 use NeneInvoice\Organization\Resolution\EnvResolutionStrategy;
 use NeneInvoice\Organization\Resolution\OrgResolverMiddleware;
@@ -153,6 +154,48 @@ final class OrgResolverMiddlewareTest extends TestCase
         self::assertSame('/admin/invoices', $seen->getUri()->getPath());
         self::assertSame($id, $seen->getAttribute('nene2.org.id'));
         self::assertSame('acme', $seen->getAttribute('nene2.org.slug'));
+    }
+
+    public function test_path_strategy_records_slug_scoped_app_base_for_cookies(): void
+    {
+        // #38: cookies must be scoped to the slug-prefixed URL. The middleware
+        // records the app base (install base + slug) before stripping the slug so
+        // Login/Refresh/Logout reissue cookies at `/{base}/{slug}` — otherwise a
+        // rotated refresh cookie lands slug-less and burns the family on reuse.
+        $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $handler = $this->passthroughHandler();
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/acme/auth/refresh');
+
+        // Root install: no base attribute → app base is just the slug.
+        $this->pathMiddleware()->process($request, $handler);
+        self::assertSame('/acme', $handler->seen?->getAttribute(BasePath::APP_BASE_ATTRIBUTE));
+        self::assertSame('/acme', BasePath::appBaseFromRequest($handler->seen ?? $request));
+
+        // Subdirectory install: the front controller has already stripped the
+        // install base from the path (public_html/index.php) and recorded it as an
+        // attribute, so the middleware sees the base-stripped `/acme/...` path.
+        $subdir = $this->psr17->createServerRequest('GET', 'https://app.example.com/acme/auth/refresh')
+            ->withAttribute(BasePath::REQUEST_ATTRIBUTE, '/invoice');
+        $subHandler = $this->passthroughHandler();
+        $this->pathMiddleware()->process($subdir, $subHandler);
+        self::assertSame('/invoice/acme', $subHandler->seen?->getAttribute(BasePath::APP_BASE_ATTRIBUTE));
+    }
+
+    public function test_env_strategy_leaves_no_app_base_so_cookies_use_install_base(): void
+    {
+        // Non-path modes carry no slug in the URL, so no app base is set and cookie
+        // issuance falls back to the install base — behaviour unchanged (#38).
+        $this->orgs->save(new Organization(name: 'Acme', slug: 'acme', plan: 'free', isActive: true));
+
+        $handler = $this->passthroughHandler();
+        $request = $this->psr17->createServerRequest('GET', 'https://app.example.com/admin/invoices')
+            ->withAttribute(BasePath::REQUEST_ATTRIBUTE, '/invoice');
+
+        $this->middleware('acme', false)->process($request, $handler);
+
+        self::assertNull($handler->seen?->getAttribute(BasePath::APP_BASE_ATTRIBUTE));
+        self::assertSame('/invoice', BasePath::appBaseFromRequest($handler->seen ?? $request));
     }
 
     public function test_env_strategy_leaves_downstream_path_untouched(): void


### PR DESCRIPTION
## 概要

Closes #693 ／ **`_work/issues.md #38` の backend 根治**。**W2b 昇格ゲート（recoverAuth の path-mode 有効化）の唯一の前提**。スコープ = backend 実装+テスト緑（デプロイ・per-mode ゲート有効化は別途施主 GO）。

## 根本原因（実測）

path テナンシー（`/{slug}/...`）で silent refresh が壊れ family-burn（ハードログアウト）:

1. **初回 cookie は正しい**: `DemoSessionSeater` は `ni_refresh`/`ni_csrf` を `$installBase . '/' . $org->slug`（`/{base}/{slug}` 配下）にスコープして発行。
2. 🔴 **rotation が slug を落とす**: `RefreshHandler`（と Login/Logout）は cookie Path を `BasePath::fromRequest` = **install base のみ**（`OrgResolverMiddleware` が path から slug を strip 済み）で組む → ローテーション cookie が `/{base}/auth`（slug なし）に着地。
3. **family-burn**: 次の `/{slug}/auth/refresh` で、ブラウザは `/{base}/auth`（非一致）でなく元の `/{base}/{slug}/auth` スコープの **rotated-away cookie** を送る → `RefreshSessionUseCase` の reuse 検知が family 全体を revoke。

## 修正

- **`BasePath`**: `APP_BASE_ATTRIBUTE` ＋ `appBaseFromRequest()`（app_base 属性、無ければ install base フォールバック）を追加。
- **`OrgResolverMiddleware`**: path-scoped strategy の slug strip の**前**に、app base（`BasePath::fromRequest` + `/` + slug）を request 属性に載せる。
- **`LoginHandler`/`RefreshHandler`/`LogoutHandler`**: cookie base を `appBaseFromRequest()` に統一 → path モードで rotation cookie も `/{base}/{slug}` に発行され、非一致・family-burn が消える。
- 非 path モードは app_base 不在で install base にフォールバック＝**現状バイト等価**。`DemoSessionSeater` は既に正しく**無変更**。

## テスト（回帰固定）

- path モードで app_base が slug スコープ（root=`/acme`・subdir=`/invoice/acme`）
- 非 path モードは app_base 不在 → cookie は install base（挙動不変）
- `appBaseFromRequest` の属性あり/なし
- `composer check` 全体緑（**1007 tests** / phpstan lv8 / cs / openapi valid / mcp valid / conformance OK）

## スコープ外（別途施主 GO）

frontend の per-mode gate 有効化（`isPathTenancy` で off の recoverAuth を path で ON に）＋デプロイ。本 PR は backend 根治のみで、昇格ゲートの「前提」を満たす。

## セルフレビュー

- `docs/review/backend-api.md` / `docs/review/middleware-security.md`

会計・税務コンプラ: 射程外（cookie スコープの修正・認証境界は OrgGuard で不変）。

## デプロイ移行注記

デプロイ後、**既存の slug なし cookie を持つセッション**（旧挙動で発行済み）は最初の path-mode refresh で Path 不一致により fail-closed → 再ログインに落ちる。**demo 環境で許容・想定挙動**（使い捨て org・one-shot 仕様）。新規セッションは正しい slug スコープで発行される。
