### PR TITLE
chore(ci): frontend-ci の paths 除去＋job を frontend-check にリネーム (#697)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -4,18 +4,12 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-ci.yml'
 
 jobs:
-  check:
+  frontend-check:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Closes #697

## 変更
- `frontend-ci.yml` の push/pull_request から `paths:` フィルタを除去 → 全 PR/push で常時実行
- job `check` → `frontend-check` にリネーム（backend の `check` context と分離）
- backend-ci の `check` は不変・`e2e` job は現状維持

## 意図
required=`["check"]` への `frontend-check` 昇格の前提整備。paths フィルタ付き required は backend-only PR で skip → 永久ブロックの罠（vault/contact 実証）を回避する第三の道。

## セルフレビュー
- [x] backend `check` context を変更していない
- [x] context 名が `frontend-check` に分離される
- [x] paths 除去で常時実行（skip ブロック回避）

merge 後に hub が branch protection の required に `frontend-check` を ADD。