### PR TITLE
chore(ci): 全 job に timeout-minutes を入れ notify-failure の --limit を 1000 にする (#766)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
   # this is what guards the dialect-portable SQL from regressing.
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     services:
       mysql:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   frontend-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -77,6 +78,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: frontend
@@ -120,6 +122,7 @@ jobs:
     if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
     needs: [frontend-check, e2e]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     env:
@@ -131,7 +134,10 @@ jobs:
       - name: Create or update the failure issue
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼし、
+          # 毎週重複 issue を立てながら「装置は動いている」ように見える。
+          # 発現条件が「通知が読まれず溜まっている状態」そのものなので、最も必要なときに壊れる。
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
             | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
           body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
           if [ -n "$existing" ]; then


### PR DESCRIPTION
Closes #766

## 何をしたか

**workflow 2本・全5 job に `timeout-minutes` を入れ、`notify-failure` の重複検出を `--limit 1000` にしました。CI 設定のみ・アプリのコードは1行も触っていません。**

| workflow | job | 設定値 |
| --- | --- | ---: |
| `backend-ci.yml` | `check` | 10 |
| `backend-ci.yml` | `integration` | 10 |
| `frontend-ci.yml` | `frontend-check` | 15 |
| `frontend-ci.yml` | `e2e` | **30** |
| `frontend-ci.yml` | `notify-failure` | 5 |

`python3 -c "yaml.safe_load(...)"` で**5 job すべてに値が載ったことを構文解析で確認**しています（grep ではなく YAML として読んだ結果）。

## なぜこの値なのか — 記憶ではなく実測から決めた

直近30 run の success ジョブ**全数**（`gh api repos/.../actions/runs/<id>/jobs` の `started_at`／`completed_at` 差分・2026-08-27 実測）:

| job | n | 中央値 | 最大 | 設定値 | 最大に対する余裕 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `check` | 13 | 49s | 60s | 10 | 10.0x |
| `integration` | 13 | 49s | 66s | 10 | 9.1x |
| `frontend-check` | 12 | 152s | 165s | 15 | 5.5x |
| `e2e` | 15 | 161s | 179s | 30 | 10.1x |
| `notify-failure` | 1 | 4s | 4s | 5 | 75x |

🔴 **最初は「e2e=30・他=15」の仮置きで出そうとしていました。** nene2-fleet-tooling から
「**短すぎる値を置くと遅い日に偽の赤を作る**。自艦の実行時間の実測と比べてほしい」と指摘を受けて計測したものです。

🔑 **計測して初めて分かったこと**: この repo の e2e は**普段3分弱で終わる**。
6時間吊りの当事者は「e2e は重い」という記憶しか持っておらず、**対極へ振って短い値を置く動機が実際にありました**。
本 PR の直前に走った e2e はちょうど 3m0s（観測最大と同値）で、30分はそこから 10 倍の余裕があります。

## 実害（この PR の発端）

PR #763 の `e2e` が **6h0m16s** 吊ってから CANCELLED になり、**docs 2ファイルだけの PR が 8日間ブロック**されました。
吊った箇所は `npx playwright install --with-deps chromium`（`frontend-ci.yml:99`）。同じ現象が nene-profile でも同時刻に発生しています。
本 PR は**吊りそのものを直すものではありません**——吊ったときに 6 時間ブロックしないようにするものです。

## `--limit 100` → `1000`

`notify-failure` は既存の失敗 issue を `gh issue list --state open --limit 100` で探していました。
**open issue が 100 件を超えると同名を取りこぼし、毎週重複 issue を立てながら「装置は動いている」ように見えます。**
発現条件が「通知が読まれず溜まっている状態」そのものなので、**最も必要なときに自分で壊れます**。
現在の open issue は 44 件（`--limit 500 --json number -q length` で実測。`--limit` の値ではありません）なので今の実害はありませんが、1文字の変更で待つ理由がないため同梱しました。理由はコードにコメントとして残しています。

## やらないこと

- `weekly-audit.yml` の新設は**含めていません**。板 (A) 2026-08-22 の配布担当は nene2-fleet-tooling（hub が 08-27 に正式発令）で、invoice は受け手として待ちです。
- Playwright インストールのキャッシュ化・高速化は別件です。

## セルフレビューチェックリスト

`docs/review/` の該当なし（アプリのコード・スキーマ・請求ロジックに変更なし＝会計コンプライアンス／用語レジストリの照合対象外）。CI 設定のみ。
