### PR TITLE
refactor(invoice): Jst 域内クロック化（域内2件・Jst の static API は不変）

### DIFF
--- a/src/Invoice/InvoiceListFilter.php
+++ b/src/Invoice/InvoiceListFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Invoice;
 
+use Nene2\Http\ClockInterface;
 use NeneInvoice\Support\Jst;
 
 /**
@@ -57,8 +58,14 @@ final readonly class InvoiceListFilter
             && $this->issuedTo === null;
     }
 
-    public function todayOrNow(): string
+    /**
+     * Reference JST calendar date for `overdueOnly`. Takes the clock from the
+     * caller rather than reading the wall clock, so the date boundary (UTC
+     * 15:00 = JST midnight) is deterministic under test. Passing a
+     * {@see \Nene2\Http\UtcClock} reproduces the previous `Jst::today()`.
+     */
+    public function todayOrNow(ClockInterface $clock): string
     {
-        return $this->today ?? Jst::today();
+        return $this->today ?? Jst::of($clock->now())->format('Y-m-d');
     }
 }

--- a/src/Invoice/InvoiceResponse.php
+++ b/src/Invoice/InvoiceResponse.php
@@ -16,6 +16,9 @@ final class InvoiceResponse
 {
     /**
      * @param list<LineItem>|null $lines
+     * @param ?string $nowJst JST wall clock (`Y-m-d H:i:s`) the overdue check compares against.
+     *                        Omit to read the wall clock (current behaviour); pass it from a
+     *                        {@see \Nene2\Http\ClockInterface} to make `is_overdue` deterministic.
      * @return array<string, mixed>
      */
     public static function toArray(
@@ -23,6 +26,7 @@ final class InvoiceResponse
         ?array $lines = null,
         ?int $outstandingCents = null,
         ?string $clientName = null,
+        ?string $nowJst = null,
     ): array {
         $data = [
             'id' => $invoice->id,
@@ -32,7 +36,7 @@ final class InvoiceResponse
             'quote_id' => $invoice->quoteId,
             'invoice_number' => $invoice->invoiceNumber,
             'status' => $invoice->status->value,
-            'is_overdue' => self::computeIsOverdue($invoice),
+            'is_overdue' => self::computeIsOverdue($invoice, $nowJst),
             'is_qualified_invoice' => $invoice->isQualifiedInvoice,
             'issued_at' => $invoice->issuedAt,
             'due_at' => $invoice->dueAt,
@@ -55,7 +59,7 @@ final class InvoiceResponse
         return $data;
     }
 
-    private static function computeIsOverdue(Invoice $invoice): bool
+    private static function computeIsOverdue(Invoice $invoice, ?string $nowJst = null): bool
     {
         if ($invoice->status !== InvoiceStatus::Issued && $invoice->status !== InvoiceStatus::PartiallyPaid) {
             return false;
@@ -65,6 +69,6 @@ final class InvoiceResponse
             return false;
         }
 
-        return $invoice->dueAt < Jst::nowString();
+        return $invoice->dueAt < ($nowJst ?? Jst::nowString());
     }
 }

--- a/src/Invoice/PdoInvoiceRepository.php
+++ b/src/Invoice/PdoInvoiceRepository.php
@@ -192,7 +192,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
         if ($filter->overdueOnly) {
             $clauses[] = "i.status IN ('issued', 'partially_paid')";
             $clauses[] = 'i.due_at IS NOT NULL AND i.due_at < ?';
-            $params[] = $filter->todayOrNow();
+            $params[] = $filter->todayOrNow($this->clock);
         }
 
         return [implode(' AND ', $clauses), $params];
@@ -258,7 +258,7 @@ final readonly class PdoInvoiceRepository implements InvoiceRepositoryInterface
 
         if ($filter->overdueOnly) {
             $clauses[] = 'due_at IS NOT NULL AND due_at < ?';
-            $params[] = $filter->todayOrNow();
+            $params[] = $filter->todayOrNow($this->clock);
         }
 
         return [implode(' AND ', $clauses), $params];

--- a/tests/Invoice/InvoiceListFilterClockTest.php
+++ b/tests/Invoice/InvoiceListFilterClockTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneInvoice\Tests\Invoice;
+
+use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
+use NeneInvoice\Invoice\Invoice;
+use NeneInvoice\Invoice\InvoiceListFilter;
+use NeneInvoice\Invoice\InvoiceSort;
+use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Support\Jst;
+use NeneInvoice\Tests\Support\FixedClock;
+use NeneInvoice\Tests\Support\InMemoryInvoiceRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the reference date `overdueOnly` resolves against (Issue #752).
+ *
+ * `todayOrNow()` used to read the wall clock via `Jst::today()`. It now takes a
+ * {@see \Nene2\Http\ClockInterface}, so the JST calendar-day boundary — UTC
+ * 15:00, where the Japanese date rolls over — is assertable instead of being
+ * whatever day the suite happened to run on.
+ */
+final class InvoiceListFilterClockTest extends TestCase
+{
+    /** JST midnight is UTC 15:00 the previous day; one second earlier is still the old JST day. */
+    public function test_reference_date_is_the_jst_day_just_before_the_boundary(): void
+    {
+        $filter = new InvoiceListFilter(overdueOnly: true);
+
+        self::assertSame('2026-08-04', $filter->todayOrNow(new FixedClock('2026-08-04T14:59:59Z')));
+    }
+
+    public function test_reference_date_rolls_over_at_utc_1500(): void
+    {
+        $filter = new InvoiceListFilter(overdueOnly: true);
+
+        self::assertSame('2026-08-05', $filter->todayOrNow(new FixedClock('2026-08-04T15:00:00Z')));
+    }
+
+    /** Reading the same instant as UTC would still say 08-04 — that is the bug this guards. */
+    public function test_reference_date_is_jst_not_utc(): void
+    {
+        $clock  = new FixedClock('2026-08-04T15:00:00Z');
+        $filter = new InvoiceListFilter(overdueOnly: true);
+
+        self::assertSame('2026-08-05', $filter->todayOrNow($clock));
+        self::assertNotSame($clock->now()->format('Y-m-d'), $filter->todayOrNow($clock));
+    }
+
+    /** An explicit `today` is a caller override and must win over the clock. */
+    public function test_explicit_today_overrides_the_clock(): void
+    {
+        $filter = new InvoiceListFilter(overdueOnly: true, today: '2020-01-01');
+
+        self::assertSame('2020-01-01', $filter->todayOrNow(new FixedClock('2026-08-04T15:00:00Z')));
+    }
+
+    /** Production passes UtcClock, which must reproduce the previous `Jst::today()` exactly. */
+    public function test_utc_clock_reproduces_the_previous_wall_clock_behaviour(): void
+    {
+        $filter = new InvoiceListFilter(overdueOnly: true);
+
+        self::assertSame(Jst::today(), $filter->todayOrNow(new UtcClock()));
+    }
+
+    /**
+     * End to end through the filter: an invoice due 2026-08-04 is not yet overdue
+     * on 2026-08-04 JST, and becomes overdue the instant the JST day rolls to 08-05
+     * — even though UTC is still on 08-04.
+     */
+    public function test_overdue_only_flips_across_the_jst_day_boundary(): void
+    {
+        $filter = new InvoiceListFilter(overdueOnly: true);
+        $sort   = InvoiceSort::fromInput(null, null);
+
+        $before = $this->repositoryAt('2026-08-04T14:59:59Z');
+        self::assertSame([], $before->findForAdminList($filter, $sort, 10, 0));
+        self::assertSame(0, $before->countForAdminList($filter));
+
+        $after = $this->repositoryAt('2026-08-04T15:00:00Z');
+        self::assertCount(1, $after->findForAdminList($filter, $sort, 10, 0));
+        self::assertSame(1, $after->countForAdminList($filter));
+    }
+
+    /** A repository holding one issued invoice due 2026-08-04, clocked at the given instant. */
+    private function repositoryAt(string $instant): InMemoryInvoiceRepository
+    {
+        $holder = new RequestScopedHolder();
+        $holder->set(1);
+
+        $repository = new InMemoryInvoiceRepository($holder, new FixedClock($instant));
+        $repository->save(new Invoice(
+            organizationId: 1,
+            clientId: 1,
+            status: InvoiceStatus::Issued,
+            subtotalCents: 1000,
+            taxCents: 100,
+            totalCents: 1100,
+            invoiceNumber: 'INV-2026-0001',
+            dueAt: '2026-08-04',
+        ));
+
+        return $repository;
+    }
+}

--- a/tests/Invoice/InvoiceResponseOverdueTest.php
+++ b/tests/Invoice/InvoiceResponseOverdueTest.php
@@ -7,6 +7,8 @@ namespace NeneInvoice\Tests\Invoice;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceResponse;
 use NeneInvoice\Invoice\InvoiceStatus;
+use NeneInvoice\Support\Jst;
+use NeneInvoice\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -62,6 +64,61 @@ final class InvoiceResponseOverdueTest extends TestCase
         $data    = InvoiceResponse::toArray($invoice);
 
         self::assertFalse($data['is_overdue']);
+    }
+
+    /**
+     * `$nowJst` (Issue #752) makes the comparison deterministic. The flip point is
+     * strict: an invoice is overdue only *after* its due instant has passed.
+     */
+    public function test_now_jst_pins_the_overdue_flip_point(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Issued, '2026-08-05 00:00:00');
+
+        self::assertFalse(InvoiceResponse::toArray($invoice, null, null, null, '2026-08-04 23:59:59')['is_overdue']);
+        self::assertFalse(InvoiceResponse::toArray($invoice, null, null, null, '2026-08-05 00:00:00')['is_overdue']);
+        self::assertTrue(InvoiceResponse::toArray($invoice, null, null, null, '2026-08-05 00:00:01')['is_overdue']);
+    }
+
+    /**
+     * The argument is a **JST** wall clock, not a UTC instant. At UTC 2026-08-04
+     * 06:00 it is already 15:00 in Japan, so an invoice due at noon JST is overdue
+     * — feeding the raw UTC string instead would wrongly report it as current.
+     */
+    public function test_now_jst_is_interpreted_as_jst_not_utc(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Issued, '2026-08-04 12:00:00');
+        $clock   = new FixedClock('2026-08-04T06:00:00Z');
+
+        $jst = Jst::of($clock->now())->format('Y-m-d H:i:s');
+        $utc = $clock->now()->format('Y-m-d H:i:s');
+
+        self::assertTrue(InvoiceResponse::toArray($invoice, null, null, null, $jst)['is_overdue']);
+        self::assertFalse(InvoiceResponse::toArray($invoice, null, null, null, $utc)['is_overdue']);
+    }
+
+    /**
+     * Omitting the argument must keep the pre-#752 wall-clock behaviour byte for
+     * byte. Due dates far from now are used so the assertion cannot straddle a
+     * second boundary between the two calls.
+     */
+    public function test_omitting_now_jst_matches_the_wall_clock_path(): void
+    {
+        foreach (['2020-01-01 00:00:00', '2099-12-31 23:59:59', null] as $dueAt) {
+            $invoice = $this->makeInvoice(InvoiceStatus::Issued, $dueAt);
+
+            self::assertSame(
+                InvoiceResponse::toArray($invoice, null, null, null, Jst::nowString()),
+                InvoiceResponse::toArray($invoice),
+            );
+        }
+    }
+
+    /** Status still short-circuits: a paid invoice is never overdue, whatever the clock says. */
+    public function test_now_jst_does_not_override_status_short_circuit(): void
+    {
+        $invoice = $this->makeInvoice(InvoiceStatus::Paid, '2026-08-05 00:00:00');
+
+        self::assertFalse(InvoiceResponse::toArray($invoice, null, null, null, '2099-01-01 00:00:00')['is_overdue']);
     }
 
     private function makeInvoice(InvoiceStatus $status, ?string $dueAt): Invoice

