### PR TITLE
chore(frontend): eslint を standards 完全合成形へ切替（判例26 台帳つき） (#739)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,11 +6,13 @@
 // config file: without a config here, moving the specs out of frontend/ would
 // have silently dropped 24 spec files from the lint gate.
 //
-// It re-exports only the `e2eConfig` array, not the whole frontend config — the
-// typed `tests/**` block there would otherwise match `tests/e2e/**` from this
-// base path and fail parsing (the specs are not in tsconfig.app.json).
+// It re-exports the `e2eConfig` array from its own module — importing the app's
+// eslint.config.js here would (a) let the typed app blocks match `tests/e2e/**`
+// from this base path and fail parsing, and (b) evaluate the shared styling
+// fragment, which resolves the Tailwind entry against the cwd and throws from
+// the repo root.
 //
 // Used by `npm run lint --prefix frontend`, which runs eslint twice:
 //   eslint .                         (app sources; config = frontend/eslint.config.js)
-//   eslint tests/e2e  from the root  (the specs; config = this file)
-export { e2eConfig as default } from './frontend/eslint.config.js'
+//   eslint tests/e2e  from the root  (the specs; config = this file → frontend/eslint.e2e.config.js)
+export { e2eConfig as default } from './frontend/eslint.e2e.config.js'

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,62 +1,147 @@
-import js from '@eslint/js'
+import nene2 from '@hideyukimori/nene2-standards'
 import eslintConfigPrettier from 'eslint-config-prettier'
-import importPlugin from 'eslint-plugin-import'
-import jsxA11y from 'eslint-plugin-jsx-a11y'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import storybook from 'eslint-plugin-storybook'
 import globals from 'globals'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { e2eConfig } from './eslint.e2e.config.js'
 import tseslint from 'typescript-eslint'
 
-const dirname = path.dirname(fileURLToPath(import.meta.url))
+// ---------------------------------------------------------------------------
+// 判例26 台帳 — 合成形の導入時点で既に違反しているファイルの列挙。
+//
+// 「既存は列挙して off・新規は full 強制」。列挙に無いファイルは初日から落ちる。
+// ここに足すのは移行のためだけで、**drain 計画つきでしか増やさない**（#739）。
+//   testing-library → C3-2 で drain
+//   no-restricted-syntax（i18n ハードコード）→ C3-3 で drain
+//   no-restricted-imports（@/shared/ui 集約バレル）→ C3-4（構造是正・判例23）
+// ---------------------------------------------------------------------------
 
-// Entity internals are private to the slice — only entities/{r}/index.ts is public.
-const entityInternalFiles = [
-  './src/entities/*/api-types.ts',
-  './src/entities/*/mapper.ts',
-  './src/entities/*/queries.ts',
-  './src/entities/*/mutations.ts',
-  './src/entities/*/query-keys.ts',
-  './src/entities/*/ids.ts',
-  './src/entities/*/model.ts',
-  './src/entities/*/enum.ts',
-  './src/entities/*/session.ts',
+/** testing-library 系の既存違反（18 ファイル・218 件）— C3-2 で drain。 */
+const testingLibraryLedger = [
+  'src/features/create-recurring-invoice/ui/CreateRecurringInvoiceForm.test.tsx',
+  'src/features/list-audit-logs/model/use-list-audit-logs.test.ts',
+  'src/features/list-clients/model/use-list-clients.test.ts',
+  'src/features/list-invoices/model/use-list-invoices.test.ts',
+  'src/features/list-items/model/use-list-items.test.ts',
+  'src/features/list-quotes/model/use-list-quotes.test.ts',
+  'src/features/sign-in/ui/SignInForm.test.tsx',
+  'src/features/view-invoice/model/use-generate-download-link.test.ts',
+  'src/features/view-invoice/ui/ViewInvoice.test.tsx',
+  'src/shared/keyboard/KeyboardShortcuts.test.tsx',
+  'src/shared/keyboard/use-line-grid-enter.test.tsx',
+  'src/shared/ui/components/ActionError.test.tsx',
+  'src/shared/ui/components/ClientCombobox.test.tsx',
+  'src/shared/ui/components/DatePicker.test.tsx',
+  'src/shared/ui/components/InlineAlert.test.tsx',
+  'src/shared/ui/components/LineItemSuggestInput.test.tsx',
+  'src/shared/ui/toast/toast.test.tsx',
+  'tests/setup/vitest.setup.ts',
 ]
 
-const importZones = [
-  { target: './src/features', from: entityInternalFiles },
-  { target: './src/features', from: './src/shared/api' },
-  { target: './src/pages', from: entityInternalFiles },
-  { target: './src/pages', from: './src/shared/api' },
-  { target: './src/shared/ui', from: './src/entities' },
-  { target: './src/shared/ui', from: './src/features' },
-  { target: './src/shared/ui', from: './src/shared/api' },
+/** i18n ハードコード等 no-restricted-syntax の既存違反（7 ファイル・188 件）— C3-3 で drain。 */
+const restrictedSyntaxLedger = [
+  'src/features/view-dashboard/ui/ViewDashboard.tsx',
+  'src/features/view-invoice/ui/ViewInvoice.tsx',
+  'src/pages/help/help-content.ts',
+  'src/shared/keyboard/shortcuts-data.ts',
+  'src/shared/lib/format-date.ts',
+  'src/shared/lib/format-money.ts',
+  'src/shared/ui/components/DatePicker.tsx',
 ]
 
-// Browser E2E specs run under the Playwright (node) runner, not the typed app
-// project, so they use the untyped recommended rules.
-//
-// The specs live at the repo root (`tests/e2e/`, 判例4) and ESLint cannot lint
-// files above its own config file. `npm run lint` therefore runs eslint twice:
-// once here in frontend/ for the app, and once from the repo root, where
-// ../eslint.config.js re-exports THIS array alone. Exporting it separately
-// matters — re-exporting the whole config would let the typed `tests/**` block
-// below match `tests/e2e/**` from the root and fail with "file was not found in
-// any of the provided project(s)".
-//
-// Both patterns are kept in one block on purpose: each run matches only what
-// exists under its own base path (specs from the root, playwright.config.ts
-// from frontend/).
-export const e2eConfig = tseslint.config({
-  files: ['tests/e2e/**/*.ts', 'playwright.config.ts'],
-  extends: [js.configs.recommended, ...tseslint.configs.recommended],
-  languageOptions: {
-    ecmaVersion: 2023,
-    globals: { ...globals.node },
-  },
-})
+/** `@/shared/ui` 集約バレル import の既存違反（60 ファイル・各1件）— C3-4 の構造是正で消える。 */
+const sharedUiBarrelLedger = [
+  'src/app/auth-gate.tsx',
+  'src/app/home-redirect.tsx',
+  'src/app/providers.tsx',
+  'src/app/require-role.tsx',
+  'src/app/root-error-boundary.tsx',
+  'src/entities/bank-transaction/status-tone.ts',
+  'src/entities/invoice/status-tone.ts',
+  'src/entities/quote/status-tone.ts',
+  'src/features/create-client/ui/CreateClientForm.tsx',
+  'src/features/create-invoice/model/use-create-invoice.ts',
+  'src/features/create-invoice/ui/CreateInvoiceForm.tsx',
+  'src/features/create-item/ui/CreateItemForm.tsx',
+  'src/features/create-organization/ui/CreateOrganizationForm.tsx',
+  'src/features/create-quote/model/use-create-quote.ts',
+  'src/features/create-quote/ui/CreateQuoteForm.tsx',
+  'src/features/create-recurring-invoice/model/use-create-recurring-invoice.ts',
+  'src/features/create-recurring-invoice/ui/CreateRecurringInvoiceForm.tsx',
+  'src/features/create-user/ui/CreateUserForm.tsx',
+  'src/features/edit-client/ui/EditClient.tsx',
+  'src/features/edit-company-settings/ui/EditCompanySettings.tsx',
+  'src/features/edit-item/ui/EditItem.tsx',
+  'src/features/edit-recurring-invoice/model/use-edit-recurring-invoice.ts',
+  'src/features/edit-recurring-invoice/ui/EditRecurringInvoice.tsx',
+  'src/features/edit-user/ui/EditUser.tsx',
+  'src/features/gateway-settings/ui/GatewaySettings.tsx',
+  'src/features/import-clients/ui/ImportClients.tsx',
+  'src/features/import-items/ui/ImportItems.tsx',
+  'src/features/issue-invoice/model/use-issue-invoice.ts',
+  'src/features/issue-invoice/ui/IssueInvoice.tsx',
+  'src/features/list-audit-logs/ui/ListAuditLogs.tsx',
+  'src/features/list-clients/ui/ListClients.tsx',
+  'src/features/list-invoices/ui/ListInvoices.tsx',
+  'src/features/list-items/ui/ListItems.tsx',
+  'src/features/list-organizations/ui/ListOrganizations.tsx',
+  'src/features/list-quotes/ui/ListQuotes.tsx',
+  'src/features/list-recurring-invoices/ui/ListRecurringInvoices.tsx',
+  'src/features/list-templates/ui/ListTemplates.tsx',
+  'src/features/list-users/ui/ListUsers.tsx',
+  'src/features/manage-company-seal/ui/ManageCompanySeal.tsx',
+  'src/features/manage-payments/model/use-manage-payments.ts',
+  'src/features/manage-payments/ui/ManagePayments.tsx',
+  'src/features/manage-service-tokens/ui/ManageServiceTokens.tsx',
+  'src/features/reconcile-bank/ui/BankImportPanel.tsx',
+  'src/features/reconcile-bank/ui/BankWorkbench.tsx',
+  'src/features/reconcile-bank/ui/ReconcileBank.tsx',
+  'src/features/sign-in/ui/SignInForm.tsx',
+  'src/features/template-bar/model/use-template-bar.ts',
+  'src/features/template-bar/ui/TemplateBar.tsx',
+  'src/features/template-form/ui/TemplateForm.tsx',
+  'src/features/view-dashboard/ui/ViewDashboard.tsx',
+  'src/features/view-invoice/ui/EmailPreviewModal.tsx',
+  'src/features/view-invoice/ui/ViewInvoice.tsx',
+  'src/features/view-quote/ui/ViewQuote.tsx',
+  'src/pages/company-settings/CompanySettingsPage.tsx',
+  'src/pages/invoice-detail/InvoiceDetailPage.tsx',
+  'src/shared/ui/components/CsvImportPanel.tsx',
+  'src/shared/ui/components/DatePicker.tsx',
+  'src/shared/ui/components/FilterBar.tsx',
+  'src/shared/ui/components/LineItemsTable.tsx',
+  'src/shared/ui/toast/ToastProvider.tsx',
+]
+
+/** style prop のキー制約の既存違反（5 ファイル・10 件）— C3-2 系の小粒 drain 対象。 */
+const stylePropLedger = [
+  'src/features/edit-company-settings/ui/EditCompanySettings.tsx',
+  'src/features/manage-company-seal/ui/ManageCompanySeal.tsx',
+  'src/features/view-dashboard/ui/ViewDashboard.tsx',
+  'src/features/view-invoice/ui/ViewInvoice.tsx',
+  'src/features/view-quote/ui/ViewQuote.tsx',
+]
+
+/** 未知クラス（z-modal / field-inline 等）の既存違反（7 ファイル・8 件）— W3 の独自クラス drain と同じ根。 */
+const unknownClassLedger = [
+  'src/features/reconcile-bank/ui/BankWorkbench.tsx',
+  'src/features/template-bar/ui/TemplateBar.tsx',
+  'src/features/view-dashboard/ui/ViewDashboard.tsx',
+  'src/features/view-invoice/ui/EmailPreviewModal.tsx',
+  'src/pages/layout/AppShell.tsx',
+  'src/shared/ui/components/ConfirmDialog.tsx',
+  'src/shared/ui/components/FilterBar.tsx',
+]
+
+/** jsx-a11y の既存違反（5 ファイル・7 件）— C3-2 系の小粒 drain 対象。 */
+const a11yLedger = [
+  'src/features/reconcile-bank/ui/BankImportPanel.tsx',
+  'src/shared/keyboard/CommandPalette.tsx',
+  'src/shared/ui/components/ClientCombobox.tsx',
+  'src/shared/ui/components/CsvImportPanel.tsx',
+  'src/shared/ui/components/LineItemSuggestInput.tsx',
+]
 
 export default tseslint.config(
   {
@@ -65,67 +150,87 @@ export default tseslint.config(
       'storybook-static',
       'node_modules',
       'coverage',
+      '.vite',
       'src/shared/api/schema.gen.ts',
       'public/mockServiceWorker.js',
+      // Build/config files live outside tsconfig; base enables the typed
+      // projectService, which errors on files it cannot place in a project.
+      '*.config.{ts,js,mjs}',
+      'tools/**',
+      '.storybook/**',
+      '**/*.mjs',
     ],
   },
+  // base enables the typed projectService (auto-discovers tsconfig), so we only
+  // supply browser globals here — no explicit parserOptions.project.
   {
-    extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
     files: ['src/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2023,
       globals: globals.browser,
-      parserOptions: {
-        project: ['./tsconfig.app.json'],
-        tsconfigRootDir: dirname,
-      },
     },
-    plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-      'jsx-a11y': jsxA11y,
-      import: importPlugin,
-    },
-    settings: {
-      'import/resolver': {
-        typescript: { project: './tsconfig.app.json' },
-      },
-    },
+  },
+  // 共有合成形（README canonical order・部分採用は C3 未達）。FSD 境界・transport
+  // 禁止・a11y・i18n ハードコード検出・testing-library 規律はここから来る。
+  ...nene2.base,
+  ...nene2.fsd,
+  ...nene2.api,
+  ...nene2.stylingWith(),
+  ...nene2.i18n,
+  ...nene2.testing,
+  // React hygiene はフリート形に含まれないのでリポ固有の追加として残す。
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks, 'react-refresh': reactRefresh },
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
-      ...jsxA11y.configs.recommended.rules,
-      // Numbers in template literals are safe (and React Hook Form's typed field
-      // paths require a numeric index, e.g. `line_items.${index}.description`).
-      '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
-      'import/no-restricted-paths': ['error', { zones: importZones }],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'JSXAttribute[name.name="className"] Literal[value=/\\[.*\\]/]',
-          message: 'Tailwind arbitrary values are forbidden outside shared/ui/theme.',
-        },
-      ],
     },
   },
