### PR TITLE
docs(daily): 2026-07-18 日報を全日分に追補 (#703)

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -1,22 +1,28 @@
 # 2026-07-18
 
 **Project:** NeNe Invoice（自己ホスト型 見積・請求・入金管理／日本の適格請求書対応・マルチテナント前提）
-**Branch state at end of day:** `origin/main` @ `089e8c3`（CI 全緑）
+**Branch state at end of day:** `origin/main` @ `ff851e7`（CI 全緑）
 **Author:** Claude Opus 4.8（Invoice リナ）／指揮は統合リナ（施主指示）
+
+> フリート文脈（伝聞・hub 同報）: 本日 **ayane.co.jp が自社スタック（NeNe Records SSR）で刷新・ローンチ**。invoice は直接関与していないが、フリート全艦が一晩規律を保って動き切った日の記録として残す。
 
 ---
 
 ## Summary
 
-統合リナの指揮下 2 日目。着任時点で invoice は **仕掛かりゼロ・CI 全緑・v1.0.0 リリース済み**で安定。統合リナへ muster（現況＋待機3件）を投げたところ、**待機台帳の実測訂正**（②W2b 完結済み／③W3 は再生成方式で決着・順番待ち／①#425 は施主手番）を受領。そのうえで今夜の小粒 2 本を受けて完遂した。
+統合リナの指揮下 2 日目。着任時点で invoice は **仕掛かりゼロ・CI 全緑・v1.0.0 リリース済み**で安定。統合リナへ muster（現況＋待機3件）を投げたところ、**待機台帳の実測訂正**（②W2b は core 完結済みで残は +ADR のみ／③W3 は再生成方式で決着・順番待ち／①#425 は施主手番）を受領。そのうえで統合リナからの依頼を順に完遂した。
 
-**本日 main 入り 1本**（self-merge・統合リナ承認済み）:
+**本日 main 入り 3本**（すべて self-merge・統合リナ承認済み・実測で CI 全緑確認）:
 
-| PR | Issue | 中身 |
-| --- | --- | --- |
-| **#698** | #697 | frontend-ci の paths フィルタ除去＋job `check`→`frontend-check` リネーム（required 昇格の前提整備） |
+| PR | Issue | 中身 | SHA |
+| --- | --- | --- | --- |
+| **#698** | #697 | frontend-ci の paths フィルタ除去＋job `check`→`frontend-check` リネーム（required 昇格の前提整備） | `089e8c3` |
+| **#700** | #699 | 本日報（初版・#698 まで記帳） | `9ef50f9` |
+| **#702** | #701 | ADR 0022 transport-layer silent refresh（W2b の残「+ADR」・方針B） | `ff851e7` |
 
-加えて **"integration" context の trigger 実測**（1行報告）を統合リナへ提出。
+加えて **"integration" context の trigger 実測**（1行報告）を統合リナへ提出。統合リナが required を **`[check, frontend-check, integration]`** に PATCH（実行は統合リナ手番＝伝聞）。
+
+> 注: 本ファイルは #700 で初版を作成後、W2b ADR（#702）まで含む全日分へ #703 で追補した（この表・下記 Task 3・末尾を追記）。
 
 ---
 
@@ -55,14 +61,53 @@ merge SHA = `089e8c3`。統合リナが branch protection の required を **`[c
 
 ---
 
+## Task 3: W2b の残「+ADR」を起草（#701 / PR #702）
+
+統合リナが `docs/adr/` 実測で確定した残タスク。W2b の core（apiClient → nene2-js
+transport `recoverAuth` seam 移行）は **#684/#685 で完結済み**・#38 の backend 根治は
+**#693/#694 で完了済み**だが、その設計判断を記録する ADR が不在だった。
+
+### 起草内容（方針B・07-14 施主裁定）
+- `docs/adr/0022-transport-layer-silent-refresh-recoverauth-seam.md`（status=accepted・0014/0016 型）。
+- **採番 0022**＝次番。0017/0019 は他 ADR から予約参照済み・0022 は未参照を実測確認。
+- **方針B** = ADR 0014 の silent refresh 挙動を byte 不変で保ちつつ、機構を共有 seam
+  （`@hideyukimori/nene2-client` >= 1.2.0 の `recoverAuth`）へ移行。将来標準化は「意図」
+  として記録し前提化しない。
+- **per-mode 昇格ゲート**（統合リナ裁定 07-16）: single/host モード=`recoverAuth` を渡す（ON）／
+  path モード（demo・型B）=#38 の family-burn 回避で渡さない（fail-closed one-shot）。
+- **線引きを明記**: 本 ADR は方向を承認するが、path-mode を実 ON にはしない。frontend の
+  per-mode gate flip ＋デプロイは**施主 GO 手番**。
+
+### 実測プロベナンス（根拠は全て一次資料で裏取り）
+- W2b core = #684/#685（behavior-preserving・behavior テスト不変で緑・`tsc -b` 緑）。
+- #38 根治 = #693/#694（commit `f8482db`）: cookie base を `appBaseFromRequest()` に統一し
+  path-mode の rotation cookie を `/{base}/{slug}` に発行。`composer check` 全体緑（1007 tests）。
+  commit 自身が「W2b 昇格ゲートの唯一の前提」と記載。
+- **名前空間規律**: 「#38」はこのリポの GitHub issue #38（組織 CRUD・無関係）**ではなく**
+  フリートバグ ID（`_work/issues.md`）。ADR では GitHub #38 とリンクせずフリートバグとして参照した
+  （伝聞と実 issue の取り違え防止・統合リナが模範と評価）。
+
+merge SHA = `ff851e7`。統合リナが受理し **board の W2b を消し込み実行**（伝聞）。path-mode flip は
+施主 GO 手番として board に単独登録された（来週バンドル候補・伝聞）。
+
+---
+
 ## 副次アウトプット
 
 - **記事ネタ供給**（フリート常設任務・施主 2026-07-18）: 「required × paths フィルタの永久 BLOCK 罠＋同名 job context 衝突」を articles リナへ relay（一次資料 = #697/#698/SHA `089e8c3`・再現 `gh pr checks <PR>`）。
 
 ---
 
+## 実測 / 伝聞の書き分け
+
+- **実測**: 3 PR の CI 全緑（`gh pr checks`）・merge SHA・ADR 採番の未参照確認・#38 の性質（GitHub issue でなくフリートバグ ID）・#693/#694 commit 本文と 1007 tests 緑。
+- **伝聞（hub 同報・統合リナ談）**: required の PATCH 実行・board の W2b 消し込み・path-mode flip の board 単独登録・ayane.co.jp ローンチ。いずれも invoice 側では未実行/未検証で、統合リナ手番として記録。
+
+---
+
 ## Next
 
-- **待機**へ復帰。次は W1 の順番（payout→vault→origin→field→**invoice**）が nene2-js の tokens publish 後に回ってくる（統合リナ談）。
+- **待機**へ復帰。次は W1 の順番（payout→vault→origin→field→**invoice**）が nene2-js の tokens publish 後に回ってくる（統合リナ談・伝聞）。
+- **W2b の残**= path-mode の `recoverAuth` 有効化（frontend gate flip ＋デプロイ）は**施主 GO 手番**。ADR 0022 に線引き記録済み。
 - #425 v1.0.0 の外向き公開実行は従来どおり**施主（税理士）確認→公開 GO**の手番。
 - 統合リナから依頼・合図が届いたら対応 → 疑問は理由付きで統合リナへ → 施主判断分のみ上げる → 完了報告＋確認＋レビュー依頼。


### PR DESCRIPTION
Closes #703

朝の #700（#698 まで）に、その後の W2b ADR（#702）・required PATCH・ayane ローンチ文脈・実測/伝聞の書き分けを追補し、本日の全日分（#698/#700/#702）を記帳。

docs のみ・実測プロベナンス付き・self-merge。