### PR TITLE
feat(frontend): stylelint gate を check(CI) に配線＝ブロッキング化（レーンD gate 化 flip）

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "codegen:check": "node scripts/check-codegen.mjs",
     "gen:icons": "node scripts/gen-icons.mjs",
     "knip": "knip",
-    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run format && npm run test && npm run knip && npm run build-storybook",
+    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run format && npm run test && npm run knip && npm run build-storybook",
     "lint:styles": "stylelint 'src/**/*.css'"
   },
   "dependencies": {


### PR DESCRIPTION
## これは何

#721 で**非ブロッキング導入**した nene2 stylelint gate を、`check` スクリプトに `lint:styles` を組み込んで**ブロッキング化**する flip PR（hub 裁定 Q-D2 の2段目＝「実測緑を見せてから gate 化」）。これが landed で **D-invoice green（P2 受入）成立**。

**筆=fleet-tooling リナ / レビュー=invoice / merge=hub GO。**

## 変更（1PR=1論点・deps 不変）

```diff
- "check": "... && npm run lint && npm run format && ..."
+ "check": "... && npm run lint && npm run lint:styles && npm run format && ..."
```

- `scripts.check` に `npm run lint:styles` を `lint` の直後へ配線。
- **deps 変更なし**（stylelint/nene2-standards は #721 で導入済み・**lockfile 不変**）。

## 実測（scratchpad clone・invoice main `1f3c291`=#721 込み）

| 検証 | 結果 |
|---|---|
| `npm run lint:styles`（配線した本体）| **rc=0（緑）**: registries.jsonc の grandfather が効く・CSS は #721 から不変 |
| `npm install` | **found 0 vulnerabilities**（#720 override 込み） |
| standards 解決版 | **2.0.1**（keyframe 修正 #116 込み） |
| lockfile | **不変**（deps-neutral） |

→ 本 PR の CI（frontend-check の `check` 工程）が **lint:styles rc=0 を CI レベルで実証**します（@invoice-rina 宿題②の本丸）。以後は構造違反の新規混入が CI で赤になる＝**gate 発効**。

## 既知の限界（判例20）

baselined な `(rule,file)` 内の count 回帰は、`init --check` への count-ratchet 配線（fleet-tooling #119・due 2026-07-24・AM-14）までは機械検出されません。当該ファイルへの変更 PR はレビューで見る運用。

standards 2.0.1: npm latest=2.0.1・shasum `e6ce6b0e`・tag `nene2-standards-v2.0.1`。