### PR TITLE
test(frontend): AppError（shared/api/errors.ts）のユニットテスト追加 (#705)

### DIFF
--- a/frontend/src/shared/api/errors.test.ts
+++ b/frontend/src/shared/api/errors.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { AppError } from './errors'
+
+describe('AppError.fromProblem', () => {
+  it('reduces the Problem Details type URL to its trailing slug', () => {
+    const error = AppError.fromProblem(422, {
+      type: 'https://errors.example.com/validation-failed',
+      title: 'Validation failed',
+    })
+    expect(error.slug).toBe('validation-failed')
+    expect(error.status).toBe(422)
+    expect(error.message).toBe('Validation failed')
+  })
+
+  it('strips trailing slashes before taking the last segment', () => {
+    const error = AppError.fromProblem(409, { type: '/problems/conflict///' })
+    expect(error.slug).toBe('conflict')
+  })
+
+  it('falls back to the "error" slug when type is missing or empty', () => {
+    expect(AppError.fromProblem(500, {}).slug).toBe('error')
+    expect(AppError.fromProblem(500, { type: '' }).slug).toBe('error')
+  })
+
+  it('falls back to "HTTP <status>" when title is absent', () => {
+    const error = AppError.fromProblem(503, { type: '/problems/unavailable' })
+    expect(error.message).toBe('HTTP 503')
+  })
+
+  it('passes detail through and leaves it undefined when absent or non-string', () => {
+    expect(AppError.fromProblem(400, { detail: 'amount too large' }).detail).toBe(
+      'amount too large',
+    )
+    expect(AppError.fromProblem(400, {}).detail).toBeUndefined()
+    expect(AppError.fromProblem(400, { detail: 42 }).detail).toBeUndefined()
+  })
+
+  it('exposes per-field errors when provided and defaults to an empty array', () => {
+    const withFields = AppError.fromProblem(422, {
+      errors: [{ field: 'email', code: 'required' }],
+    })
+    expect(withFields.fieldErrors).toEqual([{ field: 'email', code: 'required' }])
+    expect(AppError.fromProblem(422, {}).fieldErrors).toEqual([])
+    // A non-array `errors` payload must not become fieldErrors.
+    expect(AppError.fromProblem(422, { errors: 'nope' }).fieldErrors).toEqual([])
+  })
+
+  it('defends against non-object bodies', () => {
+    for (const body of [null, undefined, 'boom', 123]) {
+      const error = AppError.fromProblem(500, body)
+      expect(error.slug).toBe('error')
+      expect(error.status).toBe(500)
+      expect(error.fieldErrors).toEqual([])
+    }
+  })
+})
+
+describe('AppError.transport', () => {
+  it('builds a status-0 network error', () => {
+    const error = AppError.transport('Failed to fetch')
+    expect(error.status).toBe(0)
+    expect(error.slug).toBe('network-error')
+    expect(error.message).toBe('Failed to fetch')
+    expect(error.isRetryable).toBe(false)
+  })
+})
+
+describe('AppError status predicates', () => {
+  it('treats 5xx, 408 and 429 as retryable', () => {
+    for (const status of [500, 502, 503, 408, 429]) {
+      expect(new AppError({ status, slug: 's', title: 't' }).isRetryable).toBe(true)
+    }
+  })
+
+  it('treats ordinary 4xx as non-retryable', () => {
+    for (const status of [400, 401, 403, 404, 422]) {
+      expect(new AppError({ status, slug: 's', title: 't' }).isRetryable).toBe(false)
+    }
+  })
+
+  it('flags 401 as unauthorized only', () => {
+    const error = new AppError({ status: 401, slug: 's', title: 't' })
+    expect(error.isUnauthorized).toBe(true)
+    expect(error.isForbidden).toBe(false)
+  })
+
+  it('flags 403 as forbidden only', () => {
+    const error = new AppError({ status: 403, slug: 's', title: 't' })
+    expect(error.isForbidden).toBe(true)
+    expect(error.isUnauthorized).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #705

## 概要

フロントテスト厳格化キャンペーン（統合リナ発令 2026-07-18）の **T1-lite 先行 PR**（テスト追加のみ・config/依存変更なし・base=main）。

自リポ T0 棚卸しで zero test と判明した `shared/api/errors.ts`（`AppError`）に純ロジック UT を追加。ここは RFC 9457 `application/problem+json` → `AppError` 変換と `slug`/`status` 分岐の中枢で、全 feature の 3型エラー表示（field / ActionError·InlineAlert / toast）が依存する高 blast-radius なロジック層。A1 済みの安定層で W1/W3/A2 の移設対象と重ならない。

## 変更

- `frontend/src/shared/api/errors.test.ts`（**追加のみ**・12 test）
  - `fromProblem`: slug 抽出（末尾スラッシュ除去・最終セグメント）・空/欠落 type の `error` fallback・`HTTP <status>` title fallback・`detail` passthrough/undefined/非string・`errors` 配列/非配列・null/undefined/非オブジェクト body 防御
  - `transport`: status 0 / slug `network-error` / 非 retryable
  - `isRetryable`（5xx・408・429）／`isUnauthorized`（401）／`isForbidden`（403）

MSW・フック不要の純粋テスト。src/config/依存の変更なし。

## 検証（self-review）

- `npx vitest run src/shared/api/errors.test.ts` → 12 passed
- `npm test` 全体 → **86 files / 331 passed**（回帰なし・従来 85/319）
- `prettier --check` 緑・`eslint --max-warnings 0` 緑・`tsc -b` 緑

## 干渉回避

- W1/arm の号令が来たらテスト作業は中断・退避（本 PR はテスト専用の小粒度）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)