### PR TITLE
fix(frontend): jsx-a11y 台帳 7 件を drain し本番側を是正（C3-2b） (#744)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -91,7 +91,12 @@ const sharedUiBarrelLedger = [
   'src/shared/ui/toast/ToastProvider.tsx',
 ]
 
-/** style prop のキー制約の既存違反（5 ファイル・10 件）— C3-2 系の小粒 drain 対象。 */
+/**
+ * style prop のキー制約の既存違反（5 ファイル・10 件）— **W3 同乗**（hub 裁定 2026-07-30）。
+ * CSS 変数注入への書き換えなので、意匠再生成と同じファイル群を二度触らない。
+ * （旧記載の「C3-2 系」は C3-2 = テスト専用 drain と確定したため振り直した。a11y 分は
+ * C3-2b #744 で drain 済み。）
+ */
 const stylePropLedger = [
   'src/features/edit-company-settings/ui/EditCompanySettings.tsx',
   'src/features/manage-company-seal/ui/ManageCompanySeal.tsx',
@@ -109,15 +114,6 @@ const unknownClassLedger = [
   'src/pages/layout/AppShell.tsx',
   'src/shared/ui/components/ConfirmDialog.tsx',
   'src/shared/ui/components/FilterBar.tsx',
-]
-
-/** jsx-a11y の既存違反（5 ファイル・7 件）— C3-2 系の小粒 drain 対象。 */
-const a11yLedger = [
-  'src/features/reconcile-bank/ui/BankImportPanel.tsx',
-  'src/shared/keyboard/CommandPalette.tsx',
-  'src/shared/ui/components/ClientCombobox.tsx',
-  'src/shared/ui/components/CsvImportPanel.tsx',
-  'src/shared/ui/components/LineItemSuggestInput.tsx',
 ]
 
 export default tseslint.config(
@@ -198,14 +194,6 @@ export default tseslint.config(
   {
     files: unknownClassLedger,
     rules: { 'better-tailwindcss/no-unknown-classes': 'off' },
-  },
-  {
-    files: a11yLedger,
-    rules: {
-      'jsx-a11y/no-noninteractive-element-interactions': 'off',
-      'jsx-a11y/no-noninteractive-element-to-interactive-role': 'off',
-      'jsx-a11y/no-static-element-interactions': 'off',
-    },
   },
   ...e2eConfig,
   ...storybook.configs['flat/recommended'],

--- a/frontend/src/features/reconcile-bank/ui/BankImportPanel.tsx
+++ b/frontend/src/features/reconcile-bank/ui/BankImportPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ChangeEvent, type DragEvent } from 'react'
+import { useRef, useState, type ChangeEvent } from 'react'
 import {
   BANK_IMPORT_PRESETS,
   useImportBankCsv,
@@ -7,6 +7,7 @@ import {
 } from '@/entities/bank-transaction'
 import { useTranslation } from '@/shared/i18n'
 import { cn } from '@/shared/lib/cn'
+import { useFileDropZone } from '@/shared/lib/use-file-drop-zone'
 import { Badge, Button, Field, Select, Stack, Text, useToast } from '@/shared/ui'
 
 function formatSize(bytes: number): string {
@@ -32,7 +33,6 @@ export function BankImportPanel() {
   const [preset, setPreset] = useState<BankImportPreset>('net_bank_credit_debit')
   const [file, setFile] = useState<File | null>(null)
   const [result, setResult] = useState<BankImportResult | null>(null)
-  const [drag, setDrag] = useState(false)
 
   const pick = (picked: File): void => {
     setResult(null)
@@ -44,12 +44,7 @@ export function BankImportPanel() {
     if (picked !== undefined) pick(picked)
   }
 
-  const onDrop = (event: DragEvent<HTMLLabelElement>): void => {
-    event.preventDefault()
-    setDrag(false)
-    const picked = event.dataTransfer.files[0]
-    if (picked !== undefined) pick(picked)
-  }
+  const { ref: dropRef, dragging } = useFileDropZone(pick)
 
   const reset = (): void => {
     setFile(null)
@@ -112,20 +107,7 @@ export function BankImportPanel() {
         </Select>
       </Field>
 
-      <label
-        className={cn('dropzone', drag && 'is-drag')}
-        onDragEnter={(e) => {
-          e.preventDefault()
-          setDrag(true)
-        }}
-        onDragOver={(e) => {
-          e.preventDefault()
-        }}
-        onDragLeave={() => {
-          setDrag(false)
-        }}
-        onDrop={onDrop}
-      >
+      <label ref={dropRef} className={cn('dropzone', dragging && 'is-drag')}>
         <input
           ref={inputRef}
           type="file"

--- a/frontend/src/shared/keyboard/CommandPalette.tsx
+++ b/frontend/src/shared/keyboard/CommandPalette.tsx
@@ -107,7 +107,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
   const renderRow = (cmd: Command): ReactNode => {
     const i = indexOfId(cmd.id)
     return (
-      <li key={cmd.id}>
+      <div key={cmd.id}>
         <button
           type="button"
           role="option"
@@ -131,7 +131,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
             </span>
           </span>
         </button>
-      </li>
+      </div>
     )
   }
 
@@ -152,19 +152,21 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
             <span className="kk">{launchKey}</span>
           </span>
         </div>
-        <ul className="cmdp-list" role="listbox" aria-label={t('admin.commandPalette.title')}>
+        {/* div, not ul: jsx-a11y strict forbids putting an interactive role on a
+            list element. The listbox/option/presentation roles carry the semantics. */}
+        <div className="cmdp-list" role="listbox" aria-label={t('admin.commandPalette.title')}>
           {GROUPS.map((group) => (
             <Fragment key={group.labelKey}>
-              <li className="cmdp-grp" role="presentation">
+              <div className="cmdp-grp" role="presentation">
                 {t(group.labelKey)}
-              </li>
+              </div>
               {group.ids.map((id) => {
                 const cmd = COMMANDS[indexOfId(id)]
                 return cmd === undefined ? null : renderRow(cmd)
               })}
             </Fragment>
           ))}
-        </ul>
+        </div>
         <div className="cmdp-foot">
           <span className="hint">
             <span className="mk">↑</span>

--- a/frontend/src/shared/lib/use-file-drop-zone.test.tsx
+++ b/frontend/src/shared/lib/use-file-drop-zone.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useFileDropZone } from './use-file-drop-zone'
+
+function DropHarness({ onFile }: { onFile: (file: File) => void }) {
+  const { ref, dragging } = useFileDropZone(onFile)
+  return (
+    <label ref={ref} aria-label="drop zone" className={dragging ? 'dropzone is-drag' : 'dropzone'}>
+      <input type="file" aria-label="file" />
+    </label>
+  )
+}
+
+const zone = (): HTMLElement => screen.getByLabelText('drop zone')
+
+describe('useFileDropZone', () => {
+  it('flags dragging while a drag hovers the zone and clears it on leave', () => {
+    render(<DropHarness onFile={vi.fn()} />)
+    expect(zone()).not.toHaveClass('is-drag')
+
+    fireEvent.dragEnter(zone())
+    expect(zone()).toHaveClass('is-drag')
+
+    fireEvent.dragLeave(zone())
+    expect(zone()).not.toHaveClass('is-drag')
+  })
+
+  it('reports the dropped file and clears the dragging state', () => {
+    const onFile = vi.fn()
+    render(<DropHarness onFile={onFile} />)
+    const file = new File(['date,amount\n'], 'statement.csv', { type: 'text/csv' })
+
+    fireEvent.dragEnter(zone())
+    fireEvent.drop(zone(), { dataTransfer: { files: [file] } })
+
+    expect(onFile).toHaveBeenCalledWith(file)
+    expect(zone()).not.toHaveClass('is-drag')
+  })
+
+  it('ignores a drop that carries no file', () => {
+    const onFile = vi.fn()
+    render(<DropHarness onFile={onFile} />)
+
+    fireEvent.drop(zone(), { dataTransfer: { files: [] } })
+
+    expect(onFile).not.toHaveBeenCalled()
+  })
+
+  it('calls the latest callback after a re-render (no stale closure)', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { rerender } = render(<DropHarness onFile={first} />)
+    rerender(<DropHarness onFile={second} />)
+    const file = new File(['x'], 'x.csv', { type: 'text/csv' })
+
+    fireEvent.drop(zone(), { dataTransfer: { files: [file] } })
+
+    expect(second).toHaveBeenCalledWith(file)
+    expect(first).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/shared/lib/use-file-drop-zone.ts
+++ b/frontend/src/shared/lib/use-file-drop-zone.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+export interface FileDropZone {
+  /** Attach to the `<label>` that wraps the file input. */
+  ref: RefObject<HTMLLabelElement | null>
+  /** True while a drag hovers the zone — drive the visual state from this. */
+  dragging: boolean
+}
+
+/**
+ * Drag-and-drop file selection for a `<label>` that wraps a real
+ * `<input type="file">`.
+ *
+ * The listeners are attached imperatively instead of as JSX props because
+ * jsx-a11y strict rejects event handlers on non-interactive elements, and a
+ * `<label>` is one. Dropping is a pointer-only enhancement — keyboard and
+ * screen-reader users pick the same file through the wrapped input — so the
+ * accessible behaviour is identical either way.
+ *
+ * `onFile` is read through a ref so the listeners are attached once and still
+ * see the latest closure.
+ */
+export function useFileDropZone(onFile: (file: File) => void): FileDropZone {
+  const ref = useRef<HTMLLabelElement>(null)
+  const [dragging, setDragging] = useState(false)
+
+  const onFileRef = useRef(onFile)
+  useEffect(() => {
+    onFileRef.current = onFile
+  })
+
+  useEffect(() => {
+    const zone = ref.current
+    if (zone === null) return
+
+    const enter = (e: DragEvent): void => {
+      e.preventDefault()
+      setDragging(true)
+    }
+    // Without preventDefault on dragover the browser opens the file instead.
+    const over = (e: DragEvent): void => {
+      e.preventDefault()
+    }
+    const leave = (): void => {
+      setDragging(false)
+    }
+    const drop = (e: DragEvent): void => {
+      e.preventDefault()
+      setDragging(false)
+      const picked = e.dataTransfer?.files[0]
+      if (picked !== undefined) onFileRef.current(picked)
+    }
+
+    zone.addEventListener('dragenter', enter)
+    zone.addEventListener('dragover', over)
+    zone.addEventListener('dragleave', leave)
+    zone.addEventListener('drop', drop)
+    return () => {
+      zone.removeEventListener('dragenter', enter)
+      zone.removeEventListener('dragover', over)
+      zone.removeEventListener('dragleave', leave)
+      zone.removeEventListener('drop', drop)
+    }
+  }, [])
+
+  return { ref, dragging }
+}

--- a/frontend/src/shared/ui/components/ClientCombobox.tsx
+++ b/frontend/src/shared/ui/components/ClientCombobox.tsx
@@ -123,6 +123,28 @@ export function ClientCombobox({
     setText(selected?.name ?? '')
   }
 
+  // Close when focus leaves the whole widget. Attached imperatively rather than
+  // as an onBlur prop: jsx-a11y strict counts focus handlers as interactions, so
+  // a layout <div> must not carry them. The interactive surface is the
+  // role="combobox" input and the role="option" buttons, which are keyboard
+  // reachable on their own. closeRef keeps the listener on the latest state
+  // without re-attaching every render.
+  const closeRef = useRef(close)
+  useEffect(() => {
+    closeRef.current = close
+  })
+  useEffect(() => {
+    const wrap = wrapRef.current
+    if (wrap === null) return
+    const onFocusOut = (e: FocusEvent): void => {
+      if (!wrap.contains(e.relatedTarget as Node | null)) closeRef.current()
+    }
+    wrap.addEventListener('focusout', onFocusOut)
+    return () => {
+      wrap.removeEventListener('focusout', onFocusOut)
+    }
+  }, [])
+
   const pick = (client: ClientOption): void => {
     onChange(client.id)
     setText(client.name)
@@ -205,15 +227,7 @@ export function ClientCombobox({
   }
 
   return (
-    <div
-      ref={wrapRef}
-      className={cn('combo', open && 'open')}
-      onBlur={(e) => {
-        if (wrapRef.current !== null && !wrapRef.current.contains(e.relatedTarget)) {
-          close()
-        }
-      }}
-    >
+    <div ref={wrapRef} className={cn('combo', open && 'open')}>
       <input
         type="text"
         id={id}
@@ -240,10 +254,12 @@ export function ClientCombobox({
         onKeyDown={onKeyDown}
       />
 
+      {/* div, not ul: jsx-a11y strict forbids an interactive role on a list
+          element. The listbox/option roles carry the semantics. */}
       {open && (loading || rowCount > 0) && (
-        <ul className="combo-pop" id={id !== undefined ? `${id}-list` : undefined} role="listbox">
+        <div className="combo-pop" id={id !== undefined ? `${id}-list` : undefined} role="listbox">
           {matches.map((c, i) => (
-            <li key={c.id}>
+            <div key={c.id}>
               <button
                 type="button"
                 role="option"
@@ -264,11 +280,11 @@ export function ClientCombobox({
                   </span>
                 )}
               </button>
-            </li>
+            </div>
           ))}
 
           {showCreate && !createMode && (
-            <li>
+            <div>
               <button
                 type="button"
                 className={cn('combo-create', highlight === matches.length && 'hl')}
@@ -283,11 +299,11 @@ export function ClientCombobox({
               >
                 {createLabel !== undefined ? createLabel(text.trim()) : `+ ${text.trim()}`}
               </button>
-            </li>
+            </div>
           )}
 
           {showCreate && createMode && (
-            <li className="combo-createform">
+            <div className="combo-createform">
               <span className="combo-createform-label">
                 {createLabel !== undefined ? createLabel(text.trim()) : `+ ${text.trim()}`}
               </span>
@@ -314,9 +330,9 @@ export function ClientCombobox({
               >
                 {createConfirmLabel ?? '+'}
               </button>
-            </li>
+            </div>
           )}
-        </ul>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/shared/ui/components/CsvImportPanel.tsx
+++ b/frontend/src/shared/ui/components/CsvImportPanel.tsx
@@ -1,5 +1,6 @@
-import { useState, type ChangeEvent, type DragEvent } from 'react'
+import { useState, type ChangeEvent } from 'react'
 import { cn } from '@/shared/lib/cn'
+import { useFileDropZone } from '@/shared/lib/use-file-drop-zone'
 import type { CsvImportReport } from '@/shared/lib/csv-import'
 import { useTranslation } from '@/shared/i18n'
 import { Button } from '../primitives/Button'
@@ -49,7 +50,6 @@ export function CsvImportPanel({ template, runImport, onDone }: CsvImportPanelPr
   const [csv, setCsv] = useState<string | null>(null)
   const [report, setReport] = useState<CsvImportReport | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [drag, setDrag] = useState(false)
 
   const pick = (picked: File): void => {
     setError(null)
@@ -75,12 +75,7 @@ export function CsvImportPanel({ template, runImport, onDone }: CsvImportPanelPr
     if (picked !== undefined) pick(picked)
   }
 
-  const onDrop = (event: DragEvent<HTMLLabelElement>): void => {
-    event.preventDefault()
-    setDrag(false)
-    const picked = event.dataTransfer.files[0]
-    if (picked !== undefined) pick(picked)
-  }
+  const { ref: dropRef, dragging } = useFileDropZone(pick)
 
   const reset = (): void => {
     setPhase('idle')
@@ -154,20 +149,7 @@ export function CsvImportPanel({ template, runImport, onDone }: CsvImportPanelPr
               <div className="st-d">{t('common.csvImport.step2Desc')}</div>
             </div>
           </div>
-          <label
-            className={cn('dropzone', drag && 'is-drag')}
-            onDragEnter={(e) => {
-              e.preventDefault()
-              setDrag(true)
-            }}
-            onDragOver={(e) => {
-              e.preventDefault()
-            }}
-            onDragLeave={() => {
-              setDrag(false)
-            }}
-            onDrop={onDrop}
-          >
+          <label ref={dropRef} className={cn('dropzone', dragging && 'is-drag')}>
             <input
               type="file"
               accept=".csv,text/csv"

--- a/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
+++ b/frontend/src/shared/ui/components/LineItemSuggestInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type KeyboardEvent } from 'react'
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
 import { cn } from '@/shared/lib/cn'
 
 /** Minimal shape the suggest input needs from a line-item suggestion (#315). */
@@ -62,6 +62,22 @@ export function LineItemSuggestInput({
     setOpen(false)
   }
 
+  // Close when focus leaves the whole widget. Attached imperatively rather than
+  // as an onBlur prop: jsx-a11y strict counts focus handlers as interactions, so
+  // a layout <div> must not carry them. The interactive surface is the input and
+  // the role="option" buttons, which are keyboard reachable on their own.
+  useEffect(() => {
+    const wrap = wrapRef.current
+    if (wrap === null) return
+    const onFocusOut = (e: FocusEvent): void => {
+      if (!wrap.contains(e.relatedTarget as Node | null)) setOpen(false)
+    }
+    wrap.addEventListener('focusout', onFocusOut)
+    return () => {
+      wrap.removeEventListener('focusout', onFocusOut)
+    }
+  }, [])
+
   // Capture phase: runs before the grid's native bubble listener, so we can
   // claim Enter when the menu is actionable and otherwise let the grid have it.
   const onKeyDownCapture = (e: KeyboardEvent<HTMLInputElement>): void => {
@@ -96,15 +112,7 @@ export function LineItemSuggestInput({
   }
 
   return (
-    <div
-      ref={wrapRef}
-      className={cn('combo', open && 'open')}
-      onBlur={(e) => {
-        if (wrapRef.current !== null && !wrapRef.current.contains(e.relatedTarget)) {
-          setOpen(false)
-        }
-      }}
-    >
+    <div ref={wrapRef} className={cn('combo', open && 'open')}>
       <input
         type="text"
         id={id}
@@ -127,10 +135,12 @@ export function LineItemSuggestInput({
         onKeyDownCapture={onKeyDownCapture}
       />
 
+      {/* div, not ul: jsx-a11y strict forbids an interactive role on a list
+          element. The listbox/option roles carry the semantics. */}
       {open && matches.length > 0 && (
-        <ul className="combo-pop" id={id !== undefined ? `${id}-list` : undefined} role="listbox">
+        <div className="combo-pop" id={id !== undefined ? `${id}-list` : undefined} role="listbox">
           {matches.map((s, i) => (
-            <li key={s.description}>
+            <div key={s.description}>
               <button
                 type="button"
                 role="option"
@@ -147,9 +157,9 @@ export function LineItemSuggestInput({
                 <span className="combo-name">{s.description}</span>
                 {renderMeta !== undefined && <span className="combo-sub">{renderMeta(s)}</span>}
               </button>
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
Closes #744

判例26 台帳の `a11yLedger`（5 ファイル・7 件）を drain し、**台帳ごと削除**した。hub 裁定（2026-07-30）で「a11y 7件は C3-2b として別 PR 先行・style-prop 10件は W3 同乗」と分けた、その前者。

C3-2（#743）と違い**本番コンポーネントの markup / 実装に触る**ので、1件ずつ「なぜその形なのか」を読んでから直し、**抑止（eslint-disable）も台帳据え置きも使っていない**。

## 直し方（3 パターン）

### 1. `ul role="listbox"` → `div`（3 件）

`CommandPalette.tsx` / `ClientCombobox.tsx` / `LineItemSuggestInput.tsx`。`no-noninteractive-element-to-interactive-role` は「リスト要素に interactive role を載せるな」なので、要素側を `div` にして `listbox` / `option` / `presentation` の role に意味を担わせた。

**意匠不変の裏取り**〔実測〕: `.cmdp-list` と `.combo-pop` は CSS 側で `margin: 0` / `padding` / `list-style: none` を自前で指定しており、`ul`/`li` の既定値に依存していない（Tailwind preflight もリストを潰している）。

> 副作用として `.cmdp-list li { margin: 0 }` が当たらなくなるが、`li` に既定 margin は無く preflight も効いているので**表示は変わらない**。この 1 ルールは死んだので、W3 の dead CSS 掃除で拾うのが素直（本 PR では index.css を触っていない＝lint-baseline の frozenCount に触れないため）。

### 2. 静的 `div` の `onBlur` → `focusout` リスナ（2 件）

`ClientCombobox.tsx:208` / `LineItemSuggestInput.tsx:99`。ポップアップを閉じるための「フォーカスがウィジェット外へ出た」観測が、レイアウト用 `div` の `onBlur` に載っていた。

**なぜ焦点イベントで落ちるのか**〔実測〕: nene2 標準は `jsx-a11y.flatConfigs.strict` を採っており、strict は `no-static-element-interactions` に `handlers` を渡していない。既定は `eventHandlersByType.focus + keyboard + mouse` なので、**`onBlur` も対象**（recommended 側は click/mouse/key に絞っている）。プリセットの意図どおりの指摘で、false positive ではない。

対処は `wrapRef` への `focusout` リスナ。静的要素からハンドラが消え、挙動は同じ（React の `onBlur` は `focusout` に対応）。最新の state を見るための `closeRef` を置いた理由もコメントに書いた。既存テストは緑のまま（ClientCombobox 8 / LineItemSuggestInput 4）。

### 3. `label` のドラッグハンドラ → 共有フック `useFileDropZone`（2 件）

`BankImportPanel.tsx` / `CsvImportPanel.tsx`。同じ形が 2 箇所にあったので `shared/lib/use-file-drop-zone.ts` へ切り出し、理由を 1 箇所に書いた。

ドロップは `<input type="file">` の上に載せた**ポインタ専用の拡張**で、キーボード / スクリーンリーダーの経路（ラベルに紐づいた実 input）は元から変わらない。だからハンドラを DOM 側へ移すのは意味の欠落にならない。

## 新規テスト — 未テストだった経路を塞いだ

ドロップ経路には**テストが 1 本も無かった**ので、フックのユニットテストを 4 本追加した（dragging の立ち下がり / 落としたファイルの受け渡し / ファイル無しドロップの無視 / 再レンダ後に最新コールバックを呼ぶこと）。

**変異で実効性を確認**〔実測〕: `onFileRef` を更新する effect を外すと「no stale closure」の 1 本だけが落ちる（`1 failed | 3 passed`）。

## 負テスト（ゲートが見ていることの証明）

台帳を消したので、これらのファイルも今後は full 強制。`label` にハンドラを戻すと:

```
152:11  error  Non-interactive elements should not be assigned mouse or keyboard event listeners
                                                    jsx-a11y/no-noninteractive-element-interactions
✖ 1 problem   → eslint rc=1
```

## 実測

- `npm run check` フルチェーン緑・**349 tests / 89 files**（#743 時点の 345 / 88 から、新規フックテスト +4）。
- `tsc -b` 緑。差分 8 ファイル（本番 5・設定 1・新規フック＋そのテスト 2）。

## 途中で踏んだもの（記録）

フックが `{ ref, dragging }` を返す形にしたら `react-hooks/refs`（「ref を render 中に読む可能性」）が **6 件**出た〔実測〕。呼び出し側で `const { ref: dropRef, dragging } = ...` と分解したら解消。**ref を含むオブジェクトをそのまま render で参照させない**のが要点。

## 台帳コメントの振り直し（hub 指示）

`stylePropLedger` の「C3-2 系の小粒 drain 対象」という注記を **W3 同乗**へ書き換えた（CSS 変数注入への書き換えで意匠再生成と同じファイル群を触るため）。a11y 分は本 PR で消えた。

## セルフレビュー

`docs/development/self-review.md`