### PR TITLE
chore(deps): security lockfile sweep — nanoid + js-yaml (GHSA-2v37-7h3g-55p8, GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8353,9 +8353,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9250,9 +9250,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- nanoid <3.3.17 has a HIGH severity infinite-loop DoS when `size=0` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8))
  - Reached via a dev dependency path (nene2-standards -> postcss -> nanoid); not part of the prod bundle
  - `frontend/package-lock.json`: nanoid 3.3.16 -> 3.3.18 (patch floor is 3.3.17)
- js-yaml 4.0.0-4.3.0 has a HIGH severity quadratic CPU consumption in `!!omap` resolution ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), CVE-2026-59870 fix not backported)
  - This was the true blocker keeping the audit gate red after the nanoid fix — a separate advisory, unrelated to nanoid
  - Reached via three dev-only paths that dedupe to one node thanks to the existing `overrides: "js-yaml": "^4.3.0"` in `frontend/package.json`: eslint -> @eslint/eslintrc -> js-yaml, openapi-typescript -> @redocly/openapi-core@1.34.15 -> js-yaml, stylelint -> cosmiconfig -> js-yaml (confirmed via `npm ls js-yaml`)
  - `frontend/package-lock.json`: js-yaml 4.3.0 -> 4.3.1 (satisfies the existing `^4.3.0` override, so `package.json` needed no change)
- Both fixes are lockfile-only (`npm update <pkg> --package-lock-only`); resolved via lockfile bump, not an audit-ci allowlist entry
- react-router GHSA-qwww-vcr4-c8h2 is **not** touched by this PR — it's already allowlisted in `audit-ci.jsonc` with a reasoned exception and 2026-08-31 expiry; a separate lane owns its v8 migration
- Part of fleet-wide security lockfile sweep, wave 2 (hub directive 2026-08-12) — 6th ship

## Test plan
- [x] `git diff --name-only` confirms only `frontend/package-lock.json` changed across both commits
- [x] `package.json` has no diff (lockfile-only for both nanoid and js-yaml)
- [x] `npm audit --package-lock-only --audit-level=high` no longer reports nanoid or js-yaml
- [x] `npm run audit` (`audit-ci --config audit-ci.jsonc`) passes locally — only the already-allowlisted react-router advisory remains
- [x] No functional/runtime impact expected (both are dev dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
