### PR TITLE
feat(auth): path モードの silent refresh を有効化する（recoverAuth 昇格ゲートの flip） (#748)

### DIFF
--- a/docs/adr/0022-transport-layer-silent-refresh-recoverauth-seam.md
+++ b/docs/adr/0022-transport-layer-silent-refresh-recoverauth-seam.md
@@ -147,6 +147,30 @@ mode behind a promotion gate**.
 - Register any new identifiers introduced by the eventual path-mode enablement
   in `docs/explanation/terminology.md` in the implementing PR.
 
+## Amendment 1 (2026-07-30) — path-mode silent refresh enabled
+
+The owner GO named in "Remaining before path-mode is switched on in production"
+was given on 2026-07-30. The per-mode promotion gate is **removed**: the
+transport now receives `recoverAuth` in every tenancy mode.
+
+- `frontend/src/shared/api/client.ts` — `...(isPathTenancy ? {} : { recoverAuth })`
+  became an unconditional `recoverAuth`.
+- `frontend/src/shared/config/app-base.ts` — `isPathTenancy` existed only to feed
+  the gate and was deleted with it. `deriveInstallBase` stays (it still explains
+  how a slug is told apart from a subdirectory install).
+
+**Precondition re-verified before flipping, not assumed.** The #38 root fix
+(`#693` / `#694`, merged 2026-07-17) was covered only at the ends — the
+middleware records the slug-scoped app base (`OrgResolverMiddlewareTest`) and the
+builder turns a base into a `Path` (`SessionCookiesTest`) — with nothing on the
+join. `tests/Auth/RefreshHandlerTest.php` now covers it: rotation and the
+fail-closed clear both emit `Path=/{base}/{slug}/auth` in path mode, and the
+install base elsewhere. Reverting the handler to the pre-fix
+`BasePath::fromRequest()` fails 3 of its 4 tests, so the coverage is real.
+
+Deploying the flipped bundle is tracked separately; this amendment records the
+code change, not the rollout.
+
 ## Related
 
 - Issue: `#701` (this ADR); fleet bug `#38` (path-mode refresh-cookie

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -3,7 +3,7 @@ import {
   isNene2ClientError,
   type TokenStore,
 } from '@hideyukimori/nene2-client'
-import { apiBasePath, isPathTenancy } from '@/shared/config/app-base'
+import { apiBasePath } from '@/shared/config/app-base'
 import { AppError } from './errors'
 
 /**
@@ -12,7 +12,7 @@ import { AppError } from './errors'
  * replay) is delegated to the fleet-standard `@hideyukimori/nene2-client`
  * transport (ADR 0008 seam). This module owns only the invoice-specific bits:
  * the in-memory token posture, the refresh mechanics (endpoint + CSRF cookie),
- * the promotion gate, and mapping the transport's errors to {@link AppError}.
+ * and mapping the transport's errors to {@link AppError}.
  *
  * The exported surface (`apiClient`, `setAuthToken`, `hasAuthToken`,
  * `wasSessionExpired`, `subscribeAuthChange`, `refreshSession`, `revokeSession`)
@@ -139,13 +139,14 @@ const transport = createNene2Transport({
     sessionExpired = true
     notify()
   },
-  // Promotion gate (ADR 0008 / issue #38): silent refresh only where it is safe.
-  // Under path-scoped tenancy the rotated `ni_refresh` is reissued at a
-  // slug-stripped `Path` (#38), so a second refresh re-presents a consumed token
-  // → server-side reuse defense revokes the family (hard logout). Single/host
-  // mode has no slug, so refresh is safe there today — pass `recoverAuth`. Path
-  // mode omits it (fail-closed one-shot) until #38 lands server-side.
-  ...(isPathTenancy ? {} : { recoverAuth }),
+  // Silent refresh is enabled in every tenancy mode (ADR 0022). It used to be
+  // gated off under path-scoped tenancy because the rotated `ni_refresh` was
+  // reissued at a slug-stripped `Path` (#38), so the second refresh re-presented
+  // a consumed token and the server-side reuse defense burned the family (hard
+  // logout). The server now reissues at the app base (install base + slug) —
+  // `OrgResolverMiddleware` records it and Login/Refresh/Logout use it — so the
+  // rotation stays inside `/{base}/{slug}/auth`. See `RefreshHandlerTest`.
+  recoverAuth,
 })
 
 /**
@@ -153,7 +154,7 @@ const transport = createNene2Transport({
  * token is gone, but the refresh cookie may still be valid. Routes through
  * `transport.recover()` (never `recoverAuth` directly) so the boot probe and any
  * early 401-retry share one in-flight refresh — concurrent refreshes would trip
- * the rotation reuse defense. Resolves false in path mode (no `recoverAuth`).
+ * the rotation reuse defense.
  */
 export function refreshSession(): Promise<boolean> {
   return transport.recover()

--- a/frontend/src/shared/config/app-base.test.ts
+++ b/frontend/src/shared/config/app-base.test.ts
@@ -38,7 +38,7 @@ describe('path tenancy app base (型B Phase 2)', () => {
   })
 })
 
-describe('deriveInstallBase — install base without the tenant slug (promotion gate)', () => {
+describe('deriveInstallBase — install base without the tenant slug', () => {
   it('strips the shell-appended /admin/ to reveal the install base', () => {
     expect(deriveInstallBase('/admin/')).toBe('')
     expect(deriveInstallBase('/invoice/admin/')).toBe('/invoice')

--- a/frontend/src/shared/config/app-base.ts
+++ b/frontend/src/shared/config/app-base.ts
@@ -45,7 +45,7 @@ export const routerBasename: string = deriveRouterBasename(apiBasePath)
  * Install base **without** any tenant slug. The shell injects it as the asset
  * `<base href="<installBase>/admin/">` — its comment: "this is the install base
  * only — never the org slug" — so it lets us tell a path-scoped slug apart from
- * a plain subdirectory install.
+ * a plain subdirectory install (the API base extends past it by the slug).
  */
 export function deriveInstallBase(baseHref: string | null): string {
   if (typeof baseHref !== 'string') {
@@ -54,19 +54,3 @@ export function deriveInstallBase(baseHref: string | null): string {
 
   return baseHref.replace(/\/admin\/?$/, '').replace(/\/+$/, '')
 }
-
-function readBaseHref(): string | null {
-  if (typeof document === 'undefined') {
-    return null
-  }
-
-  return document.querySelector('base')?.getAttribute('href') ?? null
-}
-
-/**
- * True under path-scoped multi-tenancy (`/<installBase>/<slug>/`): the API base
- * (install base **plus** slug) extends past the asset base (install base only).
- * Silent re-authentication is gated off in this mode until the #38 cookie-`Path`
- * fix — see `shared/api/client.ts` and ADR 0008.
- */
-export const isPathTenancy: boolean = apiBasePath !== deriveInstallBase(readBaseHref())

--- a/tests/Auth/RefreshHandlerTest.php
+++ b/tests/Auth/RefreshHandlerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneInvoice\Auth\CsrfGuard;
+use NeneInvoice\Auth\InvalidRefreshTokenException;
+use NeneInvoice\Auth\IssuedRefreshToken;
+use NeneInvoice\Auth\RefreshedSession;
+use NeneInvoice\Auth\RefreshHandler;
+use NeneInvoice\Auth\RefreshSessionUseCaseInterface;
+use NeneInvoice\Auth\SessionCookies;
+use NeneInvoice\Http\BasePath;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The rotation half of the #38 root fix.
+ *
+ * `OrgResolverMiddlewareTest` proves the middleware records the slug-scoped app
+ * base; `SessionCookiesTest` proves the builder turns a base into a `Path`. This
+ * covers the join: the handler must reissue the rotated cookies at the **app**
+ * base (install base + slug), not the slug-stripped install base. Getting this
+ * wrong lands `ni_refresh` at `/{base}/auth`, so the next `/{slug}/auth/refresh`
+ * re-presents a spent token and the server-side reuse defense burns the family
+ * (hard logout). Silent refresh in path mode depends on this.
+ */
+final class RefreshHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+    }
+
+    private function handler(): RefreshHandler
+    {
+        $useCase = new class () implements RefreshSessionUseCaseInterface {
+            public function execute(string $rawToken): RefreshedSession
+            {
+                return new RefreshedSession(
+                    accessToken: 'access-token',
+                    refreshToken: new IssuedRefreshToken('rotated-raw-token', '2026-08-30T00:00:00+00:00', 1_787_000_000),
+                );
+            }
+        };
+
+        return new RefreshHandler(
+            $useCase,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+    }
+
+    /** A request that passes the cookie + double-submit CSRF checks. */
+    private function signedInRequest(string $path): ServerRequestInterface
+    {
+        return $this->psr17
+            ->createServerRequest('POST', 'https://app.example.com' . $path)
+            ->withCookieParams([
+                SessionCookies::REFRESH_COOKIE => 'current-raw-token',
+                SessionCookies::CSRF_COOKIE => 'csrf-value',
+            ])
+            ->withHeader(CsrfGuard::HEADER, 'csrf-value');
+    }
+
+    /** @return array<int, string> */
+    private function setCookies(ServerRequestInterface $request): array
+    {
+        return $this->handler()->handle($request)->getHeader('Set-Cookie');
+    }
+
+    private static function cookieNamed(string $name, string ...$headers): string
+    {
+        foreach ($headers as $header) {
+            if (str_starts_with($header, $name . '=')) {
+                return $header;
+            }
+        }
+
+        self::fail("No Set-Cookie for {$name}");
+    }
+
+    public function test_rotated_cookies_are_scoped_to_the_slug_in_path_tenancy(): void
+    {
+        $request = $this->signedInRequest('/acme/auth/refresh')
+            ->withAttribute(BasePath::APP_BASE_ATTRIBUTE, '/acme');
+
+        $cookies = $this->setCookies($request);
+
+        self::assertStringContainsString(
+            'Path=/acme/auth',
+            self::cookieNamed(SessionCookies::REFRESH_COOKIE, ...$cookies),
+        );
+        self::assertStringContainsString(
+            'Path=/acme/',
+            self::cookieNamed(SessionCookies::CSRF_COOKIE, ...$cookies),
+        );
+    }
+
+    public function test_rotated_cookies_keep_the_install_base_under_a_subdirectory_install(): void
+    {
+        $request = $this->signedInRequest('/invoice/acme/auth/refresh')
+            ->withAttribute(BasePath::APP_BASE_ATTRIBUTE, '/invoice/acme');
+
+        $cookies = $this->setCookies($request);
+
+        self::assertStringContainsString(
+            'Path=/invoice/acme/auth',
+            self::cookieNamed(SessionCookies::REFRESH_COOKIE, ...$cookies),
+        );
+    }
+
+    public function test_single_tenant_mode_scopes_to_the_install_base(): void
+    {
+        // No app-base attribute: `appBaseFromRequest` falls back to the install
+        // base, which is `''` at the document root.
+        $cookies = $this->setCookies($this->signedInRequest('/auth/refresh'));
+
+        self::assertStringContainsString(
+            'Path=/auth',
+            self::cookieNamed(SessionCookies::REFRESH_COOKIE, ...$cookies),
+        );
+    }
+
+    public function test_fail_closed_clears_cookies_at_the_same_scope(): void
+    {
+        $failing = new class () implements RefreshSessionUseCaseInterface {
+            public function execute(string $rawToken): RefreshedSession
+            {
+                throw new InvalidRefreshTokenException();
+            }
+        };
+        $handler = new RefreshHandler(
+            $failing,
+            new JsonResponseFactory($this->psr17, $this->psr17),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-invoice.dev/problems/'),
+        );
+
+        $request = $this->signedInRequest('/acme/auth/refresh')
+            ->withAttribute(BasePath::APP_BASE_ATTRIBUTE, '/acme');
+        $response = $handler->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        // A clear that misses the scope leaves the stale cookie in place.
+        self::assertStringContainsString(
+            'Path=/acme/auth',
+            self::cookieNamed(SessionCookies::REFRESH_COOKIE, ...$response->getHeader('Set-Cookie')),
+        );
+    }
+}


### PR DESCRIPTION
Closes #748

ADR 0022 が定めた **per-mode 昇格ゲート**を外し、全テナンシーモードで `recoverAuth` を transport へ渡す。**07-18 から待機していた単独残タスク**で、施主 GO（判断バンドル項12・2026-07-30）を受けた分。

## 🔴 フリップする前に、前提を測り直した

ADR は「#38 の根治（#693 / #694・`f8482db`・07-17 merged）が唯一の前提」と書いている。**そのまま信じずに検査状況を確認したところ、両端しか覆われていなかった**:

| 何を | どこで覆われていたか |
| --- | --- |
| middleware が slug スコープの app base を記録する | `OrgResolverMiddlewareTest`（#694 で +43 行） |
| builder が base を `Path` に変換する | `SessionCookiesTest` |
| **↑ の繋ぎ目（RefreshHandler が app base で再発行する）** | **無検査**（`RefreshHandlerTest` 自体が存在しなかった） |

ここが外れていると **path モードの全テナント（公開デモ含む）が2回目の refresh で family burn → ハードログアウト**する。ゲートを外す PR でそこが無検査のままなのは筋が悪いので、**先に塞いでから flip した**。

### `tests/Auth/RefreshHandlerTest.php`（新設・4 本）

- path テナンシー: rotation が `ni_refresh` を `Path=/acme/auth`、`ni_csrf` を `Path=/acme/` で出す
- サブディレクトリ設置 × path テナンシー: `Path=/invoice/acme/auth`
- 単一テナント: app-base 属性なし → install base（ドキュメントルートで `Path=/auth`）
- **fail-closed の clear も同じスコープで出す**（スコープを外した clear は古い cookie を残すので、ここも壊れると同じ症状になる）

**空虚でないことの実測**〔実測〕: `RefreshHandler` を根治前の `BasePath::fromRequest()` に戻すと **4 本中 3 本が落ちる**（`'ni_refresh=; Path=/auth; …' が "Path=/acme/auth" を含まない` 等）。

## フリップ本体

```diff
-  // Promotion gate (ADR 0008 / issue #38): silent refresh only where it is safe.
-  ...(isPathTenancy ? {} : { recoverAuth }),
+  // Silent refresh is enabled in every tenancy mode (ADR 0022). …
+  recoverAuth,
```

- `isPathTenancy` は**このゲート専用**だったので道連れで削除。それだけが使っていた private の `readBaseHref` も削除（`tsc` が未使用を検出）。
- `deriveInstallBase` は残した（slug とサブディレクトリ設置を見分ける説明として今も有効。`knip` 緑）。
- `refreshSession` の「path モードでは false を返す」という doc、`client.ts` 冒頭の「the promotion gate」も実態に合わせて更新。

## ADR 0022 に Amendment 1 を追記

ADR は "**Remaining before path-mode is switched on in production**: flip … **and** deploy — both are an **explicit owner (施主) GO**" と書いたままだった。GO が降りた以上そこを放置すると台帳が嘘になるので、**Amendment 1（2026-07-30）**として GO の事実・変更点・前提の再検証内容を記録した。

## 実測

- `composer check` 緑 — **1011 tests / 3695 assertions**（1007 → +4）
- `npm run check` 緑 — **351 tests / 89 files**（変化なし）
- `tsc -b` 緑・`knip` 緑

## デプロイは含まない

ADR どおり **flip とデプロイは別**。本 PR はコード変更のみで、本番反映（`invoice.ayane.co.jp` は path モードのデモ）は施主ゲートの運用に従って別途行う。**デプロイ後に family burn が起きないことの実機確認**は、その工程の受入条件。

## セルフレビュー

`docs/review/compliance.md` は非該当（会計・税務・採番・PDF・保存に触れない）。`docs/development/self-review.md`。