+  // 公認差異（override 実行可能登録）: React Hook Form の typed field path が
+  // 数値インデックスを要求する（`line_items.${index}.description`）。payout も
+  // 同じ登録を持つ。severity は緩めない。
   {
-    // Tests and test helpers may inspect internals across layer boundaries.
-    files: ['**/*.test.ts', '**/*.test.tsx', 'tests/**/*.{ts,tsx}'],
+    files: ['src/**/*.{ts,tsx}'],
     rules: {
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      'import/no-restricted-paths': 'off',
-      'react-refresh/only-export-components': 'off',
+      '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+    },
+  },
+  // --- 判例26 台帳の適用（既存のみ off・新規は full 強制） ---
+  {
+    files: testingLibraryLedger,
+    rules: {
+      'testing-library/no-container': 'off',
+      'testing-library/no-manual-cleanup': 'off',
+      'testing-library/no-node-access': 'off',
+      'testing-library/no-wait-for-multiple-assertions': 'off',
+      'testing-library/prefer-presence-queries': 'off',
+      'testing-library/prefer-screen-queries': 'off',
+      'testing-library/render-result-naming-convention': 'off',
     },
   },
   {
-    files: ['.storybook/**/*.{ts,tsx}', 'vite.config.ts', 'vitest.config.ts'],
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    languageOptions: {
-      ecmaVersion: 2023,
-      globals: { ...globals.browser, ...globals.node },
+    files: restrictedSyntaxLedger,
+    rules: { 'no-restricted-syntax': 'off' },
+  },
+  {
+    files: sharedUiBarrelLedger,
+    rules: { 'no-restricted-imports': 'off' },
+  },
+  {
+    files: stylePropLedger,
+    rules: { 'nene2/style-prop-css-vars-only': 'off' },
+  },
+  {
+    files: unknownClassLedger,
+    rules: { 'better-tailwindcss/no-unknown-classes': 'off' },
+  },
+  {
+    files: a11yLedger,
+    rules: {
+      'jsx-a11y/no-noninteractive-element-interactions': 'off',
+      'jsx-a11y/no-noninteractive-element-to-interactive-role': 'off',
+      'jsx-a11y/no-static-element-interactions': 'off',
     },
   },
   ...e2eConfig,

--- a/frontend/eslint.e2e.config.js
+++ b/frontend/eslint.e2e.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+
+// Browser E2E specs run under the Playwright (node) runner, not the typed app
+// project, so they use the untyped recommended rules.
+//
+// The specs live at the repo root (`tests/e2e/`, 判例4) and ESLint cannot lint
+// files above its own config file. `npm run lint` therefore runs eslint twice:
+// once here in frontend/ for the app, and once from the repo root, where
+// ../eslint.config.js re-exports THIS array alone. Exporting it separately
+// matters — re-exporting the whole config would let the typed app blocks match
+// `tests/e2e/**` from the root and fail with "file was not found in any of the
+// provided project(s)".
+export const e2eConfig = tseslint.config({
+  files: ['tests/e2e/**/*.ts', 'playwright.config.ts'],
+  extends: [js.configs.recommended, ...tseslint.configs.recommended],
+  languageOptions: {
+    ecmaVersion: 2023,
+    globals: { ...globals.node },
+  },
+})

--- a/frontend/knip.jsonc
+++ b/frontend/knip.jsonc
@@ -4,7 +4,10 @@
   // Playwright spec（判例4 の置き場）。config は frontend/ に残るので、knip からは
   // 相対で上を見る。
   "project": ["src/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "../tests/e2e/**/*.ts"],
-  "entry": ["../tests/e2e/**/*.spec.ts"],
+  // eslint.e2e.config.js は eslint.config.js とリポ直下 eslint.config.js の
+  // 両方から読まれる実設定（knip は既定で eslint.config.js しか config として
+  // 認識しないので明示する）。
+  "entry": ["../tests/e2e/**/*.spec.ts", "eslint.e2e.config.js"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "ignoreIssues": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,8 +40,6 @@
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "eslint-plugin-storybook": "^9.1.5",
@@ -2923,7 +2921,9 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3569,7 +3569,9 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "24.12.4",
@@ -4670,6 +4672,8 @@
       "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -5688,6 +5692,8 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -6133,6 +6139,8 @@
       "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.16.1",
@@ -6145,6 +6153,8 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -6155,6 +6165,8 @@
       "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "is-core-module": "^2.16.2",
@@ -6214,6 +6226,8 @@
       "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -6232,6 +6246,8 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -6275,6 +6291,8 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6375,6 +6393,8 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -6385,6 +6405,8 @@
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -6398,6 +6420,8 @@
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -9267,6 +9291,8 @@
       "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "array.prototype.flatmap": "^1.3.3",
         "es-errors": "^1.3.0",
@@ -9350,6 +9376,8 @@
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -9385,6 +9413,8 @@
       "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,8 +66,6 @@
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "eslint-plugin-storybook": "^9.1.5",


### PR DESCRIPTION
## Summary

完全クローズ **C3** の第1段（epic #739 の C3-1）。手書きだった `frontend/eslint.config.js`（standards を**一切 import していなかった**）を **完全合成形**へ置換する。

```js
...nene2.base, ...nene2.fsd, ...nene2.api, ...nene2.stylingWith(), ...nene2.i18n, ...nene2.testing
```

**コードは無改変**。既存違反は判例26（existing files 列挙 off・新規 full 強制）の台帳に載せるだけで、drain は後続 PR に分ける。

## 実測 548 件の行き先

| 系統 | 件数 / ファイル | 行き先 |
| --- | ---: | --- |
| `testing-library/*` | 218 / 18 | 台帳 → **C3-2** で drain |
| `no-restricted-syntax`（i18n ハードコード） | 188 / 7 | 台帳 → **C3-3** で drain（150 は `help-content.ts` に集中） |
| `no-restricted-imports`（`@/shared/ui` 集約バレル） | 60 / 60 | 台帳 → **C3-4** の構造是正（判例23）で消す |
| `@typescript-eslint/restrict-template-expressions` | 52 / 5 | **公認差異の override 登録**（RHF typed field path の数値インデックス・payout と同型・severity は緩めない） |
| `nene2/style-prop-css-vars-only` / `better-tailwindcss/no-unknown-classes` / `jsx-a11y/*` | 10 / 8 / 7 | 台帳（小粒 drain 対象） |
| `react-hooks/exhaustive-deps` | 1 | **台帳に載せない** — 既存の inline disable で足り、台帳に載せると disable 側が `Unused eslint-disable directive` になる（実測） |

台帳は「drain 計画つきでしか増やさない」注記つきで config に書いてあります。

## 付随して必要になったこと（すべて実測ドリブン）

- **e2e 用ブロックを `frontend/eslint.e2e.config.js` へ切り出し**。リポ直下 config から `frontend/eslint.config.js` を読むと、`nene2.stylingWith()` が **cwd 基準で Tailwind entry を解決してリポ直下から throw** する（`Tailwind entry point not found: <repo>/src/shared/ui/theme/index.css`）。共有するのは e2e ブロックだけにして回避。
- **knip に `eslint.e2e.config.js` を entry 登録**（既定では `eslint.config.js` しか config と認識しない）。
- **`eslint-plugin-jsx-a11y` / `eslint-plugin-import` を devDependencies から削除** — 合成形が同梱するようになったため（knip の `Unused devDependencies` 実測に従う）。
- **ignores に `.vite` を追加** — vite の依存キャッシュが parse error 4件を出していた。

## Verification

- [x] **負テスト（台帳の鋭さ）**: 台帳に無い**新規**ファイルは初日から落ちる
  - `@/shared/ui` バレル import → `no-restricted-imports` ＋ `no-restricted-syntax` が発火
  - `container.querySelector` を使うテスト → `testing-library/no-container` ＋ `no-node-access` が発火
- [x] `npm run check` 緑（lint 2本・**345 passed**・coverage ratchet OK・`init --check` 未分類0/lint-baseline 回帰0・knip 0）
- [x] `npm run audit` 緑（allowlist 2件のまま非回帰）

## 残り（epic #739）

- **C3-2** testing-library drain（18 ファイル）
- **C3-3** i18n ハードコード drain（7 ファイル・`help-content.ts` が本丸。受け皿は C4a で入れた parity ゲート）
- **C3-4** `@/shared/ui` 集約バレル解体（60 ファイル・構造是正）— 横断 board に「W3 解体と同時是正候補」として載っているため、**単独先行か W3 波と束ねるかは hub 裁定**

## セルフレビュー

`docs/development/self-review.md`

Refs #739
