### PR TITLE
feat(invoice): 登録番号が無ければ既定を qualified=false にする (#771)

### DIFF
--- a/frontend/src/features/issue-invoice/model/use-issue-invoice.test.ts
+++ b/frontend/src/features/issue-invoice/model/use-issue-invoice.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react'
+import { act, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
 import { toInvoiceId } from '@/entities/invoice'
@@ -7,13 +7,49 @@ import { buildInvoiceWithLinesDto } from '@tests/factories/invoice'
 import { renderHookWithProviders } from '@tests/render/render-with-providers'
 import { useIssueInvoice } from './use-issue-invoice'
 
+/** A draft invoice is the only issuable state, so every #771 case needs one. */
+function draftInvoice(): void {
+  server.use(
+    http.get('/admin/invoices/:id', () =>
+      HttpResponse.json(buildInvoiceWithLinesDto({ status: 'draft', invoice_number: null })),
+    ),
+  )
+}
+
+function companyRegistrationNumber(value: string | null): void {
+  server.use(
+    http.get('/admin/company-settings', () =>
+      HttpResponse.json({
+        organization_id: 1,
+        legal_name: 'テスト株式会社',
+        address: null,
+        phone: null,
+        email: null,
+        registration_number: value,
+        bank_name: null,
+        bank_branch: null,
+        account_type: null,
+        account_number: null,
+      }),
+    ),
+  )
+}
+
+/** Captures the body the issue endpoint actually receives. */
+function captureIssueBody(): { body: Record<string, unknown> | null } {
+  const captured: { body: Record<string, unknown> | null } = { body: null }
+  server.use(
+    http.post('/admin/invoices/:id/issue', async ({ request }) => {
+      captured.body = (await request.json()) as Record<string, unknown>
+      return HttpResponse.json(buildInvoiceWithLinesDto({ status: 'issued' }))
+    }),
+  )
+  return captured
+}
+
 describe('useIssueInvoice (feature)', () => {
   it('allows issuing a draft invoice', async () => {
-    server.use(
-      http.get('/admin/invoices/:id', () =>
-        HttpResponse.json(buildInvoiceWithLinesDto({ status: 'draft', invoice_number: null })),
-      ),
-    )
+    draftInvoice()
 
     const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
 
@@ -28,5 +64,90 @@ describe('useIssueInvoice (feature)', () => {
     await waitFor(() => {
       expect(result.current.canIssue).toBe(false)
     })
+  })
+
+  // ── #771 ─────────────────────────────────────────────────────────────────
+  // The issuer without a T-number could not issue anything: the UI only knew
+  // how to send `qualified: true`, which the backend refuses when the
+  // registration number is empty (accounting-compliance.md §4).
+
+  it('issues as NOT qualified when the issuer has no registration number', async () => {
+    draftInvoice()
+    companyRegistrationNumber(null)
+    const captured = captureIssueBody()
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.qualified).toBe(false)
+    })
+
+    act(() => {
+      result.current.issue()
+    })
+
+    await waitFor(() => {
+      expect(captured.body).not.toBeNull()
+    })
+    expect(captured.body).toMatchObject({ qualified: false })
+  })
+
+  it('issues as qualified when the issuer has a registration number', async () => {
+    draftInvoice()
+    companyRegistrationNumber('T1010001011111')
+    const captured = captureIssueBody()
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.qualified).toBe(true)
+    })
+
+    act(() => {
+      result.current.issue()
+    })
+
+    await waitFor(() => {
+      expect(captured.body).not.toBeNull()
+    })
+    expect(captured.body).toMatchObject({ qualified: true })
+  })
+
+  it('treats an empty registration number as no registration number', async () => {
+    // Both API boundaries collapse '' to null today, so this cannot arrive from
+    // the server as things stand. The case is pinned because the alternative —
+    // '' read as "has a number" — would issue a 適格請求書 naming an empty
+    // registration number, which §4 forbids.
+    draftInvoice()
+    companyRegistrationNumber('')
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.qualified).toBe(false)
+    })
+  })
+
+  it('does not issue while the issuer eligibility is still unknown', async () => {
+    draftInvoice()
+    // A company-settings request that never settles: `qualified` stays null.
+    server.use(http.get('/admin/company-settings', () => new Promise(() => {})))
+    const captured = captureIssueBody()
+
+    const { result } = renderHookWithProviders(() => useIssueInvoice(toInvoiceId(1)))
+
+    await waitFor(() => {
+      expect(result.current.canIssue).toBe(true)
+    })
+    expect(result.current.qualified).toBeNull()
+
+    act(() => {
+      result.current.issue()
+    })
+
+    // Nothing was sent — an unresolved query is not a measurement, and issuing
+    // is irreversible.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(captured.body).toBeNull()
   })
 })

