### PR TITLE
chore(ci): frontend check に本番 build を追加し検査対象の穴を塞ぐ (#741)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check (type-check, lint, format, test, knip, build-storybook)
+      # `build` is in the chain because `build-storybook` does not stand in for it:
+      # .storybook/main.ts only bundles src/shared/ui/**/*.stories.*, so main.tsx and
+      # everything reachable only from it (app/, entities/, features/, pages/) is never
+      # bundled by any other gate. tsc checks those files' types but not module
+      # resolution. See docs/development/frontend-standards.md.
+      - name: Check (type-check, lint, format, test, knip, build, build-storybook)
         run: npm run check
 
       # audit-ci = npm audit + a per-advisory allowlist, so a not-yet-fixable advisory can be

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -505,11 +505,19 @@ observable outcome). New `use-{feature}` hooks without a colocated `*.test.ts(x)
 npm ci --prefix frontend
 npm run dev --prefix frontend          # Vite dev server; API proxied to the PHP app
 npm run codegen --prefix frontend      # regenerate shared/api/schema.gen.ts from OpenAPI
-npm run check --prefix frontend        # type-check + lint + format + test + knip + build-storybook
+npm run check --prefix frontend        # type-check + lint + format + test + knip + build + build-storybook
 npm run build --prefix frontend        # production build → public_html/admin/
 ```
 
-CI on frontend changes: `npm ci` → `npm run check` → `npm audit --audit-level=high`.
+CI on frontend changes: `npm ci` → `npm run check` → `npm run audit` (audit-ci; see
+`dependency-audit.md`).
+
+`check` runs the production `build`, and `build-storybook` does not substitute for it:
+`.storybook/main.ts` bundles only `src/shared/ui/**/*.stories.*`, so `main.tsx` and
+everything reachable only from it — `app/`, `entities/`, `features/`, `pages/` — is bundled
+by no other gate. `tsc -b` type-checks those files but does not resolve modules, so a
+missing asset or package import there type-checks and lints clean while the production
+build fails.
 
 ESLint encodes the boundaries:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "gen:icons": "node scripts/gen-icons.mjs",
     "knip": "knip",
     "audit": "audit-ci --config audit-ci.jsonc",
-    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run check:registries && npm run format && npm run coverage:check && npm run knip && npm run build-storybook",
+    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run lint:styles && npm run check:registries && npm run format && npm run coverage:check && npm run knip && npm run build && npm run build-storybook",
     "lint:styles": "stylelint 'src/**/*.css'",
     "check:registries": "nene2-check init --check --repo nene-invoice"
   },


### PR DESCRIPTION
Closes #741

## 何が問題だったか

`npm run check`（required job `frontend-check` の本体）は `build-storybook` で終わっており、**本番 `build` を一度も走らせていなかった**。横断 board #104（deal #178/#180 由来「壊れた対象を検査しないゲートが緑」）の invoice 分。

deal は legacy CSS が本番 build を壊していたが、**invoice の穴は CSS ではなく別の場所**だった。`.storybook/main.ts` は

```ts
stories: ['../src/shared/ui/**/*.stories.@(ts|tsx)']
```

しかバンドルしない（stories 10本）。したがって `main.tsx` と、そこからしか到達しない `app/` `entities/` `features/` `pages/`（**`.tsx` 92本**）は、**どのゲートからもバンドルされていない**。`tsc -b` はそれらの型を検査するが**モジュール解決はしない**ので、存在しないアセット／パッケージの import は型検査も lint も素通りする。

## 実測（負テスト）

`src/fonts.ts`（`main.tsx` からのみ import・stories からは到達しない）へ、存在しない fontsource weight を1行注入した状態での測定:

```ts
import '@fontsource/noto-sans-jp/399.css'   // 実在しない
```

| コマンド | rc | 判定 |
| --- | --- | --- |
| `npm run type-check` | 0 | 盲目 |
| `npm run lint` | 0 | 盲目 |
| `npm run build-storybook` | 0 | 盲目 |
| **`npm run check`（現行）** | **0** | 🔴 **本番ビルドが壊れているのに required が緑** |
| `npm run build` | 1 | 検出（`Rollup failed to resolve import`） |
| **`npm run check`（本PR後）** | **1** | ✅ ゲートが見ている |

フォント weight のタイポや fontsource パッケージの削除は実際に起こりうる変更で、**本番 SPA が起動しないビルドがそのまま merge できる**状態だった。

## CSS 面は穴ではなかった（実測して除外）

deal と同型の CSS 破壊（`Invalid empty selector`）も測ったが、invoice では成立しない:

- invoice の `vite.config.ts` は `cssMinify: 'lightningcss'` を設定していないため、同じ壊れた CSS でも `vite build` は**警告止まりで rc=0**（deal が落ちたのは lightningcss 経路）。
- 一方 `lint:styles`（nene2 stylelint）が `@layer` 外・`@layer` 内の両方で確実に捕まえる（rc=2 を2パターン実測）。

したがって invoice の CSS は build ではなく stylelint が守っており、**本PRが塞ぐのはバンドル経路の穴のみ**。deal の PR 文面をそのまま写していたら、この違いを見落として「CSS を守った」と誤記するところだった。

## 変更

- `frontend/package.json` — `check` の `knip` と `build-storybook` の間に `npm run build` を追加（deal #180 と同位置）。
- `.github/workflows/frontend-ci.yml` — ステップ名に `build` を追加（**CI ログが実際に走るものと食い違わないように**）＋ なぜ build-storybook が代替にならないかの根拠コメント。
- `docs/development/frontend-standards.md` — `check` の内訳を更新し、上記の理由を明文化。
  - ついでに同じ段落の `npm audit --audit-level=high` を `npm run audit`（audit-ci）へ是正（#732 で入れ替え済みなのに doc が旧のままだった）。

## コスト

ローカル実測で `check` フルチェーン **1分33秒**。`build` の増分は **約12秒**（`tsc -b` は `type-check` で済んでおり増分は実質 `vite build` のみ）。ビルド成果物は `public_html/admin/` へ出るが `.gitignore` 済みでワークツリーは汚れない。

## セルフレビュー

`docs/development/self-review.md`