### PR TITLE
fix(pdf): 振込先の支店名を二重にしない — 無条件の「支店」付加をやめる (#769)

### DIFF
--- a/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
+++ b/frontend/src/features/view-invoice/ui/ViewInvoice.tsx
@@ -300,9 +300,7 @@ function InvoiceDocument({
               <div className="party-label">{t('admin.invoices.detail.payTo')}</div>
               <div className="party-name">
                 {bank.bank_name}
-                {bank.bank_branch !== null
-                  ? ` ${t('admin.invoices.detail.branchSuffix', { branch: bank.bank_branch })}`
-                  : ''}
+                {bank.bank_branch !== null ? ` ${bank.bank_branch}` : ''}
               </div>
               {(bank.account_type !== null || bank.account_number !== null) && (
                 <div className="party-line num">

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -560,7 +560,6 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.detail.backToList': 'Back to list',
   'admin.invoices.detail.billTo': 'Bill to',
   'admin.invoices.detail.payTo': 'Remit to',
-  'admin.invoices.detail.branchSuffix': '{{branch}} Branch',
   'admin.invoices.detail.corpHonorific': '{{name}}',
   'admin.invoices.detail.personHonorific': '{{name}}',
   'admin.invoices.detail.overdueNote': 'Past due ({{dueAt}}). Outstanding balance {{amount}}.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -564,7 +564,6 @@ export const jaMessages = {
   'admin.invoices.detail.backToList': '一覧へ戻る',
   'admin.invoices.detail.billTo': '請求先',
   'admin.invoices.detail.payTo': 'お振込先',
-  'admin.invoices.detail.branchSuffix': '{{branch}}支店',
   'admin.invoices.detail.corpHonorific': '{{name}} 御中',
   'admin.invoices.detail.personHonorific': '{{name}} 様',
   'admin.invoices.detail.overdueNote': '支払期限（{{dueAt}}）を過ぎています。残高 {{amount}}。',

--- a/src/Invoice/Pdf/InvoicePdfGenerator.php
+++ b/src/Invoice/Pdf/InvoicePdfGenerator.php
@@ -229,7 +229,7 @@ HTML;
     {
         $parts = array_filter([
             $company->bankName,
-            $company->bankBranch !== null ? $company->bankBranch . '支店' : null,
+            $company->bankBranch,
             $company->accountType,
             $company->accountNumber,
         ]);

--- a/src/Quote/Pdf/QuotePdfGenerator.php
+++ b/src/Quote/Pdf/QuotePdfGenerator.php
@@ -225,7 +225,7 @@ HTML;
     {
         $parts = array_filter([
             $company->bankName,
-            $company->bankBranch !== null ? $company->bankBranch . '支店' : null,
+            $company->bankBranch,
             $company->accountType,
             $company->accountNumber,
         ]);


### PR DESCRIPTION
Closes #769

**🔴 デプロイ待ちで止めます**（本番デモ機への再配備は施主 GO 手番）。マージ可否のご判断をお願いします。

## 何をしたか

`bank_branch` への**無条件の `支店` 付加をやめ、値をそのまま出す**（WYSIWYG）。

## 🔴 付加箇所は2箇所ではなく **3箇所** ありました

発令時の想定は「PDF 生成器2箇所」でしたが、**フロントの請求書詳細画面も同じことをしていました**。全数を grep して確認しています。

| # | 場所 | 直し方 |
|---|---|---|
| 1 | `src/Quote/Pdf/QuotePdfGenerator.php:228` | `$company->bankBranch` をそのまま |
| 2 | `src/Invoice/Pdf/InvoicePdfGenerator.php:232` | 同上 |
| 3 | **`frontend/.../view-invoice/ui/ViewInvoice.tsx:303-305`** | `admin.invoices.detail.branchSuffix` 経由で `{{branch}}支店` を合成していた → `bank.bank_branch` を直接描画 |

⇒ **PDF だけ直して画面を直さなければ、同じ帳票が2つの表記を持つ**ところでした。

使われなくなった `admin.invoices.detail.branchSuffix` は **ja / en 両方から削除**（i18n parity 維持）。

## UI ラベルは変えていません

発令では「支店名（例: マーチ支店）」への変更が案として出ていましたが、**入れなくてよいと判断しました**。付加をやめた時点で **入力した文字列がそのまま出る**ので、操作者が「支店 を付けるべきか」を知る必要が消えるためです。注記は「知らないと間違える」ときに要るもので、この変更はその前提自体を無くしています。i18n の面積を増やさない方も選びました。

## `DemoDataSeeder` はそのまま

`渋谷支店` / `新宿支店` を保持したままで正しく描画されます（本番デモ機の org 603 も同じ形）。**seed を直す必要はありません。**

## 🔴 デプロイ時に必要な データ側の作業（忘れると AYANE の帳票が壊れます）

**AYANE org（604）の `bank_branch` は現在 `マーチ`** です。付加される前提での回避策として `支店` を抜いてあります。

⇒ **この PR を本番へ入れる操作と同じ回で、`マーチ` → `マーチ支店` に戻す必要があります。** 戻さないと振込先が「楽天銀行 マーチ 普通 7040146」になります。

| org | 現在の `bank_branch` | デプロイ後の描画 | 必要な作業 |
|---|---|---|---|
| 603（demo） | `新宿支店` | 新宿支店 ✅ | なし |
| **604（ayane）** | **`マーチ`** | **マーチ ❌** | **`マーチ支店` へ戻す** |

## 検証

- PHP: `composer test` → **OK (1021 tests, 3714 assertions)**
- Frontend: `npm run check` → **exit 0**・Test Files 89 passed / Tests 351 passed（type-check・lint・format・knip・build・build-storybook を含む）

## 影響範囲

見積書 PDF・請求書 PDF・請求書詳細画面の**振込先の表示のみ**。金額・税額・採番・保存には触れていません。

## セルフレビューチェックリスト

`docs/review/compliance.md` の該当なし（金額・税・採番・保存に変更なし）。用語レジストリの識別子追加・改名なし（`bank_branch` の綴りは不変、削除したのは i18n カタログ鍵のみ）。