### PR TITLE
test(frontend): nene2-i18n の共有 parity を採用し ja 権威で CI ゲート化 (#737)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.0",
+        "@hideyukimori/nene2-i18n": "^0.2.0",
         "@hideyukimori/nene2-standards": "^2.1.0",
         "@playwright/test": "^1.60.0",
         "@storybook/addon-a11y": "^9.1.5",
@@ -1718,6 +1719,13 @@
         "node": ">=22 <25",
         "npm": ">=10 <12"
       }
+    },
+    "node_modules/@hideyukimori/nene2-i18n": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-i18n/-/nene2-i18n-0.2.0.tgz",
+      "integrity": "sha512-L7A/xRoXSObQtvaFDdVVT0blBsWakzG6K3aal4KFI75Je4YczyPI30CBw6KHRZN4AvQL0+MLUeUNkCo55jPHiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@hideyukimori/nene2-standards": {
       "version": "2.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.0",
+    "@hideyukimori/nene2-i18n": "^0.2.0",
     "@hideyukimori/nene2-standards": "^2.1.0",
     "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^9.1.5",
@@ -59,9 +60,9 @@
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "audit-ci": "^7.1.0",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.8",
+    "audit-ci": "^7.1.0",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/frontend/src/shared/i18n/locales.test.ts
+++ b/frontend/src/shared/i18n/locales.test.ts
@@ -1,5 +1,34 @@
+import { expectCatalogParity } from '@hideyukimori/nene2-i18n/testing'
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_LOCALE, LOCALES, resolveLocale } from './locales'
+import { catalogs, DEFAULT_LOCALE, LOCALES, resolveLocale } from './locales'
+
+// 規約 04 I18N-20: 全ロケール shape 一致ゲート（ja 権威）を共有実装で。
+//
+// 0.2.0 の expectCatalogParity は **vitest の test() を自己登録しない**（実測: dist/parity.js
+// は違反時に throw するだけのアサーション）。トップレベルで呼ぶと collection エラーとして
+// 落ちるので CI は止まるが、失敗が名前のあるテストに紐づかない。ここでは it() で包み、
+// 落ちたときに何のゲートが落ちたかがレポートに出るようにする。
+describe('catalog parity (nene2-i18n shared check)', () => {
+  it('keeps every locale in shape with the ja authority', () => {
+    expectCatalogParity(catalogs, {
+      authority: 'ja',
+      // 翻訳不能・同値が正のキーの列挙（数でなく列挙）。
+      identicalAllowlist: [
+        // ロケール自称名 — 言語切替 UI ではどのロケールでも自称で出す。
+        'common.locale.ja',
+        'common.locale.en',
+        // 拡張子とエンコーディングの表記そのもの。
+        'common.csvImport.dropSub',
+        // ShortcutsOverlay / CommandPalette は「ja 見出し＋en 副題」を同時に描画する
+        // ので、en カタログでも ja 見出しの値が正しい（messages/en.ts のコメント参照）。
+        'admin.shortcuts.title',
+        'admin.shortcuts.titleEn',
+        'admin.commandPalette.title',
+        'admin.commandPalette.titleEn',
+      ],
+    })
+  })
+})
 
 describe('resolveLocale', () => {
   it('defaults to ja for null or undefined input', () => {

--- a/frontend/src/shared/i18n/locales.ts
+++ b/frontend/src/shared/i18n/locales.ts
@@ -1,3 +1,4 @@
+import { enMessages } from './messages/en'
 import { jaMessages } from './messages/ja'
 import type { MessageCatalog } from './translate'
 
@@ -23,3 +24,12 @@ export function resolveLocale(input: string | null | undefined): SupportedLocale
 
 /** ja is the authoritative full catalog; en is loaded lazily by the provider. */
 export const jaCatalog: MessageCatalog = jaMessages
+
+/**
+ * Every catalog, keyed by locale — the input to the shared parity check
+ * (`@hideyukimori/nene2-i18n/testing`, see locales.test.ts). ja stays the
+ * authority; the check enforces that en carries the same key set, so the
+ * runtime ja fallback in `translate()` is a safety net rather than a licence
+ * for en to drift behind.
+ */
+export const catalogs: Record<string, MessageCatalog> = { ja: jaMessages, en: enMessages }

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -115,6 +115,11 @@ export const enMessages: MessageCatalog = {
   'admin.shortcuts.footHint': 'Press ? to reopen',
   'admin.shortcuts.footModMac': 'Modifier shown as ⌘ on macOS',
   'admin.shortcuts.footModOther': 'Modifier shown as Ctrl',
+  // Rendered together as a bilingual header (ja headline + en subtitle) in
+  // ShortcutsOverlay / CommandPalette, so the ja value is correct in the en
+  // catalog too. Listed in the parity identicalAllowlist for the same reason.
+  'admin.shortcuts.title': 'キーボードショートカット',
+  'admin.shortcuts.titleEn': 'Keyboard shortcuts',
   'admin.commandPalette.title': 'コマンドパレット',
   'admin.commandPalette.titleEn': 'Command palette',
   'admin.commandPalette.select': 'Select',


### PR DESCRIPTION
## Summary

完全クローズ **C4a**（i18n parity/catalog）。共有実装 `@hideyukimori/nene2-i18n/testing` の `expectCatalogParity` を採用し、**ja 権威の shape ゲート**を CI required（`frontend-check` → `coverage:check`）に載せる。

## 実測した現状（着手前）

- `@hideyukimori/nene2-i18n` に**未依存**。parity 検査そのものが無かった（`locales.test.ts` は `resolveLocale` と LOCALES メタのみ）。
- カタログ: **ja 839 / en 837** — en に欠落 **2件**（`admin.shortcuts.title` / `admin.shortcuts.titleEn`）・余剰 0・同値 5件。

## 変更

- `@hideyukimori/nene2-i18n` **^0.2.0 を devDependency** に（`/testing` はテスト専用・payout 前例）
- `locales.ts` に `catalogs`（`{ ja, en }`）を export
- `locales.test.ts` に parity ゲート。`identicalAllowlist` は**理由つきで列挙**（数でなく列挙）
- en の欠落 2件を追加

`ShortcutsOverlay.tsx` / `CommandPalette.tsx` は **「ja 見出し＋en 副題」を同時に描画する**ウィジェット（実測）。したがって en カタログでも ja 見出しの値が正しく、既存の `commandPalette` の扱いに揃えた。同値であることは allowlist 側にも理由を書いた。

`translate()` の ja フォールバックは安全網として残るが、**en が黙って遅れることは parity が許さなくなる**（ADR 0005 の「en は補助」は維持しつつ、欠落は CI で止まる）。

## 実装メモ（payout のコメントと実装が食い違っている）

0.2.0 の `expectCatalogParity` は **vitest の `test()` を自己登録しません**（`dist/parity.js` は違反時に `throw` するだけのアサーション・実測）。payout の in-repo コメントには「内部で self-登録するのでトップレベルで呼ぶ」とあるが、そのまま書くと**失敗が名前のあるテストに紐づかず collection エラーになる**（CI は止まるので実害は小さいが、レポートで何が落ちたか分からない）。この PR では `it()` で包み、失敗時に

```
FAIL src/shared/i18n/locales.test.ts > catalog parity (nene2-i18n shared check) > keeps every locale in shape with the ja authority
```

と出るようにした。fleet へ共有済み。

## Verification

- [x] **負テスト**: en から1キー抜くと `catalog parity FAIL: [ja×en] shape 不一致: 欠落 1 / 余剰 0` で **named test が落ちる**（実測・2キーで各1回）
- [x] `npm run check` 緑・**345 passed**（344 → +1）・coverage ratchet OK（`no metric below its floor`）
- [x] parity は `coverage:check`（vitest）で実走＝**required check に載っている**

## スコープ外（意図的）

C4a 定義にある「ハードコード検出 lint」は共有 eslint（`nene2.i18n`）由来＝**C3（eslint 合成形化）の射程**。次の PR で扱う。

## セルフレビュー

`docs/development/self-review.md`

Closes #737
