### PR TITLE
docs: AGENTS.md に `*_cents` の単位定義を明記する（#764・#763 が触っていない1箇所）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ This file is the entry point for AI agents working on NeNe Invoice.
 - Read NENE2 upstream docs for framework behavior; read local docs for product rules.
 - **Never integrate billing into NeNe Records or other sibling repos.** Dependency direction is `NeNe Invoice → upstream APIs`, never the reverse. See ADR 0002.
 - **Accounting/tax compliance is binding and non-negotiable.** Any change touching quotes, invoices, payments, tax, numbering, PDF, or retention must comply with `docs/explanation/accounting-compliance.md` and pass `docs/review/compliance.md`. A finance professional must find zero deviations. Deviations require an ADR with tax-professional sign-off — never merge one without it. When a rule is unclear, stop and consult a 税理士; do not guess.
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 - Keep the private `nene-origin/internal-docs/invoice/todo/current.md` and milestones aligned with Issues and PRs.
 - Keep changes focused. Do not mix governance, feature work, and unrelated cleanup in one PR.
 - Do not commit secrets, credentials, local `.env` files, or generated build outputs.


### PR DESCRIPTION
Closes #764

板 L93 の残り。**`origin/main` で全数を測り直した結果**、fleet 全体で残っていたのは4ファイルで、本 PR はそのうち1つです。

## この艦の現状（`origin/main` で実測・2026-08-23）

| 場所 | |
|---|---|
| `docs/development/naming-conventions.md` / `CLAUDE.md` | 🔴 未挿入 — **PR #763（OPEN）が持っている** |
| **`AGENTS.md`** | 🔴 **未挿入・どの PR も触っていない** |

⇒ **#763 がマージされても `AGENTS.md` だけ残ります。**

## 🔴 §9-2 の表に誤りがあります

> invoice の `AGENTS.md` ✅「金額: integer cents（float 禁止）」

**`AGENTS.md` には金額に関する記述が1行もありません**〔実測: 55行・`cent|amount|money|金額|float` で **0ヒット**〕。⇒ **追記ではなく新設**です。

**deal / serve について既に訂正が入っているのと同じ形**なので、正本側にも訂正を上げてあります。

## なぜ AGENTS.md にも要るか

§9 の根本原因は「**実装者が読むのは自艦の規約文書**なので届いていなかった」です。**`AGENTS.md` は AI エージェントが最初に読む1枚**なので、ここに無いと**次に金額を触るエージェントに届きません**。

## 射程

**この1ファイルだけ。** `naming-conventions.md` と `CLAUDE.md` は **#763 の持ち物なので触っていません**（二重挿入になる）。