### PR TITLE
test(frontend): hermetic な @smoke を新設し CI へ fail-fast 配線 (#733)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Install Playwright browser (chromium)
         run: npx playwright install --with-deps chromium
 
+      # @smoke first: the critical path (boot → sign in → shell → SPA nav) runs
+      # in seconds, so a broken bundle or login wiring fails here instead of
+      # after the full suite. Both runs are hermetic (page.route stubs).
+      - name: Run @smoke
+        run: npm run e2e:smoke
+
       - name: Run browser E2E tests
         run: npm run e2e
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "coverage": "vitest run --coverage",
     "coverage:check": "vitest run --coverage && node tools/coverage-ratchet.mjs",
     "e2e": "NODE_PATH=./node_modules playwright test",
+    "e2e:smoke": "npm run e2e -- --grep @smoke",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+import { json, login } from './helpers/auth'
+
+/**
+ * The @smoke tag marks the one spec that must pass before anything else is
+ * worth running: boot the SPA → sign in → land on the authenticated shell →
+ * move to another route without losing the session.
+ *
+ * It is HERMETIC — every API call is stubbed via `page.route` (see
+ * helpers/auth.ts), so it needs no backend, no DB and no Docker, and it never
+ * touches a deployed environment. `npm run e2e:smoke` runs this spec alone.
+ *
+ * Keep it thin. Feature behaviour belongs in the per-feature specs; what this
+ * one guards is the wiring that makes all of them possible — bundle boots,
+ * login form posts, token reaches the fail-closed auth gate, the shell renders,
+ * and SPA navigation keeps the in-memory token alive.
+ */
+test('@smoke sign in and reach the authenticated shell', async ({ page }) => {
+  // The clients list is the first route we navigate to; stub it before the nav
+  // click so the assertion cannot race the request.
+  await page.route('**/admin/clients*', (route) => route.fulfill(json({ items: [], total: 0 })))
+
+  await login(page)
+
+  // Landed on the post-login dashboard.
+  await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible()
+
+  // SPA navigation keeps the session (the token is in memory — a full reload
+  // would clear it, so this also guards against an accidental hard navigation).
+  await page.getByRole('link', { name: '取引先' }).click()
+  await expect(page.getByRole('heading', { name: '取引先' })).toBeVisible()
+})


### PR DESCRIPTION
## Summary

完全クローズ **C6** の残り＝`@smoke` 新設。**#734（移設）に stack しています**（base = `test/733-e2e-relocate`）。

`tests/e2e/smoke.spec.ts` を1本置く。見るのは**全 spec が成立するための配線**だけ:

boot → ログイン（フォーム送信）→ トークンが fail-closed な auth gate を通る → シェル描画 → **SPA 内遷移でセッションが生きている**

- **hermetic**: API は `helpers/auth.ts` の `page.route` stub で塞ぐ。backend / DB / Docker 不要、デプロイ先を一切叩かない。
- **薄く保つ**: 機能の振る舞いは各 feature spec の担当。ここは「壊れたら他が全部無意味になる」層だけ。
- token は in-memory なので遷移は SPA 内クリックで行う（`page.goto` のハード遷移はセッションを落とす）。**この spec 自体がその退行の番人**になる。

## CI 配線

`e2e` ジョブで full suite の**前**に `npm run e2e:smoke` を走らせる（fail-fast）。バンドルやログイン配線が壊れていれば数秒で落ち、24 spec の完走を待たない。

## 🔴 hub 手番が残ります（C6 の「required 緑」を満たすため）

playbook §2 の C6 受入は「**CI required 緑**」ですが、invoice の required contexts は実測で `["check", "frontend-check", "integration"]` ＝ **`e2e` ジョブは required に入っていません**。つまり現状、@smoke が落ちても merge はブロックされません。

選べる着地は2つで、**どちらも protection 変更＝hub 手番**です:

1. **`e2e` を required contexts に追加**（推奨）— 追加コストゼロ。ただし e2e ジョブ全体（3分前後）が merge の前提になる。
2. **`frontend-check` に @smoke ステップを足す**（chromium install ＋ 数秒）— required は据え置きで smoke だけを必須化できるが、required ジョブが 40〜60 秒伸びる。

参考: payout は `@smoke` を CI で走らせていません（`check` に e2e は含まれず、ワークフローに playwright ステップ無し・実測）。invoice は e2e ジョブが元からあるぶん、1 が素直だと考えています。裁定ください。

## Verification

- [x] `npm run e2e:smoke` → **1 passed（5.0s）**
- [x] `npm run e2e` → **76 passed**（移設前 75 ＋ smoke 1）
- [x] `npm run check` 緑
- [x] hermetic の実測: バックエンド（:8510）を上げずに緑。ログ上の proxy error は stub 済みルート外への呼び出しで、spec の判定には影響しない

## セルフレビュー

`docs/development/self-review.md`

Closes #733
