### PR TITLE
test(frontend): testing-library 台帳を drain し 218 件を解消（C3-2） (#739)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,32 +12,9 @@ import tseslint from 'typescript-eslint'
 //
 // 「既存は列挙して off・新規は full 強制」。列挙に無いファイルは初日から落ちる。
 // ここに足すのは移行のためだけで、**drain 計画つきでしか増やさない**（#739）。
-//   testing-library → C3-2 で drain
 //   no-restricted-syntax（i18n ハードコード）→ C3-3 で drain
 //   no-restricted-imports（@/shared/ui 集約バレル）→ C3-4（構造是正・判例23）
 // ---------------------------------------------------------------------------
-
-/** testing-library 系の既存違反（18 ファイル・218 件）— C3-2 で drain。 */
-const testingLibraryLedger = [
-  'src/features/create-recurring-invoice/ui/CreateRecurringInvoiceForm.test.tsx',
-  'src/features/list-audit-logs/model/use-list-audit-logs.test.ts',
-  'src/features/list-clients/model/use-list-clients.test.ts',
-  'src/features/list-invoices/model/use-list-invoices.test.ts',
-  'src/features/list-items/model/use-list-items.test.ts',
-  'src/features/list-quotes/model/use-list-quotes.test.ts',
-  'src/features/sign-in/ui/SignInForm.test.tsx',
-  'src/features/view-invoice/model/use-generate-download-link.test.ts',
-  'src/features/view-invoice/ui/ViewInvoice.test.tsx',
-  'src/shared/keyboard/KeyboardShortcuts.test.tsx',
-  'src/shared/keyboard/use-line-grid-enter.test.tsx',
-  'src/shared/ui/components/ActionError.test.tsx',
-  'src/shared/ui/components/ClientCombobox.test.tsx',
-  'src/shared/ui/components/DatePicker.test.tsx',
-  'src/shared/ui/components/InlineAlert.test.tsx',
-  'src/shared/ui/components/LineItemSuggestInput.test.tsx',
-  'src/shared/ui/toast/toast.test.tsx',
-  'tests/setup/vitest.setup.ts',
-]
 
 /** i18n ハードコード等 no-restricted-syntax の既存違反（7 ファイル・188 件）— C3-3 で drain。 */
 const restrictedSyntaxLedger = [
@@ -198,20 +175,17 @@ export default tseslint.config(
   },
   // --- 判例26 台帳の適用（既存のみ off・新規は full 強制） ---
   {
-    files: testingLibraryLedger,
-    rules: {
-      'testing-library/no-container': 'off',
-      'testing-library/no-manual-cleanup': 'off',
-      'testing-library/no-node-access': 'off',
-      'testing-library/no-wait-for-multiple-assertions': 'off',
-      'testing-library/prefer-presence-queries': 'off',
-      'testing-library/prefer-screen-queries': 'off',
-      'testing-library/render-result-naming-convention': 'off',
-    },
-  },
-  {
     files: restrictedSyntaxLedger,
     rules: { 'no-restricted-syntax': 'off' },
+  },
+  // 公認差異（台帳ではない・drain 対象外）: vitest.config.ts が `globals: false` なので
+  // React Testing Library は自前の auto-cleanup を登録できない（登録条件がグローバル
+  // afterEach の存在）。よって setup での手動 cleanup() は必須で、外すと DOM が
+  // テスト間に漏れる（実測: 11 ファイル / 42 テストが失敗）。将来 `globals: true` へ
+  // 倒すなら、この登録ごと不要になる。
+  {
+    files: ['tests/setup/**'],
+    rules: { 'testing-library/no-manual-cleanup': 'off' },
   },
   {
     files: sharedUiBarrelLedger,

--- a/frontend/src/features/create-recurring-invoice/ui/CreateRecurringInvoiceForm.test.tsx
+++ b/frontend/src/features/create-recurring-invoice/ui/CreateRecurringInvoiceForm.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
@@ -7,10 +7,10 @@ import { CreateRecurringInvoiceForm } from './CreateRecurringInvoiceForm'
 // jsdom navigator.language defaults to en-US, so the form renders the en catalog.
 describe('CreateRecurringInvoiceForm', () => {
   it('renders the schedule header with the frequency options', () => {
-    const { getByRole, getByLabelText } = renderWithProviders(<CreateRecurringInvoiceForm />)
+    renderWithProviders(<CreateRecurringInvoiceForm />)
 
-    expect(getByRole('heading', { name: 'New recurring invoice' })).toBeTruthy()
-    const frequency = getByLabelText('Frequency')
+    expect(screen.getByRole('heading', { name: 'New recurring invoice' })).toBeTruthy()
+    const frequency = screen.getByLabelText('Frequency')
     expect(frequency).toBeTruthy()
     expect(frequency.textContent).toContain('Monthly')
     expect(frequency.textContent).toContain('Quarterly')
@@ -18,23 +18,23 @@ describe('CreateRecurringInvoiceForm', () => {
 
   it('shows a validation error when required fields are empty', async () => {
     const user = userEvent.setup()
-    const { getByRole, findByText } = renderWithProviders(<CreateRecurringInvoiceForm />)
+    renderWithProviders(<CreateRecurringInvoiceForm />)
 
-    await user.click(getByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Create' }))
 
-    expect(await findByText('Please enter a name.')).toBeTruthy()
+    expect(await screen.findByText('Please enter a name.')).toBeTruthy()
   })
 
   it('lets the operator add and remove line rows', async () => {
     const user = userEvent.setup()
-    const { getAllByLabelText, getByRole } = renderWithProviders(<CreateRecurringInvoiceForm />)
+    renderWithProviders(<CreateRecurringInvoiceForm />)
 
-    expect(getAllByLabelText('Qty')).toHaveLength(1)
+    expect(screen.getAllByLabelText('Qty')).toHaveLength(1)
 
-    await user.click(getByRole('button', { name: /Add line/ }))
+    await user.click(screen.getByRole('button', { name: /Add line/ }))
 
     await waitFor(() => {
-      expect(getAllByLabelText('Qty')).toHaveLength(2)
+      expect(screen.getAllByLabelText('Qty')).toHaveLength(2)
     })
   })
 })

--- a/frontend/src/features/list-audit-logs/model/use-list-audit-logs.test.ts
+++ b/frontend/src/features/list-audit-logs/model/use-list-audit-logs.test.ts
@@ -89,13 +89,14 @@ describe('useListAuditLogs', () => {
     })
 
     await waitFor(() => {
-      const last = seen.at(-1) ?? ''
-      expect(last).toContain('entity_type=invoice')
-      expect(last).toContain('action=invoice.issued')
-      expect(last).toContain('actor_user_id=7')
-      expect(last).toContain('created_from=2026-05-01')
-      expect(last).toContain('created_to=2026-05-31')
-      expect(last).toContain('offset=0')
+      expect(seen.at(-1) ?? '').toContain('entity_type=invoice')
     })
+
+    const last = seen.at(-1) ?? ''
+    expect(last).toContain('action=invoice.issued')
+    expect(last).toContain('actor_user_id=7')
+    expect(last).toContain('created_from=2026-05-01')
+    expect(last).toContain('created_to=2026-05-31')
+    expect(last).toContain('offset=0')
   })
 })

--- a/frontend/src/features/list-clients/model/use-list-clients.test.ts
+++ b/frontend/src/features/list-clients/model/use-list-clients.test.ts
@@ -43,11 +43,12 @@ describe('useListClients', () => {
     })
 
     await waitFor(() => {
-      const last = seen.at(-1) ?? ''
-      expect(last).toContain('q=')
-      expect(last).toContain('sort=name')
-      expect(last).toContain('order=asc')
+      expect(seen.at(-1) ?? '').toContain('sort=name')
     })
+
+    const last = seen.at(-1) ?? ''
+    expect(last).toContain('q=')
+    expect(last).toContain('order=asc')
   })
 
   it('exposes the empty state when there are no clients', async () => {

--- a/frontend/src/features/list-invoices/model/use-list-invoices.test.ts
+++ b/frontend/src/features/list-invoices/model/use-list-invoices.test.ts
@@ -98,17 +98,18 @@ describe('useListInvoices', () => {
     })
 
     await waitFor(() => {
-      const last = seen.at(-1) ?? ''
-      expect(last).toContain('q=INV-001')
-      expect(last).toContain('status=issued')
-      expect(last).toContain('overdue=1')
-      expect(last).toContain('due_from=2026-06-01')
-      expect(last).toContain('issued_from=2026-04-01')
-      expect(last).toContain('issued_to=2026-06-30')
-      expect(last).toContain('total_min=1000')
-      expect(last).toContain('sort=total')
-      expect(last).toContain('order=asc')
+      expect(seen.at(-1) ?? '').toContain('sort=total')
     })
+
+    const last = seen.at(-1) ?? ''
+    expect(last).toContain('q=INV-001')
+    expect(last).toContain('status=issued')
+    expect(last).toContain('overdue=1')
+    expect(last).toContain('due_from=2026-06-01')
+    expect(last).toContain('issued_from=2026-04-01')
+    expect(last).toContain('issued_to=2026-06-30')
+    expect(last).toContain('total_min=1000')
+    expect(last).toContain('order=asc')
   })
 
   it('exposes an error state on a 5xx response', async () => {

--- a/frontend/src/features/list-items/model/use-list-items.test.ts
+++ b/frontend/src/features/list-items/model/use-list-items.test.ts
@@ -43,11 +43,12 @@ describe('useListItems', () => {
     })
 
     await waitFor(() => {
-      const last = seen.at(-1) ?? ''
-      expect(last).toContain('q=')
-      expect(last).toContain('sort=unit_price')
-      expect(last).toContain('order=asc')
+      expect(seen.at(-1) ?? '').toContain('sort=unit_price')
     })
+
+    const last = seen.at(-1) ?? ''
+    expect(last).toContain('q=')
+    expect(last).toContain('order=asc')
   })
 
   it('exposes an error state on a 5xx response', async () => {

--- a/frontend/src/features/list-quotes/model/use-list-quotes.test.ts
+++ b/frontend/src/features/list-quotes/model/use-list-quotes.test.ts
@@ -102,14 +102,15 @@ describe('useListQuotes', () => {
     })
 
     await waitFor(() => {
-      const last = seen.at(-1) ?? ''
-      expect(last).toContain('q=EST-001')
-      expect(last).toContain('status=sent')
-      expect(last).toContain('valid_from=2026-06-01')
-      expect(last).toContain('total_min=1000')
-      expect(last).toContain('sort=total')
-      expect(last).toContain('order=asc')
+      expect(seen.at(-1) ?? '').toContain('sort=total')
     })
+
+    const last = seen.at(-1) ?? ''
+    expect(last).toContain('q=EST-001')
+    expect(last).toContain('status=sent')
+    expect(last).toContain('valid_from=2026-06-01')
+    expect(last).toContain('total_min=1000')
+    expect(last).toContain('order=asc')
   })
 
   it('exposes an error state on a 5xx response', async () => {

--- a/frontend/src/features/sign-in/ui/SignInForm.test.tsx
+++ b/frontend/src/features/sign-in/ui/SignInForm.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -11,11 +11,11 @@ import { SignInForm } from './SignInForm'
 describe('SignInForm', () => {
   it('signs in and stores the session token', async () => {
     const user = userEvent.setup()
-    const { getByLabelText, getByRole } = renderWithProviders(<SignInForm />)
+    renderWithProviders(<SignInForm />)
 
-    await user.type(getByLabelText('Email'), 'admin@example.com')
-    await user.type(getByLabelText('Password'), 'password123')
-    await user.click(getByRole('button', { name: 'Sign in' }))
+    await user.type(screen.getByLabelText('Email'), 'admin@example.com')
+    await user.type(screen.getByLabelText('Password'), 'password123')
+    await user.click(screen.getByRole('button', { name: 'Sign in' }))
 
     await waitFor(() => {
       expect(hasAuthToken()).toBe(true)
@@ -39,13 +39,13 @@ describe('SignInForm', () => {
     )
 
     const user = userEvent.setup()
-    const { getByLabelText, getByRole, findByRole } = renderWithProviders(<SignInForm />)
+    renderWithProviders(<SignInForm />)
 
-    await user.type(getByLabelText('Email'), 'admin@example.com')
-    await user.type(getByLabelText('Password'), 'wrong-password')
-    await user.click(getByRole('button', { name: 'Sign in' }))
+    await user.type(screen.getByLabelText('Email'), 'admin@example.com')
+    await user.type(screen.getByLabelText('Password'), 'wrong-password')
+    await user.click(screen.getByRole('button', { name: 'Sign in' }))
 
-    await findByRole('alert')
+    await screen.findByRole('alert')
     expect(hasAuthToken()).toBe(false)
   })
 })

--- a/frontend/src/features/view-invoice/model/use-generate-download-link.test.ts
+++ b/frontend/src/features/view-invoice/model/use-generate-download-link.test.ts
@@ -8,11 +8,15 @@ import { useGenerateDownloadLink } from './use-generate-download-link'
 
 describe('useGenerateDownloadLink', () => {
   it('only allows generation for an issued invoice', () => {
-    const issued = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), true))
-    expect(issued.result.current.canGenerate).toBe(true)
+    const { result: issued } = renderHookWithProviders(() =>
+      useGenerateDownloadLink(toInvoiceId(1), true),
+    )
+    expect(issued.current.canGenerate).toBe(true)
 
-    const draft = renderHookWithProviders(() => useGenerateDownloadLink(toInvoiceId(1), false))
-    expect(draft.result.current.canGenerate).toBe(false)
+    const { result: draft } = renderHookWithProviders(() =>
+      useGenerateDownloadLink(toInvoiceId(1), false),
+    )
+    expect(draft.current.canGenerate).toBe(false)
   })
 
   it('generates a link and truncates the expiry to a date', async () => {

--- a/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -32,19 +33,17 @@ describe('ViewInvoice — send-email failure banner (#650)', () => {
     )
 
     const user = userEvent.setup()
-    const { findByRole, getByRole } = renderWithProviders(
-      <ViewInvoice invoiceId={toInvoiceId(1)} />,
-    )
+    renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
 
-    await user.click(await findByRole('button', { name: 'Send by email' }))
+    await user.click(await screen.findByRole('button', { name: 'Send by email' }))
 
-    const alert = await findByRole('alert')
+    const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent(
       'We couldn\'t reach the mail server, so the email wasn\'t sent. Try "Resend" again in a moment; if it keeps failing, contact your system administrator.',
     )
     // Not the client-address message — that would misdirect the user (#650).
     expect(alert).not.toHaveTextContent("The client's email address")
-    expect(getByRole('button', { name: 'Check client' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Check client' })).toBeInTheDocument()
   })
 
   it('shows the client-address copy for a 422 client-email-missing response', async () => {
@@ -55,11 +54,11 @@ describe('ViewInvoice — send-email failure banner (#650)', () => {
     )
 
     const user = userEvent.setup()
-    const { findByRole } = renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
+    renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
 
-    await user.click(await findByRole('button', { name: 'Send by email' }))
+    await user.click(await screen.findByRole('button', { name: 'Send by email' }))
 
-    const alert = await findByRole('alert')
+    const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent(
       "The client's email address may be missing or malformed. Please check the address and try again.",
     )
@@ -83,11 +82,11 @@ describe('ViewInvoice — demo email preview (#626)', () => {
     )
 
     const user = userEvent.setup()
-    const { findByRole } = renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
+    renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
 
-    await user.click(await findByRole('button', { name: 'Send by email' }))
+    await user.click(await screen.findByRole('button', { name: 'Send by email' }))
 
-    const dialog = await findByRole('dialog')
+    const dialog = await screen.findByRole('dialog')
     expect(dialog).toHaveTextContent('Email preview')
     // The "no email was actually sent" demo notice must be shown.
     expect(dialog).toHaveTextContent('No email was actually sent')
@@ -104,14 +103,12 @@ describe('ViewInvoice — demo email preview (#626)', () => {
     )
 
     const user = userEvent.setup()
-    const { findByRole, findByText, queryByRole } = renderWithProviders(
-      <ViewInvoice invoiceId={toInvoiceId(1)} />,
-    )
+    renderWithProviders(<ViewInvoice invoiceId={toInvoiceId(1)} />)
 
-    await user.click(await findByRole('button', { name: 'Send by email' }))
+    await user.click(await screen.findByRole('button', { name: 'Send by email' }))
 
     // Success toast (role="status") appears; no preview dialog is opened.
-    expect(await findByText('Email sent')).toBeInTheDocument()
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(await screen.findByText('Email sent')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/shared/keyboard/KeyboardShortcuts.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
@@ -6,16 +6,31 @@ import { KeyboardShortcuts } from './KeyboardShortcuts'
 import { openShortcutsOverlay } from './overlay-control'
 import { useRowCursor } from './use-row-cursor'
 
+// The probe exposes the current path through a queryable role rather than a test
+// id, so assertions use the same accessible surface a user would.
 function LocationProbe() {
-  return <div data-testid="loc">{useLocation().pathname}</div>
+  return (
+    <div role="status" aria-label="location">
+      {useLocation().pathname}
+    </div>
+  )
 }
+
+const locationProbe = () => screen.getByRole('status', { name: 'location' })
 
 function ListHarness({ onOpen }: { onOpen: (index: number) => void }) {
   const cursor = useRowCursor(3, onOpen)
   return (
     <ul>
       {[0, 1, 2].map((i) => (
-        <li key={i} data-kbd-row={i} className={cursor === i ? 'is-cursor' : undefined}>
+        <li
+          key={i}
+          data-kbd-row={i}
+          // aria-current is the accessible expression of "this row holds the
+          // cursor" — it replaces reaching into the DOM for the .is-cursor class.
+          aria-current={cursor === i ? true : undefined}
+          className={cursor === i ? 'is-cursor' : undefined}
+        >
           row{i}
         </li>
       ))}
@@ -25,7 +40,7 @@ function ListHarness({ onOpen }: { onOpen: (index: number) => void }) {
 
 describe('KeyboardShortcuts', () => {
   it('navigates with the g-prefix sequence (g then i → invoices)', async () => {
-    const { getByTestId } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -36,12 +51,12 @@ describe('KeyboardShortcuts', () => {
     fireEvent.keyDown(document.body, { key: 'i' })
 
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/invoices')
+      expect(locationProbe()).toHaveTextContent('/invoices')
     })
   })
 
   it('navigates to items (g m) and templates (g t), and n opens new item', async () => {
-    const { getByTestId } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -51,23 +66,23 @@ describe('KeyboardShortcuts', () => {
     fireEvent.keyDown(document.body, { key: 'g' })
     fireEvent.keyDown(document.body, { key: 'm' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/items')
+      expect(locationProbe()).toHaveTextContent('/items')
     })
 
     fireEvent.keyDown(document.body, { key: 'n' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/items/new')
+      expect(locationProbe()).toHaveTextContent('/items/new')
     })
 
     fireEvent.keyDown(document.body, { key: 'g' })
     fireEvent.keyDown(document.body, { key: 't' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/templates')
+      expect(locationProbe()).toHaveTextContent('/templates')
     })
   })
 
   it('returns to the parent list with u from a detail view', () => {
-    const { getByTestId } = render(
+    render(
       <MemoryRouter initialEntries={['/invoices/42']}>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -75,11 +90,11 @@ describe('KeyboardShortcuts', () => {
     )
 
     fireEvent.keyDown(document.body, { key: 'u' })
-    expect(getByTestId('loc').textContent).toBe('/invoices')
+    expect(locationProbe()).toHaveTextContent('/invoices')
   })
 
   it('returns to the parent list with u from an edit form when no field is focused (#374)', () => {
-    const { getByTestId } = render(
+    render(
       <MemoryRouter initialEntries={['/clients/42/edit']}>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -87,136 +102,139 @@ describe('KeyboardShortcuts', () => {
     )
 
     fireEvent.keyDown(document.body, { key: 'u' })
-    expect(getByTestId('loc').textContent).toBe('/clients')
+    expect(locationProbe()).toHaveTextContent('/clients')
   })
 
   it('does not fire u while a form field is focused (typing wins) (#374)', () => {
-    const { getByTestId, container } = render(
+    render(
       <MemoryRouter initialEntries={['/clients/42/edit']}>
         <KeyboardShortcuts />
         <LocationProbe />
-        <input data-testid="field" />
+        <input aria-label="field" />
       </MemoryRouter>,
     )
-    const field = container.querySelector('[data-testid="field"]') as HTMLInputElement
+    const field = screen.getByRole('textbox')
     field.focus()
 
     fireEvent.keyDown(field, { key: 'u' })
-    expect(getByTestId('loc').textContent).toBe('/clients/42/edit')
+    expect(locationProbe()).toHaveTextContent('/clients/42/edit')
   })
 
   it('blurs the search field on Esc so j/k work again (#362)', () => {
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
-        <input data-kbd="search" />
+        <input data-kbd="search" aria-label="search" />
       </>,
     )
-    const search = container.querySelector('[data-kbd="search"]') as HTMLInputElement
+    const search = screen.getByRole('textbox')
     search.focus()
-    expect(document.activeElement).toBe(search)
+    expect(search).toHaveFocus()
 
     fireEvent.keyDown(search, { key: 'Escape' })
-    expect(document.activeElement).not.toBe(search)
+    expect(search).not.toHaveFocus()
   })
 
   it('blurs any focused form field on Esc, not just search (#364)', () => {
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
-        <input id="plain" />
-        <textarea id="notes" />
+        <input aria-label="plain" />
+        <textarea aria-label="notes" />
       </>,
     )
-    const plain = container.querySelector('#plain') as HTMLInputElement
+    const plain = screen.getByRole('textbox', { name: 'plain' })
     plain.focus()
     fireEvent.keyDown(plain, { key: 'Escape' })
-    expect(document.activeElement).not.toBe(plain)
+    expect(plain).not.toHaveFocus()
 
-    const notes = container.querySelector('#notes') as HTMLTextAreaElement
+    const notes = screen.getByRole('textbox', { name: 'notes' })
     notes.focus()
     fireEvent.keyDown(notes, { key: 'Escape' })
-    expect(document.activeElement).not.toBe(notes)
+    expect(notes).not.toHaveFocus()
   })
 
   it('keeps focus on Esc while composing in the search field (IME cancel) (#362)', () => {
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
-        <input data-kbd="search" />
+        <input data-kbd="search" aria-label="search" />
       </>,
     )
-    const search = container.querySelector('[data-kbd="search"]') as HTMLInputElement
+    const search = screen.getByRole('textbox')
     search.focus()
 
     fireEvent.keyDown(search, { key: 'Escape', isComposing: true })
-    expect(document.activeElement).toBe(search)
+    expect(search).toHaveFocus()
   })
 
   it('opens the command palette on Ctrl/⌘+K and navigates with j + Enter (#370)', async () => {
-    const { getByRole, getByTestId, queryByRole } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
       </>,
     )
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
     fireEvent.keyDown(document.body, { key: 'k', ctrlKey: true })
-    expect(getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
 
     // cursor starts on the first command (dashboard); j → quotes, Enter goes.
     fireEvent.keyDown(document.body, { key: 'j' })
     fireEvent.keyDown(document.body, { key: 'Enter' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/quotes')
+      expect(locationProbe()).toHaveTextContent('/quotes')
     })
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('closes the command palette on Esc (#370)', () => {
-    const { getByRole, queryByRole } = renderWithProviders(<KeyboardShortcuts />)
+    renderWithProviders(<KeyboardShortcuts />)
     fireEvent.keyDown(document.body, { key: 'k', metaKey: true })
-    expect(getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
 
     fireEvent.keyDown(document.body, { key: 'Escape' })
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('groups palette commands with non-selectable headers (design 案A, #370)', () => {
-    const { getByRole, getAllByRole } = renderWithProviders(<KeyboardShortcuts />)
+    renderWithProviders(<KeyboardShortcuts />)
     fireEvent.keyDown(document.body, { key: 'k', metaKey: true })
 
-    const dialog = getByRole('dialog')
     // Group headers are presentation (not options); 10 navigable options remain.
-    expect(getAllByRole('option')).toHaveLength(10)
-    expect(dialog.querySelectorAll('.cmdp-grp')).toHaveLength(3)
-    // Keys render as the joined .keycombo (not the 3D .kbd).
-    expect(dialog.querySelector('.keycombo')).not.toBeNull()
+    const list = screen.getByRole('listbox')
+    expect(screen.getAllByRole('option')).toHaveLength(10)
+    expect(within(list).getAllByRole('presentation')).toHaveLength(3)
+    // Each option shows its key combo as separate caps (g then d for dashboard).
+    const firstOption = screen.getAllByRole('option')[0]
+    expect(firstOption).toBeDefined()
+    expect(within(firstOption as HTMLElement).getByText('g')).toBeInTheDocument()
+    expect(within(firstOption as HTMLElement).getByText('d')).toBeInTheDocument()
   })
 
   it('opens the cheat-sheet via openShortcutsOverlay()', () => {
-    const { getByRole, queryByRole } = renderWithProviders(<KeyboardShortcuts />)
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    renderWithProviders(<KeyboardShortcuts />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
     act(() => {
       openShortcutsOverlay()
     })
-    expect(getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
   it('opens the cheat-sheet on ? and closes it on Esc', () => {
-    const { getByRole, queryByRole } = renderWithProviders(<KeyboardShortcuts />)
+    renderWithProviders(<KeyboardShortcuts />)
 
     fireEvent.keyDown(document.body, { key: '?' })
-    expect(getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
 
     fireEvent.keyDown(document.body, { key: 'Escape' })
-    expect(queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('ignores single keys while the IME is composing', () => {
-    const { getByTestId } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -226,27 +244,27 @@ describe('KeyboardShortcuts', () => {
     fireEvent.keyDown(document.body, { key: 'g', isComposing: true })
     fireEvent.keyDown(document.body, { key: 'i' })
 
-    expect(getByTestId('loc')).toHaveTextContent('/')
+    expect(locationProbe()).toHaveTextContent('/')
   })
 
   it('ignores single keys when focus is in an editable field', () => {
-    const { getByTestId, getByRole } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
         <input aria-label="field" />
       </>,
     )
-    const input = getByRole('textbox')
+    const input = screen.getByRole('textbox')
 
     fireEvent.keyDown(input, { key: 'g' })
     fireEvent.keyDown(input, { key: 'i' })
 
-    expect(getByTestId('loc')).toHaveTextContent('/')
+    expect(locationProbe()).toHaveTextContent('/')
   })
 
   it('focuses the list search box on /', () => {
-    const { getByRole } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <input data-kbd="search" aria-label="search" />
@@ -255,11 +273,11 @@ describe('KeyboardShortcuts', () => {
 
     fireEvent.keyDown(document.body, { key: '/' })
 
-    expect(getByRole('textbox')).toHaveFocus()
+    expect(screen.getByRole('textbox')).toHaveFocus()
   })
 
   it('opens the contextual new form on n (invoices → /invoices/new)', async () => {
-    const { getByTestId } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <LocationProbe />
@@ -269,18 +287,18 @@ describe('KeyboardShortcuts', () => {
     fireEvent.keyDown(document.body, { key: 'g' })
     fireEvent.keyDown(document.body, { key: 'i' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/invoices')
+      expect(locationProbe()).toHaveTextContent('/invoices')
     })
 
     fireEvent.keyDown(document.body, { key: 'n' })
     await waitFor(() => {
-      expect(getByTestId('loc')).toHaveTextContent('/invoices/new')
+      expect(locationProbe()).toHaveTextContent('/invoices/new')
     })
   })
 
   it('moves the row cursor with j/k and opens the cursored row with o', () => {
     const onOpen = vi.fn()
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <>
         <KeyboardShortcuts />
         <ListHarness onOpen={onOpen} />
@@ -288,11 +306,11 @@ describe('KeyboardShortcuts', () => {
     )
 
     fireEvent.keyDown(document.body, { key: 'j' })
-    expect(container.querySelector('.is-cursor')).toHaveTextContent('row0')
+    expect(screen.getByRole('listitem', { current: true })).toHaveTextContent('row0')
     fireEvent.keyDown(document.body, { key: 'j' })
-    expect(container.querySelector('.is-cursor')).toHaveTextContent('row1')
+    expect(screen.getByRole('listitem', { current: true })).toHaveTextContent('row1')
     fireEvent.keyDown(document.body, { key: 'k' })
-    expect(container.querySelector('.is-cursor')).toHaveTextContent('row0')
+    expect(screen.getByRole('listitem', { current: true })).toHaveTextContent('row0')
 
     fireEvent.keyDown(document.body, { key: 'o' })
     expect(onOpen).toHaveBeenCalledWith(0)
@@ -302,7 +320,7 @@ describe('KeyboardShortcuts', () => {
     const onSubmit = vi.fn((e: { preventDefault: () => void }) => {
       e.preventDefault()
     })
-    const { getByRole } = renderWithProviders(
+    renderWithProviders(
       <form onSubmit={onSubmit}>
         <input aria-label="field" />
         <button type="submit">submit</button>
@@ -310,7 +328,7 @@ describe('KeyboardShortcuts', () => {
     )
     // KeyboardShortcuts is also needed; render it alongside via a second mount.
     renderWithProviders(<KeyboardShortcuts />)
-    const input = getByRole('textbox')
+    const input = screen.getByRole('textbox')
 
     fireEvent.keyDown(input, { key: 'Enter', ctrlKey: true })
 

--- a/frontend/src/shared/keyboard/use-line-grid-enter.test.tsx
+++ b/frontend/src/shared/keyboard/use-line-grid-enter.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
 import { describe, expect, it } from 'vitest'
 import { useLineGridEnter } from './use-line-grid-enter'
@@ -22,23 +22,24 @@ function GridHarness() {
 
 describe('useLineGridEnter', () => {
   it('moves focus to the next cell on Enter', () => {
-    const { getByLabelText } = render(<GridHarness />)
-    const a0 = getByLabelText('a0')
+    render(<GridHarness />)
+    const a0 = screen.getByLabelText('a0')
     a0.focus()
 
     fireEvent.keyDown(a0, { key: 'Enter' })
 
-    expect(getByLabelText('b0')).toHaveFocus()
+    expect(screen.getByLabelText('b0')).toHaveFocus()
   })
 
   it('adds a row and focuses its first cell from the last cell', () => {
-    const { getByLabelText, queryByLabelText } = render(<GridHarness />)
-    const b0 = getByLabelText('b0')
+    render(<GridHarness />)
+    const b0 = screen.getByLabelText('b0')
     b0.focus()
 
     fireEvent.keyDown(b0, { key: 'Enter' })
 
-    expect(queryByLabelText('a1')).not.toBeNull()
-    expect(getByLabelText('a1')).toHaveFocus()
+    const a1 = screen.getByLabelText('a1')
+    expect(a1).toBeInTheDocument()
+    expect(a1).toHaveFocus()
   })
 })

--- a/frontend/src/shared/ui/components/ActionError.test.tsx
+++ b/frontend/src/shared/ui/components/ActionError.test.tsx
@@ -1,17 +1,17 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { ActionError } from './ActionError'
 
 describe('ActionError', () => {
   it('announces the error with role="alert" and shows title + description', () => {
-    const { getByRole, getByText } = render(
+    render(
       <ActionError title="Couldn't send the email" description="Check the address and retry." />,
     )
 
-    const alert = getByRole('alert')
+    const alert = screen.getByRole('alert')
     expect(alert).toHaveTextContent("Couldn't send the email")
-    expect(getByText('Check the address and retry.')).toBeInTheDocument()
+    expect(screen.getByText('Check the address and retry.')).toBeInTheDocument()
   })
 
   it('renders recovery actions and invokes their handlers', async () => {
@@ -19,7 +19,7 @@ describe('ActionError', () => {
     const onRetry = vi.fn()
     const onCheck = vi.fn()
 
-    const { getByRole } = render(
+    render(
       <ActionError
         title="Failed"
         description="Try again."
@@ -30,8 +30,8 @@ describe('ActionError', () => {
       />,
     )
 
-    await user.click(getByRole('button', { name: 'Resend' }))
-    await user.click(getByRole('button', { name: 'Check client' }))
+    await user.click(screen.getByRole('button', { name: 'Resend' }))
+    await user.click(screen.getByRole('button', { name: 'Check client' }))
 
     expect(onRetry).toHaveBeenCalledOnce()
     expect(onCheck).toHaveBeenCalledOnce()
@@ -41,11 +41,11 @@ describe('ActionError', () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
 
-    const { getByRole } = render(
+    render(
       <ActionError title="Failed" description="Try again." onClose={onClose} closeLabel="Close" />,
     )
 
-    await user.click(getByRole('button', { name: 'Close' }))
+    await user.click(screen.getByRole('button', { name: 'Close' }))
     expect(onClose).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/shared/ui/components/ClientCombobox.test.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { ClientCombobox, type ClientOption } from './ClientCombobox'
@@ -13,38 +13,41 @@ const CLIENTS: ClientOption[] = [
   { id: 2, name: 'Acme Foods', name_kana: 'acme foods', registration_number: 'T9' },
 ]
 
+/**
+ * The name field carries `role="combobox"`; the only plain `textbox` in the tree
+ * is the furigana input, which exists *only* while the inline-create form is
+ * open. Querying it is therefore an accessible stand-in for "the create form is
+ * (not) shown".
+ */
+const nameField = (): HTMLElement => screen.getByRole('combobox')
+const createForm = (): HTMLElement | null => screen.queryByRole('textbox')
+
 describe('ClientCombobox', () => {
   it('filters by reading (name_kana) and selects on click', () => {
     const onChange = vi.fn()
-    const { container, getByRole } = renderWithProviders(
-      <ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />,
-    )
-    const input = container.querySelector('#c') as HTMLInputElement
+    renderWithProviders(<ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />)
 
     // Type kana that only matches the first client's reading.
-    fireEvent.change(input, { target: { value: 'カブシキ' } })
-    expect(getByRole('option', { name: /株式会社サンプル/ })).toBeTruthy()
+    fireEvent.change(nameField(), { target: { value: 'カブシキ' } })
+    expect(screen.getByRole('option', { name: /株式会社サンプル/ })).toBeTruthy()
 
-    fireEvent.mouseDown(getByRole('option', { name: /株式会社サンプル/ }))
+    fireEvent.mouseDown(screen.getByRole('option', { name: /株式会社サンプル/ }))
     expect(onChange).toHaveBeenCalledWith(1)
   })
 
   it('filters by latin reading too', () => {
     const onChange = vi.fn()
-    const { container, getByRole } = renderWithProviders(
-      <ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />,
-    )
-    const input = container.querySelector('#c') as HTMLInputElement
+    renderWithProviders(<ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />)
 
-    fireEvent.change(input, { target: { value: 'acme' } })
-    fireEvent.mouseDown(getByRole('option', { name: /Acme Foods/ }))
+    fireEvent.change(nameField(), { target: { value: 'acme' } })
+    fireEvent.mouseDown(screen.getByRole('option', { name: /Acme Foods/ }))
     expect(onChange).toHaveBeenCalledWith(2)
   })
 
   it('captures a reading and inline-registers an unknown name with it', async () => {
     const onChange = vi.fn()
     const onCreate = vi.fn(() => Promise.resolve(99))
-    const { container, getByText } = renderWithProviders(
+    renderWithProviders(
       <ClientCombobox
         id="c"
         clients={CLIENTS}
@@ -55,17 +58,17 @@ describe('ClientCombobox', () => {
         createConfirmLabel="登録"
       />,
     )
-    const input = container.querySelector('#c') as HTMLInputElement
 
-    fireEvent.change(input, { target: { value: '新しい取引先' } })
+    fireEvent.change(nameField(), { target: { value: '新しい取引先' } })
     // Step 1: open the inline-create form (does not create yet).
-    fireEvent.mouseDown(getByText('「新しい取引先」を登録'))
+    fireEvent.mouseDown(screen.getByRole('button', { name: '「新しい取引先」を登録' }))
     expect(onCreate).not.toHaveBeenCalled()
 
     // Step 2: type a reading and confirm.
-    const kana = container.querySelector('.combo-createform .combo-input') as HTMLInputElement
-    fireEvent.change(kana, { target: { value: 'アタラシイトリヒキサキ' } })
-    fireEvent.mouseDown(getByText('登録'))
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'アタラシイトリヒキサキ' },
+    })
+    fireEvent.mouseDown(screen.getByRole('button', { name: '登録' }))
 
     expect(onCreate).toHaveBeenCalledWith('新しい取引先', 'アタラシイトリヒキサキ')
     // onCreate resolves to 99 → selection committed.
@@ -77,7 +80,7 @@ describe('ClientCombobox', () => {
   it('inline-registers with a null reading when none is entered', () => {
     const onChange = vi.fn()
     const onCreate = vi.fn(() => Promise.resolve(7))
-    const { container, getByText } = renderWithProviders(
+    renderWithProviders(
       <ClientCombobox
         id="c"
         clients={CLIENTS}
@@ -88,18 +91,17 @@ describe('ClientCombobox', () => {
         createConfirmLabel="登録"
       />,
     )
-    const input = container.querySelector('#c') as HTMLInputElement
 
-    fireEvent.change(input, { target: { value: '読みなし商店' } })
-    fireEvent.mouseDown(getByText('「読みなし商店」を登録'))
-    fireEvent.mouseDown(getByText('登録'))
+    fireEvent.change(nameField(), { target: { value: '読みなし商店' } })
+    fireEvent.mouseDown(screen.getByRole('button', { name: '「読みなし商店」を登録' }))
+    fireEvent.mouseDown(screen.getByRole('button', { name: '登録' }))
 
     expect(onCreate).toHaveBeenCalledWith('読みなし商店', null)
   })
 
   it('reports the query and skips local filtering in server-search mode', () => {
     const onQueryChange = vi.fn()
-    const { container, getByRole } = renderWithProviders(
+    renderWithProviders(
       <ClientCombobox
         id="c"
         clients={CLIENTS}
@@ -108,20 +110,19 @@ describe('ClientCombobox', () => {
         onQueryChange={onQueryChange}
       />,
     )
-    const input = container.querySelector('#c') as HTMLInputElement
 
     // Text that matches neither client locally; the server (parent) decides.
-    fireEvent.change(input, { target: { value: 'zzz' } })
+    fireEvent.change(nameField(), { target: { value: 'zzz' } })
     expect(onQueryChange).toHaveBeenCalledWith('zzz')
     // The parent-provided list is shown as-is — no client-side narrowing.
-    expect(getByRole('option', { name: /株式会社サンプル/ })).toBeTruthy()
-    expect(getByRole('option', { name: /Acme Foods/ })).toBeTruthy()
+    expect(screen.getByRole('option', { name: /株式会社サンプル/ })).toBeTruthy()
+    expect(screen.getByRole('option', { name: /Acme Foods/ })).toBeTruthy()
   })
 
   it('ignores the IME conversion-confirm Enter, then acts on the committed Enter (#360)', () => {
     const onChange = vi.fn()
     const onCreate = vi.fn(() => Promise.resolve(99))
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <ClientCombobox
         id="c"
         clients={CLIENTS}
@@ -132,49 +133,43 @@ describe('ClientCombobox', () => {
         createConfirmLabel="登録"
       />,
     )
-    const input = container.querySelector('#c') as HTMLInputElement
-    fireEvent.change(input, { target: { value: '新規取引先' } })
+    fireEvent.change(nameField(), { target: { value: '新規取引先' } })
 
     // Enter that confirms the IME conversion (keyCode 229) must NOT act — it
     // belongs to the IME.
-    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })
-    expect(container.querySelector('.combo-createform')).toBeNull()
+    fireEvent.keyDown(nameField(), { key: 'Enter', keyCode: 229 })
+    expect(createForm()).toBeNull()
 
     // Nothing is auto-highlighted (#366): the committed Enter alone does nothing.
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(container.querySelector('.combo-createform')).toBeNull()
+    fireEvent.keyDown(nameField(), { key: 'Enter' })
+    expect(createForm()).toBeNull()
 
     // Move to the create row with ↓, then Enter opens the inline-create form.
-    fireEvent.keyDown(input, { key: 'ArrowDown' })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(container.querySelector('.combo-createform')).not.toBeNull()
+    fireEvent.keyDown(nameField(), { key: 'ArrowDown' })
+    fireEvent.keyDown(nameField(), { key: 'Enter' })
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
   })
 
   it('does not auto-highlight a suggestion; ↓ enters the list, Enter picks (#366)', () => {
     const onChange = vi.fn()
-    const { container } = renderWithProviders(
-      <ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />,
-    )
-    const input = container.querySelector('#c') as HTMLInputElement
-    fireEvent.change(input, { target: { value: 'a' } }) // matches Acme Foods
+    renderWithProviders(<ClientCombobox id="c" clients={CLIENTS} value={0} onChange={onChange} />)
+    fireEvent.change(nameField(), { target: { value: 'a' } }) // matches Acme Foods
 
     // Suggestions are shown but nothing is highlighted — the field keeps the cursor.
-    expect(container.querySelector('.combo-opt.hl')).toBeNull()
+    expect(screen.getByRole('option', { name: /Acme Foods/ })).not.toHaveClass('hl')
     // A bare Enter does not pick anything.
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.keyDown(nameField(), { key: 'Enter' })
     expect(onChange).not.toHaveBeenCalled()
 
     // ↓ highlights the first suggestion, Enter picks it.
-    fireEvent.keyDown(input, { key: 'ArrowDown' })
-    expect(container.querySelector('.combo-opt.hl')).not.toBeNull()
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.keyDown(nameField(), { key: 'ArrowDown' })
+    expect(screen.getByRole('option', { name: /Acme Foods/ })).toHaveClass('hl')
+    fireEvent.keyDown(nameField(), { key: 'Enter' })
     expect(onChange).toHaveBeenCalledWith(2)
   })
 
   it('shows the selected client name when value is set', () => {
-    const { container } = renderWithProviders(
-      <ClientCombobox id="c" clients={CLIENTS} value={2} onChange={vi.fn()} />,
-    )
-    expect((container.querySelector('#c') as HTMLInputElement).value).toBe('Acme Foods')
+    renderWithProviders(<ClientCombobox id="c" clients={CLIENTS} value={2} onChange={vi.fn()} />)
+    expect(nameField()).toHaveValue('Acme Foods')
   })
 })

--- a/frontend/src/shared/ui/components/DatePicker.test.tsx
+++ b/frontend/src/shared/ui/components/DatePicker.test.tsx
@@ -1,47 +1,47 @@
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { DatePicker } from './DatePicker'
 
+/** The icon button that toggles the calendar popover (`common.datePicker.open`). */
+const openButton = (): HTMLElement => screen.getByRole('button', { name: 'Open calendar' })
+/** The editable date field (`.dp-input`) — the only textbox rendered. */
+const dateInput = (): HTMLElement => screen.getByRole('textbox')
+
 describe('DatePicker', () => {
   it('shows the value as editable text and opens the calendar via the icon', () => {
-    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
-    expect((container.querySelector('.dp-input') as HTMLInputElement).value).toBe('2026/06/15')
-    expect(container.querySelector('.dp.open')).toBeNull()
+    renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
+    expect(dateInput()).toHaveValue('2026/06/15')
+    expect(openButton()).toHaveAttribute('aria-expanded', 'false')
 
-    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
-    expect(container.querySelector('.dp.open')).not.toBeNull()
+    fireEvent.click(openButton())
+    expect(openButton()).toHaveAttribute('aria-expanded', 'true')
   })
 
   it('emits the ISO date when a day is picked', () => {
     const onChange = vi.fn()
-    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
+    renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
 
-    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
-    const day20 = [...container.querySelectorAll('.dp-day:not(.out)')].find(
-      (d) => d.textContent === '20',
-    )
-    fireEvent.click(day20 as HTMLElement)
+    fireEvent.click(openButton())
+    fireEvent.click(screen.getByRole('button', { name: '20' }))
 
     expect(onChange).toHaveBeenCalledWith('2026-06-20')
   })
 
   it('clears the value via the clear button', () => {
     const onChange = vi.fn()
-    const { container, getByText } = renderWithProviders(
-      <DatePicker value="2026-06-15" onChange={onChange} />,
-    )
+    renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
 
-    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
-    fireEvent.click(getByText('Clear'))
+    fireEvent.click(openButton())
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
 
     expect(onChange).toHaveBeenCalledWith('')
   })
 
   it('commits a typed date on blur (accepts - or / separators, 1–2 digits)', () => {
     const onChange = vi.fn()
-    const { container } = renderWithProviders(<DatePicker value="" onChange={onChange} />)
-    const input = container.querySelector('.dp-input') as HTMLInputElement
+    renderWithProviders(<DatePicker value="" onChange={onChange} />)
+    const input = dateInput()
 
     fireEvent.change(input, { target: { value: '2026/7/3' } })
     fireEvent.blur(input)
@@ -51,8 +51,8 @@ describe('DatePicker', () => {
 
   it('commits a typed date on Enter without submitting the form', () => {
     const onChange = vi.fn()
-    const { container } = renderWithProviders(<DatePicker value="" onChange={onChange} />)
-    const input = container.querySelector('.dp-input') as HTMLInputElement
+    renderWithProviders(<DatePicker value="" onChange={onChange} />)
+    const input = dateInput()
 
     fireEvent.change(input, { target: { value: '2026-12-31' } })
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -62,25 +62,24 @@ describe('DatePicker', () => {
 
   it('reverts an invalid typed date on blur without emitting', () => {
     const onChange = vi.fn()
-    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
-    const input = container.querySelector('.dp-input') as HTMLInputElement
+    renderWithProviders(<DatePicker value="2026-06-15" onChange={onChange} />)
+    const input = dateInput()
 
     fireEvent.change(input, { target: { value: '2026/02/30' } }) // not a real date
     fireEvent.blur(input)
 
     expect(onChange).not.toHaveBeenCalled()
-    expect(input.value).toBe('2026/06/15')
+    expect(input).toHaveValue('2026/06/15')
   })
 
   it('keeps the closed calendar out of the tab order via inert (#358)', () => {
-    const { container } = renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
-    const pop = container.querySelector('.dp-pop') as HTMLElement
+    renderWithProviders(<DatePicker value="2026-06-15" onChange={vi.fn()} />)
 
     // Closed: inert so its ~45 buttons cannot trap Tab focus.
-    expect(pop.hasAttribute('inert')).toBe(true)
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute('inert')
 
-    fireEvent.click(container.querySelector('.dp-ico-btn') as HTMLElement)
+    fireEvent.click(openButton())
     // Open: interactive again.
-    expect(pop.hasAttribute('inert')).toBe(false)
+    expect(screen.getByRole('dialog', { hidden: true })).not.toHaveAttribute('inert')
   })
 })

--- a/frontend/src/shared/ui/components/InlineAlert.test.tsx
+++ b/frontend/src/shared/ui/components/InlineAlert.test.tsx
@@ -1,27 +1,27 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { InlineAlert } from './InlineAlert'
 
 describe('InlineAlert', () => {
   it('uses role="alert" for errors and shows the message', () => {
-    const { getByRole } = render(<InlineAlert tone="error" message="Could not issue." />)
-    expect(getByRole('alert')).toHaveTextContent('Could not issue.')
+    render(<InlineAlert tone="error" message="Could not issue." />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not issue.')
   })
 
   it('uses role="status" for success and info tones', () => {
-    const { getByRole, rerender } = render(<InlineAlert tone="success" message="Saved." />)
-    expect(getByRole('status')).toHaveTextContent('Saved.')
+    const { rerender } = render(<InlineAlert tone="success" message="Saved." />)
+    expect(screen.getByRole('status')).toHaveTextContent('Saved.')
 
     rerender(<InlineAlert tone="info" message="Heads up." />)
-    expect(getByRole('status')).toHaveTextContent('Heads up.')
+    expect(screen.getByRole('status')).toHaveTextContent('Heads up.')
   })
 
   it('renders a recover link that invokes its handler', async () => {
     const user = userEvent.setup()
     const onRecover = vi.fn()
 
-    const { getByRole } = render(
+    render(
       <InlineAlert
         tone="error"
         message="Could not issue."
@@ -29,7 +29,7 @@ describe('InlineAlert', () => {
       />,
     )
 
-    await user.click(getByRole('button', { name: 'Open company settings' }))
+    await user.click(screen.getByRole('button', { name: 'Open company settings' }))
     expect(onRecover).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/shared/ui/components/LineItemSuggestInput.test.tsx
+++ b/frontend/src/shared/ui/components/LineItemSuggestInput.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { LineItemSuggestInput, type LineSuggestion } from './LineItemSuggestInput'
@@ -13,11 +13,14 @@ const SUGGESTIONS: LineSuggestion[] = [
   { description: 'コンサルティング', unit_price_cents: 30000, tax_rate_bps: 1000, usage_count: 2 },
 ]
 
+/** The description field carries `role="combobox"`. */
+const descriptionField = (): HTMLElement => screen.getByRole('combobox')
+
 describe('LineItemSuggestInput', () => {
   it('suggests by description substring and fills the row on pick', () => {
     const onChange = vi.fn()
     const onPick = vi.fn()
-    const { container, getByRole } = renderWithProviders(
+    renderWithProviders(
       <LineItemSuggestInput
         id="d"
         value=""
@@ -26,17 +29,16 @@ describe('LineItemSuggestInput', () => {
         onPick={onPick}
       />,
     )
-    const input = container.querySelector('#d') as HTMLInputElement
 
-    fireEvent.change(input, { target: { value: 'Web' } })
+    fireEvent.change(descriptionField(), { target: { value: 'Web' } })
     expect(onChange).toHaveBeenCalledWith('Web')
 
-    fireEvent.mouseDown(getByRole('option', { name: /Web制作/ }))
+    fireEvent.mouseDown(screen.getByRole('option', { name: /Web制作/ }))
     expect(onPick).toHaveBeenCalledWith(SUGGESTIONS[0])
   })
 
   it('renders the meta sub-line when provided', () => {
-    const { container, getByText } = renderWithProviders(
+    renderWithProviders(
       <LineItemSuggestInput
         id="d"
         value=""
@@ -46,14 +48,14 @@ describe('LineItemSuggestInput', () => {
         renderMeta={(s) => `¥${String(s.unit_price_cents)} · ${String(s.usage_count)}×`}
       />,
     )
-    fireEvent.focus(container.querySelector('#d') as HTMLInputElement)
-    expect(getByText('¥300000 · 5×')).toBeTruthy()
+    fireEvent.focus(descriptionField())
+    expect(screen.getByText('¥300000 · 5×')).toBeTruthy()
   })
 
   it('picks the highlighted suggestion on Enter and stops the event', () => {
     const onPick = vi.fn()
     // value is the filter text (the field is free text the parent controls).
-    const { container, getByRole } = renderWithProviders(
+    renderWithProviders(
       <LineItemSuggestInput
         id="d"
         value="コンサル"
@@ -62,18 +64,17 @@ describe('LineItemSuggestInput', () => {
         onPick={onPick}
       />,
     )
-    const input = container.querySelector('#d') as HTMLInputElement
 
-    fireEvent.focus(input) // open the menu
-    expect(getByRole('option', { name: /コンサルティング/ })).toBeTruthy()
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.focus(descriptionField()) // open the menu
+    expect(screen.getByRole('option', { name: /コンサルティング/ })).toBeTruthy()
+    fireEvent.keyDown(descriptionField(), { key: 'Enter' })
 
     expect(onPick).toHaveBeenCalledWith(SUGGESTIONS[1])
   })
 
   it('does not pick on Enter when there are no matches (free text passes through)', () => {
     const onPick = vi.fn()
-    const { container } = renderWithProviders(
+    renderWithProviders(
       <LineItemSuggestInput
         id="d"
         value="完全に新しい品目"
@@ -82,10 +83,9 @@ describe('LineItemSuggestInput', () => {
         onPick={onPick}
       />,
     )
-    const input = container.querySelector('#d') as HTMLInputElement
 
-    fireEvent.focus(input)
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.focus(descriptionField())
+    fireEvent.keyDown(descriptionField(), { key: 'Enter' })
 
     expect(onPick).not.toHaveBeenCalled()
   })

--- a/frontend/src/shared/ui/toast/toast.test.tsx
+++ b/frontend/src/shared/ui/toast/toast.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent } from '@testing-library/react'
+import { act, fireEvent, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@tests/render/render-with-providers'
 import { useToast } from './context'
@@ -41,33 +41,33 @@ describe('Toast system', () => {
   })
 
   it('shows a success toast with role="status" and auto-dismisses', () => {
-    const { getByText, queryByText } = renderWithProviders(<Harness />)
+    renderWithProviders(<Harness />)
 
-    fireEvent.click(getByText('notify-ok'))
-    const toast = getByText('Email sent')
-    expect(toast).toBeInTheDocument()
-    expect(toast.closest('.toast')).toHaveAttribute('role', 'status')
+    fireEvent.click(screen.getByRole('button', { name: 'notify-ok' }))
+    // role="status" is the toast element itself, so finding it by role proves
+    // both that the toast rendered and that it carries the gentle live region.
+    expect(within(screen.getByRole('status')).getByText('Email sent')).toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(5000)
     })
-    expect(queryByText('Email sent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Email sent')).not.toBeInTheDocument()
   })
 
   it('shows an error toast with role="alert"', () => {
-    const { getByText } = renderWithProviders(<Harness />)
+    renderWithProviders(<Harness />)
 
-    fireEvent.click(getByText('notify-err'))
-    expect(getByText('Connection failed').closest('.toast')).toHaveAttribute('role', 'alert')
+    fireEvent.click(screen.getByRole('button', { name: 'notify-err' }))
+    expect(within(screen.getByRole('alert')).getByText('Connection failed')).toBeInTheDocument()
   })
 
   it('dismisses manually via the close button before the timer fires', () => {
-    const { getByText, getByLabelText, queryByText } = renderWithProviders(<Harness />)
+    renderWithProviders(<Harness />)
 
-    fireEvent.click(getByText('notify-ok'))
-    expect(getByText('Email sent')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'notify-ok' }))
+    expect(screen.getByText('Email sent')).toBeInTheDocument()
 
-    fireEvent.click(getByLabelText('Close'))
-    expect(queryByText('Email sent')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(screen.queryByText('Email sent')).not.toBeInTheDocument()
   })
 })

--- a/frontend/tests/setup/vitest.setup.ts
+++ b/frontend/tests/setup/vitest.setup.ts
@@ -1,4 +1,8 @@
 import '@testing-library/jest-dom/vitest'
+// vitest.config.ts uses `globals: false`, so React Testing Library cannot register its own
+// auto-cleanup (it only does so when a global `afterEach` exists). Manual cleanup is therefore
+// required here — removing it leaks the DOM between tests (measured: 11 files / 42 tests fail).
+// The matching no-manual-cleanup exception is registered in eslint.config.js.
 import { cleanup } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 import { setAuthToken } from '@/shared/api/client'


### PR DESCRIPTION
Refs #739（epic の C3-2。epic は C3-3 が残るのでこの PR では閉じない）

判例26 台帳の **testing-library 列挙（18 ファイル・218 件）を drain し、台帳ごと削除**した。**本番ソースは 1 行も触っていない**（差分 19 ファイル = テスト 18 ＋ `eslint.config.js`）。

## 内訳（実測）

| ルール | 件数 |
| --- | --- |
| `prefer-screen-queries` | 86 |
| `no-node-access` | 68 |
| `no-container` | 38 |
| `no-wait-for-multiple-assertions` | 22 |
| `render-result-naming-convention` | 2 |
| `prefer-presence-queries` | 1 |
| `no-manual-cleanup` | 1 |

`npm run check` フルチェーン緑・**345 tests / 88 files**（drain 前と同数）。

## 🔴 素直に drain すると別ルールへ付け替わる（この PR の一番の学び）

`prefer-screen-queries` は「分割代入をやめて `screen.getByX` を使え」と言う。素直に従うと `getByTestId` は `screen.getByTestId` になるが、**`no-restricted-syntax` が「getByTestId は registries の testid-allowlist 登録分のみ（会議R2⑧）」を課しており、本リポの `registries.jsonc` に testid-allowlist エントリは存在しない**（実測: entries は components-allowlist 1本＋lint-baseline 6本のみ）。

- 変更前は分割代入の bare call だったので `no-restricted-syntax` に当たらず、testing-library 側だけの違反だった。
- 素直に drain すると **15 件が testing-library の違反から no-restricted-syntax の違反へ付け替わるだけ**（実測）。
- **allowlist へ登録して黙らせる逃げ道を一切使っていない**（登録 0 件）。正しい終点はアクセシブルクエリで、`KeyboardShortcuts.test.tsx` では位置プローブを `role="status"` + `aria-label` へ、行カーソルを `aria-current` へ、テストローカルの input に `aria-label` を与えて `getByRole(name付き)` に寄せた。

hub 裁定: この知見は fleet の「凍結明け 06 章候補」棚へ実例つきで還流する（標準は mustTotal 凍結中で今は MUST を足せないため）。

## `no-manual-cleanup` 1 件だけは drain ではなく公認差異

`tests/setup/vitest.setup.ts` の手動 `cleanup()` は**外せない**。`vitest.config.ts` が `globals: false` なので RTL は自前の auto-cleanup を登録できない（登録条件がグローバル `afterEach` の存在）。

**実測**: `cleanup()` を外すと `345 passed` → **11 ファイル / 42 テスト失敗**（DOM がテスト間に漏れる）。

インライン `eslint-disable` ではなく、リポの既存の書き方（`restrict-template-expressions` の公認差異と同じ形）に合わせて **`eslint.config.js` の override として登録**し、理由と実測値、そして「`globals: true` へ倒すならこの登録ごと不要になる」という解除条件をコメントに書いた。台帳ではないので drain 対象ではない。

## 負テスト（ゲートが見ていることの証明）

台帳を削除したので、列挙されていた 18 ファイルも今後は full 強制になる。drain 済みファイル（`ActionError.test.tsx`）へ `container.querySelector` を差し戻すと:

```
13:5   error  Avoid using container methods...  testing-library/no-container
13:15  error  Avoid direct Node access...       testing-library/no-node-access
✖ 2 problems   → eslint rc=1
```

## 意味が変わった assertion（自己申告・レビュー観点）

drain の過程で、CSS クラス依存の assertion をアクセシブルなものへ置き換えた箇所が3つある。いずれも**両極性（成立/不成立）が今も通ることを確認済み**だが、厳密には被覆が同一ではない:

1. **DatePicker の開閉判定** — `container.querySelector('.dp.open')` → `expect(openButton()).toHaveAttribute('aria-expanded', ...)`。どちらも同じ `open` state から描画されるので実質等価だが、`cn()` から `'open'` を落とす回帰（ポップオーバーの見た目が壊れる）は捕まらなくなる。W3 でクラスが再生成される予定であることも踏まえ、ARIA 契約側を採った。
2. **ClientCombobox の作成フォーム存在** — `.combo-createform` の有無 → その中に無条件で描画される furigana input の有無。作成フォームを**入力欄なしで**描画する回帰だけがすり抜ける。
3. **ClientCombobox のハイライト** — 「どこにも `.hl` が無い」→「この option に `.hl` が無い」。当該テストでは候補が1件しか無いので被覆は同じ。**ここはクラス assertion を維持した**（コンポーネントが `aria-selected` を選択状態に束ねており、ハイライトにアクセシブルな表面が無い。露出させるには本番コードの変更が必要で、それは C3-2 の射程外）。

`use-list-*` の `no-wait-for-multiple-assertions` は、**最後の状態変化を表す assertion を `waitFor` のゲートとして残し**、残りをその直後の同期 `expect` へ出した（`seen.at(-1)` を読むので同じリクエストを検査する）。retry しなくなる点だけが弱化。

## スコープの確認（hub 判断をお願いしたい）

`eslint.config.js` のコメントは `stylePropLedger`（5 ファイル・10 件）と `a11yLedger`（5 ファイル・7 件）を「**C3-2 系の小粒 drain 対象**」と注記しているが、epic #739 の分割では C3-2 = testing-library drain と定義されている。実測したところこの 17 件は**すべて本番コンポーネント側の修正**（`ClientCombobox` / `LineItemSuggestInput` / `CommandPalette` の role 付与、`CsvImportPanel` / `BankImportPanel` のキーボード操作、`ViewDashboard` 等の style prop）で、テスト専用の本 PR とは risk の性質が違う。**勝手に広げず本 PR は testing-library に限定した。** 別 PR で拾うか W3 へ寄せるかの判断を仰ぐ。

## セルフレビュー

`docs/development/self-review.md`