### PR TITLE
fix(ci): npm audit の新規勧告2件を lockfile の fix 採用で解消（allowlist は増やさず1件減）

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -34,29 +34,22 @@
     // re-argued in a PR — not silently extended.
     "GHSA-qwww-vcr4-c8h2",
 
-    // GHSA-mh99-v99m-4gvg — brace-expansion "DoS via unbounded expansion length" (high).
-    // Vulnerable range <=5.0.7; the fix is 5.0.8. We TAKE that fix where it is adoptable
-    // (`"brace-expansion@5": "^5.0.8"` in overrides). It is not adoptable on the 1.x / 2.x
-    // branches: there is no patched 1.x or 2.x release at all, and forcing 5.0.8 into them
-    // breaks the consumers — measured 2026-07-29: brace-expansion 5 exports a *named*
-    // `expand`, while `minimatch@3` does `require('brace-expansion')` and calls the module
-    // itself, so `npm run lint` dies with `TypeError: expand is not a function`. Overriding
-    // `minimatch@3` upward fails the same way (`eslint-plugin-import` / `eslint-plugin-jsx-a11y`
-    // do `_interopRequireDefault(require('minimatch'))` and call it; minimatch >=9 has no
-    // callable default export). Retiring the 1.x/2.x chain therefore needs an eslint-10-era
-    // major upgrade of eslint + its plugins — not something this gate PR can take.
+    // NOTE (2026-08-04, Issue #755) — brace-expansion and fast-uri are deliberately NOT
+    // listed here. Both are fixed by the lockfile, which is the outcome this gate prefers.
     //
-    // Why the residual risk is acceptable here (measured 2026-07-29): brace-expansion is
-    // **dev-only** in this tree — `npm ls brace-expansion --omit=dev --all` is empty, so it
-    // is in no shipped bundle and reaches no request path. The remaining vulnerable copies
-    // are 1.1.16 (via `minimatch@3` ← eslint / eslintrc / config-array / plugin-import /
-    // plugin-jsx-a11y) and 2.1.3 (via `glob` and `@redocly/openapi-core`), i.e. lint and
-    // codegen tooling run on our own repo contents. The advisory needs an attacker-supplied
-    // brace pattern; our glob patterns are literals in committed config.
+    // * brace-expansion — `GHSA-mh99-v99m-4gvg` was allowlisted on 2026-07-29 because the
+    //   1.x / 2.x branches had no patched release at the time. They do now: upstream shipped
+    //   1.1.17 / 1.1.18 and 2.1.4, and the whole tree moved to 1.1.18 / 2.1.4 / 5.0.9. That
+    //   also clears the follow-up advisory `GHSA-rgw5-rvv9-x895` ("bypassing the
+    //   CVE-2026-14257 mitigation", patched 1.1.18 / 2.1.4 / 5.0.9), so the entry was
+    //   REMOVED rather than renewed — audit-ci itself reported it as no longer needed.
+    //   The scope-limited `"brace-expansion@5"` override stays (floor raised to ^5.0.9); the
+    //   negative control for it still passes — `require('minimatch')` is callable and
+    //   `minimatch('a.js','*.js') === true` / `minimatch('a.js','*.ts') === false`, i.e. the
+    //   named-export shape of brace-expansion 5 has not leaked into the `minimatch@3` chain.
     //
-    // Expiry: 2026-08-31. Removed by the eslint 10 / plugin major wave (which moves the whole
-    // chain to `minimatch@10` → `brace-expansion@^5`), or by an upstream 1.x/2.x backport if
-    // one appears. Re-check at expiry — do not extend by reflex.
-    "GHSA-mh99-v99m-4gvg",
+    // * fast-uri — `GHSA-7p8r-x3mc-p8w7` ("host confusion via backslash authority
+    //   introducer") is patched at 3.1.5 within the 3.x line. `ajv@8.20.0` accepts it, so a
+    //   plain patch bump from 3.1.4 resolves it with no breaking change and no exception.
   ],
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2514,9 +2514,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3815,6 +3815,19 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4946,19 +4959,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6358,6 +6358,19 @@
         }
       }
     },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -6831,9 +6844,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -7263,9 +7276,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9144,9 +9157,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,6 @@
     "esbuild": "^0.28.1",
     "js-yaml": "^4.3.0",
     "postcss": "^8.5.24",
-    "brace-expansion@5": "^5.0.8"
+    "brace-expansion@5": "^5.0.9"
   }
 }


