### PR TITLE
docs: `*_cents` の単位定義を規約に明記する (#762)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 - **マルチテナント**: テナントスコープの全テーブル/クエリに `organization_id`。superadmin のみクロステナント（ADR 0006）
 - SQL: `Pdo*Repository` 内のみ
 
+> `cents` は**その通貨の最小単位**であって、表示額の 1/100 ではない。
+> **JPY は小数点以下 0 桁（ISO 4217）なので、`*_cents` には円をそのまま格納する——×100 しない。**
+> 例: ¥1,500 は `1500` として格納する。`116480` は ¥116,480 であって ¥1,164.80 ではない。
+
 詳細: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`, `docs/explanation/terminology.md`（用語レジストリ＝唯一の真実）
 
 ---

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -117,6 +117,10 @@ Public OpenAPI summaries, descriptions, and examples: **English only**.
 
 Do not mix camelCase in public JSON. Do not use floats for money.
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ---
 
 ## 4. Problem Details and validation errors
@@ -145,6 +149,10 @@ Problem Details `title` and `detail`: English.
 | Unique constraints | `uniq_{table}_{columns}` | `uniq_invoices_number` |
 
 SQL lives only in `Pdo*Repository` classes.
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 
 ### Migrations
 


### PR DESCRIPTION
Closes #762

## 何をしたか

**`*_cents` の単位定義を規約文書に明記しました。ドキュメントのみ・コードは1行も触っていません。**

| ファイル | 位置 | 版 |
|---|---|---|
| `docs/development/naming-conventions.md` | **§3 JSON** の表の直後 | 英語版 |
| `docs/development/naming-conventions.md` | **§5 Database** の表の直後 | 英語版 |
| `CLAUDE.md` | 「金額: **integer cents**（float 禁止）」を含む箇条書きの直後 | 日本語版 |

文言は正本 `_work/reports/2026-08-20-money-unit-archaeology.md` §9-1 からの**逐語コピー**で、
**一字一句一致することを機械照合済み**です。**言い換えていません**——今回の事故は
「同じ言葉を別の意味に読んだ」ことで起きたので、**表現の揺れを増やさない**のが肝だからです。

## なぜこれが必要か

艦隊で**金額の単位が 3対3 に割れています**（🟢 円 1:1 = **invoice** / vault / profile ／ 🔴 1/100円 = clear / deal / serve）。

🔑 **正典は存在していました。** 前身 NeNe の `docs/development/money.md`（`Money::of(1500,'JPY')` → `¥1,500`）と
NENE2 の howto 2箇所（「JPY などのゼロ小数点通貨は全体の単位をセントとして保存」「`amount_cents` を各通貨の
サブ単位（**JPY は 1 円単位**）で管理」）。**ISO 4217 とも一致。**

🔴 **根本原因は、その正典が実装者の視線に入らないことでした。**
各艦の規約は「Money amounts = integer cents」としか書いておらず、
**JPY で cents が ¥1 なのか ¥0.01 なのかを定義していません**。
自艦の規約だけ読んで実装した人は、**間違えようがない形では教えられていなかった**。

🔴 **是正より先にこれをやる理由**: **やらないと4艦目が出ます。**
実証があります——**serve の `format-money.ts` は deal と冒頭6行が完全一致**
（「Amounts are stored as cents (1/100 yen) across the API」）＝**テンプレの逐語コピー**で生まれています。
**逸脱はコードのコピーで伝播する。** 定義を書くのはゼロコストで、**再発を止める唯一の手**です。

## 設計判断: なぜ2箇所に同じ文言を置くか

本リポの `naming-conventions.md` には **Money 行が2つ**あります（§3 の JSON プロパティ用と §5 の DB 列用）。
**「§3 を見よ」という参照にはしていません**——**今回の根本原因が「定義が実装者の視線に入らない」ことなので、
参照は視線に入らないからです。**

（重複による将来の乖離リスクは認識していますが、文言が固定の正典であること、
そして**視線に入ることが本件の唯一の目的**であることから、重複を選びました。
**この判断は先頭艦の型として残り5艦へ配る前にレビューを受けるべき点**です。）

## ⚠️ 正本 §9-2 の表との差分（本リポ実測・`origin/main`）

正本の表は本リポの金額行を **`AGENTS.md`** としていますが、**実際は `CLAUDE.md`（72行目）**です。
**`AGENTS.md`（55行）には `money` / `cents` / `金額` のいずれも出現しません。**
⇒ 本 PR では `CLAUDE.md` を対象にしました。**この差分は fan-out 前に hub へ報告します。**

## 本リポの位置づけ

本リポは**正典側**（円 1:1 で正しく実装できている艦）で、**是正対象ではありません**。
**横断配布の先頭艦**として、文言が既存記述と衝突しないかを最初に確認する役です。

🔑 参考: 本リポのテスト値 **`formatYen(116480) === '¥116,480'` が、値そのもので読みを証明しています**——
**116480 は100の倍数ではない**ので、1/100円として読むと **¥1,164.80 という存在しない額**になります。

## 射程外

- **コードは触っていません。** 是正（clear / deal / serve）は別の board 行が持ちます。
- `payout` / `trace` / `field` / `corpus` / `origin` / `records` / `suite` / `contact` は `_cents` 参照ゼロで対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
