### PR TITLE
test(frontend): useManageCompanySeal（features/manage-company-seal/model）のユニットテスト追加 (#709)

### DIFF
--- a/frontend/src/features/manage-company-seal/model/use-manage-company-seal.test.ts
+++ b/frontend/src/features/manage-company-seal/model/use-manage-company-seal.test.ts
@@ -1,0 +1,131 @@
+import { act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { server } from '@tests/msw/server'
+import { renderHookWithProviders } from '@tests/render/render-with-providers'
+import { useManageCompanySeal } from './use-manage-company-seal'
+
+const SEAL_URL = '/admin/company-settings/seal'
+
+/** A valid PNG-typed file whose bytes have a known base64 encoding. */
+function pngFile(bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])): {
+  file: File
+  base64: string
+} {
+  return {
+    file: new File([bytes], 'seal.png', { type: 'image/png' }),
+    base64: Buffer.from(bytes).toString('base64'),
+  }
+}
+
+describe('useManageCompanySeal', () => {
+  beforeEach(() => {
+    // Default: no seal set. Individual tests override as needed.
+    server.use(http.get(SEAL_URL, () => HttpResponse.json({ has_seal: false, image_base64: null })))
+  })
+
+  it('rejects a non-PNG file without uploading', () => {
+    let uploaded = false
+    server.use(
+      http.put(SEAL_URL, () => {
+        uploaded = true
+        return HttpResponse.json({ has_seal: true })
+      }),
+    )
+
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    act(() => {
+      result.current.onSelectFile(new File(['x'], 'seal.jpg', { type: 'image/jpeg' }))
+    })
+
+    expect(result.current.errorMessage).not.toBeNull()
+    expect(uploaded).toBe(false)
+  })
+
+  it('rejects a file over the 512 KB cap without uploading', () => {
+    let uploaded = false
+    server.use(
+      http.put(SEAL_URL, () => {
+        uploaded = true
+        return HttpResponse.json({ has_seal: true })
+      }),
+    )
+
+    const oversized = new File([new Uint8Array(512 * 1024 + 1)], 'big.png', { type: 'image/png' })
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    act(() => {
+      result.current.onSelectFile(oversized)
+    })
+
+    expect(result.current.errorMessage).not.toBeNull()
+    expect(uploaded).toBe(false)
+  })
+
+  it('reads a valid PNG and uploads its base64 payload', async () => {
+    const { file, base64 } = pngFile()
+    let captured: unknown
+    server.use(
+      http.put(SEAL_URL, async ({ request }) => {
+        captured = await request.json()
+        return HttpResponse.json({ has_seal: true })
+      }),
+    )
+
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    act(() => {
+      result.current.onSelectFile(file)
+    })
+
+    await waitFor(() => {
+      expect(captured).toEqual({ image_base64: base64 })
+    })
+    expect(result.current.errorMessage).toBeNull()
+  })
+
+  it('derives the preview data URI and hasSeal from the query', async () => {
+    server.use(
+      http.get(SEAL_URL, () => HttpResponse.json({ has_seal: true, image_base64: 'QUJD' })),
+    )
+
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.hasSeal).toBe(true)
+    expect(result.current.previewDataUri).toBe('data:image/png;base64,QUJD')
+  })
+
+  it('has no preview when no seal is set', async () => {
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.hasSeal).toBe(false)
+    expect(result.current.previewDataUri).toBeNull()
+  })
+
+  it('calls DELETE on remove', async () => {
+    let removed = false
+    server.use(
+      http.delete(SEAL_URL, () => {
+        removed = true
+        return HttpResponse.json({ has_seal: false })
+      }),
+    )
+
+    const { result } = renderHookWithProviders(() => useManageCompanySeal())
+
+    act(() => {
+      result.current.onRemove()
+    })
+
+    await waitFor(() => {
+      expect(removed).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Closes #709

## 概要

フロントテスト厳格化キャンペーンの **T1-lite**（テスト追加のみ・config/依存変更なし・base=main）。

当初 TOP5 ③ use-sign-in を予定していたが、実測で **`SignInForm.test.tsx`（UI テスト）が use-sign-in の実挙動を既に end-to-end で網羅**（成功時トークン保存・不正時 alert＋非セッション）と判明したため、重複を避け、真に zero test で検証ロジックの厚い ④ `use-manage-company-seal`（78行）へ振り替え。

社印アップロードのクライアント側検証（PNG/サイズ・FileReader base64 抽出・preview 導出）は本番の入口だが未テストだった。A1 済みの安定 model 層で W1/W3/A2 の移設対象と重ならない。

## 変更

- `frontend/src/features/manage-company-seal/model/use-manage-company-seal.test.ts`（**追加のみ**・6 test）
  - 非 PNG 拒否・512KB 超拒否（いずれも errorMessage・**PUT 未発火**を検証）
  - 正常 PNG → `FileReader` で base64 抽出 → PUT `/admin/company-settings/seal` に `{ image_base64 }` 送信（**body 検証**）
  - GET has_seal=true+image_base64 → `previewDataUri` / `hasSeal` 導出／seal 無し時は null・false
  - onRemove → DELETE 発火

`renderHookWithProviders` + MSW。src/config/依存の変更なし。

## 検証（self-review）

- `npx vitest run …use-manage-company-seal.test.ts` → 6 passed
- `npm test` 全体 → **88 files / 344 passed**（回帰なし・従来 87/338）
- `eslint --max-warnings 0` 緑・`tsc -b` 緑・`prettier --check` 緑

## 干渉回避

- W1/arm の号令が来たらテスト作業は中断・退避。

🤖 Generated with [Claude Code](https://claude.com/claude-code)