### PR DESCRIPTION
Closes #755

2026-07-31 以降に公開された勧告 2 件で `frontend-check` が赤になり、**この repo の全 PR がマージ不能**
だった状態を解消する。hub 裁定（08-05 未明）に従い、艦隊解（参照実装 = serve #204）に揃えた。

## 方針: allowlist ではなく fix 採用

`audit-ci.jsonc` の「**ゲートは鈍らせない**」方針どおり、**2 件とも lockfile の patch bump で解消**した。
allowlist への追加は**ゼロ**。むしろ 1 件**減った**（下記）。

| 勧告 | パッケージ | 対応 |
| --- | --- | --- |
| `GHSA-rgw5-rvv9-x895` | brace-expansion | 1.1.16→**1.1.18** / 2.1.3→**2.1.4** / 5.0.8→**5.0.9** |
| `GHSA-7p8r-x3mc-p8w7` | fast-uri | 3.1.4→**3.1.5** |

## 🔴 fast-uri — serve #204 の判定を上書きする実測

hub から「serve は『採用可能 fix なし』・invoice は『非破壊 fix 可能』で**食い違っているので実測で決着**」
との指示を受けた。**一次情報（GitHub Advisory API）で決着した。**

```
$ gh api /advisories/GHSA-7p8r-x3mc-p8w7
 pkg: fast-uri | vulnerable: < 2.4.4          | patched: 2.4.4
 pkg: fast-uri | vulnerable: >= 3.0.0, < 3.1.5 | patched: 3.1.5   ← ★3.x 系内に patch が実在
 pkg: fast-uri | vulnerable: >= 4.0.0, < 4.1.2 | patched: 4.1.2
```

**3.x 系内の 3.1.5 が patched 版**であり、`ajv@8.20.0` はこれを受け入れる。
したがって **3.1.4→3.1.5 の patch bump のみで解消**でき、メジャー移行も allowlist も不要。
`npm run check` は exit 0（後述）で、破壊的変更は観測されなかった。

→ **serve の「採用可能 fix なし」は現時点では成り立たない。**（advisory 公開直後に測ったか、
4.x へのメジャー移行のみを候補に見た可能性がある。）hub へ relay 済み。

## allowlist が 2 件 → 1 件に減った

`GHSA-mh99-v99m-4gvg`（brace-expansion・07-29 収載）を**削除**した。

収載時のコメントは「1.x / 2.x に patched release が**存在しない**」ことを理由にしていたが、
現在は **1.1.17 / 1.1.18 が出ている**（`patched: 1.1.17`）。今回の bump（→1.1.18）で解消済みで、
**audit-ci 自身が `Consider not allowlisting advisory: GHSA-mh99-v99m-4gvg.` と報告している**。

`audit-ci.jsonc` の「**失効エントリは更新ではなく再検査**」という自らの規約に従い、
延長ではなく**削除**とした。残る allowlist は react-router の `GHSA-qwww-vcr4-c8h2` 1 件のみ
（7.x 系に fix がなく v8 メジャー移行待ち・失効 2026-08-31・従来どおり）。

## 陰性対照（serve #204 の作法を踏襲）

`brace-expansion@5` のスコープ限定 override は維持し（floor を `^5.0.8`→`^5.0.9`）、
5 系の named-export が `minimatch@3` チェーンへ漏れていないことを**実測**した。

```
minimatch typeof: function
minimatch callable: true
minimatch("a.js","*.js") => true      ← 陽性
minimatch("a.js","*.ts") => false     ← 陰性
```

（収載時に記録されていた失敗モード `TypeError: expand is not a function` は再現しない。）

## 実測

| ゲート | 結果 |
| --- | --- |
| `npm run audit`（audit-ci＝本体） | ✅ **Passed npm security audit** |
| `npm run check`（codegen/type/lint/styles/registries/format/coverage/knip/build/storybook） | ✅ **exit 0** |
| lockfile 差分 | 38 insertions / 25 deletions — **上記 4 パッケージのみ** |

`npm audit fix` は optional なプラットフォーム別バイナリを多数追加してしまうため使わず、
`npm update brace-expansion fast-uri` で対象を絞った。差分が狭いのはそのため。

## 後続

本 PR のマージ後、**PR #753（Jst 域内クロック化）は main を取り込むか CI 再実行で緑になる**見込み。
#753 は hub 受入 PASS 済みで、audit 緑化がマージ条件になっている。
