### PR TITLE
feat(frontend): init --check count-ratchet を CI に配線＋standards ^2.1.0 pin（レーンD arm-flip）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.0",
-        "@hideyukimori/nene2-standards": "^2.0.1",
+        "@hideyukimori/nene2-standards": "^2.1.0",
         "@playwright/test": "^1.60.0",
         "@storybook/addon-a11y": "^9.1.5",
         "@storybook/react-vite": "^9.1.5",
@@ -1708,9 +1708,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-standards": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-standards/-/nene2-standards-2.0.1.tgz",
-      "integrity": "sha512-fUHRIMIxaEp1KRleTzC7cEbu8i8JiYQL6APjbHe3WD3rep6XnowREux2RBI6kgtpVWGBVPbwJt5PfPz+jmAPfQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-standards/-/nene2-standards-2.1.0.tgz",
+      "integrity": "sha512-IIAezDfALYbMGS0FtF3i113aDW8TR1xDRY68aXR2LyCjUFei6GDJoX4w44crWXkJnFnrfByXp9jrSlwbE7DBeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,8 +24,9 @@
     "codegen:check": "node scripts/check-codegen.mjs",
     "gen:icons": "node scripts/gen-icons.mjs",
     "knip": "knip",
-    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run format && npm run test && npm run knip && npm run build-storybook",
-    "lint:styles": "stylelint 'src/**/*.css'"
+    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run check:registries && npm run format && npm run test && npm run knip && npm run build-storybook",
+    "lint:styles": "stylelint 'src/**/*.css'",
+    "check:registries": "nene2-check init --check --repo nene-invoice"
   },
   "dependencies": {
     "@fontsource/noto-sans-jp": "^5.2.9",
@@ -41,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",
-    "@hideyukimori/nene2-standards": "^2.0.1",
+    "@hideyukimori/nene2-standards": "^2.1.0",
     "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^9.1.5",
     "@storybook/react-vite": "^9.1.5",


### PR DESCRIPTION
## これは何

standards **2.1.0（#119 lint-baseline count-ratchet）publish landed** を受け、invoice CI に **count-ratchet の実強制**を配線する arm-flip（hub 裁定 (a) 型＝gate と同じ場所に1行）。これで **判例20 の穴が invoice で閉じる**（stylelint gate＋count-ratchet の両輪が CI 稼働）。

## 変更（deps は standards 版 bump のみ）

- devDep `@hideyukimori/nene2-standards` `^2.0.1` → **`^2.1.0`**。
- script `check:registries`（`nene2-check init --check --repo nene-invoice`）を `check` に `lint:styles` の直後へ配線。

## 実測（scratchpad clone・invoice main `2b0955d`＝gate 発効済みの上）

| 検証 | 結果 |
|---|---|
| `npx nene2-check init --check` | **rc=0**: 未分類 0・lint-baseline 回帰 0・shrinkable 0 |
| standards 解決版 | **2.1.0**（count-ratchet 込み） |
| `npm install` | found 0 vulnerabilities・lockfile 差分は standards 版 bump のみ |

以後、baselined `(rule,file)` 内の count 回帰（例: index.css の color-no-hex を 12→13 に増やす）が CI で赤になる。standards 2.1.0: npm latest=2.1.0・shasum `4921c61d`（独立実測）。

## 段取り

これが landed で invoice の判例20 の穴が閉じる。deal も同型 flip を並行で出します。両艦 landed で hub が**横展開ガード解除**を宣言（field/origin/vault/残艦へ）。