### PR TITLE
ci: 週次 schedule ハーネス導入 + composer audit を追加

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
+      # Verified locally with `composer audit --format=plain` before adding this step:
+      # 0 advisories at the time of introduction (2026-08-12).
+      - name: composer audit
+        run: composer audit --no-interaction
+
       - name: Prepare environment
         run: cp .env.example .env
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,6 +8,29 @@ on:
     branches:
       - main
 
+  # Weekly run so npm audit / audit-ci re-checks against newly published
+  # advisories even when nobody touches this repo for a while.
+  # CAUTION: GitHub auto-disables scheduled workflows after 60 days of repo
+  # inactivity — during a long-dormant stretch this stops firing silently.
+  # A cross-repo watchdog (outside this repo) is needed to catch that; see
+  # _work/handoff-nene2-python-2026-08-12-schedule-rollout-note.md §9.
+  schedule:
+    - cron: '55 0 * * 1' # Monday 00:55 UTC = 09:55 JST
+
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: '意図的に frontend-check を失敗させ、失敗通知の経路を検証する'
+        type: boolean
+        default: false
+
+concurrency:
+  # github.event_name is required here: without it, schedule/workflow_dispatch
+  # runs get cancelled by a concurrent push run to the same ref (observed in
+  # nene-origin's rollout).
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   frontend-check:
     runs-on: ubuntu-latest
@@ -18,6 +41,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Placed right after Checkout, not at the job's head: this job has
+      # defaults.run.working-directory: frontend, which does not exist before
+      # Checkout. A step placed before Checkout would fail on `cd` itself
+      # instead of at `exit 1`, making the log's stated cause misleading.
+      - name: Simulate failure (validation only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -83,3 +114,28 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report
           retention-days: 7
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [frontend-check, e2e]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 [nene-invoice] 週次 CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }} # required: this job doesn't checkout, so gh can't infer the repo without it
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi


### PR DESCRIPTION
## Summary

フリート横断の週次 CI ハーネス配布（第2波）。この PR は 2 件を同梱する。

### A. 週次 schedule ハーネス（frontend-ci.yml）

依存監査（`npm run audit` = audit-ci）を持つ **frontend-ci.yml** を「本体の CI」と判断し、そこに正典の3点セット＋踏み台＋notify-failure を導入。backend-ci.yml（デプロイ関連ではないが依存監査を持たない）には schedule を足していない。

- `schedule`: `55 0 * * 1`（月曜 00:55 UTC = 09:55 JST・この艦の割当 cron 枠）
- `workflow_dispatch` の `simulate_failure` 入力（踏み台は **Checkout の直後**に配置。`frontend-check` ジョブは `defaults.run.working-directory: frontend` を持つため、Checkout 前に置くと `cd` が先に失敗し、ログの原因表示が嘘になる — 正典 §6 追記#3 の教訓）
- `concurrency.group` に `github.event_name` を含める（push による schedule/dispatch の cancel を防止）
- `notify-failure`: `needs: [frontend-check, e2e]`（この艦の実ジョブ名）・`GH_REPO` 必須・既存 Issue には追記（再オープンしない）
- **60日自動無効化の限界をコメントに明記**（GitHub は 60 日無活動の public repo で scheduled workflow を自動停止する。この装置自体がその停止に巻き込まれうる）

参照: `_work/handoff-nene2-python-2026-08-12-schedule-rollout-note.md`

### B. composer audit（backend-ci.yml）

`check` ジョブの `composer install` 直後に独立ステップとして追加:

```yaml
- name: composer audit
  run: composer audit --no-interaction
```

追加前にローカルで `composer audit --format=plain` を実行し、**advisory 0件**を確認済み（2026-08-12時点）。既存ジョブ・ステップの中身は変更していない。

## Test plan

- [x] `composer audit --format=plain` をローカル実行し advisory 0件を確認（B の前提）
- [x] YAML 構文チェック（`python3 -c "yaml.safe_load(...)"`）
- [ ] マージ後 DoD（正典 §7）:
  1. `workflow_dispatch`（`simulate_failure` なし）→ 緑
  2. `simulate_failure=true` → Issue が新規起票される
  3. `simulate_failure=true` もう一度 → 同じ Issue に追記（2本目が立たない）
  4. 検証で立てた Issue を経緯コメント付きでクローズ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>