--- a/tests/Support/InMemoryInvoiceRepository.php
+++ b/tests/Support/InMemoryInvoiceRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NeneInvoice\Tests\Support;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Http\RequestScopedHolder;
+use Nene2\Http\UtcClock;
 use NeneInvoice\Invoice\Invoice;
 use NeneInvoice\Invoice\InvoiceListFilter;
 use NeneInvoice\Invoice\InvoiceListRow;
@@ -28,8 +30,11 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
     /** @var RequestScopedHolder<int> */
     private RequestScopedHolder $orgId;
 
+    /** Mirrors PdoInvoiceRepository's clock; pass a FixedClock to pin `overdueOnly`. */
+    private ClockInterface $clock;
+
     /** @param RequestScopedHolder<int>|null $orgId */
-    public function __construct(?RequestScopedHolder $orgId = null)
+    public function __construct(?RequestScopedHolder $orgId = null, ?ClockInterface $clock = null)
     {
         if ($orgId === null) {
             $orgId = new RequestScopedHolder();
@@ -37,6 +42,7 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
         }
 
         $this->orgId = $orgId;
+        $this->clock = $clock ?? new UtcClock();
     }
 
     public function existsForQuote(int $quoteId): bool
@@ -128,7 +134,7 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
     private function adminFiltered(InvoiceListFilter $filter): array
     {
         $orgId = $this->orgId->get();
-        $today = $filter->todayOrNow();
+        $today = $filter->todayOrNow($this->clock);
 
         return array_values(array_filter($this->byId, static function (Invoice $i) use ($orgId, $filter, $today): bool {
             if ($i->organizationId !== $orgId || $i->isDeleted) {
@@ -168,8 +174,9 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
     {
         $open  = [InvoiceStatus::Issued, InvoiceStatus::PartiallyPaid];
         $orgId = $this->orgId->get();
+        $today = $filter->todayOrNow($this->clock);
 
-        return array_values(array_filter($this->byId, function (Invoice $i) use ($orgId, $filter, $open): bool {
+        return array_values(array_filter($this->byId, static function (Invoice $i) use ($orgId, $filter, $open, $today): bool {
             if ($i->organizationId !== $orgId || $i->isDeleted) {
                 return false;
             }
@@ -188,7 +195,7 @@ final class InMemoryInvoiceRepository implements InvoiceRepositoryInterface
             if (($filter->outstandingOnly || $filter->overdueOnly) && !in_array($i->status, $open, true)) {
                 return false;
             }
-            if ($filter->overdueOnly && ($i->dueAt === null || $i->dueAt >= $filter->todayOrNow())) {
+            if ($filter->overdueOnly && ($i->dueAt === null || $i->dueAt >= $today)) {
                 return false;
             }
 


### PR DESCRIPTION
Closes #752

hub 発令の work order（`_work/handoff-invoice-jst-2026-08-04-work-order.md`・2026-08-04）に沿って、
**Jst の static API を触らずに**域内 2 件の wall-clock read を clock 化した。#600 の縮小案。

## ① `InvoiceListFilter::todayOrNow()` の clock 化

`overdueOnly` の既定基準日が `Jst::today()` で壁時計を直読みしており、絞り込み結果が
**テスト実行日に依存**していた。`ClockInterface` を引数で受ける形に変更。

- `PdoInvoiceRepository` は既に `ClockInterface` を受領済み（`:22`）＝**新規配線ゼロ**。
- `UtcClock` を渡すと `Jst::today()` と**完全同値**（テストで固定）。

## ② `InvoiceResponse::toArray` に `?string $nowJst` の seam 追加

後方互換の optional 引数を**末尾**に追加し `computeIsOverdue` へ貫通。
省略時は従来どおり `Jst::nowString()` を読むため **API レスポンスはバイト不変**。

呼び出し側 20+ 箇所の clock 化は**次波**（本 PR のスコープ外・work order の明示指示）。
死んだ seam にしないため、新規の決定論テストが必ず `$nowJst` を渡して JST 境界での反転を固定している。

## 🔴 work order からの逸脱 1 点（実測にもとづく訂正）

work order ② の signature 案は

```php
public static function toArray(Invoice $invoice, ?array $lines = null, ?int $outstandingCents = null, ?string $nowJst = null): array
```

だったが、**第 4 引数は既に `?string $clientName = null` が占めている**（実測）。
この位置に挿入すると `ListInvoicesHandler:43` が client 名を `$nowJst` として渡すことになり、
一覧の `client_name` が消えたうえ `is_overdue` が壊れる。型は両方 `?string` なので**静かに壊れる**。
よって `$nowJst` は**第 5 引数（末尾）**に置いた。意図（後方互換 optional 追加）は不変。

## 🔴 work order に記載のなかった 4 つ目の呼び出し面

work order は `todayOrNow()` の呼び出し元を `PdoInvoiceRepository:195,261` の 2 箇所としていたが、
実測では `tests/Support/InMemoryInvoiceRepository.php` にも 2 箇所ある。
テスト用フェイクに `?ClockInterface $clock = null`（既定 `UtcClock`）を足して追随した。
既存の生成箇所は全て第 1 引数のみを渡しており**無改修で動く**。

## テスト

- `tests/Invoice/InvoiceListFilterClockTest.php`（新設・6 ケース）— JST 日付境界 UTC 15:00 の前後、
  JST≠UTC の証明、明示 `today` の優先、`UtcClock` の従来同値、`overdueOnly` の end-to-end 反転。
- `tests/Invoice/InvoiceResponseOverdueTest.php`（追加 4 ケース）— `is_overdue` の反転点、
  JST 解釈であることの証明、**既定省略時の同値**、status 短絡の維持。

## 不変条件（すべて維持）

- `src/Support/Jst.php` は**未編集**（signature 不変・ADR 0010 維持）。
- CSV ファイル名の `Jst::today()` 6 件は**未変更**（スコープ外・明示）。
- `is_overdue` は既定経路でバイト不変。
- `conformance.baseline.json` の D4 ignore 2 件は**残る**（Jst static を残す方針の当然の帰結）。#600 は open のまま。

## 実測ゲート

| ゲート | 結果 |
| --- | --- |
| `composer test` | ✅ OK (1021 tests, 3714 assertions) |
| `composer analyse` | ✅ No errors (795 files) |
| `composer cs` | ✅ 差分なし |
| `composer openapi` | ✅ valid (2 documents) |
| `composer mcp` | ✅ valid |
| `composer conformance` | ✅ no findings (2 suppressed = 想定どおり Jst.php) |
| `composer test:integration` | ⚪ ローカル MySQL 未起動につき 6 skip（CI で実行） |

## セルフレビューチェックリスト

`docs/review/compliance.md`（会計・税務コンプライアンス）— **判定: 該当するが影響なし**。
`is_overdue` は会計に隣接するが、本 PR は既定経路をバイト不変に保つ seam 追加のみで、
採番・税額・PDF・保存のいずれにも触れていない。`overdueOnly` は表示上の絞り込みで、
`UtcClock` 経路が従来と完全同値であることをテストで固定した。

## 別件（本 PR では直さない・hub 判断待ち）

実装中に **`is_overdue` と `overdueOnly` の overdue 定義が支払期限当日でズレる**ことを実測で確認した。
work order が「`is_overdue` はバイト不変」と明示しているため本 PR のスコープ外とし、別途起票する。