--- a/frontend/src/features/issue-invoice/model/use-issue-invoice.ts
+++ b/frontend/src/features/issue-invoice/model/use-issue-invoice.ts
@@ -1,3 +1,4 @@
+import { useCompanySettings } from '@/entities/company-settings'
 import {
   useInvoice,
   useIssueInvoice as useIssueInvoiceMutation,
@@ -9,26 +10,80 @@ import { useToast } from '@/shared/ui'
 export interface UseIssueInvoice {
   /** Only draft invoices can be issued; the action hides otherwise. */
   canIssue: boolean
+  /**
+   * Whether this invoice will be issued as a 適格請求書.
+   *
+   * `null` while the company settings are still unresolved — the caller must
+   * not offer the action yet. See the note on `qualifiedFrom` below for why
+   * this is three-valued rather than defaulting to `false`.
+   */
+  qualified: boolean | null
   issue: () => void
   isPending: boolean
   errorMessage: string | null
 }
 
 /**
- * Issues the invoice as a qualified invoice. Reads the (cached) invoice to gate
- * the action on draft status — shares the detail query, so no extra fetch.
+ * Decides whether the issuer can hand out a 適格請求書 at all (#771).
+ *
+ * 🔴 The registration number is the ONLY input. `accounting-compliance.md` §4:
+ * "An invoice MUST NOT be markable as qualified while the issuer registration
+ * number is empty." Before #771 the UI sent `qualified: true` unconditionally,
+ * so an issuer without a T-number could not issue anything — the backend
+ * rejected the only request the UI knew how to make (422
+ * `QualifiedInvoiceIncompleteException`). The API already accepted
+ * `qualified: false`; nothing but the UI was closed.
+ *
+ * 🔴 There is exactly ONE representation of "no registration number" in the
+ * domain, and it is `null`. Both boundaries collapse the empty string before a
+ * value can reach here — `RequestField::optionalString` on the way in
+ * (`''` → `null`) and `PdoCompanySettingsRepository::nullableString` on the way
+ * out. So `''` cannot arrive from the API today. The check below still names it
+ * to keep the decision readable at the point it is made: an issuer's
+ * eligibility must not depend on remembering that two layers away.
+ *
+ * 🔴 Three-valued on purpose. `false` while loading would be indistinguishable
+ * from "measured, and this issuer has no number" — and it is the difference
+ * between a document that claims to be a 適格請求書 and one that does not. An
+ * unresolved query is not a measurement of anything.
+ */
+function qualifiedFrom(registrationNumber: string | null | undefined): boolean {
+  return (
+    registrationNumber !== null && registrationNumber !== undefined && registrationNumber !== ''
+  )
+}
+
+/**
+ * Issues the invoice, as a 適格請求書 only when the issuer has a registration
+ * number. Reads the (cached) invoice to gate the action on draft status —
+ * shares the detail query, so no extra fetch. The company settings are already
+ * on the detail screen for the bank block, so that is cached too.
  */
 export function useIssueInvoice(invoiceId: InvoiceId): UseIssueInvoice {
   const { t } = useTranslation()
   const { showToast } = useToast()
   const invoice = useInvoice(invoiceId)
+  const company = useCompanySettings()
   const mutation = useIssueInvoiceMutation()
+
+  // `data` is `CompanySettings | null` — null is a settled answer (no settings
+  // row yet), which means no registration number. Only an unsettled query is
+  // unknown.
+  const qualified = company.isSuccess ? qualifiedFrom(company.data?.registration_number) : null
 
   return {
     canIssue: invoice.data?.status === 'draft',
+    qualified,
     issue: () => {
+      // Guard rather than assert: `issue` is a callback the UI could fire from a
+      // stale render. Issuing is irreversible (it allocates the number), so an
+      // unknown eligibility must not resolve to a guess.
+      if (qualified === null) {
+        return
+      }
+
       mutation.mutate(
-        { id: invoiceId, qualified: true, due_at: null },
+        { id: invoiceId, qualified, due_at: null },
         {
           onSuccess: (issued) => {
             showToast({
@@ -44,6 +99,12 @@ export function useIssueInvoice(invoiceId: InvoiceId): UseIssueInvoice {
       )
     },
     isPending: mutation.isPending,
-    errorMessage: mutation.isError ? t('admin.invoices.issue.error') : null,
+    errorMessage: mutation.isError
+      ? t(
+          qualified === false
+            ? 'admin.invoices.issue.errorUnqualified'
+            : 'admin.invoices.issue.error',
+        )
+      : null,
   }
 }

--- a/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
+++ b/frontend/src/features/issue-invoice/ui/IssueInvoice.tsx
@@ -10,16 +10,28 @@ export interface IssueInvoiceProps {
 }
 
 /** Issue action — renders only for a draft invoice. Issuing is irreversible
- * (allocates the INV number and locks the document), so it is confirmed. */
+ * (allocates the INV number and locks the document), so it is confirmed.
+ *
+ * 🔴 The 適格請求書 wording is ADDITIVE, never the fallback (#771). The plain
+ * label is what renders while the issuer's eligibility is still unknown, and
+ * the qualifier is appended only once `qualified === true`. The two mistakes
+ * are not symmetric: a button that says 適格請求書 before we have measured the
+ * registration number makes a tax claim on the operator's behalf, while a
+ * button that says 発行する understates one. Only the second is recoverable. */
 export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { canIssue, issue, isPending, errorMessage } = useIssueInvoice(invoiceId)
+  const { canIssue, qualified, issue, isPending, errorMessage } = useIssueInvoice(invoiceId)
   const [confirming, setConfirming] = useState(false)
 
   if (!canIssue) {
     return null
   }
+
+  const actionLabel =
+    qualified === true
+      ? t('admin.invoices.issue.actionQualified')
+      : t('admin.invoices.issue.action')
 
   const onConfirm = (): void => {
     setConfirming(false)
@@ -33,9 +45,9 @@ export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
           onClick={() => {
             setConfirming(true)
           }}
-          disabled={isPending}
+          disabled={isPending || qualified === null}
         >
-          {isPending ? t('admin.invoices.issue.submitting') : t('admin.invoices.issue.action')}
+          {isPending ? t('admin.invoices.issue.submitting') : actionLabel}
         </Button>
       </div>
       {errorMessage !== null && (
@@ -43,20 +55,33 @@ export function IssueInvoice({ invoiceId }: IssueInvoiceProps) {
           <InlineAlert
             tone="error"
             message={errorMessage}
-            recover={{
-              label: t('admin.invoices.issue.recover'),
-              onClick: () => {
-                void navigate('/settings')
-              },
-            }}
+            /* The settings link is the recovery for a MISSING registration
+               number. An unqualified issue cannot fail that way, so pointing
+               there would send the operator to fix something that is not
+               broken — and imply the T-number is required to invoice at all,
+               which is the misreading #771 was opened about. */
+            {...(qualified === false
+              ? {}
+              : {
+                  recover: {
+                    label: t('admin.invoices.issue.recover'),
+                    onClick: () => {
+                      void navigate('/settings')
+                    },
+                  },
+                })}
           />
         </div>
       )}
       {confirming && (
         <ConfirmDialog
           title={t('admin.invoices.issue.confirmTitle')}
-          message={t('admin.invoices.issue.confirmMessage')}
-          confirmLabel={t('admin.invoices.issue.action')}
+          message={
+            qualified === false
+              ? t('admin.invoices.issue.confirmMessageUnqualified')
+              : t('admin.invoices.issue.confirmMessage')
+          }
+          confirmLabel={actionLabel}
           cancelLabel={t('common.actions.cancel')}
           destructive={false}
           pending={isPending}

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -706,10 +706,14 @@ export const enMessages: MessageCatalog = {
   'admin.bankReconciliation.confirm.done': 'Reconciled',
   'admin.bankReconciliation.confirm.doneBody': 'Recorded {{amount}} as a payment.',
   'admin.bankReconciliation.confirm.error': 'Could not reconcile.',
-  'admin.invoices.issue.action': 'Issue (qualified invoice)',
+  // Plain by default. The qualified wording is added only when a registration
+  // number exists (#771).
+  'admin.invoices.issue.action': 'Issue',
+  'admin.invoices.issue.actionQualified': 'Issue (qualified invoice)',
   'admin.invoices.issue.submitting': 'Issuing…',
   'admin.invoices.issue.error':
     'Could not issue. Please check the registration number in company settings.',
+  'admin.invoices.issue.errorUnqualified': 'Could not issue. Please try again in a moment.',
   'admin.invoices.issue.recover': 'Open company settings →',
   'admin.invoices.issue.successTitle': 'Issued',
   'admin.invoices.issue.successBody': '{{number}} has been issued.',
@@ -717,6 +721,8 @@ export const enMessages: MessageCatalog = {
   'admin.invoices.issue.confirmTitle': 'Issue this invoice?',
   'admin.invoices.issue.confirmMessage':
     'Issuing allocates the invoice number and locks the contents (no further edits). The accuracy of the contents and their tax treatment are your responsibility to verify.',
+  'admin.invoices.issue.confirmMessageUnqualified':
+    'Company settings hold no registration number, so this will be issued as a non-qualified invoice. Issuing allocates the invoice number and locks the contents (no further edits). The accuracy of the contents and their tax treatment are your responsibility to verify.',
   'admin.payments.title': 'Payments',
   'admin.payments.loading': 'Loading payments…',
   'admin.payments.empty': 'No payments yet.',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -709,9 +709,13 @@ export const jaMessages = {
   'admin.bankReconciliation.confirm.done': '消込しました',
   'admin.bankReconciliation.confirm.doneBody': '{{amount}} を入金として記録しました。',
   'admin.bankReconciliation.confirm.error': '消込できませんでした。',
-  'admin.invoices.issue.action': '発行する（適格請求書）',
+  // 既定は括弧なし。適格の名乗りは登録番号が在るときだけ足す（#771）。
+  'admin.invoices.issue.action': '発行する',
+  'admin.invoices.issue.actionQualified': '発行する（適格請求書）',
   'admin.invoices.issue.submitting': '発行中…',
   'admin.invoices.issue.error': '発行できませんでした。会社情報の登録番号をご確認ください。',
+  'admin.invoices.issue.errorUnqualified':
+    '発行できませんでした。時間をおいて、もう一度お試しください。',
   'admin.invoices.issue.recover': '会社設定を開く →',
   'admin.invoices.issue.successTitle': '発行しました',
   'admin.invoices.issue.successBody': '{{number}} を発行しました。',
@@ -719,6 +723,8 @@ export const jaMessages = {
   'admin.invoices.issue.confirmTitle': '請求書を発行しますか？',
   'admin.invoices.issue.confirmMessage':
     '発行すると番号が採番され、内容は確定（変更不可）になります。内容の正確性および税務上の取り扱いは、ご利用者の責任でご確認ください。',
+  'admin.invoices.issue.confirmMessageUnqualified':
+    '会社情報に登録番号がないため、適格請求書ではない請求書として発行します。発行すると番号が採番され、内容は確定（変更不可）になります。内容の正確性および税務上の取り扱いは、ご利用者の責任でご確認ください。',
   'admin.payments.title': '入金',
   'admin.payments.loading': '入金を読み込み中…',
   'admin.payments.empty': '入金はまだありません。',

--- a/tests/e2e/daily-workflow.spec.ts
+++ b/tests/e2e/daily-workflow.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { json, login } from './helpers/auth'
+import { json, login, stubCompanySettings } from './helpers/auth'
 
 /**
  * 正常系「1日分の業務」シナリオ。
@@ -150,6 +150,9 @@ test.describe('1日の業務（正常系）', () => {
     })
 
     // --- 請求 API（draft → issued、入金記録まで） ---
+    // 1日の流れは適格請求書として発行する（#771 の既定は登録番号の有無で決まる）。
+    await stubCompanySettings(page, 'T1234567890123')
+
     await page.route('**/admin/invoices/1/issue', (route) => {
       invoiceStatus = 'issued'
       route.fulfill(json(invoicePayload()))

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -70,3 +70,43 @@ export async function login(
   // The primary nav only renders once the auth gate reveals the app shell.
   await page.getByRole('link', { name: '取引先' }).waitFor()
 }
+
+/** Issuer profile stub. Only `registration_number` matters to most specs. */
+const COMPANY_SETTINGS = {
+  organization_id: 1,
+  legal_name: 'テスト株式会社',
+  address: null,
+  phone: null,
+  email: null,
+  registration_number: null as string | null,
+  bank_name: null,
+  bank_branch: null,
+  account_type: null,
+  account_number: null,
+}
+
+/**
+ * Stubs GET /admin/company-settings.
+ *
+ * 🔴 Any spec that reaches the invoice detail needs this (#771). The issue
+ * action derives 適格請求書 eligibility from the registration number, and an
+ * UNSTUBBED request does not fail loudly here — the preview server answers the
+ * XHR with `index.html`, the query errors, and eligibility stays unknown, so
+ * the button renders plain and disabled. That reads as "the label changed"
+ * rather than "the stub is missing", which is what it actually is.
+ *
+ * Pass a `T`+13-digit number for an issuer that can hand out a 適格請求書, or
+ * `null` for one that cannot.
+ */
+export async function stubCompanySettings(
+  page: Page,
+  registrationNumber: string | null,
+): Promise<void> {
+  await page.route('**/admin/company-settings', (route, request) => {
+    if (request.method() === 'GET') {
+      route.fulfill(json({ ...COMPANY_SETTINGS, registration_number: registrationNumber }))
+    } else {
+      route.fallback()
+    }
+  })
+}

--- a/tests/e2e/issue-invoice.spec.ts
+++ b/tests/e2e/issue-invoice.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test'
-import { json, login, problem } from './helpers/auth'
+import { json, login, problem, stubCompanySettings } from './helpers/auth'
+
+const REGISTERED = 'T1234567890123'
 
 const DRAFT_INVOICE = {
   id: 1,
@@ -16,23 +18,31 @@ const DRAFT_INVOICE = {
 }
 
 /** Reaches a draft invoice's detail through login → invoices list → the row link. */
-test.describe('Issue invoice', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.route('**/admin/invoices*', (route, request) => {
-      if (request.method() === 'GET') {
-        route.fulfill(json({ items: [DRAFT_INVOICE], total: 1, limit: 20, offset: 0 }))
-      } else {
-        route.fallback()
-      }
-    })
-    await page.route('**/admin/invoices/1', (route) => route.fulfill(json(DRAFT_INVOICE)))
-    await page.route('**/admin/invoices/1/payments', (route) =>
-      route.fulfill(json({ items: [], total_paid_cents: 0 })),
-    )
+async function openDraftInvoice(
+  page: Parameters<typeof login>[0],
+  registrationNumber: string | null,
+): Promise<void> {
+  await page.route('**/admin/invoices*', (route, request) => {
+    if (request.method() === 'GET') {
+      route.fulfill(json({ items: [DRAFT_INVOICE], total: 1, limit: 20, offset: 0 }))
+    } else {
+      route.fallback()
+    }
+  })
+  await page.route('**/admin/invoices/1', (route) => route.fulfill(json(DRAFT_INVOICE)))
+  await page.route('**/admin/invoices/1/payments', (route) =>
+    route.fulfill(json({ items: [], total_paid_cents: 0 })),
+  )
+  await stubCompanySettings(page, registrationNumber)
 
-    await login(page)
-    await page.getByRole('link', { name: '請求書', exact: true }).click()
-    await page.locator('a[href="/invoices/1"]').click()
+  await login(page)
+  await page.getByRole('link', { name: '請求書', exact: true }).click()
+  await page.locator('a[href="/invoices/1"]').click()
+}
+
+test.describe('Issue invoice — 登録番号あり', () => {
+  test.beforeEach(async ({ page }) => {
+    await openDraftInvoice(page, REGISTERED)
     await expect(page.getByRole('button', { name: '発行する（適格請求書）' })).toBeVisible()
   })
 
@@ -44,7 +54,7 @@ test.describe('Issue invoice', () => {
     await expect(dialog.getByText('請求書を発行しますか？')).toBeVisible()
   })
 
-  test('surfaces an error when issuing an invoice without a registration number', async ({
+  test('surfaces the registration-number recovery when the API rejects the qualified issue', async ({
     page,
   }) => {
     await page.route('**/admin/invoices/1/issue', (route) =>
@@ -59,5 +69,53 @@ test.describe('Issue invoice', () => {
     ).toBeVisible()
     // 型2 recovery affordance: a link to the company settings.
     await expect(page.getByRole('button', { name: '会社設定を開く →' })).toBeVisible()
+  })
+})
+
+/**
+ * 🔴 #771. Before the fix, an issuer with no registration number could not
+ * issue ANYTHING: the UI only knew how to send `qualified: true`, which the API
+ * refuses when the number is empty. The spec that used to live here asserted
+ * that dead end as if it were the product — it drove the qualified button and
+ * expected the 422. It is replaced, not deleted: the same starting state now
+ * has to reach an issued invoice.
+ */
+test.describe('Issue invoice — 登録番号なし', () => {
+  test.beforeEach(async ({ page }) => {
+    await openDraftInvoice(page, null)
+  })
+
+  test('offers a plain issue action, with no 適格請求書 claim', async ({ page }) => {
+    await expect(page.getByRole('button', { name: '発行する' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: '発行する（適格請求書）' })).toHaveCount(0)
+  })
+
+  test('says the invoice will not be a 適格請求書 before issuing it', async ({ page }) => {
+    await page.getByRole('button', { name: '発行する' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('適格請求書ではない請求書として発行します')).toBeVisible()
+  })
+
+  test('issues as NOT qualified', async ({ page }) => {
+    let issuedBody: Record<string, unknown> | null = null
+    await page.route('**/admin/invoices/1/issue', (route, request) => {
+      issuedBody = request.postDataJSON() as Record<string, unknown>
+      route.fulfill(
+        json({
+          ...DRAFT_INVOICE,
+          status: 'issued',
+          invoice_number: 'INV-2026-001',
+          is_qualified_invoice: false,
+        }),
+      )
+    })
+
+    await page.getByRole('button', { name: '発行する' }).click()
+    await page.getByRole('dialog').getByRole('button', { name: '発行する' }).click()
+
+    await expect(page.getByText('INV-2026-001 を発行しました。')).toBeVisible()
+    expect(issuedBody).toMatchObject({ qualified: false })
   })
 })


### PR DESCRIPTION
Closes #771

施主裁定（2026-08-28）: **登録番号が無ければ既定を `qualified=false` にする。**

## 何が塞がっていたか

フロントが `qualified: true` を**固定で**送っており（`use-issue-invoice.ts` の1箇所・呼び出し元も1箇所）、バックエンドは登録番号が空のとき適格請求書を拒否する（422 `QualifiedInvoiceIncompleteException`）。⇒ **UI が作れる唯一のリクエストが、必ず弾かれる**状態だった。

**API は最初から `qualified: false` を受け付ける。** 塞いでいたのは UI だけなので、変更は**フロントに閉じる（PHP 無変更）**。

バックエンドは既に未適格を正しく描く:

| | |
|---|---|
| `InvoicePdfGenerator.php:100` | `$title = $isQualified ? '適格請求書' : '請求書'` |
| `InvoicePdfGenerator.php:131` | 登録番号が空なら登録番号行を出さない |
| `ViewInvoice.tsx:153` | バッジは `invoice.is_qualified_invoice` 条件つき |

⇒ Issue の提案のうち「PDF に登録番号欄を出さない」「詳細画面のバッジを出さない」は**実装済み**で、必要なのは**フロントが `qualified` を決めること**だけだった。

## 変更

- 会社設定の登録番号の有無から `qualified` を導出する
- 発行ボタンの既定を「発行する」にし、**（適格請求書）は登録番号が在るときだけ足す**
- 未適格の確認ダイアログで、適格請求書ではない旨を明示する
- 未適格時のエラーから「登録番号をご確認ください」の導線を外す（その経路では登録番号起因の失敗が起きない）

### `qualified` は三値（true / false / null）

`null` は会社設定が**未解決**の状態で、その間は発行させない。**発行は不可逆**（採番して確定する）ので、未測定を `false` に潰すと「測って登録番号が無かった」と区別できなくなる。

同じ理由で **適格の名乗りは加算方向のみ**にした。未測定のまま「適格請求書」と表示するのは利用者に代わって税務上の主張をすることになり、逆向き（控えめに出す）だけが回復可能なため。

### 「登録番号が無い」の表現は `null` の一つに確定している（測って確認）

- 入口: `RequestField::optionalString` が `''` → `null`
- 出口: `PdoCompanySettingsRepository::nullableString` が `''` → `null`

⇒ 空文字は API から到達し得ない。それでも判定に空文字を明記し、テストで固定した（`''` を「番号が在る」と読むと、**空の登録番号を名乗る適格請求書**が出てしまい §4 に反するため）。

## コンプライアンス

`docs/explanation/accounting-compliance.md` §4:

> An invoice **MUST NOT** be markable as qualified while the issuer registration number is empty.

本 PR は**この規定に沿う方向**の変更（逸脱ではない）。従来の UI は登録番号が空でも適格としてマークしようとしており、バックエンドの拒否だけがそれを止めていた。

## デモ組織への影響: なし

`DemoDataSeeder.php:326` / `:384` の2プロファイルとも `registration_number` を seed している（`T1010001011111` / `T6060006066666`）ので、デモは従来どおり `qualified === true`・ラベルも「発行する（適格請求書）」のまま。

## テスト（変異で確認済み）

`use-issue-invoice.test.ts` に4件追加（計6件）。**装置が動くことを陽性対照で確認**:

| 変異 | 結果 |
|---|---|
| `qualified` を `true` 固定へ戻す（旧実装） | **赤**（未適格のテスト） |
| 未解決ガードを外し `null` を `false` に潰す | **赤**（null のテスト） |
| 復元（陰性対照） | **緑** 6/6 |

`npm run check` 全段緑（型・lint・stylelint・registries・format・カバレッジ ratchet・knip・build・storybook）。355 tests 全緑、カバレッジは4指標とも floor 超え（+0.26〜+0.99）。

## セルフレビューチェックリスト

- `docs/review/compliance.md`
- `docs/review/frontend.md`

## 目視のお願い

登録番号を持たない組織（AYANE）で、請求書の発行ボタンが「**発行する**」になり、確認ダイアログに適格請求書ではない旨が出て、発行後の PDF が「**請求書**」（登録番号行なし）になることをご確認ください。
