### PR TITLE
chore(ci): npm audit gate を audit-ci 化＋修正可能な5勧告を bump で解消 (#731)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,8 +32,12 @@ jobs:
       - name: Check (type-check, lint, format, test, knip, build-storybook)
         run: npm run check
 
+      # audit-ci = npm audit + a per-advisory allowlist, so a not-yet-fixable advisory can be
+      # excepted with a written, expiring reason instead of blunting the whole gate. Anything
+      # high/critical that is not listed in frontend/audit-ci.jsonc still fails.
+      # Policy: docs/development/dependency-audit.md
       - name: Audit (fail on high/critical)
-        run: npm audit --audit-level=high
+        run: npm run audit
 
   e2e:
     runs-on: ubuntu-latest

--- a/docs/development/dependency-audit.md
+++ b/docs/development/dependency-audit.md
@@ -1,0 +1,93 @@
+# Dependency vulnerability gate (frontend)
+
+Every PR runs a dependency audit as a **merge gate**. This document says what the gate is,
+how an exception is granted, and what is currently excepted.
+
+- Config: [`frontend/audit-ci.jsonc`](../../frontend/audit-ci.jsonc) (the file itself carries
+  the reasoning for each entry — keep the two in sync)
+- Command: `npm run audit --prefix frontend`
+- CI: the `Audit (fail on high/critical)` step of `Frontend CI` (required check `frontend-check`)
+
+## The gate
+
+`audit-ci` fails the build on any **high** or **critical** advisory that is not explicitly
+allowlisted. Moderate and below do not fail (they are still reported).
+
+We use `audit-ci` rather than bare `npm audit --audit-level=high` for one reason: **`npm audit`
+has no way to record a reasoned exception.** Without one, the only ways past a
+not-yet-fixable advisory are to lower the severity threshold or drop the step — both of which
+blind the gate to _everything_, not just the advisory in question.
+
+## Rules for an exception
+
+1. **Per advisory id, never per severity.** Allowlist `GHSA-…`; do not raise `--audit-level`
+   and do not set `high: false`. A new advisory must still fail the build the day it lands.
+2. **The reason must be measured, not assumed.** State why the vulnerable code path does not
+   exist _in this codebase_, and how that was checked (a grep, a build artifact, a config).
+   "We probably don't use that" is not a reason.
+3. **Every entry has an expiry** and a named condition that removes it (an upgrade wave, an
+   upstream fix). An expired entry is a task — re-argue it in a PR; do not extend it by reflex.
+4. **Prefer the fix.** If a patched version exists in a range we can take, take it. An
+   exception is only for "no fix exists that we can adopt".
+
+## Current exceptions
+
+| Advisory                                                                 | Package                                               | Why it does not apply here                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Expires        |
+| ------------------------------------------------------------------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) | `react-router` (7.12.0–8.2.0)                         | The admin UI is a **static SPA built by Vite** (`vite.config.ts` → `outDir: ../public_html/admin`, `base: './'`) and served as files by the PHP app shell. `src/app/router.tsx` is the only router and uses `createBrowserRouter` with **element-only routes** — **no RSC mode, no server components, no route `action`/`loader`, no `@react-router/dev` runtime**. The advisory's attack path (a server executing a route action before returning 400) has no counterpart in a client-only bundle. Measured 2026-07-29: no `action:` / `loader:` route keys in `src/`, all 44 react-router imports are from `react-router-dom`, and the tree contains no `react-router/rsc` / `createStaticHandler` / `StaticRouterProvider` / `@react-router/dev`. | **2026-08-31** |
+| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | `brace-expansion` (≤ 5.0.7), **1.x / 2.x paths only** | The 5.x path **is** fixed (override `^5.0.8`); this entry covers only the copies that cannot take the fix. Measured 2026-07-29: `npm ls brace-expansion --omit=dev --all` is **empty** — the package is dev-only, in no shipped bundle and on no request path. The vulnerable copies are `1.1.16` (via `minimatch@3` ← eslint / eslintrc / config-array / plugin-import / plugin-jsx-a11y) and `2.1.3` (via `glob`, `@redocly/openapi-core`) — lint and codegen tooling running over our own committed globs, while the advisory needs an attacker-supplied brace pattern.                                                                                                                                                                           | **2026-08-31** |
+
+There is **no fix available in the 7.x line** for `react-router`: `react-router-dom` ends at
+7.18.1, and the fix lands in `react-router` v8 (≥ 8.2.1) — a different package and a breaking
+upgrade. The exception is removed by the **react-router v8 migration wave** (bundled with the
+NENE2 RR8 re-evaluation).
+
+For `brace-expansion` there is **no patched 1.x or 2.x release at all**, and forcing 5.0.8 into
+those branches breaks the consumers — measured: brace-expansion 5 exports a _named_ `expand`
+while `minimatch@3` calls the module itself, so `npm run lint` dies with
+`TypeError: expand is not a function`. Overriding `minimatch@3` upward fails the same way
+(`eslint-plugin-import` / `eslint-plugin-jsx-a11y` do `_interopRequireDefault(require('minimatch'))`
+and call it; `minimatch` ≥ 9 has no callable default export). The exception is removed by the
+**eslint 10 / plugin major wave**, which moves the chain to `minimatch@10` → `brace-expansion@^5`.
+
+## What was fixed rather than excepted (2026-07-29)
+
+The gate went red on six advisories at once. Five of them had a version we could take, so we
+took it (rule 4); one had no adoptable fix, and one was fixed only on part of its tree:
+
+| Advisory                                                                      | Package                        | Action                                                                      |
+| ----------------------------------------------------------------------------- | ------------------------------ | --------------------------------------------------------------------------- |
+| GHSA-wrjc-x8rr-h8h6 (open redirect via backslash in `<Link>` / `useNavigate`) | `react-router`                 | fixed in 7.18.0 → floor raised to `react-router-dom` `^7.18.1`              |
+| GHSA-h8fp-f39c-q6mh (RSCErrorHandler XSS)                                     | `react-router`                 | same bump                                                                   |
+| GHSA-337j-9hxr-rhxg (`deserializeErrors()` constructor injection)             | `react-router`                 | same bump                                                                   |
+| GHSA-chx6-hx7r-mcp5 (route-matching DoS)                                      | `react-router`                 | same bump                                                                   |
+| GHSA-r28c-9q8g-f849 (`sourceMappingURL` path traversal)                       | `postcss` (transitive)         | override `^8.5.24`                                                          |
+| GHSA-mh99-v99m-4gvg (unbounded expansion DoS)                                 | `brace-expansion` (transitive) | override `brace-expansion@5` → `^5.0.8`; 1.x/2.x paths excepted (see above) |
+
+Note on `react-router-dom`: the declared range is the **floor** (`^7.18.1`), not just whatever
+the lockfile happens to resolve. A caret range that merely _happened_ to resolve to a patched
+version can silently regress on a fresh install; the floor cannot.
+
+Note on pins: pinning a version to dodge an advisory is a **time-limited** measure, not a fix —
+the pinned version can itself fall inside a later advisory. That is exactly what happened here:
+the `brace-expansion` pins added in #719 (`1.1.16` / `2.1.2` / `5.0.7`) became the vulnerable
+versions on 2026-07-29. Prefer ranges, and revisit pins.
+
+## Fleet note
+
+The fleet reference implementation is **contact** (contact #524, 施主 GO 2026-07-29); this repo
+mirrors it (#731). The RSC-unused claim above was **re-measured in this tree** before the
+allowlist entry was copied — copying an exception without re-measuring is exactly the failure
+mode the rules exist to prevent.
+
+The re-measuring paid off: invoice needed a **second** entry that contact does not have.
+contact's blanket `"brace-expansion": "^5.0.8"` override works there; here it breaks `npm run
+lint`, because this tree still carries a `minimatch@3` chain (eslint 9 core + `eslint-plugin-import`
+
+- `eslint-plugin-jsx-a11y`). Sibling products copying this setup should run `npm run lint` after
+  the override, not just `npm run audit`.
+
+## Related
+
+- [`coding-standards.md`](./coding-standards.md) — the wider merge-gate set
+- [`frontend-standards.md`](./frontend-standards.md) — frontend conventions

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -1,0 +1,62 @@
+{
+  // Dependency-vulnerability gate for CI (replaces the bare `npm audit --audit-level=high`,
+  // which has no way to record a reasoned exception).
+  //
+  // The gate stays sharp: anything high/critical that is NOT listed below fails the build.
+  // `allowlist` is per-advisory (GHSA id), never per-severity — we do not lower the level.
+  //
+  // Adding an entry requires, in this file: (1) the advisory id, (2) why it does not apply to
+  // THIS codebase, measured — not assumed, (3) an expiry date, (4) what removes the need for it.
+  // An expired entry is a task, not a renewal: re-check it, do not extend it by reflex.
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": false,
+  "high": true,
+  "critical": true,
+  "allowlist": [
+    // GHSA-qwww-vcr4-c8h2 — react-router "RSC Mode CSRF Bypass Allows Action Execution Before
+    // 400 Response" (high). Vulnerable range 7.12.0–8.2.0; there is NO fix in the 7.x line
+    // (react-router-dom stops at 7.18.1; the fix is react-router v8 >= 8.2.1, a different
+    // package and a breaking upgrade).
+    //
+    // Why it does not apply here (measured in THIS tree, 2026-07-29): the admin UI is a
+    // **static SPA built by Vite** (`vite.config.ts` → `outDir: ../public_html/admin`,
+    // `base: './'` for Tier A sub-path installs) and served as files by the PHP app shell.
+    // `src/app/router.tsx` is the only router: `createBrowserRouter` with **element-only
+    // routes** — grep for `^\s*(action|loader):` over `src/` returns no route hits (only an
+    // unrelated `action` field on toast props and on the audit-log entity/DTO). All 44
+    // react-router imports come from `react-router-dom`; there is no `@react-router/dev`,
+    // no `react-router/rsc`, no `createStaticHandler`, no `StaticRouterProvider`. The
+    // advisory's attack path (a server executing a route action before returning 400) has no
+    // counterpart in a client-only bundle.
+    //
+    // Expiry: 2026-08-31. Removed by the react-router v8 migration wave (bundled with the
+    // NENE2 RR8 re-evaluation). If that wave slips past the expiry, the entry must be
+    // re-argued in a PR — not silently extended.
+    "GHSA-qwww-vcr4-c8h2",
+
+    // GHSA-mh99-v99m-4gvg — brace-expansion "DoS via unbounded expansion length" (high).
+    // Vulnerable range <=5.0.7; the fix is 5.0.8. We TAKE that fix where it is adoptable
+    // (`"brace-expansion@5": "^5.0.8"` in overrides). It is not adoptable on the 1.x / 2.x
+    // branches: there is no patched 1.x or 2.x release at all, and forcing 5.0.8 into them
+    // breaks the consumers — measured 2026-07-29: brace-expansion 5 exports a *named*
+    // `expand`, while `minimatch@3` does `require('brace-expansion')` and calls the module
+    // itself, so `npm run lint` dies with `TypeError: expand is not a function`. Overriding
+    // `minimatch@3` upward fails the same way (`eslint-plugin-import` / `eslint-plugin-jsx-a11y`
+    // do `_interopRequireDefault(require('minimatch'))` and call it; minimatch >=9 has no
+    // callable default export). Retiring the 1.x/2.x chain therefore needs an eslint-10-era
+    // major upgrade of eslint + its plugins — not something this gate PR can take.
+    //
+    // Why the residual risk is acceptable here (measured 2026-07-29): brace-expansion is
+    // **dev-only** in this tree — `npm ls brace-expansion --omit=dev --all` is empty, so it
+    // is in no shipped bundle and reaches no request path. The remaining vulnerable copies
+    // are 1.1.16 (via `minimatch@3` ← eslint / eslintrc / config-array / plugin-import /
+    // plugin-jsx-a11y) and 2.1.3 (via `glob` and `@redocly/openapi-core`), i.e. lint and
+    // codegen tooling run on our own repo contents. The advisory needs an attacker-supplied
+    // brace pattern; our glob patterns are literals in committed config.
+    //
+    // Expiry: 2026-08-31. Removed by the eslint 10 / plugin major wave (which moves the whole
+    // chain to `minimatch@10` → `brace-expansion@^5`), or by an upstream 1.x/2.x backport if
+    // one appears. Re-check at expiry — do not extend by reflex.
+    "GHSA-mh99-v99m-4gvg",
+  ],
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.66.1",
-        "react-router-dom": "^7.9.6",
+        "react-router-dom": "^7.18.1",
         "zod": "^4.1.13"
       },
       "devDependencies": {
@@ -35,6 +35,7 @@
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.0",
         "@vitest/coverage-v8": "^4.1.8",
+        "audit-ci": "^7.1.0",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -2499,10 +2500,17 @@
         "npm": ">=9.5.0"
       }
     },
+    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3797,29 +3805,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4832,6 +4817,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/audit-ci/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4869,11 +4891,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.32",
@@ -4912,14 +4937,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5682,6 +5709,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -6298,29 +6332,6 @@
         }
       }
     },
-    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6693,6 +6704,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -6998,6 +7025,13 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7189,10 +7223,17 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7606,6 +7647,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -8235,6 +8283,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -8408,6 +8463,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8914,6 +8996,13 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9015,6 +9104,24 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -9098,9 +9205,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -9626,6 +9733,19 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9813,9 +9933,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -9833,7 +9953,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10101,9 +10221,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10123,12 +10243,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10143,6 +10263,31 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -10407,6 +10552,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -10732,6 +10898,19 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -10829,12 +11008,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -11470,6 +11670,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tiny-invariant": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "codegen:check": "node scripts/check-codegen.mjs",
     "gen:icons": "node scripts/gen-icons.mjs",
     "knip": "knip",
+    "audit": "audit-ci --config audit-ci.jsonc",
     "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run check:registries && npm run format && npm run coverage:check && npm run knip && npm run build-storybook",
     "lint:styles": "stylelint 'src/**/*.css'",
     "check:registries": "nene2-check init --check --repo nene-invoice"
@@ -39,7 +40,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.66.1",
-    "react-router-dom": "^7.9.6",
+    "react-router-dom": "^7.18.1",
     "zod": "^4.1.13"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "audit-ci": "^7.1.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.0",
@@ -83,8 +85,7 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "js-yaml": "^4.3.0",
-    "brace-expansion@1": "1.1.16",
-    "brace-expansion@2": "2.1.2",
-    "brace-expansion@5": "5.0.7"
+    "postcss": "^8.5.24",
+    "brace-expansion@5": "^5.0.8"
   }
 }


### PR DESCRIPTION
## Summary

frontend の required check `frontend-check` が新規勧告 **6件**で赤になっていた（07-21 の緑以降に landed）。hub 裁定（**bump 優先・ID 列挙は修正なし系のみ・severity 緩和は不採用**）に沿って処理した。

### bump で解消（5件）

| 勧告 | パッケージ | 対応 |
| --- | --- | --- |
| GHSA-wrjc-x8rr-h8h6（`<Link>`/`useNavigate` の open redirect） | react-router | 7.18.0 で修正済み → **`react-router-dom` を `^7.18.1`** へ |
| GHSA-h8fp-f39c-q6mh（RSCErrorHandler XSS） | react-router | 同上 |
| GHSA-337j-9hxr-rhxg（`deserializeErrors()` コンストラクタ注入） | react-router | 同上 |
| GHSA-chx6-hx7r-mcp5（ルート照合 DoS） | react-router | 同上 |
| GHSA-r28c-9q8g-f849（`sourceMappingURL` パストラバーサル） | postcss | override `^8.5.24` |

hub の読み（「RR 系4件は 7.18.1 で解消する見込み・5件とも v8 要は要再実測」）は**実測で正**でした。advisory の vulnerable range は 4件が `<7.18.0`、qwww のみ `<8.3.0`。
**wrjc（open redirect）は bump で消えたので、承認いただいた実装調査は不要**になりました。

宣言レンジを `^7.9.6` のままにせず **floor として `^7.18.1`** へ上げています（lock の解決値任せだと fresh install で静かに戻りうるため）。

### 例外（2件・期限 2026-08-31・解除条件つき）

1. **GHSA-qwww-vcr4-c8h2**（react-router RSC CSRF）— 7.x に修正なし（fix は v8 ≥ 8.2.1＝別パッケージ・breaking）。**RSC 不使用をこの tree で再実測**: `src/app/router.tsx` は唯一の router で `createBrowserRouter` の element-only（`src/` に route の `action:`/`loader:` なし・44 imports すべて `react-router-dom`・`react-router/rsc`／`createStaticHandler`／`@react-router/dev` なし）、ビルドは `public_html/admin` への静的 SPA。解除＝RR8 移行波。
2. **GHSA-mh99-v99m-4gvg の 1.x/2.x 経路** — 🔴 **hub 想定（qwww 1件）からの逸脱です。裁定ください。** 5.x 系は override `^5.0.8` で実際に潰しました。1.x/2.x は patched リリースが**存在せず**、5.0.8 を流し込むと `npm run lint` が `TypeError: expand is not a function` で死にます（実測・v5 は named export、`minimatch@3` はモジュール自体を呼ぶ）。`minimatch@3` を上げる案も `eslint-plugin-import`／`jsx-a11y` の `_interopRequireDefault(require('minimatch'))` で同じ壊れ方（実測）。退役には **eslint 10 + plugin major** が要り、この PR では取れません。残置の根拠は **dev-only を実測**（`npm ls brace-expansion --omit=dev --all` が空＝出荷バンドルにもリクエスト経路にも無い／残る 1.1.16・2.1.3 は lint・codegen が自リポの literal glob を舐めるだけ）。解除＝eslint 10 波。

### ゲート

- `npm audit --audit-level=high` → **audit-ci**（`frontend/audit-ci.jsonc`）。severity は緩めず、**ID 単位**の allowlist のみ。未登録の high/critical は当日から落ちる。
- ポリシー文書 `docs/development/dependency-audit.md` を新設（contact 参照実装を写しつつ、invoice 実測へ差し替え）。

## Verification

- [x] `npm run audit` 緑（`Found vulnerable allowlisted advisories: GHSA-mh99-v99m-4gvg, GHSA-qwww-vcr4-c8h2` → `Passed`）
- [x] **負テスト**: allowlist から `GHSA-qwww-vcr4-c8h2` を外す → exit 1／`GHSA-mh99-v99m-4gvg` を外す → exit 1（両方個別に実測）
- [x] `npm run check` 緑（codegen:check / type-check / lint / lint:styles / check:registries / format / coverage:check / knip / build-storybook）
- [x] `npm run e2e` **75 passed**（react-router 7.9.6 → 7.18.1 の回帰確認）
- [x] `npm ls brace-expansion --omit=dev --all` / `npm ls postcss --omit=dev --all` → いずれも空（prod 非露出の実測）

## セルフレビュー

`docs/development/self-review.md`

## Note for the fleet

contact の blanket `"brace-expansion": "^5.0.8"` は invoice では **lint を壊します**（この tree には `minimatch@3` 連鎖が残っているため）。写す艦は `npm run audit` だけでなく **`npm run lint` まで回してください**。この差分は `dependency-audit.md` の Fleet note に明記しました。

Closes #731
